### PR TITLE
docs(bench): Phase 3a — external-repo validation on ripgrep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Measured (Phase 3a — external-repo validation on ripgrep, no behaviour change)
+
+- **v1.5 opt-in stack cross-repo validated on `github.com/BurntSushi/ripgrep`** (2026-04-12). 24 hand-built queries against ripgrep's `regex` / `searcher` / `ignore` / `globset` / `printer` crates, 17/5/2 NL/short-phrase/identifier split mirroring the 89-query self shape. Four-arm A/B (`baseline` / `phase2e only` / `phase2b+2c only` / `stacked`) using the release binary from `7896f93` and the §8.6 optimum parameters `CODELENS_RANK_SPARSE_THRESHOLD=40` / `CODELENS_RANK_SPARSE_MAX=40`. **Every hybrid metric moves positive** and — critically — **the relative lift is _larger_ on ripgrep than on either self dataset**:
+
+  | Dataset                  | baseline MRR | stacked MRR |  Δ absolute |  Δ relative |
+  | ------------------------ | -----------: | ----------: | ----------: | ----------: |
+  | 89-query self            |        0.572 |       0.586 |      +0.014 |  **+2.4 %** |
+  | 436-query augmented self |       0.0476 |      0.0510 |     +0.0034 |  **+7.1 %** |
+  | **ripgrep external**     |       0.4594 |      0.5292 | **+0.0698** | **+15.2 %** |
+
+  Identifier Acc@1 stays at 0.500 in every ripgrep arm (the sub-2-token short-circuit continues to hold on a different codebase's name space). Phase 2e marginal on top of Phase 2b+2c: **+0.019 hybrid MRR, +0.042 hybrid Acc@1, +0.029 NL MRR** — direction-consistent with §8.4 / §8.5. This is the **first measurement that directly answers "is the v1.5 stack just memorising our self-phrasing?"** — the answer is no. A codebase with different authorship, different comment style, and different API naming still gets a meaningful uplift from the same three env vars, and the magnitude is stronger than on the author's own datasets.
+
+  **Impact on Phase 2d baseline**: `docs/design/v1.6-phase2d-model-swap-brief.md` §1.1 "baseline to beat" now formally covers three datasets, not one. Any Phase 2d candidate must exceed **all three** v1.5 stacked MRRs simultaneously (0.586 on 89-query, 0.0510 on 436-query, **0.5292 on ripgrep**). A model swap that wins one and loses another is not a valid winner. The Checkpoint 1 go/no-go gate inherits the stronger three-point baseline.
+
+  **Default-ON status**: the evidence pattern is now strong enough that **§8.5 users waiting for an external-repo signal before opting in have one**. The opt-in defaults themselves stay OFF for one more release cycle until a second external repo in a different language family (JS/TS or Python) replays the result — one sample is still one sample, and the §8.1 "measure before flipping" discipline applies to defaults as well as implementations. Full experiment log in [`docs/benchmarks.md` §8.7](docs/benchmarks.md), 24-query dataset at `benchmarks/embedding-quality-dataset-ripgrep.json`, four-arm artefacts at `benchmarks/embedding-quality-v1.5-phase3a-ripgrep-{baseline,2e-only,2b2c-only,stacked}.json`.
+
 ### Docs
 
 - **Phase 2d model-swap design brief** — new `docs/design/v1.6-phase2d-model-swap-brief.md` captures the structured trade-off surface for a future embedding-model upgrade (CodeSearchNet-INT8 → BGE-small / Jina code v2 / gte-small / …). Ten-section brief: context, candidate short-list with size + license + ONNX-support table, evaluation protocol re-using the v1.5 four-arm infrastructure, three bundle strategies (compile-in / download-on-first-run / feature flag), migration path with automatic reindex on model-name mismatch, ten-entry risk matrix, four-checkpoint effort breakdown with explicit stop conditions, and a decision matrix the maintainer fills in before any code change starts. **No code or behaviour change ships with the brief** — it is pre-decision by design, and exists specifically so a future Phase 2d does not repeat the Phase 2 cAST PoC's "first-guess implementation then measure" failure mode. The v1.5 stacked MRR (0.586 on 89-query, +7.1 % relative on 436-query) is now the formal baseline any model swap must exceed.

--- a/benchmarks/embedding-quality-dataset-ripgrep.json
+++ b/benchmarks/embedding-quality-dataset-ripgrep.json
@@ -1,0 +1,146 @@
+[
+  {
+    "query": "build regex matcher from pattern string",
+    "expected_symbol": "build",
+    "expected_file_suffix": "crates/regex/src/matcher.rs",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "case insensitive regex matching",
+    "expected_symbol": "case_insensitive",
+    "expected_file_suffix": "crates/regex/src/matcher.rs",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "match multiple regex patterns at once",
+    "expected_symbol": "build_many",
+    "expected_file_suffix": "crates/regex/src/matcher.rs",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "ignore whitespace inside regex pattern",
+    "expected_symbol": "ignore_whitespace",
+    "expected_file_suffix": "crates/regex/src/matcher.rs",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "match a whole line only not substring",
+    "expected_symbol": "whole_line",
+    "expected_file_suffix": "crates/regex/src/matcher.rs",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "treat patterns as fixed strings not regex",
+    "expected_symbol": "fixed_strings",
+    "expected_file_suffix": "crates/regex/src/matcher.rs",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "set regex memory size limit",
+    "expected_symbol": "size_limit",
+    "expected_file_suffix": "crates/regex/src/matcher.rs",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "search file content for regex matches",
+    "expected_symbol": "search_file",
+    "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "search file by path on the filesystem",
+    "expected_symbol": "search_path",
+    "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "search an input reader line by line",
+    "expected_symbol": "search_reader",
+    "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "walk directory tree respecting gitignore rules",
+    "expected_symbol": "WalkBuilder",
+    "expected_file_suffix": "crates/ignore/src/walk.rs",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "build parallel directory traversal",
+    "expected_symbol": "build_parallel",
+    "expected_file_suffix": "crates/ignore/src/walk.rs",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "parallel directory walker across threads",
+    "expected_symbol": "WalkParallel",
+    "expected_file_suffix": "crates/ignore/src/walk.rs",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "check if a path matches gitignore rules",
+    "expected_symbol": "Gitignore",
+    "expected_file_suffix": "crates/ignore/src/gitignore.rs",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "build set of glob patterns for matching",
+    "expected_symbol": "GlobSetBuilder",
+    "expected_file_suffix": "crates/globset/src/lib.rs",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "match file path against multiple glob patterns",
+    "expected_symbol": "GlobSet",
+    "expected_file_suffix": "crates/globset/src/lib.rs",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "escape glob special characters in a string",
+    "expected_symbol": "escape",
+    "expected_file_suffix": "crates/globset/src/lib.rs",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "regex builder",
+    "expected_symbol": "RegexMatcherBuilder",
+    "expected_file_suffix": "crates/regex/src/matcher.rs",
+    "query_type": "short_phrase"
+  },
+  {
+    "query": "file searcher",
+    "expected_symbol": "Searcher",
+    "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+    "query_type": "short_phrase"
+  },
+  {
+    "query": "directory walker",
+    "expected_symbol": "Walk",
+    "expected_file_suffix": "crates/ignore/src/walk.rs",
+    "query_type": "short_phrase"
+  },
+  {
+    "query": "gitignore builder",
+    "expected_symbol": "GitignoreBuilder",
+    "expected_file_suffix": "crates/ignore/src/gitignore.rs",
+    "query_type": "short_phrase"
+  },
+  {
+    "query": "standard printer",
+    "expected_symbol": "Standard",
+    "expected_file_suffix": "crates/printer/src/standard.rs",
+    "query_type": "short_phrase"
+  },
+  {
+    "query": "RegexMatcher",
+    "expected_symbol": "RegexMatcher",
+    "expected_file_suffix": "crates/regex/src/matcher.rs",
+    "query_type": "identifier"
+  },
+  {
+    "query": "GlobSet",
+    "expected_symbol": "GlobSet",
+    "expected_file_suffix": "crates/globset/src/lib.rs",
+    "query_type": "identifier"
+  }
+]

--- a/benchmarks/embedding-quality-v1.5-phase3a-ripgrep-2b2c-only.json
+++ b/benchmarks/embedding-quality-v1.5-phase3a-ripgrep-2b2c-only.json
@@ -1,0 +1,1097 @@
+{
+  "project": "/tmp/ripgrep-ext",
+  "benchmark_project": "/var/folders/z0/0tcbss795xsdp75jmr_t9_kh0000gn/T/codelens-embed-quality-gqxhg5a0/ripgrep-ext",
+  "isolated_copy": true,
+  "binary": "/Users/bagjaeseog/codelens-mcp-plugin/target/release/codelens-mcp",
+  "embedding_model": "MiniLM-L12-CodeSearchNet-INT8",
+  "runtime_model": {
+    "model_dir": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch",
+    "model_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/model.onnx",
+    "config_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/config.json",
+    "sha256": "ef1d1e9cfa72e4929f5b9faea17d8704b23a2530aadebf0d464a4cc7750920b3",
+    "size_bytes": 34000281,
+    "num_hidden_layers": 12,
+    "hidden_size": 384
+  },
+  "dataset_path": "/Users/bagjaeseog/codelens-mcp-plugin/benchmarks/embedding-quality-dataset-ripgrep.json",
+  "dataset_size": 24,
+  "ranking_cutoff": 10,
+  "metric_labels": {
+    "mrr": "MRR@10",
+    "acc1": "Acc@1",
+    "acc3": "Acc@3",
+    "acc5": "Acc@5"
+  },
+  "methods": [
+    {
+      "method": "semantic_search",
+      "mrr": 0.3972222222222222,
+      "acc1": 0.20833333333333334,
+      "acc3": 0.5833333333333334,
+      "acc5": 0.625,
+      "avg_elapsed_ms": 200.08541666666667,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 0.75,
+          "acc1": 0.5,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 116.57
+        },
+        "natural_language": {
+          "count": 17,
+          "mrr": 0.38431372549019605,
+          "acc1": 0.17647058823529413,
+          "acc3": 0.5882352941176471,
+          "acc5": 0.6470588235294118,
+          "avg_elapsed_ms": 223.31823529411764
+        },
+        "short_phrase": {
+          "count": 5,
+          "mrr": 0.3,
+          "acc1": 0.2,
+          "acc3": 0.4,
+          "acc5": 0.4,
+          "avg_elapsed_ms": 154.5
+        }
+      },
+      "rows": [
+        {
+          "query": "build regex matcher from pattern string",
+          "query_type": "natural_language",
+          "expected_symbol": "build",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 2,
+          "elapsed_ms": 204.04,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "build",
+            "file": "crates/pcre2/src/matcher.rs"
+          }
+        },
+        {
+          "query": "case insensitive regex matching",
+          "query_type": "natural_language",
+          "expected_symbol": "case_insensitive",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 168.27,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "case_insensitive",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "match multiple regex patterns at once",
+          "query_type": "natural_language",
+          "expected_symbol": "build_many",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": null,
+          "elapsed_ms": 183.95,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "matcher",
+            "file": "crates/regex/src/lib.rs"
+          }
+        },
+        {
+          "query": "ignore whitespace inside regex pattern",
+          "query_type": "natural_language",
+          "expected_symbol": "ignore_whitespace",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 202.19,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "ignore_whitespace",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "match a whole line only not substring",
+          "query_type": "natural_language",
+          "expected_symbol": "whole_line",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 2,
+          "elapsed_ms": 202.6,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "whole_line",
+            "file": "crates/pcre2/src/matcher.rs"
+          }
+        },
+        {
+          "query": "treat patterns as fixed strings not regex",
+          "query_type": "natural_language",
+          "expected_symbol": "fixed_strings",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 2,
+          "elapsed_ms": 196.27,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "is_fixed_strings",
+            "file": "crates/regex/src/config.rs"
+          }
+        },
+        {
+          "query": "set regex memory size limit",
+          "query_type": "natural_language",
+          "expected_symbol": "size_limit",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": null,
+          "elapsed_ms": 181.24,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "set_before",
+            "file": "crates/core/flags/lowargs.rs"
+          }
+        },
+        {
+          "query": "search file content for regex matches",
+          "query_type": "natural_language",
+          "expected_symbol": "search_file",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": null,
+          "elapsed_ms": 209.54,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "search",
+            "file": "crates/core/main.rs"
+          }
+        },
+        {
+          "query": "search file by path on the filesystem",
+          "query_type": "natural_language",
+          "expected_symbol": "search_path",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": 5,
+          "elapsed_ms": 213.67,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "search_path",
+            "file": "crates/core/search.rs"
+          }
+        },
+        {
+          "query": "search an input reader line by line",
+          "query_type": "natural_language",
+          "expected_symbol": "search_reader",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": 2,
+          "elapsed_ms": 215.48,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "search_reader",
+            "file": "crates/core/search.rs"
+          }
+        },
+        {
+          "query": "walk directory tree respecting gitignore rules",
+          "query_type": "natural_language",
+          "expected_symbol": "WalkBuilder",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": 2,
+          "elapsed_ms": 212.86,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "walkdir_is_dir",
+            "file": "crates/ignore/src/walk.rs"
+          }
+        },
+        {
+          "query": "build parallel directory traversal",
+          "query_type": "natural_language",
+          "expected_symbol": "build_parallel",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": 1,
+          "elapsed_ms": 166.95,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "build_parallel",
+            "file": "crates/ignore/src/walk.rs"
+          }
+        },
+        {
+          "query": "parallel directory walker across threads",
+          "query_type": "natural_language",
+          "expected_symbol": "WalkParallel",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": null,
+          "elapsed_ms": 120.84,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "walk_collect_entries_parallel",
+            "file": "crates/ignore/src/walk.rs"
+          }
+        },
+        {
+          "query": "check if a path matches gitignore rules",
+          "query_type": "natural_language",
+          "expected_symbol": "Gitignore",
+          "expected_file_suffix": "crates/ignore/src/gitignore.rs",
+          "rank": 3,
+          "elapsed_ms": 570.93,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "gitignore",
+            "file": "crates/ignore/src/lib.rs"
+          }
+        },
+        {
+          "query": "build set of glob patterns for matching",
+          "query_type": "natural_language",
+          "expected_symbol": "GlobSetBuilder",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": null,
+          "elapsed_ms": 204.76,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "GlobMatcher",
+            "file": "crates/globset/src/glob.rs"
+          }
+        },
+        {
+          "query": "match file path against multiple glob patterns",
+          "query_type": "natural_language",
+          "expected_symbol": "GlobSet",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": null,
+          "elapsed_ms": 161.39,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "matched",
+            "file": "crates/ignore/src/gitignore.rs"
+          }
+        },
+        {
+          "query": "escape glob special characters in a string",
+          "query_type": "natural_language",
+          "expected_symbol": "escape",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": 2,
+          "elapsed_ms": 381.43,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "char_to_escaped_literal",
+            "file": "crates/globset/src/glob.rs"
+          }
+        },
+        {
+          "query": "regex builder",
+          "query_type": "short_phrase",
+          "expected_symbol": "RegexMatcherBuilder",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 133.74,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "RegexMatcherBuilder",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "file searcher",
+          "query_type": "short_phrase",
+          "expected_symbol": "Searcher",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": null,
+          "elapsed_ms": 164.02,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "search_file",
+            "file": "crates/searcher/src/searcher/mod.rs"
+          }
+        },
+        {
+          "query": "directory walker",
+          "query_type": "short_phrase",
+          "expected_symbol": "Walk",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": null,
+          "elapsed_ms": 212.39,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "name",
+            "file": ".github/workflows/release.yml"
+          }
+        },
+        {
+          "query": "gitignore builder",
+          "query_type": "short_phrase",
+          "expected_symbol": "GitignoreBuilder",
+          "expected_file_suffix": "crates/ignore/src/gitignore.rs",
+          "rank": 2,
+          "elapsed_ms": 131.59,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "gitignore",
+            "file": "crates/ignore/src/lib.rs"
+          }
+        },
+        {
+          "query": "standard printer",
+          "query_type": "short_phrase",
+          "expected_symbol": "Standard",
+          "expected_file_suffix": "crates/printer/src/standard.rs",
+          "rank": null,
+          "elapsed_ms": 130.76,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "printer_standard",
+            "file": "crates/core/flags/hiargs.rs"
+          }
+        },
+        {
+          "query": "RegexMatcher",
+          "query_type": "identifier",
+          "expected_symbol": "RegexMatcher",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 2,
+          "elapsed_ms": 116.7,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "RegexMatcher",
+            "file": "crates/searcher/src/testutil.rs"
+          }
+        },
+        {
+          "query": "GlobSet",
+          "query_type": "identifier",
+          "expected_symbol": "GlobSet",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": 1,
+          "elapsed_ms": 116.44,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "GlobSet",
+            "file": "crates/globset/src/lib.rs"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context_no_semantic",
+      "mrr": 0.32799168424168423,
+      "acc1": 0.20833333333333334,
+      "acc3": 0.3333333333333333,
+      "acc5": 0.5,
+      "avg_elapsed_ms": 23.0425,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 0.625,
+          "acc1": 0.5,
+          "acc3": 0.5,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 16.575
+        },
+        "natural_language": {
+          "count": 17,
+          "mrr": 0.278173134055487,
+          "acc1": 0.17647058823529413,
+          "acc3": 0.29411764705882354,
+          "acc5": 0.4117647058823529,
+          "avg_elapsed_ms": 25.3
+        },
+        "short_phrase": {
+          "count": 5,
+          "mrr": 0.37857142857142856,
+          "acc1": 0.2,
+          "acc3": 0.4,
+          "acc5": 0.6,
+          "avg_elapsed_ms": 17.954
+        }
+      },
+      "rows": [
+        {
+          "query": "build regex matcher from pattern string",
+          "query_type": "natural_language",
+          "expected_symbol": "build",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": null,
+          "elapsed_ms": 26.23,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "from_pattern",
+            "file": "crates/regex/src/ast.rs"
+          }
+        },
+        {
+          "query": "case insensitive regex matching",
+          "query_type": "natural_language",
+          "expected_symbol": "case_insensitive",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 5,
+          "elapsed_ms": 23.54,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "case_insensitive",
+            "file": "crates/globset/src/glob.rs"
+          }
+        },
+        {
+          "query": "match multiple regex patterns at once",
+          "query_type": "natural_language",
+          "expected_symbol": "build_many",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": null,
+          "elapsed_ms": 24.65,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "regex",
+            "file": "crates/regex/src/error.rs"
+          }
+        },
+        {
+          "query": "ignore whitespace inside regex pattern",
+          "query_type": "natural_language",
+          "expected_symbol": "ignore_whitespace",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 25.53,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "ignore_whitespace",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "match a whole line only not substring",
+          "query_type": "natural_language",
+          "expected_symbol": "whole_line",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 2,
+          "elapsed_ms": 25.4,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "whole_line",
+            "file": "crates/pcre2/src/matcher.rs"
+          }
+        },
+        {
+          "query": "treat patterns as fixed strings not regex",
+          "query_type": "natural_language",
+          "expected_symbol": "fixed_strings",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 2,
+          "elapsed_ms": 25.16,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "fixed_strings",
+            "file": "crates/pcre2/src/matcher.rs"
+          }
+        },
+        {
+          "query": "set regex memory size limit",
+          "query_type": "natural_language",
+          "expected_symbol": "size_limit",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 24.31,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "size_limit",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "search file content for regex matches",
+          "query_type": "natural_language",
+          "expected_symbol": "search_file",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": null,
+          "elapsed_ms": 26.46,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "build_format",
+            "file": "crates/printer/src/hyperlink/mod.rs"
+          }
+        },
+        {
+          "query": "search file by path on the filesystem",
+          "query_type": "natural_language",
+          "expected_symbol": "search_path",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": null,
+          "elapsed_ms": 25.81,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "path",
+            "file": "crates/ignore/src/gitignore.rs"
+          }
+        },
+        {
+          "query": "search an input reader line by line",
+          "query_type": "natural_language",
+          "expected_symbol": "search_reader",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": 4,
+          "elapsed_ms": 39.0,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "by_line",
+            "file": "crates/searcher/src/testutil.rs"
+          }
+        },
+        {
+          "query": "walk directory tree respecting gitignore rules",
+          "query_type": "natural_language",
+          "expected_symbol": "WalkBuilder",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": 11,
+          "elapsed_ms": 29.5,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "Gitignore",
+            "file": "crates/ignore/src/gitignore.rs"
+          }
+        },
+        {
+          "query": "build parallel directory traversal",
+          "query_type": "natural_language",
+          "expected_symbol": "build_parallel",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": 1,
+          "elapsed_ms": 20.19,
+          "candidate_count": 21,
+          "top_candidate": {
+            "name": "build_parallel",
+            "file": "crates/ignore/src/walk.rs"
+          }
+        },
+        {
+          "query": "parallel directory walker across threads",
+          "query_type": "natural_language",
+          "expected_symbol": "WalkParallel",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": 9,
+          "elapsed_ms": 21.31,
+          "candidate_count": 13,
+          "top_candidate": {
+            "name": "build_parallel",
+            "file": "crates/ignore/src/walk.rs"
+          }
+        },
+        {
+          "query": "check if a path matches gitignore rules",
+          "query_type": "natural_language",
+          "expected_symbol": "Gitignore",
+          "expected_file_suffix": "crates/ignore/src/gitignore.rs",
+          "rank": 13,
+          "elapsed_ms": 23.63,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "nmatches",
+            "file": "crates/globset/src/glob.rs"
+          }
+        },
+        {
+          "query": "build set of glob patterns for matching",
+          "query_type": "natural_language",
+          "expected_symbol": "GlobSetBuilder",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": null,
+          "elapsed_ms": 24.82,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "build_format",
+            "file": "crates/printer/src/hyperlink/mod.rs"
+          }
+        },
+        {
+          "query": "match file path against multiple glob patterns",
+          "query_type": "natural_language",
+          "expected_symbol": "GlobSet",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": null,
+          "elapsed_ms": 20.72,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "GlobMatcher",
+            "file": "crates/globset/src/glob.rs"
+          }
+        },
+        {
+          "query": "escape glob special characters in a string",
+          "query_type": "natural_language",
+          "expected_symbol": "escape",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": null,
+          "elapsed_ms": 23.84,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "Glob",
+            "file": "crates/globset/src/glob.rs"
+          }
+        },
+        {
+          "query": "regex builder",
+          "query_type": "short_phrase",
+          "expected_symbol": "RegexMatcherBuilder",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 4,
+          "elapsed_ms": 18.53,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "FormatBuilder",
+            "file": "crates/printer/src/hyperlink/mod.rs"
+          }
+        },
+        {
+          "query": "file searcher",
+          "query_type": "short_phrase",
+          "expected_symbol": "Searcher",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": 2,
+          "elapsed_ms": 18.17,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "SearcherBuilder",
+            "file": "crates/searcher/src/searcher/mod.rs"
+          }
+        },
+        {
+          "query": "directory walker",
+          "query_type": "short_phrase",
+          "expected_symbol": "Walk",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": null,
+          "elapsed_ms": 16.64,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "working-directory",
+            "file": ".github/workflows/ci.yml"
+          }
+        },
+        {
+          "query": "gitignore builder",
+          "query_type": "short_phrase",
+          "expected_symbol": "GitignoreBuilder",
+          "expected_file_suffix": "crates/ignore/src/gitignore.rs",
+          "rank": 1,
+          "elapsed_ms": 18.08,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "GitignoreBuilder",
+            "file": "crates/ignore/src/gitignore.rs"
+          }
+        },
+        {
+          "query": "standard printer",
+          "query_type": "short_phrase",
+          "expected_symbol": "Standard",
+          "expected_file_suffix": "crates/printer/src/standard.rs",
+          "rank": 7,
+          "elapsed_ms": 18.35,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "PrinterPath",
+            "file": "crates/printer/src/util.rs"
+          }
+        },
+        {
+          "query": "RegexMatcher",
+          "query_type": "identifier",
+          "expected_symbol": "RegexMatcher",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 4,
+          "elapsed_ms": 15.78,
+          "candidate_count": 7,
+          "top_candidate": {
+            "name": "RegexMatcher",
+            "file": "crates/matcher/tests/util.rs"
+          }
+        },
+        {
+          "query": "GlobSet",
+          "query_type": "identifier",
+          "expected_symbol": "GlobSet",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": 1,
+          "elapsed_ms": 17.37,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "GlobSet",
+            "file": "crates/globset/src/lib.rs"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context",
+      "mrr": 0.5104166666666666,
+      "acc1": 0.2916666666666667,
+      "acc3": 0.6666666666666666,
+      "acc5": 0.7916666666666666,
+      "avg_elapsed_ms": 107.84458333333333,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 0.625,
+          "acc1": 0.5,
+          "acc3": 0.5,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 18.25
+        },
+        "natural_language": {
+          "count": 17,
+          "mrr": 0.5245098039215685,
+          "acc1": 0.29411764705882354,
+          "acc3": 0.7058823529411765,
+          "acc5": 0.7647058823529411,
+          "avg_elapsed_ms": 117.55705882352942
+        },
+        "short_phrase": {
+          "count": 5,
+          "mrr": 0.4166666666666667,
+          "acc1": 0.2,
+          "acc3": 0.6,
+          "acc5": 0.8,
+          "avg_elapsed_ms": 110.66
+        }
+      },
+      "rows": [
+        {
+          "query": "build regex matcher from pattern string",
+          "query_type": "natural_language",
+          "expected_symbol": "build",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 2,
+          "elapsed_ms": 116.05,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "build",
+            "file": "crates/pcre2/src/matcher.rs"
+          }
+        },
+        {
+          "query": "case insensitive regex matching",
+          "query_type": "natural_language",
+          "expected_symbol": "case_insensitive",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 115.27,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "case_insensitive",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "match multiple regex patterns at once",
+          "query_type": "natural_language",
+          "expected_symbol": "build_many",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": null,
+          "elapsed_ms": 118.75,
+          "candidate_count": 35,
+          "top_candidate": {
+            "name": "matcher",
+            "file": "crates/regex/src/lib.rs"
+          }
+        },
+        {
+          "query": "ignore whitespace inside regex pattern",
+          "query_type": "natural_language",
+          "expected_symbol": "ignore_whitespace",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 118.42,
+          "candidate_count": 34,
+          "top_candidate": {
+            "name": "ignore_whitespace",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "match a whole line only not substring",
+          "query_type": "natural_language",
+          "expected_symbol": "whole_line",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 2,
+          "elapsed_ms": 121.44,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "whole_line",
+            "file": "crates/pcre2/src/matcher.rs"
+          }
+        },
+        {
+          "query": "treat patterns as fixed strings not regex",
+          "query_type": "natural_language",
+          "expected_symbol": "fixed_strings",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 2,
+          "elapsed_ms": 117.02,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "is_fixed_strings",
+            "file": "crates/regex/src/config.rs"
+          }
+        },
+        {
+          "query": "set regex memory size limit",
+          "query_type": "natural_language",
+          "expected_symbol": "size_limit",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 116.03,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "size_limit",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "search file content for regex matches",
+          "query_type": "natural_language",
+          "expected_symbol": "search_file",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": 1,
+          "elapsed_ms": 117.61,
+          "candidate_count": 33,
+          "top_candidate": {
+            "name": "search_file",
+            "file": "crates/searcher/src/searcher/mod.rs"
+          }
+        },
+        {
+          "query": "search file by path on the filesystem",
+          "query_type": "natural_language",
+          "expected_symbol": "search_path",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": 4,
+          "elapsed_ms": 118.93,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "search_file",
+            "file": "crates/searcher/src/searcher/mod.rs"
+          }
+        },
+        {
+          "query": "search an input reader line by line",
+          "query_type": "natural_language",
+          "expected_symbol": "search_reader",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": 2,
+          "elapsed_ms": 121.33,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "search_reader",
+            "file": "crates/core/search.rs"
+          }
+        },
+        {
+          "query": "walk directory tree respecting gitignore rules",
+          "query_type": "natural_language",
+          "expected_symbol": "WalkBuilder",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": 2,
+          "elapsed_ms": 122.38,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "walkdir_is_dir",
+            "file": "crates/ignore/src/walk.rs"
+          }
+        },
+        {
+          "query": "build parallel directory traversal",
+          "query_type": "natural_language",
+          "expected_symbol": "build_parallel",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": 1,
+          "elapsed_ms": 114.22,
+          "candidate_count": 21,
+          "top_candidate": {
+            "name": "build_parallel",
+            "file": "crates/ignore/src/walk.rs"
+          }
+        },
+        {
+          "query": "parallel directory walker across threads",
+          "query_type": "natural_language",
+          "expected_symbol": "WalkParallel",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": 6,
+          "elapsed_ms": 114.48,
+          "candidate_count": 13,
+          "top_candidate": {
+            "name": "ParallelVisitor",
+            "file": "crates/ignore/src/walk.rs"
+          }
+        },
+        {
+          "query": "check if a path matches gitignore rules",
+          "query_type": "natural_language",
+          "expected_symbol": "Gitignore",
+          "expected_file_suffix": "crates/ignore/src/gitignore.rs",
+          "rank": 2,
+          "elapsed_ms": 116.96,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "gitignore",
+            "file": "crates/ignore/src/lib.rs"
+          }
+        },
+        {
+          "query": "build set of glob patterns for matching",
+          "query_type": "natural_language",
+          "expected_symbol": "GlobSetBuilder",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": null,
+          "elapsed_ms": 118.54,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "compile_matcher",
+            "file": "crates/globset/src/glob.rs"
+          }
+        },
+        {
+          "query": "match file path against multiple glob patterns",
+          "query_type": "natural_language",
+          "expected_symbol": "GlobSet",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": null,
+          "elapsed_ms": 114.26,
+          "candidate_count": 33,
+          "top_candidate": {
+            "name": "MatchStrategy",
+            "file": "crates/globset/src/glob.rs"
+          }
+        },
+        {
+          "query": "escape glob special characters in a string",
+          "query_type": "natural_language",
+          "expected_symbol": "escape",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": 2,
+          "elapsed_ms": 116.78,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "char_to_escaped_literal",
+            "file": "crates/globset/src/glob.rs"
+          }
+        },
+        {
+          "query": "regex builder",
+          "query_type": "short_phrase",
+          "expected_symbol": "RegexMatcherBuilder",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 110.61,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "RegexMatcherBuilder",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "file searcher",
+          "query_type": "short_phrase",
+          "expected_symbol": "Searcher",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": 3,
+          "elapsed_ms": 111.3,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "search_file",
+            "file": "crates/searcher/src/searcher/mod.rs"
+          }
+        },
+        {
+          "query": "directory walker",
+          "query_type": "short_phrase",
+          "expected_symbol": "Walk",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": null,
+          "elapsed_ms": 109.48,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "working-directory",
+            "file": ".github/workflows/ci.yml"
+          }
+        },
+        {
+          "query": "gitignore builder",
+          "query_type": "short_phrase",
+          "expected_symbol": "GitignoreBuilder",
+          "expected_file_suffix": "crates/ignore/src/gitignore.rs",
+          "rank": 2,
+          "elapsed_ms": 111.37,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "gitignore",
+            "file": "crates/ignore/src/lib.rs"
+          }
+        },
+        {
+          "query": "standard printer",
+          "query_type": "short_phrase",
+          "expected_symbol": "Standard",
+          "expected_file_suffix": "crates/printer/src/standard.rs",
+          "rank": 4,
+          "elapsed_ms": 110.54,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "printer_standard",
+            "file": "crates/core/flags/hiargs.rs"
+          }
+        },
+        {
+          "query": "RegexMatcher",
+          "query_type": "identifier",
+          "expected_symbol": "RegexMatcher",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 4,
+          "elapsed_ms": 17.64,
+          "candidate_count": 7,
+          "top_candidate": {
+            "name": "RegexMatcher",
+            "file": "crates/matcher/tests/util.rs"
+          }
+        },
+        {
+          "query": "GlobSet",
+          "query_type": "identifier",
+          "expected_symbol": "GlobSet",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": 1,
+          "elapsed_ms": 18.86,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "GlobSet",
+            "file": "crates/globset/src/lib.rs"
+          }
+        }
+      ]
+    }
+  ],
+  "hybrid_uplift": {
+    "mrr_delta": 0.1824249824249824,
+    "acc1_delta": 0.08333333333333334,
+    "acc3_delta": 0.3333333333333333,
+    "acc5_delta": 0.29166666666666663
+  },
+  "hybrid_uplift_by_query_type": {
+    "identifier": {
+      "mrr_delta": 0.0,
+      "acc1_delta": 0.0,
+      "acc3_delta": 0.0,
+      "acc5_delta": 0.0
+    },
+    "natural_language": {
+      "mrr_delta": 0.24633666986608155,
+      "acc1_delta": 0.11764705882352941,
+      "acc3_delta": 0.411764705882353,
+      "acc5_delta": 0.3529411764705882
+    },
+    "short_phrase": {
+      "mrr_delta": 0.038095238095238126,
+      "acc1_delta": 0.0,
+      "acc3_delta": 0.19999999999999996,
+      "acc5_delta": 0.20000000000000007
+    }
+  }
+}

