### PR TITLE
docs(design): Phase 2d — embedding model swap design brief

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Docs
+
+- **Phase 2d model-swap design brief** — new `docs/design/v1.6-phase2d-model-swap-brief.md` captures the structured trade-off surface for a future embedding-model upgrade (CodeSearchNet-INT8 → BGE-small / Jina code v2 / gte-small / …). Ten-section brief: context, candidate short-list with size + license + ONNX-support table, evaluation protocol re-using the v1.5 four-arm infrastructure, three bundle strategies (compile-in / download-on-first-run / feature flag), migration path with automatic reindex on model-name mismatch, ten-entry risk matrix, four-checkpoint effort breakdown with explicit stop conditions, and a decision matrix the maintainer fills in before any code change starts. **No code or behaviour change ships with the brief** — it is pre-decision by design, and exists specifically so a future Phase 2d does not repeat the Phase 2 cAST PoC's "first-guess implementation then measure" failure mode. The v1.5 stacked MRR (0.586 on 89-query, +7.1 % relative on 436-query) is now the formal baseline any model swap must exceed.
+
 ## [1.5.0] — 2026-04-12
 
 Second public release. This version cuts the v1.5 experiment iteration into a shippable package: three stackable opt-in gates for NL-heavy retrieval, all cross-dataset validated on the 89-query self dataset and the 436-query augmented dataset, with a parameter sweep locking in the recommended `(threshold = 40, max = 40)` values. No behaviour change is turned on by default — every new gate is `CODELENS_*=1` opt-in — so existing deployments upgrade in place with zero surprises.

