### PR TITLE
Track MCP recommendation outcomes in Codex harness

### DIFF
--- a/benchmarks/harness/codex-task-runner.py
+++ b/benchmarks/harness/codex-task-runner.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import shutil
 import subprocess
+import tempfile
 from datetime import datetime
 from pathlib import Path
 
@@ -21,6 +24,7 @@ DEFAULT_PROMPT_DIR = Path.home() / ".codex" / "harness" / "bootstrap" / "prompts
 DEFAULT_RUN_DIR = Path.home() / ".codex" / "harness" / "runs"
 DEFAULT_WORKSPACE_ALIAS_DIR = Path.home() / ".codex" / "harness" / "workspaces"
 DEFAULT_MCP_URL = "http://127.0.0.1:7837/mcp"
+DEFAULT_CODEX_HOME = Path.home() / ".codex"
 
 
 def load_bootstrap_module():
@@ -29,6 +33,50 @@ def load_bootstrap_module():
 
 def load_session_eval_module():
     return common.load_module(SESSION_EVAL_SCRIPT, "session_eval_module")
+
+
+def build_minimal_codex_home_config(*, repo_paths: list[Path], mcp_url: str) -> str:
+    lines = [
+        'model = "gpt-5.4"',
+        'model_reasoning_effort = "none"',
+        "",
+        "[mcp_servers.codelens]",
+        f'url = "{mcp_url}"',
+        "",
+    ]
+    seen_paths: set[str] = set()
+    for repo_path in repo_paths:
+        canonical = str(Path(repo_path).expanduser().resolve())
+        if canonical in seen_paths:
+            continue
+        seen_paths.add(canonical)
+        lines.extend(
+            [
+                f"[projects.{json.dumps(canonical)}]",
+                'trust_level = "trusted"',
+                "",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def prepare_isolated_codex_home(
+    *,
+    source_home: Path,
+    repo_paths: list[Path],
+    mcp_url: str,
+):
+    auth_path = source_home / "auth.json"
+    if not auth_path.exists():
+        return None, None, "auth.json missing"
+
+    tempdir = tempfile.TemporaryDirectory(prefix="codex-harness-home-")
+    home_path = Path(tempdir.name)
+    shutil.copy2(auth_path, home_path / "auth.json")
+    (home_path / "config.toml").write_text(
+        build_minimal_codex_home_config(repo_paths=repo_paths, mcp_url=mcp_url)
+    )
+    return tempdir, home_path, None
 
 
 def main():
@@ -64,6 +112,8 @@ def main():
     parser.add_argument("--exec", action="store_true")
     parser.add_argument("--json", action="store_true")
     parser.add_argument("--output-last-message", default="")
+    parser.add_argument("--no-ephemeral", action="store_true")
+    parser.add_argument("--no-isolated-codex-home", action="store_true")
     args = parser.parse_args()
 
     bootstrap = load_bootstrap_module()
@@ -165,6 +215,11 @@ def main():
             ),
             "fallback_to_native": mcp_preflight.get("fallback_to_native", False),
         }
+    metrics_session_id = (
+        mcp_preflight.get("session_id")
+        if isinstance(mcp_preflight, dict)
+        else None
+    )
     if workspace_alias:
         result["workspace_alias"] = workspace_alias
 
@@ -185,8 +240,11 @@ def main():
         last_message_file = run_dir / "last-message.md"
         codex_cmd[2:2] = ["--output-last-message", str(last_message_file)]
         result["last_message_file"] = str(last_message_file)
+    if not args.no_ephemeral:
+        codex_cmd.insert(-1, "--ephemeral")
 
     result["codex_command"] = codex_cmd
+    result["codex_ephemeral"] = not args.no_ephemeral
 
     before_metrics = None
     before_metrics_file = run_dir / "metrics-before.json"
@@ -194,7 +252,11 @@ def main():
     delta_metrics_file = run_dir / "metrics-delta.json"
     recommendation_outcome = None
     if args.capture_eval:
-        before_metrics, before_error = common.safe_capture_metrics_snapshot(args.mcp_url, request_id=9101)
+        before_metrics, before_error = common.safe_capture_metrics_snapshot(
+            args.mcp_url,
+            request_id=9101,
+            session_id=metrics_session_id,
+        )
         if before_metrics is not None:
             before_metrics_file.write_text(json.dumps(before_metrics, ensure_ascii=False, indent=2) + "\n")
             result["metrics_before_file"] = str(before_metrics_file)
@@ -205,12 +267,46 @@ def main():
         print(json.dumps(result, ensure_ascii=False, indent=2))
         return
 
-    proc = subprocess.run(codex_cmd, input=prompt, text=True, cwd=execution_repo_path)
-    if proc.returncode != 0:
-        raise SystemExit(proc.returncode)
+    codex_env = None
+    codex_home_tempdir = None
+    if args.no_isolated_codex_home:
+        result["codex_home_mode"] = "default"
+    elif args.profile:
+        result["codex_home_mode"] = "default-profile-preserved"
+    else:
+        codex_home_tempdir, isolated_home, isolated_error = prepare_isolated_codex_home(
+            source_home=DEFAULT_CODEX_HOME,
+            repo_paths=[repo_path, execution_repo_path],
+            mcp_url=args.mcp_url,
+        )
+        if isolated_home is not None:
+            codex_env = dict(os.environ)
+            codex_env["CODEX_HOME"] = str(isolated_home)
+            result["codex_home_mode"] = "isolated-minimal"
+        else:
+            result["codex_home_mode"] = "default"
+            result["codex_home_error"] = isolated_error
+
+    try:
+        proc = subprocess.run(
+            codex_cmd,
+            input=prompt,
+            text=True,
+            cwd=execution_repo_path,
+            env=codex_env,
+        )
+        if proc.returncode != 0:
+            raise SystemExit(proc.returncode)
+    finally:
+        if codex_home_tempdir is not None:
+            codex_home_tempdir.cleanup()
 
     if args.capture_eval and before_metrics is not None:
-        after_metrics, after_error = common.safe_capture_metrics_snapshot(args.mcp_url, request_id=9102)
+        after_metrics, after_error = common.safe_capture_metrics_snapshot(
+            args.mcp_url,
+            request_id=9102,
+            session_id=metrics_session_id,
+        )
         if after_metrics is None:
             if after_error:
                 result["metrics_after_error"] = after_error
@@ -267,25 +363,35 @@ def main():
 
             harness_eval_json = Path(args.harness_eval_json).expanduser() if args.harness_eval_json else run_dir / "harness-eval.json"
             harness_eval_md = Path(args.harness_eval_md).expanduser() if args.harness_eval_md else run_dir / "harness-eval.md"
-            result["harness_eval_result"] = common.run_harness_eval(
-                HARNESS_EVAL_SCRIPT,
-                repo_path=repo_path,
-                archive_entry_json=artifact_paths["archive_entry_json_path"],
-                output_json=harness_eval_json,
-                output_md=harness_eval_md,
-                label=f"live-{repo['id']}-{common.slugify(args.task_kind)}",
-                base_report_path=policy.get("source_report_path", ""),
-            )
-            result["harness_eval_json"] = str(harness_eval_json)
-            result["harness_eval_markdown"] = str(harness_eval_md)
+            try:
+                result["harness_eval_result"] = common.run_harness_eval(
+                    HARNESS_EVAL_SCRIPT,
+                    repo_path=repo_path,
+                    archive_entry_json=artifact_paths["archive_entry_json_path"],
+                    output_json=harness_eval_json,
+                    output_md=harness_eval_md,
+                    label=f"live-{repo['id']}-{common.slugify(args.task_kind)}",
+                    base_report_path=policy.get("source_report_path", ""),
+                )
+                result["harness_eval_json"] = str(harness_eval_json)
+                result["harness_eval_markdown"] = str(harness_eval_md)
+            except subprocess.CalledProcessError as exc:
+                result["harness_eval_error"] = (
+                    exc.stderr.strip() or exc.stdout.strip() or str(exc)
+                )
 
             refresh_result_file = run_dir / "routing-policy-refresh.json"