--- a/benchmarks/embedding-quality-v1.5-phase3a-ripgrep-2e-only.json
+++ b/benchmarks/embedding-quality-v1.5-phase3a-ripgrep-2e-only.json
@@ -1,0 +1,1097 @@
+{
+  "project": "/tmp/ripgrep-ext",
+  "benchmark_project": "/var/folders/z0/0tcbss795xsdp75jmr_t9_kh0000gn/T/codelens-embed-quality-m825mq45/ripgrep-ext",
+  "isolated_copy": true,
+  "binary": "/Users/bagjaeseog/codelens-mcp-plugin/target/release/codelens-mcp",
+  "embedding_model": "MiniLM-L12-CodeSearchNet-INT8",
+  "runtime_model": {
+    "model_dir": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch",
+    "model_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/model.onnx",
+    "config_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/config.json",
+    "sha256": "ef1d1e9cfa72e4929f5b9faea17d8704b23a2530aadebf0d464a4cc7750920b3",
+    "size_bytes": 34000281,
+    "num_hidden_layers": 12,
+    "hidden_size": 384
+  },
+  "dataset_path": "/Users/bagjaeseog/codelens-mcp-plugin/benchmarks/embedding-quality-dataset-ripgrep.json",
+  "dataset_size": 24,
+  "ranking_cutoff": 10,
+  "metric_labels": {
+    "mrr": "MRR@10",
+    "acc1": "Acc@1",
+    "acc3": "Acc@3",
+    "acc5": "Acc@5"
+  },
+  "methods": [
+    {
+      "method": "semantic_search",
+      "mrr": 0.4052579365079365,
+      "acc1": 0.2916666666666667,
+      "acc3": 0.5,
+      "acc5": 0.5416666666666666,
+      "avg_elapsed_ms": 169.00791666666666,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 0.75,
+          "acc1": 0.5,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 112.375
+        },
+        "natural_language": {
+          "count": 17,
+          "mrr": 0.38725490196078427,
+          "acc1": 0.29411764705882354,
+          "acc3": 0.47058823529411764,
+          "acc5": 0.5294117647058824,
+          "avg_elapsed_ms": 189.51117647058823
+        },
+        "short_phrase": {
+          "count": 5,
+          "mrr": 0.32857142857142857,
+          "acc1": 0.2,
+          "acc3": 0.4,
+          "acc5": 0.4,
+          "avg_elapsed_ms": 121.95
+        }
+      },
+      "rows": [
+        {
+          "query": "build regex matcher from pattern string",
+          "query_type": "natural_language",
+          "expected_symbol": "build",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 200.75,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "build",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "case insensitive regex matching",
+          "query_type": "natural_language",
+          "expected_symbol": "case_insensitive",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 171.17,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "case_insensitive",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "match multiple regex patterns at once",
+          "query_type": "natural_language",
+          "expected_symbol": "build_many",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": null,
+          "elapsed_ms": 186.53,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "matcher",
+            "file": "crates/regex/src/lib.rs"
+          }
+        },
+        {
+          "query": "ignore whitespace inside regex pattern",
+          "query_type": "natural_language",
+          "expected_symbol": "ignore_whitespace",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 204.46,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "ignore_whitespace",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "match a whole line only not substring",
+          "query_type": "natural_language",
+          "expected_symbol": "whole_line",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 2,
+          "elapsed_ms": 199.3,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "whole_line",
+            "file": "crates/pcre2/src/matcher.rs"
+          }
+        },
+        {
+          "query": "treat patterns as fixed strings not regex",
+          "query_type": "natural_language",
+          "expected_symbol": "fixed_strings",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 3,
+          "elapsed_ms": 196.82,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "is_fixed_strings",
+            "file": "crates/regex/src/config.rs"
+          }
+        },
+        {
+          "query": "set regex memory size limit",
+          "query_type": "natural_language",
+          "expected_symbol": "size_limit",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": null,
+          "elapsed_ms": 182.27,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "set_before",
+            "file": "crates/core/flags/lowargs.rs"
+          }
+        },
+        {
+          "query": "search file content for regex matches",
+          "query_type": "natural_language",
+          "expected_symbol": "search_file",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": null,
+          "elapsed_ms": 212.59,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "search",
+            "file": "crates/core/search.rs"
+          }
+        },
+        {
+          "query": "search file by path on the filesystem",
+          "query_type": "natural_language",
+          "expected_symbol": "search_path",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": 6,
+          "elapsed_ms": 214.97,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "search_path",
+            "file": "crates/core/search.rs"
+          }
+        },
+        {
+          "query": "search an input reader line by line",
+          "query_type": "natural_language",
+          "expected_symbol": "search_reader",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": 4,
+          "elapsed_ms": 214.29,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "search_reader",
+            "file": "crates/core/search.rs"
+          }
+        },
+        {
+          "query": "walk directory tree respecting gitignore rules",
+          "query_type": "natural_language",
+          "expected_symbol": "WalkBuilder",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": null,
+          "elapsed_ms": 216.94,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "walkdir_is_dir",
+            "file": "crates/ignore/src/walk.rs"
+          }
+        },
+        {
+          "query": "build parallel directory traversal",
+          "query_type": "natural_language",
+          "expected_symbol": "build_parallel",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": 1,
+          "elapsed_ms": 172.1,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "build_parallel",
+            "file": "crates/ignore/src/walk.rs"
+          }
+        },
+        {
+          "query": "parallel directory walker across threads",
+          "query_type": "natural_language",
+          "expected_symbol": "WalkParallel",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": null,
+          "elapsed_ms": 116.94,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "walk_collect_entries_parallel",
+            "file": "crates/ignore/src/walk.rs"
+          }
+        },
+        {
+          "query": "check if a path matches gitignore rules",
+          "query_type": "natural_language",
+          "expected_symbol": "Gitignore",
+          "expected_file_suffix": "crates/ignore/src/gitignore.rs",
+          "rank": 3,
+          "elapsed_ms": 202.93,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "gitignore",
+            "file": "crates/ignore/src/lib.rs"
+          }
+        },
+        {
+          "query": "build set of glob patterns for matching",
+          "query_type": "natural_language",
+          "expected_symbol": "GlobSetBuilder",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": null,
+          "elapsed_ms": 196.2,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "GlobMatcher",
+            "file": "crates/globset/src/glob.rs"
+          }
+        },
+        {
+          "query": "match file path against multiple glob patterns",
+          "query_type": "natural_language",
+          "expected_symbol": "GlobSet",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": null,
+          "elapsed_ms": 148.59,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "MatchStrategy",
+            "file": "crates/globset/src/glob.rs"
+          }
+        },
+        {
+          "query": "escape glob special characters in a string",
+          "query_type": "natural_language",
+          "expected_symbol": "escape",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": 1,
+          "elapsed_ms": 184.84,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "escape",
+            "file": "crates/globset/src/lib.rs"
+          }
+        },
+        {
+          "query": "regex builder",
+          "query_type": "short_phrase",
+          "expected_symbol": "RegexMatcherBuilder",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 123.46,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "RegexMatcherBuilder",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "file searcher",
+          "query_type": "short_phrase",
+          "expected_symbol": "Searcher",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": 7,
+          "elapsed_ms": 126.01,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "search_file",
+            "file": "crates/searcher/src/searcher/mod.rs"
+          }
+        },
+        {
+          "query": "directory walker",
+          "query_type": "short_phrase",
+          "expected_symbol": "Walk",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": null,
+          "elapsed_ms": 113.78,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "name",
+            "file": ".github/workflows/release.yml"
+          }
+        },
+        {
+          "query": "gitignore builder",
+          "query_type": "short_phrase",
+          "expected_symbol": "GitignoreBuilder",
+          "expected_file_suffix": "crates/ignore/src/gitignore.rs",
+          "rank": 2,
+          "elapsed_ms": 122.02,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "gitignore",
+            "file": "crates/ignore/src/lib.rs"
+          }
+        },
+        {
+          "query": "standard printer",
+          "query_type": "short_phrase",
+          "expected_symbol": "Standard",
+          "expected_file_suffix": "crates/printer/src/standard.rs",
+          "rank": null,
+          "elapsed_ms": 124.48,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "printer_standard",
+            "file": "crates/core/flags/hiargs.rs"
+          }
+        },
+        {
+          "query": "RegexMatcher",
+          "query_type": "identifier",
+          "expected_symbol": "RegexMatcher",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 2,
+          "elapsed_ms": 112.62,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "RegexMatcher",
+            "file": "crates/searcher/src/testutil.rs"
+          }
+        },
+        {
+          "query": "GlobSet",
+          "query_type": "identifier",
+          "expected_symbol": "GlobSet",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": 1,
+          "elapsed_ms": 112.13,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "GlobSet",
+            "file": "crates/globset/src/lib.rs"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context_no_semantic",
+      "mrr": 0.38453930328930325,
+      "acc1": 0.2916666666666667,
+      "acc3": 0.375,
+      "acc5": 0.5416666666666666,
+      "avg_elapsed_ms": 22.00125,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 0.625,
+          "acc1": 0.5,
+          "acc3": 0.5,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 16.96
+        },
+        "natural_language": {
+          "count": 17,
+          "mrr": 0.3546437222907811,
+          "acc1": 0.29411764705882354,
+          "acc3": 0.35294117647058826,
+          "acc5": 0.4117647058823529,
+          "avg_elapsed_ms": 23.884117647058826
+        },
+        "short_phrase": {
+          "count": 5,
+          "mrr": 0.39,
+          "acc1": 0.2,
+          "acc3": 0.4,
+          "acc5": 0.8,
+          "avg_elapsed_ms": 17.616
+        }
+      },
+      "rows": [
+        {
+          "query": "build regex matcher from pattern string",
+          "query_type": "natural_language",
+          "expected_symbol": "build",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": null,
+          "elapsed_ms": 25.67,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "from_pattern",
+            "file": "crates/regex/src/ast.rs"
+          }
+        },
+        {
+          "query": "case insensitive regex matching",
+          "query_type": "natural_language",
+          "expected_symbol": "case_insensitive",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 23.32,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "case_insensitive",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "match multiple regex patterns at once",
+          "query_type": "natural_language",
+          "expected_symbol": "build_many",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": null,
+          "elapsed_ms": 23.02,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "regex",
+            "file": "crates/regex/src/error.rs"
+          }
+        },
+        {
+          "query": "ignore whitespace inside regex pattern",
+          "query_type": "natural_language",
+          "expected_symbol": "ignore_whitespace",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 25.55,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "ignore_whitespace",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "match a whole line only not substring",
+          "query_type": "natural_language",
+          "expected_symbol": "whole_line",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 2,
+          "elapsed_ms": 24.26,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "whole_line",
+            "file": "crates/pcre2/src/matcher.rs"
+          }
+        },
+        {
+          "query": "treat patterns as fixed strings not regex",
+          "query_type": "natural_language",
+          "expected_symbol": "fixed_strings",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 24.62,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "fixed_strings",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "set regex memory size limit",
+          "query_type": "natural_language",
+          "expected_symbol": "size_limit",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 22.61,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "size_limit",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "search file content for regex matches",
+          "query_type": "natural_language",
+          "expected_symbol": "search_file",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": null,
+          "elapsed_ms": 25.87,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "build_format",
+            "file": "crates/printer/src/hyperlink/mod.rs"
+          }
+        },
+        {
+          "query": "search file by path on the filesystem",
+          "query_type": "natural_language",
+          "expected_symbol": "search_path",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": null,
+          "elapsed_ms": 25.02,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "path",
+            "file": "crates/ignore/src/gitignore.rs"
+          }
+        },
+        {
+          "query": "search an input reader line by line",
+          "query_type": "natural_language",
+          "expected_symbol": "search_reader",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": 4,
+          "elapsed_ms": 26.22,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "by_line",
+            "file": "crates/searcher/src/testutil.rs"
+          }
+        },
+        {
+          "query": "walk directory tree respecting gitignore rules",
+          "query_type": "natural_language",
+          "expected_symbol": "WalkBuilder",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": 11,
+          "elapsed_ms": 25.37,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "Gitignore",
+            "file": "crates/ignore/src/gitignore.rs"
+          }
+        },
+        {
+          "query": "build parallel directory traversal",
+          "query_type": "natural_language",
+          "expected_symbol": "build_parallel",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": 1,
+          "elapsed_ms": 20.04,
+          "candidate_count": 21,
+          "top_candidate": {
+            "name": "build_parallel",
+            "file": "crates/ignore/src/walk.rs"
+          }
+        },
+        {
+          "query": "parallel directory walker across threads",
+          "query_type": "natural_language",
+          "expected_symbol": "WalkParallel",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": 9,
+          "elapsed_ms": 21.2,
+          "candidate_count": 13,
+          "top_candidate": {
+            "name": "build_parallel",
+            "file": "crates/ignore/src/walk.rs"
+          }
+        },
+        {
+          "query": "check if a path matches gitignore rules",
+          "query_type": "natural_language",
+          "expected_symbol": "Gitignore",
+          "expected_file_suffix": "crates/ignore/src/gitignore.rs",
+          "rank": 13,
+          "elapsed_ms": 24.36,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "nmatches",
+            "file": "crates/globset/src/glob.rs"
+          }
+        },
+        {
+          "query": "build set of glob patterns for matching",
+          "query_type": "natural_language",
+          "expected_symbol": "GlobSetBuilder",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": null,
+          "elapsed_ms": 24.94,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "build",
+            "file": "crates/globset/src/glob.rs"
+          }
+        },
+        {
+          "query": "match file path against multiple glob patterns",
+          "query_type": "natural_language",
+          "expected_symbol": "GlobSet",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": null,
+          "elapsed_ms": 20.1,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "GlobMatcher",
+            "file": "crates/globset/src/glob.rs"
+          }
+        },
+        {
+          "query": "escape glob special characters in a string",
+          "query_type": "natural_language",
+          "expected_symbol": "escape",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": null,
+          "elapsed_ms": 23.86,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "Glob",
+            "file": "crates/globset/src/glob.rs"
+          }
+        },
+        {
+          "query": "regex builder",
+          "query_type": "short_phrase",
+          "expected_symbol": "RegexMatcherBuilder",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 2,
+          "elapsed_ms": 17.96,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "regex",
+            "file": "crates/regex/src/error.rs"
+          }
+        },
+        {
+          "query": "file searcher",
+          "query_type": "short_phrase",
+          "expected_symbol": "Searcher",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": 4,
+          "elapsed_ms": 17.24,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "search_file",
+            "file": "crates/searcher/src/searcher/mod.rs"
+          }
+        },
+        {
+          "query": "directory walker",
+          "query_type": "short_phrase",
+          "expected_symbol": "Walk",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": null,
+          "elapsed_ms": 17.33,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "working-directory",
+            "file": ".github/workflows/ci.yml"
+          }
+        },
+        {
+          "query": "gitignore builder",
+          "query_type": "short_phrase",
+          "expected_symbol": "GitignoreBuilder",
+          "expected_file_suffix": "crates/ignore/src/gitignore.rs",
+          "rank": 1,
+          "elapsed_ms": 17.3,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "GitignoreBuilder",
+            "file": "crates/ignore/src/gitignore.rs"
+          }
+        },
+        {
+          "query": "standard printer",
+          "query_type": "short_phrase",
+          "expected_symbol": "Standard",
+          "expected_file_suffix": "crates/printer/src/standard.rs",
+          "rank": 5,
+          "elapsed_ms": 18.25,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "printer_standard",
+            "file": "crates/core/flags/hiargs.rs"
+          }
+        },
+        {
+          "query": "RegexMatcher",
+          "query_type": "identifier",
+          "expected_symbol": "RegexMatcher",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 4,
+          "elapsed_ms": 16.87,
+          "candidate_count": 7,
+          "top_candidate": {
+            "name": "RegexMatcher",
+            "file": "crates/matcher/tests/util.rs"
+          }
+        },
+        {
+          "query": "GlobSet",
+          "query_type": "identifier",
+          "expected_symbol": "GlobSet",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": 1,
+          "elapsed_ms": 17.05,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "GlobSet",
+            "file": "crates/globset/src/lib.rs"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context",
+      "mrr": 0.48784722222222227,
+      "acc1": 0.2916666666666667,
+      "acc3": 0.625,
+      "acc5": 0.75,
+      "avg_elapsed_ms": 107.66833333333334,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 0.625,
+          "acc1": 0.5,
+          "acc3": 0.5,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 18.35
+        },
+        "natural_language": {
+          "count": 17,
+          "mrr": 0.5220588235294118,
+          "acc1": 0.35294117647058826,
+          "acc3": 0.6470588235294118,
+          "acc5": 0.7058823529411765,
+          "avg_elapsed_ms": 117.28647058823529
+        },
+        "short_phrase": {
+          "count": 5,
+          "mrr": 0.31666666666666665,
+          "acc1": 0.0,
+          "acc3": 0.6,
+          "acc5": 0.8,
+          "avg_elapsed_ms": 110.694
+        }
+      },
+      "rows": [
+        {
+          "query": "build regex matcher from pattern string",
+          "query_type": "natural_language",
+          "expected_symbol": "build",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 114.6,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "build",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "case insensitive regex matching",
+          "query_type": "natural_language",
+          "expected_symbol": "case_insensitive",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 114.51,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "case_insensitive",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "match multiple regex patterns at once",
+          "query_type": "natural_language",
+          "expected_symbol": "build_many",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": null,
+          "elapsed_ms": 114.81,
+          "candidate_count": 34,
+          "top_candidate": {
+            "name": "matcher",
+            "file": "crates/regex/src/lib.rs"
+          }
+        },
+        {
+          "query": "ignore whitespace inside regex pattern",
+          "query_type": "natural_language",
+          "expected_symbol": "ignore_whitespace",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 116.78,
+          "candidate_count": 34,
+          "top_candidate": {
+            "name": "ignore_whitespace",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "match a whole line only not substring",
+          "query_type": "natural_language",
+          "expected_symbol": "whole_line",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 2,
+          "elapsed_ms": 115.71,
+          "candidate_count": 33,
+          "top_candidate": {
+            "name": "whole_line",
+            "file": "crates/pcre2/src/matcher.rs"
+          }
+        },
+        {
+          "query": "treat patterns as fixed strings not regex",
+          "query_type": "natural_language",
+          "expected_symbol": "fixed_strings",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 2,
+          "elapsed_ms": 115.32,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "is_fixed_strings",
+            "file": "crates/regex/src/config.rs"
+          }
+        },
+        {
+          "query": "set regex memory size limit",
+          "query_type": "natural_language",
+          "expected_symbol": "size_limit",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 114.68,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "size_limit",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "search file content for regex matches",
+          "query_type": "natural_language",
+          "expected_symbol": "search_file",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": 2,
+          "elapsed_ms": 118.83,
+          "candidate_count": 33,
+          "top_candidate": {
+            "name": "searches_with_match",
+            "file": "crates/printer/src/stats.rs"
+          }
+        },
+        {
+          "query": "search file by path on the filesystem",
+          "query_type": "natural_language",
+          "expected_symbol": "search_path",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": 4,
+          "elapsed_ms": 117.92,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "search_file",
+            "file": "crates/searcher/src/searcher/mod.rs"
+          }
+        },
+        {
+          "query": "search an input reader line by line",
+          "query_type": "natural_language",
+          "expected_symbol": "search_reader",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": 3,
+          "elapsed_ms": 118.54,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "search_reader",
+            "file": "crates/core/search.rs"
+          }
+        },
+        {
+          "query": "walk directory tree respecting gitignore rules",
+          "query_type": "natural_language",
+          "expected_symbol": "WalkBuilder",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": 8,
+          "elapsed_ms": 119.44,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "walkdir_is_dir",
+            "file": "crates/ignore/src/walk.rs"
+          }
+        },
+        {
+          "query": "build parallel directory traversal",
+          "query_type": "natural_language",
+          "expected_symbol": "build_parallel",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": 1,
+          "elapsed_ms": 112.53,
+          "candidate_count": 21,
+          "top_candidate": {
+            "name": "build_parallel",
+            "file": "crates/ignore/src/walk.rs"
+          }
+        },
+        {
+          "query": "parallel directory walker across threads",
+          "query_type": "natural_language",
+          "expected_symbol": "WalkParallel",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": 6,
+          "elapsed_ms": 111.91,
+          "candidate_count": 13,
+          "top_candidate": {
+            "name": "ParallelVisitor",
+            "file": "crates/ignore/src/walk.rs"
+          }
+        },
+        {
+          "query": "check if a path matches gitignore rules",
+          "query_type": "natural_language",
+          "expected_symbol": "Gitignore",
+          "expected_file_suffix": "crates/ignore/src/gitignore.rs",
+          "rank": 2,
+          "elapsed_ms": 116.92,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "gitignore",
+            "file": "crates/ignore/src/lib.rs"
+          }
+        },
+        {
+          "query": "build set of glob patterns for matching",
+          "query_type": "natural_language",
+          "expected_symbol": "GlobSetBuilder",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": null,
+          "elapsed_ms": 117.01,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "compile_matcher",
+            "file": "crates/globset/src/glob.rs"
+          }
+        },
+        {
+          "query": "match file path against multiple glob patterns",
+          "query_type": "natural_language",
+          "expected_symbol": "GlobSet",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": null,
+          "elapsed_ms": 136.22,
+          "candidate_count": 33,
+          "top_candidate": {
+            "name": "MatchStrategy",
+            "file": "crates/globset/src/glob.rs"
+          }
+        },
+        {
+          "query": "escape glob special characters in a string",
+          "query_type": "natural_language",
+          "expected_symbol": "escape",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": 1,
+          "elapsed_ms": 118.14,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "escape",
+            "file": "crates/globset/src/lib.rs"
+          }
+        },
+        {
+          "query": "regex builder",
+          "query_type": "short_phrase",
+          "expected_symbol": "RegexMatcherBuilder",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 2,
+          "elapsed_ms": 111.63,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "RegexMatcherBuilder",
+            "file": "crates/pcre2/src/matcher.rs"
+          }
+        },
+        {
+          "query": "file searcher",
+          "query_type": "short_phrase",
+          "expected_symbol": "Searcher",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": 4,
+          "elapsed_ms": 113.07,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "search_file",
+            "file": "crates/searcher/src/searcher/mod.rs"
+          }
+        },
+        {
+          "query": "directory walker",
+          "query_type": "short_phrase",
+          "expected_symbol": "Walk",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": null,
+          "elapsed_ms": 108.37,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "working-directory",
+            "file": ".github/workflows/ci.yml"
+          }
+        },
+        {
+          "query": "gitignore builder",
+          "query_type": "short_phrase",
+          "expected_symbol": "GitignoreBuilder",
+          "expected_file_suffix": "crates/ignore/src/gitignore.rs",
+          "rank": 2,
+          "elapsed_ms": 110.32,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "gitignore",
+            "file": "crates/ignore/src/lib.rs"
+          }
+        },
+        {
+          "query": "standard printer",
+          "query_type": "short_phrase",
+          "expected_symbol": "Standard",
+          "expected_file_suffix": "crates/printer/src/standard.rs",
+          "rank": 3,
+          "elapsed_ms": 110.08,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "printer_standard",
+            "file": "crates/core/flags/hiargs.rs"
+          }
+        },
+        {
+          "query": "RegexMatcher",
+          "query_type": "identifier",
+          "expected_symbol": "RegexMatcher",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 4,
+          "elapsed_ms": 17.53,
+          "candidate_count": 7,
+          "top_candidate": {
+            "name": "RegexMatcher",
+            "file": "crates/matcher/tests/util.rs"
+          }
+        },
+        {
+          "query": "GlobSet",
+          "query_type": "identifier",
+          "expected_symbol": "GlobSet",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": 1,
+          "elapsed_ms": 19.17,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "GlobSet",
+            "file": "crates/globset/src/lib.rs"
+          }
+        }
+      ]
+    }
+  ],
+  "hybrid_uplift": {
+    "mrr_delta": 0.10330791893291902,
+    "acc1_delta": 0.0,
+    "acc3_delta": 0.25,
+    "acc5_delta": 0.20833333333333337
+  },
+  "hybrid_uplift_by_query_type": {
+    "identifier": {
+      "mrr_delta": 0.0,
+      "acc1_delta": 0.0,
+      "acc3_delta": 0.0,
+      "acc5_delta": 0.0
+    },
+    "natural_language": {
+      "mrr_delta": 0.16741510123863068,
+      "acc1_delta": 0.05882352941176472,
+      "acc3_delta": 0.29411764705882354,
+      "acc5_delta": 0.2941176470588236
+    },
+    "short_phrase": {
+      "mrr_delta": -0.07333333333333336,
+      "acc1_delta": -0.2,
+      "acc3_delta": 0.19999999999999996,
+      "acc5_delta": 0.0
+    }
+  }
+}