--- a/docs/design/v1.6-phase2d-model-swap-brief.md
+++ b/docs/design/v1.6-phase2d-model-swap-brief.md
@@ -1,0 +1,481 @@
+# Phase 2d — Embedding model swap design brief
+
+**Status**: DRAFT, pre-decision. This document is a design brief, not an
+implementation plan. The goal is to give the maintainer (and anyone
+reviewing the repo after v1.5.0) enough structured context to decide
+whether Phase 2d should happen at all, and — if it does — which
+branch of the candidate tree to commit to before a single line of
+model-loading code is touched.
+
+**Not an actual Phase**: no code change ships with this brief. Merging
+this document does not launch Phase 2d. A follow-up "go / no-go"
+decision is required after the brief is reviewed. If "no go" is the
+answer, the brief stays as a historical design record next to the
+Phase 2 cAST PoC revert log in `docs/benchmarks.md §8.1` — rejected
+experiments are still evidence.
+
+**Audience**: maintainer + any external reviewer who will see v1.5.0
+on GitHub and wonder "why not just use a bigger model?". This brief
+exists specifically to answer that question with numbers and
+trade-offs instead of handwaving.
+
+---
+
+## 1. Context
+
+### 1.1 What v1.5.0 ships (baseline to beat)
+
+v1.5.0 is the result of an NL-retrieval quality iteration that treated
+the embedding model as fixed and improved everything _around_ it:
+
+- **Phase 2b** — NL token extractor (comments + NL-shaped string
+  literals) appended to the embedding text. `CODELENS_EMBED_HINT_INCLUDE_COMMENTS=1`.
+- **Phase 2c** — `Type::method` API-call extractor appended to the
+  embedding text. `CODELENS_EMBED_HINT_INCLUDE_API_CALLS=1`.
+- **Phase 2e** — sparse term coverage re-ranker running in the MCP
+  `get_ranked_context` post-process on the _original_ user query.
+  `CODELENS_RANK_SPARSE_TERM_WEIGHT=1` + `_THRESHOLD=40` + `_MAX=40`.
+
+All three are **opt-in**. The stacked configuration on the 89-query
+self dataset lifts `get_ranked_context` hybrid MRR from **0.572** to
+**0.586** (+2.4 % relative) and NL hybrid Acc@3 from **0.491** to
+**0.545** (+11.2 % relative). On the 436-query augmented dataset the
+relative lift is larger still (+7.1 % hybrid MRR, +24.9 % NL Acc@3).
+Identifier queries are untouched.
+
+**This is the baseline Phase 2d must beat.** Not 0.572 (v1.4.0
+baseline), not 0.573 (the §8.1 PoC baseline). **0.586** hybrid MRR on
+the 89-query self dataset with the full stack on. Any model swap that
+does not exceed that number is, for this repo, net-zero — because the
+user already has the option of enabling the v1.5 stack for free.
+
+### 1.2 What v1.5.0 does _not_ fix
+
+The bundled model (`MiniLM-L12-CodeSearchNet-INT8`, 32 MB, 384-dim,
+12 layers) was picked in v1.4.0 for install footprint. It is a
+_signature-optimised_ code search model, which is exactly why the
+Phase 2 cAST PoC failed: adding raw body code to the embedding text
+diluted the signature signal. Phase 2b/2c/2e succeeded because they
+added _natural language_ or used the model's output as-is, leaving
+the signature path alone.
+
+That design decision has a hard ceiling. The NL path is essentially
+bolted-on — we are feeding a signature-optimised model natural-
+language strings and hoping its CodeSearchNet pre-training gives
+enough NL generalization to make it work. Measured NL hybrid MRR on
+the 89-query set is **0.490 with the full stack, 0.470 without** —
+versus an identifier MRR of **0.800 in every arm**. The gap between
+0.490 and 0.800 is roughly how much headroom remains at the model
+level.
+
+The `get_ranked_context` hybrid MRR ceiling is another way to see
+the same gap: stacked = 0.586 vs. semantic_search = 0.522 (stacked)
+/ 0.528 (baseline). The hybrid path barely beats pure lexical
+retrieval because the pure semantic path is weak on NL queries.
+**The model is the ceiling for NL retrieval.** Nothing in v1.5
+attacks it directly.
+
+### 1.3 Why now
+
+Three reasons the brief is written now and not earlier:
+
+1. The v1.5 stack is a _real baseline to beat_, not a straw man.
+   Any model swap benchmark can be reported against `(v1.4.0 baseline,
+v1.5 stacked, new model solo, new model + v1.5 stack)` — a clean
+   four-arm story.
+2. v1.5.0 is cut and tagged. Phase 2d can be scheduled as v1.6 or
+   v2.0 without blocking the currently-shipping release.
+3. The iteration rate on embedding models has accelerated in
+   2025–2026. `E5`, `BGE`, `Jina`, `Nomic`, and several code-specific
+   variants now have OSS checkpoints with INT8 ONNX exports. The
+   trade-off surface is wider than it was when v1.4.0 picked MiniLM.
+
+---
+
+## 2. Candidate models
+
+The candidates below are **capabilities**, not locked-in choices. The
+evaluation protocol (§3) and bundle strategy (§4) apply to whichever
+candidate is picked. The short-list is what a maintainer should at
+least measure before choosing.
+
+| Candidate                                   |       Dim |   Size (FP16) | Size (INT8 est.) | Code-tuned | OSS        | ONNX export | Notes                                                                                                                                                                               |
+| ------------------------------------------- | --------: | ------------: | ---------------: | :--------- | :--------- | :---------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **MiniLM-L12-CodeSearchNet-INT8** (current) |       384 |        ~64 MB |        **32 MB** | **Yes**    | MIT        | Yes         | Baseline. Signature-optimised, NL ceiling is the problem.                                                                                                                           |
+| **BGE-small-en-v1.5**                       |       384 |        ~60 MB |           ~33 MB | Neutral    | MIT        | Yes         | Strong general-purpose NL, similar size profile. Minimal install-size cost, likely meaningful NL uplift. Biggest upside / risk ratio.                                               |
+| **BGE-base-en-v1.5**                        |       768 |       ~140 MB |           ~75 MB | Neutral    | MIT        | Yes         | Larger-dim variant. Bigger binary, probably better NL. Requires vector store migration (384 → 768).                                                                                 |
+| **Jina embeddings v2 base code**            |       768 |       ~160 MB |           ~85 MB | **Yes**    | Apache-2.0 | Yes         | Explicitly code-tuned in addition to NL. The "both sides of the trade-off" candidate.                                                                                               |
+| **Nomic Embed v1.5**                        |       768 |       ~275 MB |          ~140 MB | Neutral    | Apache-2.0 | Yes         | Longer context (8192 tokens). Overkill for symbol embedding but useful if we move to chunk embedding later.                                                                         |
+| **gte-small / gte-base**                    | 384 / 768 |  ~55 / 220 MB |     ~30 / 115 MB | Neutral    | MIT        | Yes         | Strong benchmark scores on MTEB; worth measuring.                                                                                                                                   |
+| **E5-small-v2 / E5-base-v2**                | 384 / 768 | ~130 / 440 MB |     ~70 / 220 MB | Neutral    | MIT        | Yes         | Microsoft's E5 series. Stronger NL than MiniLM but install-footprint cost is higher. Query prefix convention (`query:` / `passage:`) needs our code paths to wrap inputs correctly. |
+
+**Size numbers are estimates.** Real INT8 sizes depend on the ONNX
+export path (dynamic vs. static quantization) and whether the
+tokenizer + config files are bundled. Any real selection needs the
+actual artefact measured.
+
+**Explicit non-candidates**:
+
+- **Voyage Code 2**, **OpenAI text-embedding-3**, **Cohere Embed** —
+  API-only. A code intelligence MCP server that requires network
+  egress for every embedding call is a non-starter for this project's
+  offline-first and self-contained design principles.
+- **Larger LLMs used as encoders** — out of scope. We want embedding
+  models, not a full-model shim.
+
+### 2.1 Short-list recommendation
+
+If only three candidates can be measured in the first pass, the
+recommended short-list is:
+
+1. **BGE-small-en-v1.5 INT8** — minimal size cost (same ~32 MB class
+   as current), meaningful NL uplift potential, zero migration cost
+   because it stays at 384-dim. **The "free-ish upgrade" candidate.**
+2. **Jina embeddings v2 base code INT8** — the "both sides" candidate.
+   Dedicated code tuning plus strong NL. Bigger (dim 768 → vector
+   store migration required) but probably the highest ceiling.
+3. **gte-small INT8** — the "independent reference" candidate. If the
+   two strong candidates both disappoint, gte-small gives a neutral
+   third data point before abandoning the swap.
+
+Nomic and E5 are explicit **second-pass** candidates — only measured
+if the first three produce a surprising loss (e.g. Jina wins on
+code-only queries but loses on NL-heavy queries).
+
+### 2.2 Red flags to watch per candidate
+
+- **Query prefix conventions** (E5, Nomic v1.5): require the caller
+  to wrap inputs with `query:` / `passage:` / similar. If our
+  `build_embedding_text` path does not honour the convention, scores
+  silently drop.
+- **Tokenizer changes**: a candidate with a different tokenizer
+  vocabulary cannot share our current cache. Full reindex on first
+  launch.
+- **INT8 quality loss**: some models lose noticeable quality under
+  INT8. Always measure FP16 → INT8 delta on the candidate as a
+  sanity check before committing.
+- **License**: we currently ship under a licence that assumes all
+  bundled artefacts are OSS-compatible. Any candidate with a research-
+  use-only or non-commercial licence is out.
+
+---
+
+## 3. Evaluation protocol
+
+Phase 2d must be measured against the **same infrastructure** that
+Phase 2b/2c/2e/2f/2g used, so the numbers are directly comparable
+with `docs/benchmarks.md §8.2–§8.6`. No new metric definitions, no
+new dataset shape.
+
+### 3.1 Arms
+
+For each candidate model, run **four arms** on both the 89-query
+self dataset and the 436-query augmented dataset:
+
+1. **baseline** — new model, all three v1.5 env gates OFF.
+2. **v1.5 stack** — new model, all three v1.5 env gates ON with
+   `(threshold = 40, max = 40)`.
+3. **reference baseline** — current model (CodeSearchNet-INT8), all
+   gates OFF. (Already measured, can be re-used from v1.5.0
+   release artefacts.)
+4. **reference stack** — current model, full v1.5 stack. (Also
+   already measured.)
+
+Arms 3 and 4 exist to confirm that the new model's _solo_ beats the
+_stack_ — if it only matches it, the stack is cheaper to ship and
+the swap is not justified. This is the **go / no-go gate**: new model
+solo must exceed v1.5 stacked on hybrid MRR, not just baseline.
+
+### 3.2 Metrics
+
+Same as v1.5 (`docs/benchmarks.md §4`):
+
+- `semantic_search` MRR / Acc@1 / Acc@3 / Acc@5 — pure semantic path.
+- `get_ranked_context` hybrid MRR / Acc@1 / Acc@3 / Acc@5 — primary
+  agent-facing metric.
+- `get_ranked_context_no_semantic` — structural-only, should be
+  invariant under model swap (sanity check).
+- Per-query-type breakdown (identifier / natural_language /
+  short_phrase) — the model swap should primarily move
+  natural_language, leave identifier untouched, and maybe move
+  short_phrase.
+
+### 3.3 Datasets
+
+- **89-query self** (`benchmarks/embedding-quality-dataset-self.json`) —
+  direct comparability with §8.2–§8.6. **Required.**
+- **436-query augmented** (`benchmarks/embedding-quality-dataset.json`) —
+  harder distribution, cross-dataset check. **Required.**
+- **One external repo** with hand-built 20–40 query dataset. This
+  is the v1.5 "still-open work" from §8.5. Phase 2d is a good excuse
+  to finally do it, because the model swap is exactly the class of
+  change that can overfit to self-measurement. **Required before
+  any model becomes the new default.**
+
+### 3.4 Non-measured dimensions
+
+These are intentionally **not** part of the go / no-go gate, though
+they feed into the bundle strategy in §4:
+
+- Embedding throughput (symbols/sec during indexing). Important for
+  user experience but not a retrieval-quality metric.
+- Index size on disk. Informational, not decision-driving unless the
+  new model explodes it by > 2×.
+- Cold-start latency of the first `index_embeddings` call. User-
+  visible but not comparable across models with different sizes.
+
+If a candidate passes §3.1 and §3.2 but fails badly on §3.4 (e.g.
+indexes 5× slower), the brief is re-opened rather than the model
+committed.
+
+---
+
+## 4. Bundle strategy
+
+v1.4.0 picked "compile-in the INT8 artefact" because 32 MB was
+acceptable overhead for a single-binary MCP server. Any candidate
+larger than ~50 MB forces a rethink.
+
+Three bundle strategies are worth considering:
+
+### Option A — Compile-in (current approach extended)
+
+Ship the model as a byte array inside the binary. Works for
+candidates under ~50 MB. Simple, atomic, no network dependency.
+Probably viable for **BGE-small INT8** if the full INT8 artefact
+lands under 40 MB including tokenizer.
+
+- **Pros**: no first-run friction, offline-safe, atomic upgrade,
+  matches current UX.
+- **Cons**: binary size scales with model size, every release redownloads
+  the model as part of the binary, forks that pin an older binary can
+  never change model.
+
+### Option B — Download on first `index_embeddings`
+
+Ship a tiny binary with no bundled model. First `index_embeddings`
+call downloads the selected model from a stable mirror (GitHub
+release asset or HuggingFace via `hf_hub` equivalent). Cache under
+`~/.cache/codelens/models/<model-id>/`.
+
+- **Pros**: binary stays small (~10–15 MB), multiple candidate
+  models can ship in the same release (pick at launch via env var),
+  the "free upgrade" story for users who don't need semantic
+  retrieval (they never download anything).
+- **Cons**: first-run friction, offline environments break, mirror
+  availability becomes a dependency, integrity / checksum needs to
+  be pinned.
+
+Option B is the **most flexible** and matches how most modern MCP-
+style tools ship. It is also the most work: mirror management,
+checksum verification, offline fallback messaging, progress output.
+
+### Option C — Feature flag (cargo feature)
+
+Ship current MiniLM as default, gate the new model behind
+`--features big-embed` (or similar). Users who want the upgrade
+rebuild with the feature enabled.
+
+- **Pros**: trivial to implement, perfectly backwards-compatible,
+  existing users see literally zero change.
+- **Cons**: feature-gated binaries are a poor user experience for
+  an end-user tool, `cargo install` without the feature flag silently
+  delivers the old model, the `get_ranked_context` numbers users
+  see in benchmarks don't match what they're actually running.
+
+**Recommendation**: **Option A if a < 50 MB candidate wins**, **Option B
+if a 50–200 MB candidate wins**, never Option C. Option C is listed
+only for completeness because someone will suggest it.
+
+---
+
+## 5. Migration path
+
+Swapping the embedding model invalidates every existing index. Users
+of v1.5.0 or earlier who upgrade must reindex once on first
+`index_embeddings` call, and the migration must be **automatic** —
+no user-run migration script.
+
+### 5.1 Version tagging the index
+
+The current `embedding_store.rs` schema stores the model name with
+each indexed embedding. The upgrade path is:
+
+1. Read the model-name column from the existing index on open.
+2. If it does not match the newly-loaded model, run `force_reindex`
+   automatically. Log a single user-visible line explaining why.
+3. If the existing rows match, keep them and fall through to the
+   normal incremental-index code path.
+
+The v1.5.0 inspect helpers already surface the model name via
+`get_capabilities` — no schema change required.
+
+### 5.2 Cold-start time budget
+
+The first `index_embeddings` after a model swap is going to be
+expensive. For a mid-size codebase (say, 10 k symbols, ~500 files)
+a 384-dim model re-indexes in roughly 30–60 seconds on current
+hardware. Phase 2d needs to stay within a tolerable multiple of
+that — **no more than 3× the current cold-start time** is a
+reasonable "don't make users rage-quit" budget.
+
+If the new model is so heavy that cold-start explodes beyond 3×, the
+bundle strategy must compensate with either (a) a background
+progressive reindex that keeps the lexical path live while semantic
+catches up, or (b) smaller `embed_batch_size` defaults.
+
+### 5.3 Rollback
+
+If v1.6 ships the swap and users hit quality regressions or excessive
+size cost, the rollback path is:
+
+1. v1.6.1 adds an env var `CODELENS_EMBED_MODEL=codesearchnet-int8`
+   that re-selects the v1.5 model at launch time.
+2. Users set the env var and restart. Next `index_embeddings` call
+   automatically reindexes using the legacy model (because the
+   model-name column mismatch triggers reindex).
+3. If the rollback stream is large, v1.6.2 flips the default back
+   to `codesearchnet-int8` and moves the new model behind the same
+   env var with the opposite value. One release cycle, no data loss.
+
+This is only realistic if Option A (compile-in) ships both models
+simultaneously, or Option B (download) keeps both mirrors live. The
+brief's §4 recommendation already supports both.
+
+---
+
+## 6. Risk matrix
+
+| #   | Risk                                                                                             | Probability | Impact | Mitigation                                                                                                                                                |
+| --- | ------------------------------------------------------------------------------------------------ | :---------: | :----: | :-------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| R1  | New model's solo MRR does not beat v1.5 stacked MRR on 89-query set                              |     Med     |  High  | Clear go / no-go in §3.1. Rejected candidate goes in the brief, not the code.                                                                             |
+| R2  | New model passes 89-query but loses on 436-query                                                 |     Med     |  High  | Both datasets are **required** before merge. Cross-dataset fail = rejection.                                                                              |
+| R3  | New model passes both self datasets but loses on external repo                                   |     Low     |  Med   | External-repo A/B is **required** before default flip. Fail = still available as opt-in, no default swap.                                                 |
+| R4  | INT8 quantization loss invalidates the candidate                                                 |     Med     |  Med   | Measure FP16 → INT8 delta as a sanity check on the candidate before committing. Fall back to FP16 artefact if the loss is > 0.01 MRR.                     |
+| R5  | Bundle size explosion triggers install / distribution friction                                   |    High     |  Med   | §4 bundle strategy. Option B exists specifically for this.                                                                                                |
+| R6  | Tokenizer change breaks cache                                                                    |    High     |  Low   | Already expected — §5.1 auto-reindex handles it. Not a regression, just a one-time cost.                                                                  |
+| R7  | Model-prefix convention (E5 / Nomic) applied inconsistently                                      |     Low     |  Med   | Linted in unit tests: every input to the embedding function goes through a single wrap helper.                                                            |
+| R8  | Upstream model license changes or gets pulled                                                    |     Low     |  Med   | Pin an artefact by checksum and host a mirror. Don't depend on HF availability at build time.                                                             |
+| R9  | A candidate that looks best on benchmarks uses training data that overlaps with the self dataset |     Low     |  High  | External-repo A/B is the only defence. Self-datasets are forever vulnerable to benchmark contamination.                                                   |
+| R10 | v1.5 stack gets silently bypassed in the new model's implementation path                         |     Low     |  Low   | `get_ranked_context` still runs the Phase 2e post-process — that path is model-agnostic. Sanity test checks stack deltas on new model match v1.5 pattern. |
+
+Any **High** impact risk without a **High** mitigation means the
+brief is re-scoped, not the code shipped.
+
+---
+
+## 7. Effort breakdown
+
+Work items are grouped by **go / no-go checkpoints**. Each checkpoint
+is a commit / PR where the maintainer can stop cleanly.
+
+### Checkpoint 1 — Short-list measurement (no code change)
+
+- **Task 1.1**: Download (manually or via script) the three short-list
+  INT8 artefacts (BGE-small, Jina code v2, gte-small). Confirm ONNX
+  loadable by `ort`.
+- **Task 1.2**: Write a temporary `CODELENS_EMBED_MODEL_OVERRIDE=<path>`
+  hack that swaps the model at runtime. Hacky, lives in a branch,
+  not merged.
+- **Task 1.3**: Four-arm A/B on each candidate (89-query self).
+- **Stop here if**: all three candidates fail to beat v1.5 stacked
+  on hybrid MRR. Brief re-opens, no commit.
+
+**Exit artefact**: a `docs/benchmarks.md §8.7` entry with the three
+short-list candidate numbers and a verdict. Either "proceed with
+candidate X" or "none of these beat the v1.5 stack, Phase 2d parked".
+
+### Checkpoint 2 — Bundle strategy implementation (code change)
+
+Only if Checkpoint 1 produced a winner.
+
+- **Task 2.1**: Implement §4 Option A or B (whichever matches the
+  winner's size class).
+- **Task 2.2**: Implement §5.1 auto-reindex on model-name mismatch.
+- **Task 2.3**: Implement §5.3 rollback env var.
+- **Task 2.4**: Update `crates/codelens-engine/src/embedding/mod.rs`
+  model loader to the new path.
+- **Task 2.5**: Cargo.toml workspace bump (1.6.0 if additive, 2.0.0
+  if breaking).
+
+**Exit artefact**: one PR that swaps the default model, ships the
+rollback env var, and passes the existing 238 + 148 + 191 test suite.
+
+### Checkpoint 3 — Cross-dataset + external-repo validation
+
+- **Task 3.1**: Four-arm A/B on 89-query self (replay).
+- **Task 3.2**: Four-arm A/B on 436-query augmented.
+- **Task 3.3**: Hand-build a 20–40 query dataset on one mid-size
+  external repo. Candidates from §8.5 `still-open work`: `ripgrep`,
+  `tokio`, `rust-analyzer` (small / medium / large of Rust world).
+- **Task 3.4**: Four-arm A/B on the external repo.
+- **Stop here if**: external repo numbers contradict the self
+  datasets. Ship the new model as opt-in only, do not flip default.
+
+**Exit artefact**: `docs/benchmarks.md §8.8` with the full cross-
+dataset + external-repo measurement.
+
+### Checkpoint 4 — Release cut
+
+- **Task 4.1**: CHANGELOG entry + version bump.
+- **Task 4.2**: Release notes with the headline numbers.
+- **Task 4.3**: Tag + GitHub release.
+
+**Exit artefact**: v1.6.0 or v2.0.0 tagged release.
+
+---
+
+## 8. Decision matrix
+
+For the maintainer to fill in _before_ Checkpoint 1 starts. This
+section exists specifically to turn "Phase 2d sounds good" into a
+bounded commitment.
+
+| Decision                                                                                | Default recommendation                                                                              | User answer |
+| --------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------- | :---------- |
+| D1: Is Phase 2d worth attempting at all given v1.5.0 already ships a +0.014 hybrid MRR? | Yes — the NL ceiling is real                                                                        |             |
+| D2: Is 3× current cold-start time the acceptable budget?                                | Yes                                                                                                 |             |
+| D3: Which bundle strategy (§4)?                                                         | A if winner < 50 MB, B if winner 50–200 MB                                                          |             |
+| D4: Which short-list candidate to measure first?                                        | BGE-small, Jina code v2, gte-small (all three)                                                      |             |
+| D5: External-repo choice for Checkpoint 3?                                              | `ripgrep` (mid-size Rust, search-related queries match intent)                                      |             |
+| D6: If all three short-list candidates fail, retry with FP16 / a different short-list?  | No — park Phase 2d for v2, measured rejection is evidence too                                       |             |
+| D7: Version to release under (1.6.0 vs 2.0.0)?                                          | 1.6.0 if the swap stays backwards-compatible via rollback env var; 2.0.0 if the index schema breaks |             |
+
+---
+
+## 9. What this brief does _not_ commit to
+
+- It does not commit to doing Phase 2d.
+- It does not commit to any specific candidate model.
+- It does not commit to any bundle strategy.
+- It does not commit to any version number.
+
+It commits only to one thing: **if Phase 2d happens, it follows this
+structure rather than the first-guess path**. The Phase 2 cAST PoC
+revert (§8.1) is the pattern this brief exists to avoid repeating.
+
+---
+
+## 10. Supersedes / follows
+
+This brief **supersedes** the stub entries under "Still-open work" in
+`docs/benchmarks.md §8.4–§8.6` that mention Phase 2d. Those entries
+can now point here.
+
+This brief **follows**:
+
+- `docs/benchmarks.md §8.1` — Phase 2 cAST PoC revert (the class of
+  failure this brief is trying to avoid).
+- `docs/benchmarks.md §8.4` — Phase 2e expansion-query dilution
+  finding (the class of infrastructure bug this brief explicitly
+  flags as R10).
+- `docs/benchmarks.md §8.5` — Phase 2f cross-dataset verdict (the
+  "single dataset is not enough" lesson that §3.3 makes a hard
+  requirement).
+- `docs/benchmarks.md §8.6` — Phase 2g parameter sweep (the
+  "measured optimum, not first guess" discipline §8 decision matrix
+  inherits).
+
+---
+
+_Drafted 2026-04-12, post-v1.5.0._


### PR DESCRIPTION
## Summary

**Docs-only change, no code or behaviour change.** Adds a pre-decision design brief for a future Phase 2d (embedding model swap from the current `MiniLM-L12-CodeSearchNet-INT8` to a stronger NL-capable model).

**Explicit purpose**: give the maintainer (and any reviewer after v1.5.0) enough structured context to decide whether Phase 2d should happen at all, and — if it does — which branch of the candidate tree to commit to **before a single line of model-loading code is touched**.

**This PR does not launch Phase 2d.** Merging the brief is not a commitment to the swap. A follow-up go / no-go decision is required after review. If the answer is "no go", the brief stays as a historical design record, which is still evidence (see the Phase 2 cAST PoC revert in §8.1 for the same pattern).

## What's in the brief

Ten sections under `docs/design/v1.6-phase2d-model-swap-brief.md`:

1. **Context** — what v1.5.0 ships, what it does *not* fix, why now.
2. **Candidate models** — seven-row comparison table (MiniLM current + BGE-small / base, Jina code v2, Nomic, gte, E5) with dim, size, INT8 size estimate, code-tuning status, license, ONNX export, notes. Three-model short-list recommendation (BGE-small / Jina code v2 / gte-small). Explicit non-candidates (API-only services, larger LLMs).
3. **Evaluation protocol** — re-uses the v1.5 four-arm infrastructure on 89-query self + 436-query augmented + one external repo. **Explicit go / no-go gate**: the new model's solo MRR must exceed the v1.5 *stacked* MRR, not just the v1.4.0 baseline (0.586 vs 0.572).
4. **Bundle strategy** — three options (compile-in / download-on-first-run / feature flag) with an explicit recommendation (Option A if winner < 50 MB, Option B if 50–200 MB, never C).
5. **Migration path** — model-name column mismatch triggers automatic reindex on first `index_embeddings` call. Rollback env var stream.
6. **Risk matrix** — ten entries with probability + impact + mitigation across quality loss, bundle size, tokenizer change, license pull, benchmark contamination, v1.5 stack bypass.
7. **Effort breakdown** — four go / no-go checkpoints (short-list measurement → bundle implementation → cross-dataset validation → release cut) with clear stop conditions at each.
8. **Decision matrix** — seven pre-filled defaults for the maintainer to confirm or override before Checkpoint 1 starts.
9. **What the brief does not commit to** — explicit list.
10. **Supersedes / follows** — links into the §8.1–§8.6 experiment log and the v1.5.0 "still-open work" stubs.

The brief explicitly inherits lessons from:

- §8.1 Phase 2 cAST PoC revert — the "first-guess implementation then measure" failure mode this brief is built to avoid.
- §8.4 Phase 2e expansion-query dilution finding — flagged as R10 in the risk matrix.
- §8.5 Phase 2f cross-dataset verdict — the "single dataset is not enough" lesson becomes a hard requirement in §3.3.
- §8.6 Phase 2g parameter sweep discipline — "measured optimum, not first guess" is the rule §8 decision matrix inherits.

## Why ship this as its own PR

Three reasons:

1. **Brief reviewability**. A 485-line design brief mixed into a real Phase 2d implementation PR would drown the code review. Shipping it first means the design debate happens on the design document, and the implementation PR (if it happens) can focus on code.
2. **Pre-commit anchor for the v1.5 stacked baseline**. The brief pins `(v1.5.0 stacked hybrid MRR = 0.586 on 89-query, +7.1 % relative on 436-query)` as the baseline any model swap must beat. Writing this down in `[Unreleased]` before v1.6 work starts prevents "baseline drift" across PRs.
3. **Optionality**. If a maintainer looks at the brief and decides Phase 2d is not worth it for this repo, the correct outcome is "brief stays merged, Phase 2d parked". That is a cleaner artefact than a deleted branch.

## Changes

- `docs/design/v1.6-phase2d-model-swap-brief.md` — new file (485 lines).
- `CHANGELOG.md` `[Unreleased]` — new `### Docs` section summarising the brief in one paragraph.
- **No code changes.** No `.rs`, `Cargo.toml`, `Cargo.lock`, or benchmark file touched.

## Test plan

- [x] No code change — nothing for `cargo check` / `cargo test` / `clippy` to verify.
- [x] Markdown renders on GitHub (tables, headings, code blocks).
- [x] Internal links resolve (§ anchors to `docs/benchmarks.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)