-            result["routing_policy_refresh"] = common.run_refresh(
-                REFRESH_POLICY_SCRIPT,
-                label=f"post-session-{repo['id']}-{common.slugify(args.task_kind)}",
-                output_json=refresh_result_file,
-            )
-            result["routing_policy_refresh_json"] = str(refresh_result_file)
+            try:
+                result["routing_policy_refresh"] = common.run_refresh(
+                    REFRESH_POLICY_SCRIPT,
+                    label=f"post-session-{repo['id']}-{common.slugify(args.task_kind)}",
+                    output_json=refresh_result_file,
+                )
+                result["routing_policy_refresh_json"] = str(refresh_result_file)
+            except subprocess.CalledProcessError as exc:
+                result["routing_policy_refresh_error"] = (
+                    exc.stderr.strip() or exc.stdout.strip() or str(exc)
+                )
 
     print(json.dumps(result, ensure_ascii=False, indent=2))
 

--- a/benchmarks/harness/codex-task-runner.py
+++ b/benchmarks/harness/codex-task-runner.py
@@ -192,6 +192,7 @@ def main():
     before_metrics_file = run_dir / "metrics-before.json"
     after_metrics_file = run_dir / "metrics-after.json"
     delta_metrics_file = run_dir / "metrics-delta.json"
+    recommendation_outcome = None
     if args.capture_eval:
         before_metrics, before_error = common.safe_capture_metrics_snapshot(args.mcp_url, request_id=9101)
         if before_metrics is not None:
@@ -219,6 +220,21 @@ def main():
             delta_payload = common.build_metrics_delta(session_eval, before_metrics, after_metrics)
             delta_metrics_file.write_text(json.dumps(delta_payload, ensure_ascii=False, indent=2) + "\n")
             result["metrics_delta_file"] = str(delta_metrics_file)
+            recommendation_outcome = common.build_codex_recommendation_outcome(
+                mcp_preflight,
+                delta_payload,
+            )
+            if recommendation_outcome is not None:
+                recommendation_outcome_file = run_dir / "mcp-recommendation-outcome.json"
+                recommendation_outcome_file.write_text(
+                    json.dumps(recommendation_outcome, ensure_ascii=False, indent=2) + "\n"
+                )
+                result["mcp_recommendation_outcome_file"] = str(recommendation_outcome_file)
+                result["mcp_recommendation_outcome"] = recommendation_outcome
+            notes = args.notes
+            recommendation_note = common.summarize_codex_recommendation_outcome(recommendation_outcome)
+            if recommendation_note:
+                notes = f"{notes} | {recommendation_note}" if notes else recommendation_note
 
             entry_args = common.build_entry_args(
                 repo_path=repo_path,
@@ -232,7 +248,7 @@ def main():
                 verify_passed=args.verify_passed,
                 quality_score=args.quality_score,
                 recommended_policy=brief["recommended_policy"],
-                notes=args.notes,
+                notes=notes,
             )
             session_entry = session_eval.build_entry(entry_args, delta_payload)
             session_entry["repo_label"] = repo.get("label", session_entry.get("repo_label", repo["id"]))

--- a/benchmarks/harness/harness_runner_common.py
+++ b/benchmarks/harness/harness_runner_common.py
@@ -296,9 +296,13 @@ def extract_tool_payload(response):
     return {}
 
 
-def safe_capture_metrics_snapshot(base_url: str, request_id: int):
+def safe_capture_metrics_snapshot(base_url: str, request_id: int, session_id: str | None = None):
     try:
-        return capture_metrics_snapshot(base_url, request_id=request_id), None
+        return capture_metrics_snapshot(
+            base_url,
+            request_id=request_id,
+            session_id=session_id,
+        ), None
     except Exception as exc:
         return None, str(exc)
 
@@ -663,8 +667,14 @@ def probe_codex_mcp(base_url: str, repo_path: Path, brief: dict, request_id_base
         }
 
 
-def capture_metrics_snapshot(base_url: str, request_id: int):
-    return mcp_http_tool_call(base_url, "get_tool_metrics", {}, request_id=request_id)
+def capture_metrics_snapshot(base_url: str, request_id: int, session_id: str | None = None):
+    return mcp_http_tool_call(
+        base_url,
+        "get_tool_metrics",
+        {},
+        request_id=request_id,
+        session_id=session_id,
+    )
 
 
 def delta_mapping(before: dict, after: dict):

--- a/benchmarks/harness/harness_runner_common.py
+++ b/benchmarks/harness/harness_runner_common.py
@@ -425,6 +425,100 @@ def build_codex_routing_recommendation(
     }
 
 
+def summarize_called_tools(delta_payload: dict) -> list[dict]:
+    rows = []
+    for row in delta_payload.get("tools", []) if isinstance(delta_payload, dict) else []:
+        if not isinstance(row, dict):
+            continue
+        tool = row.get("tool")
+        calls = int(row.get("calls") or 0)
+        if not isinstance(tool, str) or calls <= 0:
+            continue
+        rows.append(
+            {
+                "tool": tool,
+                "calls": calls,
+                "total_ms": int(row.get("total_ms") or 0),
+                "total_tokens": int(row.get("total_tokens") or 0),
+            }
+        )
+    rows.sort(key=lambda item: (-item["calls"], -item["total_ms"], item["tool"]))
+    return rows
+
+
+def build_codex_recommendation_outcome(mcp_preflight: dict | None, delta_payload: dict) -> dict | None:
+    if not isinstance(mcp_preflight, dict) or not mcp_preflight.get("available"):
+        return None
+
+    recommended_entrypoint = mcp_preflight.get("recommended_entrypoint")
+    recommended_followup_tools = list(mcp_preflight.get("recommended_followup_tools") or [])
+    recommended_contract_action = mcp_preflight.get("recommended_contract_action")
+    called_tools = summarize_called_tools(delta_payload)
+    called_counts = {row["tool"]: row["calls"] for row in called_tools}
+    session = delta_payload.get("session", {}) if isinstance(delta_payload, dict) else {}
+    deferred_expansions = int(session.get("deferred_namespace_expansion_count") or 0)
+    deferred_hidden_denials = int(session.get("deferred_hidden_tool_call_denied_count") or 0)
+
+    recommended_entrypoint_called = (
+        recommended_entrypoint in called_counts if isinstance(recommended_entrypoint, str) else None
+    )
+    recommended_followup_tools_called = [
+        tool for tool in recommended_followup_tools if tool in called_counts
+    ]
+    recommended_followup_tools_missed = [
+        tool for tool in recommended_followup_tools if tool not in called_counts
+    ]
+
+    alignment = "no-recommendation"
+    if recommended_entrypoint_called:
+        alignment = "matched-entrypoint"
+    elif recommended_followup_tools_called:
+        alignment = "matched-followup"
+    elif recommended_entrypoint or recommended_followup_tools:
+        alignment = "no-match"
+
+    contract_action_aligned = None
+    if recommended_contract_action == "stay_lean_until_shape_needed":
+        contract_action_aligned = deferred_expansions == 0 and deferred_hidden_denials == 0
+    elif recommended_contract_action == "use_prefetched_workflow_contract":
+        contract_action_aligned = bool(mcp_preflight.get("richer_contract_prefetched"))
+    elif recommended_contract_action in {"stay_on_default_contract", "open_primitive_tier"}:
+        contract_action_aligned = True
+
+    return {
+        "recommended_entrypoint": recommended_entrypoint,
+        "recommended_entrypoint_called": recommended_entrypoint_called,
+        "recommended_entrypoint_call_count": (
+            called_counts.get(recommended_entrypoint, 0) if isinstance(recommended_entrypoint, str) else 0
+        ),
+        "recommended_followup_tools": recommended_followup_tools,
+        "recommended_followup_tools_called": recommended_followup_tools_called,
+        "recommended_followup_tools_missed": recommended_followup_tools_missed,
+        "recommended_contract_action": recommended_contract_action,
+        "contract_action_aligned": contract_action_aligned,
+        "deferred_namespace_expansion_count": deferred_expansions,
+        "deferred_hidden_tool_call_denied_count": deferred_hidden_denials,
+        "alignment": alignment,
+        "top_called_tools": called_tools[:5],
+    }
+
+
+def summarize_codex_recommendation_outcome(outcome: dict | None) -> str:
+    if not isinstance(outcome, dict):
+        return ""
+    recommended_entrypoint = outcome.get("recommended_entrypoint")
+    alignment = outcome.get("alignment")
+    if alignment == "matched-entrypoint" and recommended_entrypoint:
+        return f"recommended entrypoint {recommended_entrypoint} was exercised"
+    if alignment == "matched-followup":
+        called = outcome.get("recommended_followup_tools_called") or []
+        if called:
+            return f"recommended follow-up tools exercised: {', '.join(called)}"
+    if alignment == "no-match" and recommended_entrypoint:
+        return f"recommended entrypoint {recommended_entrypoint} was not observed in tool metrics"
+    return ""
+
+
 def probe_codex_mcp(base_url: str, repo_path: Path, brief: dict, request_id_base: int = 9000):
     preferred_entrypoints = list(brief.get("preferred_entrypoints") or [])
     fallback_to_native = brief.get("recommended_policy") in {

--- a/benchmarks/harness/test_policy_integrity.py
+++ b/benchmarks/harness/test_policy_integrity.py
@@ -5,12 +5,25 @@ from __future__ import annotations
 
 import json
 import sys
+import importlib.util
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import harness_eval_common as common
 import harness_runner_common as runner_common
+
+
+def load_script_module(module_name: str, filename: str):
+    path = Path(__file__).resolve().parent / filename
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+CODEX_RUNNER = load_script_module("codex_task_runner_test", "codex-task-runner.py")
 
 
 def test_repo_override_trumps_global():
@@ -338,6 +351,21 @@ def test_build_codex_recommendation_outcome_tracks_entrypoint_and_contract_align
     )
 
 
