### PR TITLE
chore(release): v1.5.0 — NL-retrieval quality release (opt-in stack)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added (v1.5 work-in-progress)
+## [1.5.0] — 2026-04-12
+
+Second public release. This version cuts the v1.5 experiment iteration into a shippable package: three stackable opt-in gates for NL-heavy retrieval, all cross-dataset validated on the 89-query self dataset and the 436-query augmented dataset, with a parameter sweep locking in the recommended `(threshold = 40, max = 40)` values. No behaviour change is turned on by default — every new gate is `CODELENS_*=1` opt-in — so existing deployments upgrade in place with zero surprises.
+
+### Headline stacked result (89-query self dataset)
+
+| Metric                          | v1.4.0 baseline | v1.5.0 stacked |          Δ |
+| ------------------------------- | --------------: | -------------: | ---------: |
+| `get_ranked_context` hybrid MRR |           0.572 |      **0.586** | **+0.014** |
+| hybrid Acc@3                    |           0.607 |      **0.652** | **+0.045** |
+| NL hybrid MRR                   |           0.470 |      **0.490** | **+0.020** |
+| NL hybrid Acc@3                 |           0.491 |      **0.545** | **+0.055** |
+| identifier Acc@1                |           0.800 |          0.800 |     +0.000 |
+
+Opt-in configuration (all three env vars, threshold + max at the Phase 2g optimum):
+
+```
+CODELENS_EMBED_HINT_INCLUDE_COMMENTS=1
+CODELENS_EMBED_HINT_INCLUDE_API_CALLS=1
+CODELENS_RANK_SPARSE_TERM_WEIGHT=1
+CODELENS_RANK_SPARSE_THRESHOLD=40
+CODELENS_RANK_SPARSE_MAX=40
+```
+
+### Added (v1.5)
 
 - **`embedding/vec_store.rs` submodule** — split `SqliteVecStore` + its `EmbeddingStore` impl out of `embedding.rs` (2,934 LOC → 2,501 + 451). Pure structural refactor, git rename-detected at 84% similarity. Phase 1 of the planned embedding-crate decomposition.
 - **Embedding hint infrastructure** — new `join_hint_lines`, `hint_line_budget`, `hint_char_budget` helpers plus `CODELENS_EMBED_HINT_LINES` (1..=10) and `CODELENS_EMBED_HINT_CHARS` (60..=512) env overrides. Multi-line body hints separated by `·` when a future PoC needs more than one line. The defaults stay at 1 line / 60 chars (v1.4.0 parity) — see "Changed" below for the reasoning.
@@ -55,7 +79,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Rationale
 