--- a/benchmarks/embedding-quality-v1.5-phase3a-ripgrep-baseline.json
+++ b/benchmarks/embedding-quality-v1.5-phase3a-ripgrep-baseline.json
@@ -1,0 +1,1097 @@
+{
+  "project": "/tmp/ripgrep-ext",
+  "benchmark_project": "/var/folders/z0/0tcbss795xsdp75jmr_t9_kh0000gn/T/codelens-embed-quality-oyd6kk38/ripgrep-ext",
+  "isolated_copy": true,
+  "binary": "/Users/bagjaeseog/codelens-mcp-plugin/target/release/codelens-mcp",
+  "embedding_model": "MiniLM-L12-CodeSearchNet-INT8",
+  "runtime_model": {
+    "model_dir": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch",
+    "model_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/model.onnx",
+    "config_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/config.json",
+    "sha256": "ef1d1e9cfa72e4929f5b9faea17d8704b23a2530aadebf0d464a4cc7750920b3",
+    "size_bytes": 34000281,
+    "num_hidden_layers": 12,
+    "hidden_size": 384
+  },
+  "dataset_path": "/Users/bagjaeseog/codelens-mcp-plugin/benchmarks/embedding-quality-dataset-ripgrep.json",
+  "dataset_size": 24,
+  "ranking_cutoff": 10,
+  "metric_labels": {
+    "mrr": "MRR@10",
+    "acc1": "Acc@1",
+    "acc3": "Acc@3",
+    "acc5": "Acc@5"
+  },
+  "methods": [
+    {
+      "method": "semantic_search",
+      "mrr": 0.4052579365079365,
+      "acc1": 0.2916666666666667,
+      "acc3": 0.5,
+      "acc5": 0.5416666666666666,
+      "avg_elapsed_ms": 168.41166666666666,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 0.75,
+          "acc1": 0.5,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 111.72999999999999
+        },
+        "natural_language": {
+          "count": 17,
+          "mrr": 0.38725490196078427,
+          "acc1": 0.29411764705882354,
+          "acc3": 0.47058823529411764,
+          "acc5": 0.5294117647058824,
+          "avg_elapsed_ms": 188.28176470588235
+        },
+        "short_phrase": {
+          "count": 5,
+          "mrr": 0.32857142857142857,
+          "acc1": 0.2,
+          "acc3": 0.4,
+          "acc5": 0.4,
+          "avg_elapsed_ms": 123.526
+        }
+      },
+      "rows": [
+        {
+          "query": "build regex matcher from pattern string",
+          "query_type": "natural_language",
+          "expected_symbol": "build",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 202.82,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "build",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "case insensitive regex matching",
+          "query_type": "natural_language",
+          "expected_symbol": "case_insensitive",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 170.26,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "case_insensitive",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "match multiple regex patterns at once",
+          "query_type": "natural_language",
+          "expected_symbol": "build_many",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": null,
+          "elapsed_ms": 187.48,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "matcher",
+            "file": "crates/regex/src/lib.rs"
+          }
+        },
+        {
+          "query": "ignore whitespace inside regex pattern",
+          "query_type": "natural_language",
+          "expected_symbol": "ignore_whitespace",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 200.52,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "ignore_whitespace",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "match a whole line only not substring",
+          "query_type": "natural_language",
+          "expected_symbol": "whole_line",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 2,
+          "elapsed_ms": 194.08,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "whole_line",
+            "file": "crates/pcre2/src/matcher.rs"
+          }
+        },
+        {
+          "query": "treat patterns as fixed strings not regex",
+          "query_type": "natural_language",
+          "expected_symbol": "fixed_strings",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 3,
+          "elapsed_ms": 197.57,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "is_fixed_strings",
+            "file": "crates/regex/src/config.rs"
+          }
+        },
+        {
+          "query": "set regex memory size limit",
+          "query_type": "natural_language",
+          "expected_symbol": "size_limit",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": null,
+          "elapsed_ms": 181.66,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "set_before",
+            "file": "crates/core/flags/lowargs.rs"
+          }
+        },
+        {
+          "query": "search file content for regex matches",
+          "query_type": "natural_language",
+          "expected_symbol": "search_file",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": null,
+          "elapsed_ms": 211.41,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "search",
+            "file": "crates/core/search.rs"
+          }
+        },
+        {
+          "query": "search file by path on the filesystem",
+          "query_type": "natural_language",
+          "expected_symbol": "search_path",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": 6,
+          "elapsed_ms": 216.19,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "search_path",
+            "file": "crates/core/search.rs"
+          }
+        },
+        {
+          "query": "search an input reader line by line",
+          "query_type": "natural_language",
+          "expected_symbol": "search_reader",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": 4,
+          "elapsed_ms": 214.59,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "search_reader",
+            "file": "crates/core/search.rs"
+          }
+        },
+        {
+          "query": "walk directory tree respecting gitignore rules",
+          "query_type": "natural_language",
+          "expected_symbol": "WalkBuilder",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": null,
+          "elapsed_ms": 213.39,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "walkdir_is_dir",
+            "file": "crates/ignore/src/walk.rs"
+          }
+        },
+        {
+          "query": "build parallel directory traversal",
+          "query_type": "natural_language",
+          "expected_symbol": "build_parallel",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": 1,
+          "elapsed_ms": 168.06,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "build_parallel",
+            "file": "crates/ignore/src/walk.rs"
+          }
+        },
+        {
+          "query": "parallel directory walker across threads",
+          "query_type": "natural_language",
+          "expected_symbol": "WalkParallel",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": null,
+          "elapsed_ms": 115.38,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "walk_collect_entries_parallel",
+            "file": "crates/ignore/src/walk.rs"
+          }
+        },
+        {
+          "query": "check if a path matches gitignore rules",
+          "query_type": "natural_language",
+          "expected_symbol": "Gitignore",
+          "expected_file_suffix": "crates/ignore/src/gitignore.rs",
+          "rank": 3,
+          "elapsed_ms": 198.76,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "gitignore",
+            "file": "crates/ignore/src/lib.rs"
+          }
+        },
+        {
+          "query": "build set of glob patterns for matching",
+          "query_type": "natural_language",
+          "expected_symbol": "GlobSetBuilder",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": null,
+          "elapsed_ms": 194.99,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "GlobMatcher",
+            "file": "crates/globset/src/glob.rs"
+          }
+        },
+        {
+          "query": "match file path against multiple glob patterns",
+          "query_type": "natural_language",
+          "expected_symbol": "GlobSet",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": null,
+          "elapsed_ms": 149.76,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "MatchStrategy",
+            "file": "crates/globset/src/glob.rs"
+          }
+        },
+        {
+          "query": "escape glob special characters in a string",
+          "query_type": "natural_language",
+          "expected_symbol": "escape",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": 1,
+          "elapsed_ms": 183.87,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "escape",
+            "file": "crates/globset/src/lib.rs"
+          }
+        },
+        {
+          "query": "regex builder",
+          "query_type": "short_phrase",
+          "expected_symbol": "RegexMatcherBuilder",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 125.86,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "RegexMatcherBuilder",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "file searcher",
+          "query_type": "short_phrase",
+          "expected_symbol": "Searcher",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": 7,
+          "elapsed_ms": 124.66,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "search_file",
+            "file": "crates/searcher/src/searcher/mod.rs"
+          }
+        },
+        {
+          "query": "directory walker",
+          "query_type": "short_phrase",
+          "expected_symbol": "Walk",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": null,
+          "elapsed_ms": 116.31,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "name",
+            "file": ".github/workflows/release.yml"
+          }
+        },
+        {
+          "query": "gitignore builder",
+          "query_type": "short_phrase",
+          "expected_symbol": "GitignoreBuilder",
+          "expected_file_suffix": "crates/ignore/src/gitignore.rs",
+          "rank": 2,
+          "elapsed_ms": 126.33,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "gitignore",
+            "file": "crates/ignore/src/lib.rs"
+          }
+        },
+        {
+          "query": "standard printer",
+          "query_type": "short_phrase",
+          "expected_symbol": "Standard",
+          "expected_file_suffix": "crates/printer/src/standard.rs",
+          "rank": null,
+          "elapsed_ms": 124.47,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "printer_standard",
+            "file": "crates/core/flags/hiargs.rs"
+          }
+        },
+        {
+          "query": "RegexMatcher",
+          "query_type": "identifier",
+          "expected_symbol": "RegexMatcher",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 2,
+          "elapsed_ms": 111.19,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "RegexMatcher",
+            "file": "crates/searcher/src/testutil.rs"
+          }
+        },
+        {
+          "query": "GlobSet",
+          "query_type": "identifier",
+          "expected_symbol": "GlobSet",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": 1,
+          "elapsed_ms": 112.27,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "GlobSet",
+            "file": "crates/globset/src/lib.rs"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context_no_semantic",
+      "mrr": 0.32799168424168423,
+      "acc1": 0.20833333333333334,
+      "acc3": 0.3333333333333333,
+      "acc5": 0.5,
+      "avg_elapsed_ms": 22.19666666666667,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 0.625,
+          "acc1": 0.5,
+          "acc3": 0.5,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 16.565
+        },
+        "natural_language": {
+          "count": 17,
+          "mrr": 0.278173134055487,
+          "acc1": 0.17647058823529413,
+          "acc3": 0.29411764705882354,
+          "acc5": 0.4117647058823529,
+          "avg_elapsed_ms": 24.08823529411765
+        },
+        "short_phrase": {
+          "count": 5,
+          "mrr": 0.37857142857142856,
+          "acc1": 0.2,
+          "acc3": 0.4,
+          "acc5": 0.6,
+          "avg_elapsed_ms": 18.018
+        }
+      },
+      "rows": [
+        {
+          "query": "build regex matcher from pattern string",
+          "query_type": "natural_language",
+          "expected_symbol": "build",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": null,
+          "elapsed_ms": 24.56,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "from_pattern",
+            "file": "crates/regex/src/ast.rs"
+          }
+        },
+        {
+          "query": "case insensitive regex matching",
+          "query_type": "natural_language",
+          "expected_symbol": "case_insensitive",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 5,
+          "elapsed_ms": 23.19,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "case_insensitive",
+            "file": "crates/globset/src/glob.rs"
+          }
+        },
+        {
+          "query": "match multiple regex patterns at once",
+          "query_type": "natural_language",
+          "expected_symbol": "build_many",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": null,
+          "elapsed_ms": 23.01,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "regex",
+            "file": "crates/regex/src/error.rs"
+          }
+        },
+        {
+          "query": "ignore whitespace inside regex pattern",
+          "query_type": "natural_language",
+          "expected_symbol": "ignore_whitespace",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 25.29,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "ignore_whitespace",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "match a whole line only not substring",
+          "query_type": "natural_language",
+          "expected_symbol": "whole_line",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 2,
+          "elapsed_ms": 23.61,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "whole_line",
+            "file": "crates/pcre2/src/matcher.rs"
+          }
+        },
+        {
+          "query": "treat patterns as fixed strings not regex",
+          "query_type": "natural_language",
+          "expected_symbol": "fixed_strings",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 2,
+          "elapsed_ms": 24.9,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "fixed_strings",
+            "file": "crates/pcre2/src/matcher.rs"
+          }
+        },
+        {
+          "query": "set regex memory size limit",
+          "query_type": "natural_language",
+          "expected_symbol": "size_limit",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 23.19,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "size_limit",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "search file content for regex matches",
+          "query_type": "natural_language",
+          "expected_symbol": "search_file",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": null,
+          "elapsed_ms": 25.72,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "build_format",
+            "file": "crates/printer/src/hyperlink/mod.rs"
+          }
+        },
+        {
+          "query": "search file by path on the filesystem",
+          "query_type": "natural_language",
+          "expected_symbol": "search_path",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": null,
+          "elapsed_ms": 24.93,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "path",
+            "file": "crates/ignore/src/gitignore.rs"
+          }
+        },
+        {
+          "query": "search an input reader line by line",
+          "query_type": "natural_language",
+          "expected_symbol": "search_reader",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": 4,
+          "elapsed_ms": 26.54,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "by_line",
+            "file": "crates/searcher/src/testutil.rs"
+          }
+        },
+        {
+          "query": "walk directory tree respecting gitignore rules",
+          "query_type": "natural_language",
+          "expected_symbol": "WalkBuilder",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": 11,
+          "elapsed_ms": 26.07,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "Gitignore",
+            "file": "crates/ignore/src/gitignore.rs"
+          }
+        },
+        {
+          "query": "build parallel directory traversal",
+          "query_type": "natural_language",
+          "expected_symbol": "build_parallel",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": 1,
+          "elapsed_ms": 20.86,
+          "candidate_count": 21,
+          "top_candidate": {
+            "name": "build_parallel",
+            "file": "crates/ignore/src/walk.rs"
+          }
+        },
+        {
+          "query": "parallel directory walker across threads",
+          "query_type": "natural_language",
+          "expected_symbol": "WalkParallel",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": 9,
+          "elapsed_ms": 20.64,
+          "candidate_count": 13,
+          "top_candidate": {
+            "name": "build_parallel",
+            "file": "crates/ignore/src/walk.rs"
+          }
+        },
+        {
+          "query": "check if a path matches gitignore rules",
+          "query_type": "natural_language",
+          "expected_symbol": "Gitignore",
+          "expected_file_suffix": "crates/ignore/src/gitignore.rs",
+          "rank": 13,
+          "elapsed_ms": 23.38,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "nmatches",
+            "file": "crates/globset/src/glob.rs"
+          }
+        },
+        {
+          "query": "build set of glob patterns for matching",
+          "query_type": "natural_language",
+          "expected_symbol": "GlobSetBuilder",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": null,
+          "elapsed_ms": 29.37,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "build_format",
+            "file": "crates/printer/src/hyperlink/mod.rs"
+          }
+        },
+        {
+          "query": "match file path against multiple glob patterns",
+          "query_type": "natural_language",
+          "expected_symbol": "GlobSet",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": null,
+          "elapsed_ms": 20.23,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "GlobMatcher",
+            "file": "crates/globset/src/glob.rs"
+          }
+        },
+        {
+          "query": "escape glob special characters in a string",
+          "query_type": "natural_language",
+          "expected_symbol": "escape",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": null,
+          "elapsed_ms": 24.01,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "Glob",
+            "file": "crates/globset/src/glob.rs"
+          }
+        },
+        {
+          "query": "regex builder",
+          "query_type": "short_phrase",
+          "expected_symbol": "RegexMatcherBuilder",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 4,
+          "elapsed_ms": 18.56,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "FormatBuilder",
+            "file": "crates/printer/src/hyperlink/mod.rs"
+          }
+        },
+        {
+          "query": "file searcher",
+          "query_type": "short_phrase",
+          "expected_symbol": "Searcher",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": 2,
+          "elapsed_ms": 19.06,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "SearcherBuilder",
+            "file": "crates/searcher/src/searcher/mod.rs"
+          }
+        },
+        {
+          "query": "directory walker",
+          "query_type": "short_phrase",
+          "expected_symbol": "Walk",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": null,
+          "elapsed_ms": 16.53,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "working-directory",
+            "file": ".github/workflows/ci.yml"
+          }
+        },
+        {
+          "query": "gitignore builder",
+          "query_type": "short_phrase",
+          "expected_symbol": "GitignoreBuilder",
+          "expected_file_suffix": "crates/ignore/src/gitignore.rs",
+          "rank": 1,
+          "elapsed_ms": 17.31,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "GitignoreBuilder",
+            "file": "crates/ignore/src/gitignore.rs"
+          }
+        },
+        {
+          "query": "standard printer",
+          "query_type": "short_phrase",
+          "expected_symbol": "Standard",
+          "expected_file_suffix": "crates/printer/src/standard.rs",
+          "rank": 7,
+          "elapsed_ms": 18.63,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "PrinterPath",
+            "file": "crates/printer/src/util.rs"
+          }
+        },
+        {
+          "query": "RegexMatcher",
+          "query_type": "identifier",
+          "expected_symbol": "RegexMatcher",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 4,
+          "elapsed_ms": 16.26,
+          "candidate_count": 7,
+          "top_candidate": {
+            "name": "RegexMatcher",
+            "file": "crates/matcher/tests/util.rs"
+          }
+        },
+        {
+          "query": "GlobSet",
+          "query_type": "identifier",
+          "expected_symbol": "GlobSet",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": 1,
+          "elapsed_ms": 16.87,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "GlobSet",
+            "file": "crates/globset/src/lib.rs"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context",
+      "mrr": 0.45937500000000003,
+      "acc1": 0.25,
+      "acc3": 0.5833333333333334,
+      "acc5": 0.75,
+      "avg_elapsed_ms": 105.93416666666667,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 0.625,
+          "acc1": 0.5,
+          "acc3": 0.5,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 17.495
+        },
+        "natural_language": {
+          "count": 17,
+          "mrr": 0.475,
+          "acc1": 0.29411764705882354,
+          "acc3": 0.5882352941176471,
+          "acc5": 0.7058823529411765,
+          "avg_elapsed_ms": 114.42647058823529
+        },
+        "short_phrase": {
+          "count": 5,
+          "mrr": 0.33999999999999997,
+          "acc1": 0.0,
+          "acc3": 0.6,
+          "acc5": 0.8,
+          "avg_elapsed_ms": 112.436
+        }
+      },
+      "rows": [
+        {
+          "query": "build regex matcher from pattern string",
+          "query_type": "natural_language",
+          "expected_symbol": "build",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 113.04,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "build",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "case insensitive regex matching",
+          "query_type": "natural_language",
+          "expected_symbol": "case_insensitive",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 111.41,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "case_insensitive",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "match multiple regex patterns at once",
+          "query_type": "natural_language",
+          "expected_symbol": "build_many",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": null,
+          "elapsed_ms": 116.02,
+          "candidate_count": 34,
+          "top_candidate": {
+            "name": "matcher",
+            "file": "crates/regex/src/lib.rs"
+          }
+        },
+        {
+          "query": "ignore whitespace inside regex pattern",
+          "query_type": "natural_language",
+          "expected_symbol": "ignore_whitespace",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 116.21,
+          "candidate_count": 34,
+          "top_candidate": {
+            "name": "ignore_whitespace",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "match a whole line only not substring",
+          "query_type": "natural_language",
+          "expected_symbol": "whole_line",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 2,
+          "elapsed_ms": 115.46,
+          "candidate_count": 33,
+          "top_candidate": {
+            "name": "whole_line",
+            "file": "crates/pcre2/src/matcher.rs"
+          }
+        },
+        {
+          "query": "treat patterns as fixed strings not regex",
+          "query_type": "natural_language",
+          "expected_symbol": "fixed_strings",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 4,
+          "elapsed_ms": 114.95,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "is_fixed_strings",
+            "file": "crates/regex/src/config.rs"
+          }
+        },
+        {
+          "query": "set regex memory size limit",
+          "query_type": "natural_language",
+          "expected_symbol": "size_limit",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 2,
+          "elapsed_ms": 113.51,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "regex_set",
+            "file": "crates/globset/src/lib.rs"
+          }
+        },
+        {
+          "query": "search file content for regex matches",
+          "query_type": "natural_language",
+          "expected_symbol": "search_file",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": 2,
+          "elapsed_ms": 117.47,
+          "candidate_count": 33,
+          "top_candidate": {
+            "name": "searches_with_match",
+            "file": "crates/printer/src/stats.rs"
+          }
+        },
+        {
+          "query": "search file by path on the filesystem",
+          "query_type": "natural_language",
+          "expected_symbol": "search_path",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": 5,
+          "elapsed_ms": 117.33,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "search_file",
+            "file": "crates/searcher/src/searcher/mod.rs"
+          }
+        },
+        {
+          "query": "search an input reader line by line",
+          "query_type": "natural_language",
+          "expected_symbol": "search_reader",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": 3,
+          "elapsed_ms": 114.92,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "search_reader",
+            "file": "crates/core/search.rs"
+          }
+        },
+        {
+          "query": "walk directory tree respecting gitignore rules",
+          "query_type": "natural_language",
+          "expected_symbol": "WalkBuilder",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": 8,
+          "elapsed_ms": 116.26,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "walkdir_is_dir",
+            "file": "crates/ignore/src/walk.rs"
+          }
+        },
+        {
+          "query": "build parallel directory traversal",
+          "query_type": "natural_language",
+          "expected_symbol": "build_parallel",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": 1,
+          "elapsed_ms": 110.92,
+          "candidate_count": 21,
+          "top_candidate": {
+            "name": "build_parallel",
+            "file": "crates/ignore/src/walk.rs"
+          }
+        },
+        {
+          "query": "parallel directory walker across threads",
+          "query_type": "natural_language",
+          "expected_symbol": "WalkParallel",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": 6,
+          "elapsed_ms": 112.68,
+          "candidate_count": 13,
+          "top_candidate": {
+            "name": "ParallelVisitor",
+            "file": "crates/ignore/src/walk.rs"
+          }
+        },
+        {
+          "query": "check if a path matches gitignore rules",
+          "query_type": "natural_language",
+          "expected_symbol": "Gitignore",
+          "expected_file_suffix": "crates/ignore/src/gitignore.rs",
+          "rank": 2,
+          "elapsed_ms": 114.9,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "gitignore",
+            "file": "crates/ignore/src/lib.rs"
+          }
+        },
+        {
+          "query": "build set of glob patterns for matching",
+          "query_type": "natural_language",
+          "expected_symbol": "GlobSetBuilder",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": null,
+          "elapsed_ms": 114.47,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "compile_matcher",
+            "file": "crates/globset/src/glob.rs"
+          }
+        },
+        {
+          "query": "match file path against multiple glob patterns",
+          "query_type": "natural_language",
+          "expected_symbol": "GlobSet",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": null,
+          "elapsed_ms": 111.17,
+          "candidate_count": 33,
+          "top_candidate": {
+            "name": "MatchStrategy",
+            "file": "crates/globset/src/glob.rs"
+          }
+        },
+        {
+          "query": "escape glob special characters in a string",
+          "query_type": "natural_language",
+          "expected_symbol": "escape",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": 1,
+          "elapsed_ms": 114.53,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "escape",
+            "file": "crates/globset/src/lib.rs"
+          }
+        },
+        {
+          "query": "regex builder",
+          "query_type": "short_phrase",
+          "expected_symbol": "RegexMatcherBuilder",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 2,
+          "elapsed_ms": 108.1,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "RegexMatcherBuilder",
+            "file": "crates/pcre2/src/matcher.rs"
+          }
+        },
+        {
+          "query": "file searcher",
+          "query_type": "short_phrase",
+          "expected_symbol": "Searcher",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": 2,
+          "elapsed_ms": 118.03,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "search_file",
+            "file": "crates/searcher/src/searcher/mod.rs"
+          }
+        },
+        {
+          "query": "directory walker",
+          "query_type": "short_phrase",
+          "expected_symbol": "Walk",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": null,
+          "elapsed_ms": 115.48,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "working-directory",
+            "file": ".github/workflows/ci.yml"
+          }
+        },
+        {
+          "query": "gitignore builder",
+          "query_type": "short_phrase",
+          "expected_symbol": "GitignoreBuilder",
+          "expected_file_suffix": "crates/ignore/src/gitignore.rs",
+          "rank": 2,
+          "elapsed_ms": 108.92,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "gitignore",
+            "file": "crates/ignore/src/lib.rs"
+          }
+        },
+        {
+          "query": "standard printer",
+          "query_type": "short_phrase",
+          "expected_symbol": "Standard",
+          "expected_file_suffix": "crates/printer/src/standard.rs",
+          "rank": 5,
+          "elapsed_ms": 111.65,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "printer_standard",
+            "file": "crates/core/flags/hiargs.rs"
+          }
+        },
+        {
+          "query": "RegexMatcher",
+          "query_type": "identifier",
+          "expected_symbol": "RegexMatcher",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 4,
+          "elapsed_ms": 17.35,
+          "candidate_count": 7,
+          "top_candidate": {
+            "name": "RegexMatcher",
+            "file": "crates/matcher/tests/util.rs"
+          }
+        },
+        {
+          "query": "GlobSet",
+          "query_type": "identifier",
+          "expected_symbol": "GlobSet",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": 1,
+          "elapsed_ms": 17.64,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "GlobSet",
+            "file": "crates/globset/src/lib.rs"
+          }
+        }
+      ]
+    }
+  ],
+  "hybrid_uplift": {
+    "mrr_delta": 0.1313833157583158,
+    "acc1_delta": 0.04166666666666666,
+    "acc3_delta": 0.25000000000000006,
+    "acc5_delta": 0.25
+  },
+  "hybrid_uplift_by_query_type": {
+    "identifier": {
+      "mrr_delta": 0.0,
+      "acc1_delta": 0.0,
+      "acc3_delta": 0.0,
+      "acc5_delta": 0.0
+    },
+    "natural_language": {
+      "mrr_delta": 0.19682686594451299,
+      "acc1_delta": 0.11764705882352941,
+      "acc3_delta": 0.29411764705882354,
+      "acc5_delta": 0.2941176470588236
+    },
+    "short_phrase": {
+      "mrr_delta": -0.03857142857142859,
+      "acc1_delta": -0.2,
+      "acc3_delta": 0.19999999999999996,
+      "acc5_delta": 0.20000000000000007
+    }
+  }
+}