+def test_build_minimal_codex_home_config_dedupes_paths_and_keeps_codelens_only():
+    config = CODEX_RUNNER.build_minimal_codex_home_config(
+        repo_paths=[
+            Path("/tmp/repo"),
+            Path("/tmp/repo"),
+            Path("/tmp/repo-alias"),
+        ],
+        mcp_url="http://127.0.0.1:9999/mcp",
+    )
+    assert '[mcp_servers.codelens]' in config
+    assert 'url = "http://127.0.0.1:9999/mcp"' in config
+    assert config.count('trust_level = "trusted"') == 2
+    assert "[plugins." not in config
+
+
 def main():
     tests = [
         test_repo_override_trumps_global,
@@ -351,6 +379,7 @@ def main():
         test_compute_quality_score_empty_claude_session,
         test_summarize_called_tools_orders_and_filters_zero_call_rows,
         test_build_codex_recommendation_outcome_tracks_entrypoint_and_contract_alignment,
+        test_build_minimal_codex_home_config_dedupes_paths_and_keeps_codelens_only,
         test_promotion_structural_identity,
         test_promotion_structural_ignores_timestamps,
         test_normalize_repo_id_fallback,

--- a/benchmarks/harness/test_policy_integrity.py
+++ b/benchmarks/harness/test_policy_integrity.py
@@ -10,6 +10,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import harness_eval_common as common
+import harness_runner_common as runner_common
 
 
 def test_repo_override_trumps_global():
@@ -286,6 +287,57 @@ def test_compute_quality_score_empty_claude_session():
     assert common.compute_quality_score(entry) is None
 
 
+def test_summarize_called_tools_orders_and_filters_zero_call_rows():
+    delta_payload = {
+        "tools": [
+            {"tool": "impact_report", "calls": 1, "total_ms": 90, "total_tokens": 200},
+            {"tool": "analyze_change_request", "calls": 3, "total_ms": 40, "total_tokens": 150},
+            {"tool": "verify_change_readiness", "calls": 3, "total_ms": 60, "total_tokens": 120},
+            {"tool": "get_capabilities", "calls": 0, "total_ms": 99, "total_tokens": 99},
+            {"tool": None, "calls": 2, "total_ms": 10, "total_tokens": 10},
+        ]
+    }
+    rows = runner_common.summarize_called_tools(delta_payload)
+    assert [row["tool"] for row in rows] == [
+        "verify_change_readiness",
+        "analyze_change_request",
+        "impact_report",
+    ]
+    assert rows[0]["calls"] == 3
+    assert rows[0]["total_ms"] == 60
+
+
+def test_build_codex_recommendation_outcome_tracks_entrypoint_and_contract_alignment():
+    mcp_preflight = {
+        "available": True,
+        "recommended_entrypoint": "impact_report",
+        "recommended_followup_tools": ["get_analysis_section", "verify_change_readiness"],
+        "recommended_contract_action": "stay_lean_until_shape_needed",
+    }
+    delta_payload = {
+        "tools": [
+            {"tool": "impact_report", "calls": 2, "total_ms": 80, "total_tokens": 200},
+            {"tool": "get_analysis_section", "calls": 1, "total_ms": 20, "total_tokens": 40},
+        ],
+        "session": {
+            "deferred_namespace_expansion_count": 0,
+            "deferred_hidden_tool_call_denied_count": 0,
+        },
+    }
+    outcome = runner_common.build_codex_recommendation_outcome(mcp_preflight, delta_payload)
+    assert outcome is not None
+    assert outcome["alignment"] == "matched-entrypoint"
+    assert outcome["recommended_entrypoint_called"] is True
+    assert outcome["recommended_entrypoint_call_count"] == 2
+    assert outcome["recommended_followup_tools_called"] == ["get_analysis_section"]
+    assert outcome["recommended_followup_tools_missed"] == ["verify_change_readiness"]
+    assert outcome["contract_action_aligned"] is True
+    assert (
+        runner_common.summarize_codex_recommendation_outcome(outcome)
+        == "recommended entrypoint impact_report was exercised"
+    )
+
+
 def main():
     tests = [
         test_repo_override_trumps_global,
@@ -297,6 +349,8 @@ def main():
         test_compute_quality_score_errors_lower_score,
         test_compute_quality_score_no_tool_calls,
         test_compute_quality_score_empty_claude_session,
+        test_summarize_called_tools_orders_and_filters_zero_call_rows,
+        test_build_codex_recommendation_outcome_tracks_entrypoint_and_contract_alignment,
         test_promotion_structural_identity,
         test_promotion_structural_ignores_timestamps,
         test_normalize_repo_id_fallback,

--- a/benchmarks/harness/tests/test_policy_integrity.py
+++ b/benchmarks/harness/tests/test_policy_integrity.py
@@ -11,6 +11,7 @@ if str(HARNESS_DIR) not in sys.path:
     sys.path.insert(0, str(HARNESS_DIR))
 
 import harness_eval_common as common  # noqa: E402
+import harness_runner_common as runner_common  # noqa: E402
 
 
 def load_script_module(module_name: str, filename: str):
@@ -276,6 +277,41 @@ class PolicyIntegrityTests(unittest.TestCase):
         self.assertIn("authoritative policy JSON", policy_section)
         self.assertIn("Policy target: `claude`", claude_override)
         self.assertIn("reference only", claude_override)
+
+    def test_recommendation_outcome_detects_followup_only_match(self):
+        outcome = runner_common.build_codex_recommendation_outcome(
+            {
+                "available": True,
+                "recommended_entrypoint": "impact_report",
+                "recommended_followup_tools": ["get_analysis_section", "verify_change_readiness"],
+                "recommended_contract_action": "use_prefetched_workflow_contract",
+                "richer_contract_prefetched": True,
+            },
+            {
+                "tools": [
+                    {
+                        "tool": "get_analysis_section",
+                        "calls": 2,
+                        "total_ms": 25,
+                        "total_tokens": 40,
+                    }
+                ],
+                "session": {
+                    "deferred_namespace_expansion_count": 1,
+                    "deferred_hidden_tool_call_denied_count": 0,
+                },
+            },
+        )
+
+        self.assertIsNotNone(outcome)
+        self.assertEqual(outcome["alignment"], "matched-followup")
+        self.assertEqual(outcome["recommended_followup_tools_called"], ["get_analysis_section"])
+        self.assertEqual(outcome["recommended_followup_tools_missed"], ["verify_change_readiness"])
+        self.assertTrue(outcome["contract_action_aligned"])
+        self.assertEqual(
+            runner_common.summarize_codex_recommendation_outcome(outcome),
+            "recommended follow-up tools exercised: get_analysis_section",
+        )
 
 
 if __name__ == "__main__":

--- a/benchmarks/harness/tests/test_policy_integrity.py
+++ b/benchmarks/harness/tests/test_policy_integrity.py
@@ -28,6 +28,7 @@ EXPORT = load_script_module("export_routing_policy_test", "export-routing-policy
 HARNESS_EVAL = load_script_module("harness_eval_test", "harness-eval.py")
 REFRESH = load_script_module("refresh_routing_policy_test", "refresh-routing-policy.py")
 TASK_BOOTSTRAP = load_script_module("task_bootstrap_test", "task-bootstrap.py")
+CODEX_RUNNER = load_script_module("codex_task_runner_test", "codex-task-runner.py")
 
 
 def make_repo():
@@ -312,6 +313,21 @@ class PolicyIntegrityTests(unittest.TestCase):
             runner_common.summarize_codex_recommendation_outcome(outcome),
             "recommended follow-up tools exercised: get_analysis_section",
         )
+
+    def test_minimal_codex_home_config_stays_small_and_trusted(self):
+        config = CODEX_RUNNER.build_minimal_codex_home_config(
+            repo_paths=[
+                Path("/tmp/repo"),
+                Path("/tmp/repo"),
+                Path("/tmp/repo-alias"),
+            ],
+            mcp_url="http://127.0.0.1:7847/mcp",
+        )
+
+        self.assertIn('[mcp_servers.codelens]', config)
+        self.assertIn('url = "http://127.0.0.1:7847/mcp"', config)
+        self.assertEqual(config.count('trust_level = "trusted"'), 2)
+        self.assertNotIn("[plugins.", config)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- track whether Codex sessions actually exercised the recommended CodeLens entrypoint or follow-up tools
- persist recommendation outcome telemetry alongside metrics delta output
- append a concise recommendation-alignment note into session entry notes
- add regression coverage for recommendation outcome ranking, alignment, and summary rendering

## Validation
- python3 -m py_compile benchmarks/harness/codex-task-runner.py benchmarks/harness/harness_runner_common.py benchmarks/harness/test_policy_integrity.py benchmarks/harness/tests/test_policy_integrity.py
- python3 benchmarks/harness/test_policy_integrity.py
- python3 benchmarks/harness/tests/test_policy_integrity.py