-These changes are bundled into a single Unreleased block because the refactor (`vec_store.rs` split), the new env knobs, the dataset fix, and the PoC revert all arrived in the same 2026-04-11 iteration. Each item is its own commit/PR so `git log` and GitHub PR history stay bisectable.
+v1.5 is an **NL-retrieval quality** release, not a feature release. Every new env knob is opt-in by design: the underlying embedding model (bundled CodeSearchNet-INT8) was chosen in v1.4 for its install footprint, and v1.5 treats that choice as fixed while improving what can be improved on top — the text the model sees at indexing time (Phase 2b NL tokens, Phase 2c `Type::method` hints) and the way the final results are re-ordered (Phase 2e sparse coverage bonus). Because each gate is OFF by default, upgrading v1.4.0 → v1.5.0 is a zero-behaviour-change drop-in. Users who want the uplift flip the three env vars at launch and pay one index rebuild; the stacked config is cross-dataset validated on both the 89-query self set (+2.4 % hybrid MRR, +11.2 % NL Acc@3 relative) and the 436-query augmented set (+7.1 % hybrid MRR, +24.9 % NL Acc@3 relative). The Phase 2g sweep locked in `(threshold = 40, max = 40)` as the minimal-aggressive optimum inside a four-cell plateau, so the recommended configuration is grounded in measurement rather than a first guess. The entire v1.5 iteration — Phase 1 refactor, rejected Phase 2 cAST PoC, revived Phase 2b NL-token extractor, orthogonal Phase 2c API-call extractor, MCP-layer Phase 2e sparse re-ranker, Phase 2f cross-dataset validation, Phase 2g parameter sweep — is bisectable PR-by-PR in the GitHub history (#10–#17) and reproducible via the measurement artefacts checked into `benchmarks/embedding-quality-v1.5-*.{json,md}`.
 
 ## [1.4.0] — 2026-04-11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,7 +265,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "codelens-engine"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -328,7 +328,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-mcp"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "Apache-2.0"
-version = "1.4.0"
+version = "1.5.0"
 description = "Pure Rust MCP server for code intelligence — 89 tools (+6 semantic), 25 languages, tree-sitter-first, 50-87% fewer tokens"
 repository = "https://github.com/mupozg823/codelens-mcp-plugin"
 homepage = "https://github.com/mupozg823/codelens-mcp-plugin"


### PR DESCRIPTION
## Summary

Second public release. Cuts the v1.5 experiment iteration (Phase 1 → 2b → 2c → 2e → 2f → 2g) into a shippable package: three stackable opt-in gates for NL-heavy retrieval, all cross-dataset validated on the 89-query self dataset and the 436-query augmented dataset, with a parameter sweep locking in the recommended `(threshold = 40, max = 40)` values.

**Zero default behaviour change** — every new gate is `CODELENS_*=1` opt-in, so v1.4.0 → v1.5.0 upgrades in place with no surprises.

## Headline stacked result (89-query self dataset)

| Metric | v1.4.0 baseline | v1.5.0 stacked | Δ |
|---|---:|---:|---:|
| `get_ranked_context` hybrid MRR | 0.572 | **0.586** | **+0.014 (+2.4 %)** |
| hybrid Acc@3 | 0.607 | **0.652** | **+0.045** |
| NL hybrid MRR | 0.470 | **0.490** | **+0.020** |
| NL hybrid Acc@3 | 0.491 | **0.545** | **+0.055 (+11.2 %)** |
| identifier Acc@1 | 0.800 | 0.800 | ±0.000 |

## Recommended opt-in config (NL-heavy traffic)

```
CODELENS_EMBED_HINT_INCLUDE_COMMENTS=1
CODELENS_EMBED_HINT_INCLUDE_API_CALLS=1
CODELENS_RANK_SPARSE_TERM_WEIGHT=1
CODELENS_RANK_SPARSE_THRESHOLD=40
CODELENS_RANK_SPARSE_MAX=40
```

## What's in v1.5

- **Phase 1** (#10) — `embedding/vec_store.rs` submodule split (pure refactor)
- **Phase 2 cAST PoC** (#11, #12) — rejected and reverted on A/B measurement
- **Phase 2b** (#13) — NL token extractor (comments + NL-shaped string literals), `CODELENS_EMBED_HINT_INCLUDE_COMMENTS=1`
- **Phase 2c** (#14) — `Type::method` API-call extractor, `CODELENS_EMBED_HINT_INCLUDE_API_CALLS=1`, Phase 2b의 정화기 역할
- **Phase 2e** (#15) — sparse term coverage re-ranker in MCP post-process, `CODELENS_RANK_SPARSE_TERM_WEIGHT=1` + threshold/max knobs. **첫 positive-solo arm**
- **Phase 2f** (#16) — cross-dataset validation on 436-query augmented set (direction-consistent, +7.1 % relative hybrid MRR)
- **Phase 2g** (#17) — parameter sweep confirms `(40, 40)` is the data-backed optimum inside a four-cell plateau

Full experiment narrative in `docs/benchmarks.md` §8.1–§8.6. All measurement artefacts checked in under `benchmarks/embedding-quality-v1.5-*.{json,md}` — every table in the release is reproducible via `benchmarks/embedding-quality.py --isolated-copy`.

## Changes in this PR

- `Cargo.toml`: workspace version `1.4.0` → `1.5.0` (`codelens-engine` + `codelens-mcp` inherit via `workspace.package`)
- `Cargo.lock`: regenerated
- `CHANGELOG.md`:
  - New `[1.5.0] — 2026-04-12` section with headline table, recommended opt-in config block, and all `Added` / `Measured` / `Rationale` entries previously held in `[Unreleased]`
  - Fresh empty `[Unreleased]` placeholder at the top
- **No code changes** — everything that v1.5 adds is already merged via #10–#17

## Still open (v1.6+)

- **True external-repo A/B** — hand-built 20–40 query dataset on a second codebase. The gate before flipping any env default to ON.
- **Phase 2d — Model swap** — CodeSearchNet-INT8 → E5-large / BGE-base. The v1.5 stacked baseline (hybrid MRR 0.586 on 89, +7.1 % relative on 436) is the formal baseline to beat before taking on the binary-size cost.

## Test plan

- [x] `cargo test -p codelens-engine` — **238 passed**
- [x] `cargo test -p codelens-mcp` — **148 passed**
- [x] `cargo test -p codelens-mcp --features http` — **191 passed**
- [x] `cargo clippy --all-targets -- -D warnings` — **0 warnings**
- [x] `cargo build --release -p codelens-mcp` — v1.5.0 binary built
- [x] Both crates compile with new workspace version (`codelens-engine v1.5.0`, `codelens-mcp v1.5.0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)