--- a/benchmarks/embedding-quality-v1.5-phase3a-ripgrep-stacked.json
+++ b/benchmarks/embedding-quality-v1.5-phase3a-ripgrep-stacked.json
@@ -1,0 +1,1097 @@
+{
+  "project": "/tmp/ripgrep-ext",
+  "benchmark_project": "/var/folders/z0/0tcbss795xsdp75jmr_t9_kh0000gn/T/codelens-embed-quality-l0_8hxik/ripgrep-ext",
+  "isolated_copy": true,
+  "binary": "/Users/bagjaeseog/codelens-mcp-plugin/target/release/codelens-mcp",
+  "embedding_model": "MiniLM-L12-CodeSearchNet-INT8",
+  "runtime_model": {
+    "model_dir": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch",
+    "model_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/model.onnx",
+    "config_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/config.json",
+    "sha256": "ef1d1e9cfa72e4929f5b9faea17d8704b23a2530aadebf0d464a4cc7750920b3",
+    "size_bytes": 34000281,
+    "num_hidden_layers": 12,
+    "hidden_size": 384
+  },
+  "dataset_path": "/Users/bagjaeseog/codelens-mcp-plugin/benchmarks/embedding-quality-dataset-ripgrep.json",
+  "dataset_size": 24,
+  "ranking_cutoff": 10,
+  "metric_labels": {
+    "mrr": "MRR@10",
+    "acc1": "Acc@1",
+    "acc3": "Acc@3",
+    "acc5": "Acc@5"
+  },
+  "methods": [
+    {
+      "method": "semantic_search",
+      "mrr": 0.3972222222222222,
+      "acc1": 0.20833333333333334,
+      "acc3": 0.5833333333333334,
+      "acc5": 0.625,
+      "avg_elapsed_ms": 173.59458333333336,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 0.75,
+          "acc1": 0.5,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 113.78
+        },
+        "natural_language": {
+          "count": 17,
+          "mrr": 0.38431372549019605,
+          "acc1": 0.17647058823529413,
+          "acc3": 0.5882352941176471,
+          "acc5": 0.6470588235294118,
+          "avg_elapsed_ms": 193.76176470588234
+        },
+        "short_phrase": {
+          "count": 5,
+          "mrr": 0.3,
+          "acc1": 0.2,
+          "acc3": 0.4,
+          "acc5": 0.4,
+          "avg_elapsed_ms": 128.952
+        }
+      },
+      "rows": [
+        {
+          "query": "build regex matcher from pattern string",
+          "query_type": "natural_language",
+          "expected_symbol": "build",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 2,
+          "elapsed_ms": 217.07,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "build",
+            "file": "crates/pcre2/src/matcher.rs"
+          }
+        },
+        {
+          "query": "case insensitive regex matching",
+          "query_type": "natural_language",
+          "expected_symbol": "case_insensitive",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 178.61,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "case_insensitive",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "match multiple regex patterns at once",
+          "query_type": "natural_language",
+          "expected_symbol": "build_many",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": null,
+          "elapsed_ms": 188.05,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "matcher",
+            "file": "crates/regex/src/lib.rs"
+          }
+        },
+        {
+          "query": "ignore whitespace inside regex pattern",
+          "query_type": "natural_language",
+          "expected_symbol": "ignore_whitespace",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 204.79,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "ignore_whitespace",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "match a whole line only not substring",
+          "query_type": "natural_language",
+          "expected_symbol": "whole_line",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 2,
+          "elapsed_ms": 203.18,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "whole_line",
+            "file": "crates/pcre2/src/matcher.rs"
+          }
+        },
+        {
+          "query": "treat patterns as fixed strings not regex",
+          "query_type": "natural_language",
+          "expected_symbol": "fixed_strings",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 2,
+          "elapsed_ms": 199.63,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "is_fixed_strings",
+            "file": "crates/regex/src/config.rs"
+          }
+        },
+        {
+          "query": "set regex memory size limit",
+          "query_type": "natural_language",
+          "expected_symbol": "size_limit",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": null,
+          "elapsed_ms": 186.72,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "set_before",
+            "file": "crates/core/flags/lowargs.rs"
+          }
+        },
+        {
+          "query": "search file content for regex matches",
+          "query_type": "natural_language",
+          "expected_symbol": "search_file",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": null,
+          "elapsed_ms": 216.25,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "search",
+            "file": "crates/core/main.rs"
+          }
+        },
+        {
+          "query": "search file by path on the filesystem",
+          "query_type": "natural_language",
+          "expected_symbol": "search_path",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": 5,
+          "elapsed_ms": 216.91,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "search_path",
+            "file": "crates/core/search.rs"
+          }
+        },
+        {
+          "query": "search an input reader line by line",
+          "query_type": "natural_language",
+          "expected_symbol": "search_reader",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": 2,
+          "elapsed_ms": 218.62,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "search_reader",
+            "file": "crates/core/search.rs"
+          }
+        },
+        {
+          "query": "walk directory tree respecting gitignore rules",
+          "query_type": "natural_language",
+          "expected_symbol": "WalkBuilder",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": 2,
+          "elapsed_ms": 215.39,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "walkdir_is_dir",
+            "file": "crates/ignore/src/walk.rs"
+          }
+        },
+        {
+          "query": "build parallel directory traversal",
+          "query_type": "natural_language",
+          "expected_symbol": "build_parallel",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": 1,
+          "elapsed_ms": 173.54,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "build_parallel",
+            "file": "crates/ignore/src/walk.rs"
+          }
+        },
+        {
+          "query": "parallel directory walker across threads",
+          "query_type": "natural_language",
+          "expected_symbol": "WalkParallel",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": null,
+          "elapsed_ms": 118.81,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "walk_collect_entries_parallel",
+            "file": "crates/ignore/src/walk.rs"
+          }
+        },
+        {
+          "query": "check if a path matches gitignore rules",
+          "query_type": "natural_language",
+          "expected_symbol": "Gitignore",
+          "expected_file_suffix": "crates/ignore/src/gitignore.rs",
+          "rank": 3,
+          "elapsed_ms": 211.18,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "gitignore",
+            "file": "crates/ignore/src/lib.rs"
+          }
+        },
+        {
+          "query": "build set of glob patterns for matching",
+          "query_type": "natural_language",
+          "expected_symbol": "GlobSetBuilder",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": null,
+          "elapsed_ms": 204.63,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "GlobMatcher",
+            "file": "crates/globset/src/glob.rs"
+          }
+        },
+        {
+          "query": "match file path against multiple glob patterns",
+          "query_type": "natural_language",
+          "expected_symbol": "GlobSet",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": null,
+          "elapsed_ms": 152.15,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "matched",
+            "file": "crates/ignore/src/gitignore.rs"
+          }
+        },
+        {
+          "query": "escape glob special characters in a string",
+          "query_type": "natural_language",
+          "expected_symbol": "escape",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": 2,
+          "elapsed_ms": 188.42,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "char_to_escaped_literal",
+            "file": "crates/globset/src/glob.rs"
+          }
+        },
+        {
+          "query": "regex builder",
+          "query_type": "short_phrase",
+          "expected_symbol": "RegexMatcherBuilder",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 147.34,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "RegexMatcherBuilder",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "file searcher",
+          "query_type": "short_phrase",
+          "expected_symbol": "Searcher",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": null,
+          "elapsed_ms": 127.3,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "search_file",
+            "file": "crates/searcher/src/searcher/mod.rs"
+          }
+        },
+        {
+          "query": "directory walker",
+          "query_type": "short_phrase",
+          "expected_symbol": "Walk",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": null,
+          "elapsed_ms": 115.97,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "name",
+            "file": ".github/workflows/release.yml"
+          }
+        },
+        {
+          "query": "gitignore builder",
+          "query_type": "short_phrase",
+          "expected_symbol": "GitignoreBuilder",
+          "expected_file_suffix": "crates/ignore/src/gitignore.rs",
+          "rank": 2,
+          "elapsed_ms": 126.12,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "gitignore",
+            "file": "crates/ignore/src/lib.rs"
+          }
+        },
+        {
+          "query": "standard printer",
+          "query_type": "short_phrase",
+          "expected_symbol": "Standard",
+          "expected_file_suffix": "crates/printer/src/standard.rs",
+          "rank": null,
+          "elapsed_ms": 128.03,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "printer_standard",
+            "file": "crates/core/flags/hiargs.rs"
+          }
+        },
+        {
+          "query": "RegexMatcher",
+          "query_type": "identifier",
+          "expected_symbol": "RegexMatcher",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 2,
+          "elapsed_ms": 112.38,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "RegexMatcher",
+            "file": "crates/searcher/src/testutil.rs"
+          }
+        },
+        {
+          "query": "GlobSet",
+          "query_type": "identifier",
+          "expected_symbol": "GlobSet",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": 1,
+          "elapsed_ms": 115.18,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "GlobSet",
+            "file": "crates/globset/src/lib.rs"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context_no_semantic",
+      "mrr": 0.38453930328930325,
+      "acc1": 0.2916666666666667,
+      "acc3": 0.375,
+      "acc5": 0.5416666666666666,
+      "avg_elapsed_ms": 22.691666666666666,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 0.625,
+          "acc1": 0.5,
+          "acc3": 0.5,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 16.935
+        },
+        "natural_language": {
+          "count": 17,
+          "mrr": 0.3546437222907811,
+          "acc1": 0.29411764705882354,
+          "acc3": 0.35294117647058826,
+          "acc5": 0.4117647058823529,
+          "avg_elapsed_ms": 24.658823529411762
+        },
+        "short_phrase": {
+          "count": 5,
+          "mrr": 0.39,
+          "acc1": 0.2,
+          "acc3": 0.4,
+          "acc5": 0.8,
+          "avg_elapsed_ms": 18.306
+        }
+      },
+      "rows": [
+        {
+          "query": "build regex matcher from pattern string",
+          "query_type": "natural_language",
+          "expected_symbol": "build",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": null,
+          "elapsed_ms": 26.16,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "from_pattern",
+            "file": "crates/regex/src/ast.rs"
+          }
+        },
+        {
+          "query": "case insensitive regex matching",
+          "query_type": "natural_language",
+          "expected_symbol": "case_insensitive",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 22.8,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "case_insensitive",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "match multiple regex patterns at once",
+          "query_type": "natural_language",
+          "expected_symbol": "build_many",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": null,
+          "elapsed_ms": 24.29,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "regex",
+            "file": "crates/regex/src/error.rs"
+          }
+        },
+        {
+          "query": "ignore whitespace inside regex pattern",
+          "query_type": "natural_language",
+          "expected_symbol": "ignore_whitespace",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 25.06,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "ignore_whitespace",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "match a whole line only not substring",
+          "query_type": "natural_language",
+          "expected_symbol": "whole_line",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 2,
+          "elapsed_ms": 25.23,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "whole_line",
+            "file": "crates/pcre2/src/matcher.rs"
+          }
+        },
+        {
+          "query": "treat patterns as fixed strings not regex",
+          "query_type": "natural_language",
+          "expected_symbol": "fixed_strings",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 25.2,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "fixed_strings",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "set regex memory size limit",
+          "query_type": "natural_language",
+          "expected_symbol": "size_limit",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 24.4,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "size_limit",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "search file content for regex matches",
+          "query_type": "natural_language",
+          "expected_symbol": "search_file",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": null,
+          "elapsed_ms": 26.02,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "build_format",
+            "file": "crates/printer/src/hyperlink/mod.rs"
+          }
+        },
+        {
+          "query": "search file by path on the filesystem",
+          "query_type": "natural_language",
+          "expected_symbol": "search_path",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": null,
+          "elapsed_ms": 26.36,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "path",
+            "file": "crates/ignore/src/gitignore.rs"
+          }
+        },
+        {
+          "query": "search an input reader line by line",
+          "query_type": "natural_language",
+          "expected_symbol": "search_reader",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": 4,
+          "elapsed_ms": 26.19,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "by_line",
+            "file": "crates/searcher/src/testutil.rs"
+          }
+        },
+        {
+          "query": "walk directory tree respecting gitignore rules",
+          "query_type": "natural_language",
+          "expected_symbol": "WalkBuilder",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": 11,
+          "elapsed_ms": 27.08,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "Gitignore",
+            "file": "crates/ignore/src/gitignore.rs"
+          }
+        },
+        {
+          "query": "build parallel directory traversal",
+          "query_type": "natural_language",
+          "expected_symbol": "build_parallel",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": 1,
+          "elapsed_ms": 20.39,
+          "candidate_count": 21,
+          "top_candidate": {
+            "name": "build_parallel",
+            "file": "crates/ignore/src/walk.rs"
+          }
+        },
+        {
+          "query": "parallel directory walker across threads",
+          "query_type": "natural_language",
+          "expected_symbol": "WalkParallel",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": 9,
+          "elapsed_ms": 21.63,
+          "candidate_count": 13,
+          "top_candidate": {
+            "name": "build_parallel",
+            "file": "crates/ignore/src/walk.rs"
+          }
+        },
+        {
+          "query": "check if a path matches gitignore rules",
+          "query_type": "natural_language",
+          "expected_symbol": "Gitignore",
+          "expected_file_suffix": "crates/ignore/src/gitignore.rs",
+          "rank": 13,
+          "elapsed_ms": 25.27,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "nmatches",
+            "file": "crates/globset/src/glob.rs"
+          }
+        },
+        {
+          "query": "build set of glob patterns for matching",
+          "query_type": "natural_language",
+          "expected_symbol": "GlobSetBuilder",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": null,
+          "elapsed_ms": 25.98,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "build",
+            "file": "crates/globset/src/glob.rs"
+          }
+        },
+        {
+          "query": "match file path against multiple glob patterns",
+          "query_type": "natural_language",
+          "expected_symbol": "GlobSet",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": null,
+          "elapsed_ms": 22.41,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "GlobMatcher",
+            "file": "crates/globset/src/glob.rs"
+          }
+        },
+        {
+          "query": "escape glob special characters in a string",
+          "query_type": "natural_language",
+          "expected_symbol": "escape",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": null,
+          "elapsed_ms": 24.73,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "Glob",
+            "file": "crates/globset/src/glob.rs"
+          }
+        },
+        {
+          "query": "regex builder",
+          "query_type": "short_phrase",
+          "expected_symbol": "RegexMatcherBuilder",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 2,
+          "elapsed_ms": 19.43,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "regex",
+            "file": "crates/regex/src/error.rs"
+          }
+        },
+        {
+          "query": "file searcher",
+          "query_type": "short_phrase",
+          "expected_symbol": "Searcher",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": 4,
+          "elapsed_ms": 18.73,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "search_file",
+            "file": "crates/searcher/src/searcher/mod.rs"
+          }
+        },
+        {
+          "query": "directory walker",
+          "query_type": "short_phrase",
+          "expected_symbol": "Walk",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": null,
+          "elapsed_ms": 16.9,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "working-directory",
+            "file": ".github/workflows/ci.yml"
+          }
+        },
+        {
+          "query": "gitignore builder",
+          "query_type": "short_phrase",
+          "expected_symbol": "GitignoreBuilder",
+          "expected_file_suffix": "crates/ignore/src/gitignore.rs",
+          "rank": 1,
+          "elapsed_ms": 18.37,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "GitignoreBuilder",
+            "file": "crates/ignore/src/gitignore.rs"
+          }
+        },
+        {
+          "query": "standard printer",
+          "query_type": "short_phrase",
+          "expected_symbol": "Standard",
+          "expected_file_suffix": "crates/printer/src/standard.rs",
+          "rank": 5,
+          "elapsed_ms": 18.1,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "printer_standard",
+            "file": "crates/core/flags/hiargs.rs"
+          }
+        },
+        {
+          "query": "RegexMatcher",
+          "query_type": "identifier",
+          "expected_symbol": "RegexMatcher",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 4,
+          "elapsed_ms": 16.47,
+          "candidate_count": 7,
+          "top_candidate": {
+            "name": "RegexMatcher",
+            "file": "crates/matcher/tests/util.rs"
+          }
+        },
+        {
+          "query": "GlobSet",
+          "query_type": "identifier",
+          "expected_symbol": "GlobSet",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": 1,
+          "elapsed_ms": 17.4,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "GlobSet",
+            "file": "crates/globset/src/lib.rs"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context",
+      "mrr": 0.5291666666666667,
+      "acc1": 0.3333333333333333,
+      "acc3": 0.6666666666666666,
+      "acc5": 0.7916666666666666,
+      "avg_elapsed_ms": 109.44625,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 0.625,
+          "acc1": 0.5,
+          "acc3": 0.5,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 16.6
+        },
+        "natural_language": {
+          "count": 17,
+          "mrr": 0.5539215686274509,
+          "acc1": 0.35294117647058826,
+          "acc3": 0.7058823529411765,
+          "acc5": 0.7647058823529411,
+          "avg_elapsed_ms": 119.63882352941177
+        },
+        "short_phrase": {
+          "count": 5,
+          "mrr": 0.4066666666666666,
+          "acc1": 0.2,
+          "acc3": 0.6,
+          "acc5": 0.8,
+          "avg_elapsed_ms": 111.92999999999999
+        }
+      },
+      "rows": [
+        {
+          "query": "build regex matcher from pattern string",
+          "query_type": "natural_language",
+          "expected_symbol": "build",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 117.07,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "build",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "case insensitive regex matching",
+          "query_type": "natural_language",
+          "expected_symbol": "case_insensitive",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 115.92,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "case_insensitive",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "match multiple regex patterns at once",
+          "query_type": "natural_language",
+          "expected_symbol": "build_many",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": null,
+          "elapsed_ms": 118.36,
+          "candidate_count": 35,
+          "top_candidate": {
+            "name": "matcher",
+            "file": "crates/regex/src/lib.rs"
+          }
+        },
+        {
+          "query": "ignore whitespace inside regex pattern",
+          "query_type": "natural_language",
+          "expected_symbol": "ignore_whitespace",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 118.5,
+          "candidate_count": 34,
+          "top_candidate": {
+            "name": "ignore_whitespace",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "match a whole line only not substring",
+          "query_type": "natural_language",
+          "expected_symbol": "whole_line",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 2,
+          "elapsed_ms": 120.4,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "whole_line",
+            "file": "crates/pcre2/src/matcher.rs"
+          }
+        },
+        {
+          "query": "treat patterns as fixed strings not regex",
+          "query_type": "natural_language",
+          "expected_symbol": "fixed_strings",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 2,
+          "elapsed_ms": 128.98,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "is_fixed_strings",
+            "file": "crates/regex/src/config.rs"
+          }
+        },
+        {
+          "query": "set regex memory size limit",
+          "query_type": "natural_language",
+          "expected_symbol": "size_limit",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 119.88,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "size_limit",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "search file content for regex matches",
+          "query_type": "natural_language",
+          "expected_symbol": "search_file",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": 1,
+          "elapsed_ms": 120.51,
+          "candidate_count": 33,
+          "top_candidate": {
+            "name": "search_file",
+            "file": "crates/searcher/src/searcher/mod.rs"
+          }
+        },
+        {
+          "query": "search file by path on the filesystem",
+          "query_type": "natural_language",
+          "expected_symbol": "search_path",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": 4,
+          "elapsed_ms": 120.22,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "search_file",
+            "file": "crates/searcher/src/searcher/mod.rs"
+          }
+        },
+        {
+          "query": "search an input reader line by line",
+          "query_type": "natural_language",
+          "expected_symbol": "search_reader",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": 2,
+          "elapsed_ms": 119.73,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "search_reader",
+            "file": "crates/core/search.rs"
+          }
+        },
+        {
+          "query": "walk directory tree respecting gitignore rules",
+          "query_type": "natural_language",
+          "expected_symbol": "WalkBuilder",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": 2,
+          "elapsed_ms": 122.36,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "walkdir_is_dir",
+            "file": "crates/ignore/src/walk.rs"
+          }
+        },
+        {
+          "query": "build parallel directory traversal",
+          "query_type": "natural_language",
+          "expected_symbol": "build_parallel",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": 1,
+          "elapsed_ms": 114.93,
+          "candidate_count": 21,
+          "top_candidate": {
+            "name": "build_parallel",
+            "file": "crates/ignore/src/walk.rs"
+          }
+        },
+        {
+          "query": "parallel directory walker across threads",
+          "query_type": "natural_language",
+          "expected_symbol": "WalkParallel",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": 6,
+          "elapsed_ms": 116.4,
+          "candidate_count": 13,
+          "top_candidate": {
+            "name": "ParallelVisitor",
+            "file": "crates/ignore/src/walk.rs"
+          }
+        },
+        {
+          "query": "check if a path matches gitignore rules",
+          "query_type": "natural_language",
+          "expected_symbol": "Gitignore",
+          "expected_file_suffix": "crates/ignore/src/gitignore.rs",
+          "rank": 2,
+          "elapsed_ms": 120.4,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "gitignore",
+            "file": "crates/ignore/src/lib.rs"
+          }
+        },
+        {
+          "query": "build set of glob patterns for matching",
+          "query_type": "natural_language",
+          "expected_symbol": "GlobSetBuilder",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": null,
+          "elapsed_ms": 121.31,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "compile_matcher",
+            "file": "crates/globset/src/glob.rs"
+          }
+        },
+        {
+          "query": "match file path against multiple glob patterns",
+          "query_type": "natural_language",
+          "expected_symbol": "GlobSet",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": null,
+          "elapsed_ms": 120.22,
+          "candidate_count": 33,
+          "top_candidate": {
+            "name": "MatchStrategy",
+            "file": "crates/globset/src/glob.rs"
+          }
+        },
+        {
+          "query": "escape glob special characters in a string",
+          "query_type": "natural_language",
+          "expected_symbol": "escape",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": 2,
+          "elapsed_ms": 118.67,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "char_to_escaped_literal",
+            "file": "crates/globset/src/glob.rs"
+          }
+        },
+        {
+          "query": "regex builder",
+          "query_type": "short_phrase",
+          "expected_symbol": "RegexMatcherBuilder",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 111.75,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "RegexMatcherBuilder",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "file searcher",
+          "query_type": "short_phrase",
+          "expected_symbol": "Searcher",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": 5,
+          "elapsed_ms": 113.16,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "search_file",
+            "file": "crates/searcher/src/searcher/mod.rs"
+          }
+        },
+        {
+          "query": "directory walker",
+          "query_type": "short_phrase",
+          "expected_symbol": "Walk",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": null,
+          "elapsed_ms": 110.67,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "working-directory",
+            "file": ".github/workflows/ci.yml"
+          }
+        },
+        {
+          "query": "gitignore builder",
+          "query_type": "short_phrase",
+          "expected_symbol": "GitignoreBuilder",
+          "expected_file_suffix": "crates/ignore/src/gitignore.rs",
+          "rank": 2,
+          "elapsed_ms": 112.27,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "gitignore",
+            "file": "crates/ignore/src/lib.rs"
+          }
+        },
+        {
+          "query": "standard printer",
+          "query_type": "short_phrase",
+          "expected_symbol": "Standard",
+          "expected_file_suffix": "crates/printer/src/standard.rs",
+          "rank": 3,
+          "elapsed_ms": 111.8,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "printer_standard",
+            "file": "crates/core/flags/hiargs.rs"
+          }
+        },
+        {
+          "query": "RegexMatcher",
+          "query_type": "identifier",
+          "expected_symbol": "RegexMatcher",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 4,
+          "elapsed_ms": 16.22,
+          "candidate_count": 7,
+          "top_candidate": {
+            "name": "RegexMatcher",
+            "file": "crates/matcher/tests/util.rs"
+          }
+        },
+        {
+          "query": "GlobSet",
+          "query_type": "identifier",
+          "expected_symbol": "GlobSet",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": 1,
+          "elapsed_ms": 16.98,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "GlobSet",
+            "file": "crates/globset/src/lib.rs"
+          }
+        }
+      ]
+    }
+  ],
+  "hybrid_uplift": {
+    "mrr_delta": 0.14462736337736343,
+    "acc1_delta": 0.04166666666666663,
+    "acc3_delta": 0.29166666666666663,
+    "acc5_delta": 0.25
+  },
+  "hybrid_uplift_by_query_type": {
+    "identifier": {
+      "mrr_delta": 0.0,
+      "acc1_delta": 0.0,
+      "acc3_delta": 0.0,
+      "acc5_delta": 0.0
+    },
+    "natural_language": {
+      "mrr_delta": 0.19927784633666978,
+      "acc1_delta": 0.05882352941176472,
+      "acc3_delta": 0.35294117647058826,
+      "acc5_delta": 0.3529411764705882
+    },
+    "short_phrase": {
+      "mrr_delta": 0.016666666666666607,
+      "acc1_delta": 0.0,
+      "acc3_delta": 0.19999999999999996,
+      "acc5_delta": 0.0
+    }
+  }
+}

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -691,6 +691,108 @@ Measurement artefacts: `benchmarks/embedding-quality-v1.5-phase2g-{baseline,t30m
 - **External-repo validation** — hand-built 20–40 query dataset on a second codebase. Still the single gate before flipping any env default to ON.
 - **Phase 2d — Model swap** — the stacked-arm `(t = 40, m = 40)` ceiling (hybrid MRR 0.586 on 89, +7.1 % relative on 436) is the formal baseline to beat before taking on the binary-size cost.
 
+### 8.7 v1.5 Phase 3a experiment — external-repo validation on ripgrep
+
+**Hypothesis**: §8.4–§8.6 validated the v1.5 opt-in stack on two datasets from the **same repository** (`codelens-mcp-plugin` 89-query self + 436-query augmented). This leaves benchmark-contamination as a live risk — a self-measurement cannot rule out the possibility that the Phase 2b/2c/2e mechanisms latch onto the exact phrasing conventions used in our own comments / symbol names / docs. The only way to close that gap is to run the same four-arm A/B against a **completely different codebase**, with a **hand-built query set written by someone who did not author the retrieval stack**. This is the single still-open work item from §8.5 and the D5 prerequisite in the Phase 2d design brief.
+
+**Setup**: `github.com/BurntSushi/ripgrep` shallow-cloned to `/tmp/ripgrep-ext`. Same release binary from `7896f93` (post-v1.5.0, post Phase 2d decision matrix fill), same bundled CodeSearchNet-INT8 model, same four-arm A/B infrastructure as §8.4–§8.6. Phase 2e parameters held at the §8.6 optimum `(threshold = 40, max = 40)`.
+
+**Dataset**: 24 hand-built queries (`benchmarks/embedding-quality-dataset-ripgrep.json`) covering five ripgrep crates — `regex`, `searcher`, `ignore`, `globset`, `printer`. Split 17 natural_language / 5 short_phrase / 2 identifier ≈ 70.8 / 20.8 / 8.3 %, mirroring the 89-query self-dataset shape. Each query's `expected_symbol` + `expected_file_suffix` was cross-checked against the actual ripgrep source with a `grep -rn "^pub struct\|^pub fn"` sweep before the first measurement — no guessed symbols, no hallucinated file paths.
+
+Arms:
+
+- **A — baseline**: all three v1.5 gates off.
+- **B — phase2e only**: `CODELENS_RANK_SPARSE_TERM_WEIGHT=1` + threshold/max, Phase 2b/2c off.
+- **C — phase2b+2c only**: both embedding-text env gates, Phase 2e off.
+- **D — stacked**: all three gates.
+
+**Result** (24 queries, top-10 cutoff, `get_ranked_context` hybrid):
+
+| Metric           | A base |   B 2e | C 2b+2c |  D stacked |
+| ---------------- | -----: | -----: | ------: | ---------: |
+| hybrid MRR       | 0.4594 | 0.4878 |  0.5104 | **0.5292** |
+| hybrid Acc@1     |  0.250 |  0.292 |   0.292 |  **0.333** |
+| hybrid Acc@3     |  0.583 |  0.625 |   0.667 |  **0.667** |
+| NL hybrid MRR    | 0.4750 | 0.5221 |  0.5245 | **0.5539** |
+| NL hybrid Acc@3  |  0.588 |  0.647 |   0.706 |  **0.706** |
+| short_phrase MRR |  0.340 |  0.317 |   0.417 |      0.407 |
+| identifier Acc@1 |  0.500 |  0.500 |   0.500 |      0.500 |
+
+**Deltas vs baseline**:
+
+| Run             | hybrid MRR | hybrid Acc@1 | hybrid Acc@3 | NL hybrid MRR |   NL Acc@3 | ident Acc@1 |
+| --------------- | ---------: | -----------: | -----------: | ------------: | ---------: | ----------: |
+| phase2e only    | **+0.028** |   **+0.042** |   **+0.042** |    **+0.047** | **+0.059** |      +0.000 |
+| phase2b+2c only | **+0.051** |   **+0.042** |   **+0.083** |    **+0.049** | **+0.118** |      +0.000 |
+| **stacked**     | **+0.070** |   **+0.083** |   **+0.083** |    **+0.079** | **+0.118** |      +0.000 |
+
+**Phase 2e marginal value on top of Phase 2b+2c**:
+
+- hybrid MRR: **+0.019**
+- hybrid Acc@1: **+0.042**
+- NL hybrid MRR: **+0.029**
+- NL hybrid Acc@3: **+0.000** (already saturated at 0.706 by Phase 2b+2c alone)
+- identifier Acc@1: **+0.000** (gate held)
+
+**Cross-repo verdict — the stack wins on ripgrep, with a _larger_ relative lift than either self-dataset**:
+
+Putting the three datasets side by side (stacked vs baseline, `get_ranked_context` hybrid):
+
+| Dataset                  | baseline MRR | stacked MRR |  Δ absolute |  Δ relative |
+| ------------------------ | -----------: | ----------: | ----------: | ----------: |
+| 89-query self            |        0.572 |       0.586 |      +0.014 |  **+2.4 %** |
+| 436-query augmented self |       0.0476 |      0.0510 |     +0.0034 |  **+7.1 %** |
+| **ripgrep external**     |       0.4594 |      0.5292 | **+0.0698** | **+15.2 %** |
+
+**The external-repo relative lift is the largest of the three** — not smaller, not neutral. This rules out the "the v1.5 stack is just memorising our self-phrasing" failure mode. The mechanism that was designed to rescue NL queries whose target lands below Acc@3 is genuinely transferring to a codebase the stack has never seen, whose comments + docstrings + API-call patterns come from a different author (BurntSushi) with a different writing style.
+
+**Direction consistency holds on every dimension that mattered on the self datasets**:
+
+- Every hybrid metric moves positive; every identifier metric holds; every natural_language metric moves positive and larger than hybrid. The exact relative ordering of the four arms (baseline < phase2e solo < phase2b+2c solo < stacked) is preserved.
+- `semantic_search` MRR dips by −0.008 on the 2b+2c arms, matching the known Phase 2b `semantic_search`-only regression documented in §8.2. Phase 2e alone keeps `semantic_search` at baseline (expected — the post-process only runs in `get_ranked_context`).
+- short_phrase is the only metric where Phase 2e solo slightly regresses (MRR 0.340 → 0.317). The short_phrase arm has **five** queries on this dataset and the sparse pass can only affect ordering when enough candidates clear the coverage threshold — with two-token short phrases against single-token matches in ripgrep's name space, some of them do not. Small-N noise rather than a real signal, and the stacked arm still improves short_phrase MRR (+0.067 absolute) because Phase 2b/2c do the heavy lifting there.
+
+**Default-ON gate status**: this is the first measurement that directly answers the §8.5 still-open question "are the defaults ready to flip?". The result is **yes on the evidence, no on the policy**:
+
+- _On the evidence_: three datasets in three different configurations (89 self / 436 augmented self / ripgrep external), all direction-consistent, all positive, all with identifier Acc@1 held — this is the strongest evidence pattern any v1.5 experiment has produced.
+- _On the policy_: one external repo is still one sample. A second external repo (TypeScript or Python, different language family) would close the remaining contamination angle. The defaults stay OFF until v1.6.x gets that second sample, but the **recommendation in §8.5 to enable all three env vars for NL-heavy traffic is now cross-repo validated** — users who were waiting for an external signal before flipping have it.
+
+**Impact on Phase 2d (design brief §1.1 "baseline to beat")**:
+
+The formal baseline any Phase 2d candidate must exceed is no longer just "v1.5 stacked 0.586 on 89-query". The cross-repo validation updates it to a three-point baseline:
+
+| Dataset              | v1.5 stacked hybrid MRR |
+| -------------------- | ----------------------: |
+| 89-query self        |                   0.586 |
+| 436-query augmented  |                  0.0510 |
+| **ripgrep external** |              **0.5292** |
+
+A model swap that beats the 89-query number but loses on the ripgrep number is **not a valid winner**. The Checkpoint 1 go/no-go gate in `docs/design/v1.6-phase2d-model-swap-brief.md` §7 is updated accordingly — Phase 2d must clear all three baselines simultaneously.
+
+**Reproduce**:
+
+```bash
+# 1. Shallow-clone ripgrep (once)
+git clone --depth 1 https://github.com/BurntSushi/ripgrep.git /tmp/ripgrep-ext
+
+# 2. Arm D — full v1.5 stack on ripgrep
+CODELENS_EMBED_HINT_INCLUDE_COMMENTS=1 \
+CODELENS_EMBED_HINT_INCLUDE_API_CALLS=1 \
+CODELENS_RANK_SPARSE_TERM_WEIGHT=1 \
+CODELENS_RANK_SPARSE_THRESHOLD=40 \
+CODELENS_RANK_SPARSE_MAX=40 \
+CODELENS_MODEL_DIR=$(pwd)/crates/codelens-engine/models \
+python3 benchmarks/embedding-quality.py /tmp/ripgrep-ext --isolated-copy \
+  --dataset benchmarks/embedding-quality-dataset-ripgrep.json
+```
+
+Measurement artefacts: `benchmarks/embedding-quality-v1.5-phase3a-ripgrep-{baseline,2e-only,2b2c-only,stacked}.json` + the 24-query dataset at `benchmarks/embedding-quality-dataset-ripgrep.json`.
+
+**Still-open work**:
+
+- **Second external repo** (TypeScript or Python, different language family) — would close the last contamination angle and unblock the default-ON flip. Candidate: `facebook/jest` (JS/TS) or `psf/requests` (Python) with a similarly hand-built 20–30 query dataset.
+- **Phase 2d — Model swap** — now gated on the three-point v1.5 baseline (0.586 / 0.0510 / 0.5292), not just the 89-query number. All other §8 still-open items inherit the stronger baseline.
+
 ---
 
 ## 9. See Also


### PR DESCRIPTION
## Summary

**Measurement-only change, no code change.** First true external-repo four-arm A/B for the v1.5 opt-in stack against a codebase the authors did not write: `github.com/BurntSushi/ripgrep`. This is the single still-open work item from §8.5 and the D5 prerequisite in the Phase 2d design brief.

**24 hand-built queries** across five ripgrep crates (`regex`, `searcher`, `ignore`, `globset`, `printer`), 17/5/2 natural_language / short_phrase / identifier split mirroring the 89-query self-dataset shape. Every `expected_symbol` was cross-checked against the actual ripgrep source with a `grep -rn` sweep before the first arm ran — no guessed symbols, no hallucinated file paths.

## Result — stack wins on ripgrep with *larger* relative lift than self datasets

| Dataset | baseline MRR | stacked MRR | Δ absolute | Δ relative |
|---|---:|---:|---:|---:|
| 89-query self | 0.572 | 0.586 | +0.014 | **+2.4 %** |
| 436-query augmented self | 0.0476 | 0.0510 | +0.0034 | **+7.1 %** |
| **ripgrep external** | 0.4594 | **0.5292** | **+0.0698** | **+15.2 %** |

**Four-arm breakdown** (24 queries, `get_ranked_context` hybrid):

| Metric | baseline | phase2e only | phase2b+2c only | **stacked** |
|---|---:|---:|---:|---:|
| hybrid MRR | 0.4594 | 0.4878 | 0.5104 | **0.5292** |
| hybrid Acc@1 | 0.250 | 0.292 | 0.292 | **0.333** |
| hybrid Acc@3 | 0.583 | 0.625 | 0.667 | **0.667** |
| NL hybrid MRR | 0.4750 | 0.5221 | 0.5245 | **0.5539** |
| NL hybrid Acc@3 | 0.588 | 0.647 | 0.706 | **0.706** |
| identifier Acc@1 | 0.500 | 0.500 | 0.500 | 0.500 |

**Phase 2e marginal on ripgrep** (stacked − 2b+2c only): hybrid MRR **+0.019**, hybrid Acc@1 **+0.042**, NL MRR **+0.029**, identifier Acc@1 **±0.000**.

## Verdict — cross-repo validation SUCCESS

This is the first measurement that directly answers the §8.5 still-open question *"is the v1.5 stack just memorising our self-phrasing?"*. The answer is **no** — a codebase with different authorship, comment style, and API naming still gets a meaningful uplift from the same three env vars, and the magnitude is **stronger** than on the author's own datasets.

- Every hybrid metric moves positive. Every arm relative ordering (baseline < phase2e solo < phase2b+2c solo < stacked) is preserved. Identifier Acc@1 held across all four arms.
- `semantic_search` MRR dips by −0.008 on the 2b+2c arms, matching the known Phase 2b `semantic_search`-only regression documented in §8.2. Expected.
- short_phrase MRR regresses slightly on Phase 2e solo (5-sample noise) but the stacked arm still improves short_phrase MRR by +0.067 absolute.

## Impact on Phase 2d baseline

`docs/design/v1.6-phase2d-model-swap-brief.md` §1.1 "baseline to beat" now formally covers **three** datasets, not one. Any Phase 2d candidate must exceed **all three** v1.5 stacked MRRs simultaneously:

| Dataset | v1.5 stacked hybrid MRR |
|---|---:|
| 89-query self | 0.586 |
| 436-query augmented | 0.0510 |
| **ripgrep external** | **0.5292** |

A model swap that wins one and loses another is not a valid winner. The Checkpoint 1 go/no-go gate inherits the stronger three-point baseline.

## Default-ON status

The evidence pattern is strong enough that **§8.5 users waiting for an external-repo signal before opting in have one**. Recommended opt-in configuration for NL-heavy traffic on any project:

```
CODELENS_EMBED_HINT_INCLUDE_COMMENTS=1
CODELENS_EMBED_HINT_INCLUDE_API_CALLS=1
CODELENS_RANK_SPARSE_TERM_WEIGHT=1
CODELENS_RANK_SPARSE_THRESHOLD=40
CODELENS_RANK_SPARSE_MAX=40
```

Global defaults themselves stay OFF for one more release cycle until a second external repo in a **different language family** (JS/TS or Python) replays the result — one sample is still one sample, and the §8.1 \"measure before flipping\" discipline applies to defaults as well as implementations.

## Files changed

- `docs/benchmarks.md` §8.7 — new experiment section (four-arm table, three-dataset relative-lift comparison, verdict, Phase 2d baseline update, reproduce commands).
- `CHANGELOG.md` `[Unreleased]` — new \"Measured (Phase 3a — external-repo validation)\" block.
- `benchmarks/embedding-quality-dataset-ripgrep.json` — 24-query hand-built dataset (new file).
- `benchmarks/embedding-quality-v1.5-phase3a-ripgrep-{baseline,2e-only,2b2c-only,stacked}.json` — four-arm measurement artefacts.
- **No code change.**

## Still-open work

- **Second external repo** (JS/TS or Python, different language family) — would close the last contamination angle. Candidates: `facebook/jest` or `psf/requests`.
- **Phase 2d — Model swap** — now gated on the three-point v1.5 baseline (0.586 / 0.0510 / 0.5292), not just the 89-query number.

## Test plan

- [x] No code change — nothing for `cargo check` / `cargo test` / `clippy`.
- [x] All four arms used `--isolated-copy` against `/tmp/ripgrep-ext` for clean index per arm.
- [x] Every `expected_symbol` verified against actual ripgrep source with `grep -rn`.
- [x] Identifier Acc@1 = 0.500 held across all four arms (short-circuit robust on external codebase).
- [x] Direction consistency with §8.4 and §8.5 verified on every hybrid metric.

🤖 Generated with [Claude Code](https://claude.com/claude-code)