### PR TITLE
v1.6.0 default flip: CODELENS_EMBED_HINT_AUTO=1 becomes the default (§8.14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed (v1.6.0 default flip — `CODELENS_EMBED_HINT_AUTO=1` becomes the default, §8.14)
+
+- **Default behaviour flipped** (`crates/codelens-engine/src/embedding/mod.rs:auto_hint_mode_enabled`): `parse_bool_env("CODELENS_EMBED_HINT_AUTO").unwrap_or(false)` → `unwrap_or(true)`. After the five-dataset measurement arc (§8.2–§8.13) justified it, the v1.5.x opt-in default-off semantics flip to v1.6.0 default-on. A supported-language project (Rust / C / C++ / Go / Java / Kotlin / Scala / C# / TypeScript / JavaScript) now silently starts producing the §8.7 / §8.13 stacked results without any env-var configuration. A Python / Ruby / PHP / Lua / shell / unknown-language project silently stays on baseline via the §8.11 language gate + conservative default-off branch of `language_supports_nl_stack`.
+- **MCP-layer helper kept in lock-step** (`crates/codelens-mcp/src/tools/session/project_ops.rs:auto_set_embed_hint_lang`): the helper had its own inline env-var parser that also needed flipping — otherwise the MCP layer short-circuits before computing dominant language, leaving `CODELENS_EMBED_HINT_AUTO_LANG` unset and the engine falling through to the "no language tag" conservative-off branch. Mirrored the engine's default-true behaviour with an explicit match on `1/true/yes/on` vs `0/false/no/off`, with unknown values falling through to default-on.
+- **Unit test semantics reversed** (`auto_hint_mode_gated_off_by_default` → `auto_hint_mode_defaults_on_unless_explicit_off`): three-case assertion — env-unset → true (the flip), explicit `=0` → false (opt-out preserved), explicit `=1` → true (explicit still wins). Also updated `auto_hint_should_enable_requires_both_gate_and_supported_lang` Case 1 to use `set_var("0")` instead of `remove_var` — the old test was ambiguous under the flipped semantics.
+- **Env-var race hardening** (`ENV_LOCK: Mutex<()>`): the flip surfaced a latent race in the test suite. Previously, `unwrap_or(false)` meant that if two parallel env-mutating tests interfered, both tests would often still observe "off" for the unset case, masking the race. Under `unwrap_or(true)`, an interfering test setting `AUTO=1` now visibly collides with a test expecting the default path. Added a module-static `ENV_LOCK` (mirroring the existing `MODEL_LOCK` for fastembed ONNX tests) and wrapped the eleven `CODELENS_EMBED_HINT_*`-mutating test functions with `let _env_guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());` as their first line. Engine test count unchanged at 257.
+- **Measurement verification** (v1.6.0 flip, 2026-04-11, same infrastructure as §8.12):
+
+  | Dataset           |              Expected (from §8.12) | v1.6.0 flip actual |     Δ |
+  | ----------------- | ---------------------------------: | -----------------: | ----: |
+  | ripgrep (Rust)    |  0.5291666666666667 (§8.7 stacked) | 0.5291666666666667 | 0.000 |
+  | requests (Python) | 0.5837009803921568 (§8.8 baseline) | 0.5837009803921568 | 0.000 |
+
+  **Bit-identical to the tenth decimal**. The flip produces exactly the same results as explicit `CODELENS_EMBED_HINT_AUTO=1` + `CODELENS_EMBED_HINT_AUTO_LANG=rust` (§8.12 ripgrep-mcpauto) and explicit `AUTO=1` + `AUTO_LANG=python` (§8.12 requests-mcpauto), but with **zero env vars** beyond the Phase 2e tuning knobs `SPARSE_THRESHOLD=40` / `SPARSE_MAX=40`. The three-step flip (engine gate + MCP helper + test semantics) is verified end-to-end with no user action beyond upgrading the binary.
+
+- **Migration note for v1.5.x users**:
+  - **Most users**: no action. Supported-language projects silently gain the stacked behaviour, Python/other projects silently stay on baseline.
+  - **Opt-out escape hatch**: `CODELENS_EMBED_HINT_AUTO=0` restores v1.5.x default-off semantics. Also accepts `false` / `no` / `off` (case-insensitive).
+  - **Per-gate explicit overrides still win** (`CODELENS_EMBED_HINT_INCLUDE_COMMENTS=1` / `_API_CALLS=1` / `CODELENS_RANK_SPARSE_TERM_WEIGHT=1`) — explicit-first-then-auto rule from §8.11 preserved.
+  - **Python users who want to force stack ON**: set the three explicit per-gate env vars plus the sparse tuning knobs to bypass the language gate. Not recommended based on §8.8 measurement.
+- **v1.6.0 flip ships as a `[Changed]` entry, not `[Added]`** — this is a default behaviour change, not a new feature. Users upgrading must read the migration note. Full §8.14 write-up with the bit-identical comparison table, implementation walkthrough, and limitations in [`docs/benchmarks.md` §8.14](docs/benchmarks.md). Artefacts at `benchmarks/embedding-quality-v1.6-flip-{ripgrep,requests}-default-on.json`.
+
 ### Added (v1.5 Phase 2j follow-up — MCP-layer auto-set of `CODELENS_EMBED_HINT_AUTO_LANG`)
 
 - **New engine helper `codelens_engine::compute_dominant_language(&Path) → Option<String>`** (`crates/codelens-engine/src/project.rs`). WalkDir-based dominant-language detection: counts files by extension (filtered to known `lang_registry` extensions), respects `EXCLUDED_DIRS` (`node_modules`, `.git`, `target`, `.venv`, `dist`, `build`, `__pycache__`, `.next`, …), capped at 16 k files so large monorepos pay bounded cost. Returns the most common extension tag (`rs`, `py`, `ts`, …) or `None` below a 3-file minimum. Re-exported from `codelens_engine::lib`.
@@ -44,8 +66,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **v1.6.0 default flip readiness — now covers ~95 % of the user base**. With JS/TS joining the supported set, the `CODELENS_EMBED_HINT_AUTO=1` default is measurement-validated positive for Rust / C / C++ / Go / Java / Kotlin / Scala / C# / TypeScript / JavaScript projects, and the §8.8 regression-avoidance branch catches the remaining Python / Ruby / PHP / untested-dynamic projects. The engine-side gate (§8.11), and the JS/TS language classification (§8.13) are in place; combined with the Phase 2j MCP auto-set follow-up (PR #26, separate feature branch), the v1.6.0 default flip is a one-line change to `auto_hint_mode_enabled()`.
 - **Artefacts**: `benchmarks/embedding-quality-v1.5-phase3c-jest-{baseline,2e-only,2b2c-only,stacked}.json`. Full experiment narrative with the per-query rank tables, pre-indexing cleanup notes, and limitations discussion in [`docs/benchmarks.md` §8.13](docs/benchmarks.md).
-
-> > > > > > > f5a5765 (feat(engine): Phase 3c — JS/TS validation on facebook/jest, add ts/js to language_supports_nl_stack)
 
 ### Added (v1.5 Phase 2j — language-gated auto-detection, opt-in)
 

--- a/benchmarks/embedding-quality-v1.6-flip-requests-default-on.json
+++ b/benchmarks/embedding-quality-v1.6-flip-requests-default-on.json
@@ -1,0 +1,1097 @@
+{
+  "project": "/tmp/requests-ext",
+  "benchmark_project": "/var/folders/z0/0tcbss795xsdp75jmr_t9_kh0000gn/T/codelens-embed-quality-odc6kasv/requests-ext",
+  "isolated_copy": true,
+  "binary": "/Users/bagjaeseog/codelens-mcp-plugin/target/release/codelens-mcp",
+  "embedding_model": "MiniLM-L12-CodeSearchNet-INT8",
+  "runtime_model": {
+    "model_dir": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch",
+    "model_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/model.onnx",
+    "config_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/config.json",
+    "sha256": "ef1d1e9cfa72e4929f5b9faea17d8704b23a2530aadebf0d464a4cc7750920b3",
+    "size_bytes": 34000281,
+    "num_hidden_layers": 12,
+    "hidden_size": 384
+  },
+  "dataset_path": "/Users/bagjaeseog/codelens-mcp-plugin/benchmarks/embedding-quality-dataset-requests.json",
+  "dataset_size": 24,
+  "ranking_cutoff": 10,
+  "metric_labels": {
+    "mrr": "MRR@10",
+    "acc1": "Acc@1",
+    "acc3": "Acc@3",
+    "acc5": "Acc@5"
+  },
+  "methods": [
+    {
+      "method": "semantic_search",
+      "mrr": 0.5409722222222222,
+      "acc1": 0.4583333333333333,
+      "acc3": 0.5833333333333334,
+      "acc5": 0.6666666666666666,
+      "avg_elapsed_ms": 184.48375,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 1.0,
+          "acc1": 1.0,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 581.9
+        },
+        "natural_language": {
+          "count": 17,
+          "mrr": 0.6073529411764705,
+          "acc1": 0.5294117647058824,
+          "acc3": 0.6470588235294118,
+          "acc5": 0.7058823529411765,
+          "avg_elapsed_ms": 157.33529411764704
+        },
+        "short_phrase": {
+          "count": 5,
+          "mrr": 0.13166666666666665,
+          "acc1": 0.0,
+          "acc3": 0.2,
+          "acc5": 0.4,
+          "avg_elapsed_ms": 117.822
+        }
+      },
+      "rows": [
+        {
+          "query": "send HTTP GET request to a URL",
+          "query_type": "natural_language",
+          "expected_symbol": "get",
+          "expected_file_suffix": "src/requests/api.py",
+          "rank": 1,
+          "elapsed_ms": 170.22,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "get",
+            "file": "src/requests/api.py"
+          }
+        },
+        {
+          "query": "send HTTP POST request with JSON body",
+          "query_type": "natural_language",
+          "expected_symbol": "post",
+          "expected_file_suffix": "src/requests/api.py",
+          "rank": 1,
+          "elapsed_ms": 144.47,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "post",
+            "file": "src/requests/api.py"
+          }
+        },
+        {
+          "query": "send HTTP request with custom method",
+          "query_type": "natural_language",
+          "expected_symbol": "request",
+          "expected_file_suffix": "src/requests/api.py",
+          "rank": 1,
+          "elapsed_ms": 172.29,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "request",
+            "file": "src/requests/api.py"
+          }
+        },
+        {
+          "query": "delete resource over HTTP",
+          "query_type": "natural_language",
+          "expected_symbol": "delete",
+          "expected_file_suffix": "src/requests/api.py",
+          "rank": 1,
+          "elapsed_ms": 154.18,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "delete",
+            "file": "src/requests/api.py"
+          }
+        },
+        {
+          "query": "send HTTP PATCH request to update resource",
+          "query_type": "natural_language",
+          "expected_symbol": "patch",
+          "expected_file_suffix": "src/requests/api.py",
+          "rank": 1,
+          "elapsed_ms": 173.72,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "patch",
+            "file": "src/requests/api.py"
+          }
+        },
+        {
+          "query": "HTTP session object that reuses connections",
+          "query_type": "natural_language",
+          "expected_symbol": "Session",
+          "expected_file_suffix": "src/requests/sessions.py",
+          "rank": 2,
+          "elapsed_ms": 170.06,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "session",
+            "file": "src/requests/sessions.py"
+          }
+        },
+        {
+          "query": "prepare HTTP request before sending it",
+          "query_type": "natural_language",
+          "expected_symbol": "PreparedRequest",
+          "expected_file_suffix": "src/requests/models.py",
+          "rank": null,
+          "elapsed_ms": 164.46,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "prepare_method",
+            "file": "src/requests/models.py"
+          }
+        },
+        {
+          "query": "HTTP response from the server",
+          "query_type": "natural_language",
+          "expected_symbol": "Response",
+          "expected_file_suffix": "src/requests/models.py",
+          "rank": 5,
+          "elapsed_ms": 163.46,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "response",
+            "file": "src/requests/adapters.py"
+          }
+        },
+        {
+          "query": "HTTP adapter that manages connection pool",
+          "query_type": "natural_language",
+          "expected_symbol": "HTTPAdapter",
+          "expected_file_suffix": "src/requests/adapters.py",
+          "rank": null,
+          "elapsed_ms": 169.53,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "init_poolmanager",
+            "file": "src/requests/adapters.py"
+          }
+        },
+        {
+          "query": "basic authentication for HTTP requests",
+          "query_type": "natural_language",
+          "expected_symbol": "HTTPBasicAuth",
+          "expected_file_suffix": "src/requests/auth.py",
+          "rank": 8,
+          "elapsed_ms": 163.83,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "test_set_basicauth",
+            "file": "tests/test_requests.py"
+          }
+        },
+        {
+          "query": "digest authentication scheme",
+          "query_type": "natural_language",
+          "expected_symbol": "HTTPDigestAuth",
+          "expected_file_suffix": "src/requests/auth.py",
+          "rank": null,
+          "elapsed_ms": 111.67,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "parsed",
+            "file": "src/requests/utils.py"
+          }
+        },
+        {
+          "query": "proxy authentication for requests",
+          "query_type": "natural_language",
+          "expected_symbol": "HTTPProxyAuth",
+          "expected_file_suffix": "src/requests/auth.py",
+          "rank": 2,
+          "elapsed_ms": 144.21,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "test_proxy_auth",
+            "file": "tests/test_requests.py"
+          }
+        },
+        {
+          "query": "cookie jar that stores cookies across requests",
+          "query_type": "natural_language",
+          "expected_symbol": "RequestsCookieJar",
+          "expected_file_suffix": "src/requests/cookies.py",
+          "rank": null,
+          "elapsed_ms": 135.02,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "extract_cookies_to_jar",
+            "file": "src/requests/cookies.py"
+          }
+        },
+        {
+          "query": "create a cookie from name and value",
+          "query_type": "natural_language",
+          "expected_symbol": "create_cookie",
+          "expected_file_suffix": "src/requests/cookies.py",
+          "rank": 1,
+          "elapsed_ms": 158.66,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "create_cookie",
+            "file": "src/requests/cookies.py"
+          }
+        },
+        {
+          "query": "extract cookies from HTTP response",
+          "query_type": "natural_language",
+          "expected_symbol": "extract_cookies_to_jar",
+          "expected_file_suffix": "src/requests/cookies.py",
+          "rank": 1,
+          "elapsed_ms": 174.46,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "extract_cookies_to_jar",
+            "file": "src/requests/cookies.py"
+          }
+        },
+        {
+          "query": "merge two cookie jars together",
+          "query_type": "natural_language",
+          "expected_symbol": "merge_cookies",
+          "expected_file_suffix": "src/requests/cookies.py",
+          "rank": 1,
+          "elapsed_ms": 149.82,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "merge_cookies",
+            "file": "src/requests/cookies.py"
+          }
+        },
+        {
+          "query": "build cookie jar from a dictionary",
+          "query_type": "natural_language",
+          "expected_symbol": "cookiejar_from_dict",
+          "expected_file_suffix": "src/requests/cookies.py",
+          "rank": 1,
+          "elapsed_ms": 154.64,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "cookiejar_from_dict",
+            "file": "src/requests/cookies.py"
+          }
+        },
+        {
+          "query": "http session",
+          "query_type": "short_phrase",
+          "expected_symbol": "Session",
+          "expected_file_suffix": "src/requests/sessions.py",
+          "rank": 5,
+          "elapsed_ms": 118.66,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "session",
+            "file": "src/requests/sessions.py"
+          }
+        },
+        {
+          "query": "prepared request",
+          "query_type": "short_phrase",
+          "expected_symbol": "PreparedRequest",
+          "expected_file_suffix": "src/requests/models.py",
+          "rank": 3,
+          "elapsed_ms": 121.51,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "prepare",
+            "file": "src/requests/models.py"
+          }
+        },
+        {
+          "query": "http adapter",
+          "query_type": "short_phrase",
+          "expected_symbol": "HTTPAdapter",
+          "expected_file_suffix": "src/requests/adapters.py",
+          "rank": null,
+          "elapsed_ms": 116.65,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "adapter",
+            "file": "tests/test_requests.py"
+          }
+        },
+        {
+          "query": "cookie jar",
+          "query_type": "short_phrase",
+          "expected_symbol": "RequestsCookieJar",
+          "expected_file_suffix": "src/requests/cookies.py",
+          "rank": null,
+          "elapsed_ms": 115.46,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "jar",
+            "file": "tests/test_requests.py"
+          }
+        },
+        {
+          "query": "basic auth",
+          "query_type": "short_phrase",
+          "expected_symbol": "HTTPBasicAuth",
+          "expected_file_suffix": "src/requests/auth.py",
+          "rank": 8,
+          "elapsed_ms": 116.83,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "authstr",
+            "file": "src/requests/auth.py"
+          }
+        },
+        {
+          "query": "Session",
+          "query_type": "identifier",
+          "expected_symbol": "Session",
+          "expected_file_suffix": "src/requests/sessions.py",
+          "rank": 1,
+          "elapsed_ms": 176.51,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "Session",
+            "file": "src/requests/sessions.py"
+          }
+        },
+        {
+          "query": "HTTPAdapter",
+          "query_type": "identifier",
+          "expected_symbol": "HTTPAdapter",
+          "expected_file_suffix": "src/requests/adapters.py",
+          "rank": 1,
+          "elapsed_ms": 987.29,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "HTTPAdapter",
+            "file": "src/requests/adapters.py"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context_no_semantic",
+      "mrr": 0.3945034497666076,
+      "acc1": 0.25,
+      "acc3": 0.5,
+      "acc5": 0.5,
+      "avg_elapsed_ms": 102.57458333333334,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 1.0,
+          "acc1": 1.0,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 15.07
+        },
+        "natural_language": {
+          "count": 17,
+          "mrr": 0.2922401643763873,
+          "acc1": 0.17647058823529413,
+          "acc3": 0.35294117647058826,
+          "acc5": 0.35294117647058826,
+          "avg_elapsed_ms": 138.1729411764706
+        },
+        "short_phrase": {
+          "count": 5,
+          "mrr": 0.5,
+          "acc1": 0.2,
+          "acc3": 0.8,
+          "acc5": 0.8,
+          "avg_elapsed_ms": 16.542
+        }
+      },
+      "rows": [
+        {
+          "query": "send HTTP GET request to a URL",
+          "query_type": "natural_language",
+          "expected_symbol": "get",
+          "expected_file_suffix": "src/requests/api.py",
+          "rank": 30,
+          "elapsed_ms": 800.97,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "request_url",
+            "file": "src/requests/adapters.py"
+          }
+        },
+        {
+          "query": "send HTTP POST request with JSON body",
+          "query_type": "natural_language",
+          "expected_symbol": "post",
+          "expected_file_suffix": "src/requests/api.py",
+          "rank": 19,
+          "elapsed_ms": 825.09,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "_r",
+            "file": "src/requests/auth.py"
+          }
+        },
+        {
+          "query": "send HTTP request with custom method",
+          "query_type": "natural_language",
+          "expected_symbol": "request",
+          "expected_file_suffix": "src/requests/api.py",
+          "rank": 13,
+          "elapsed_ms": 24.22,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "_r",
+            "file": "src/requests/auth.py"
+          }
+        },
+        {
+          "query": "delete resource over HTTP",
+          "query_type": "natural_language",
+          "expected_symbol": "delete",
+          "expected_file_suffix": "src/requests/api.py",
+          "rank": 7,
+          "elapsed_ms": 244.94,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "httpbin",
+            "file": "tests/conftest.py"
+          }
+        },
+        {
+          "query": "send HTTP PATCH request to update resource",
+          "query_type": "natural_language",
+          "expected_symbol": "patch",
+          "expected_file_suffix": "src/requests/api.py",
+          "rank": 11,
+          "elapsed_ms": 196.09,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "_r",
+            "file": "src/requests/auth.py"
+          }
+        },
+        {
+          "query": "HTTP session object that reuses connections",
+          "query_type": "natural_language",
+          "expected_symbol": "Session",
+          "expected_file_suffix": "src/requests/sessions.py",
+          "rank": null,
+          "elapsed_ms": 28.31,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "session",
+            "file": "src/requests/sessions.py"
+          }
+        },
+        {
+          "query": "prepare HTTP request before sending it",
+          "query_type": "natural_language",
+          "expected_symbol": "PreparedRequest",
+          "expected_file_suffix": "src/requests/models.py",
+          "rank": null,
+          "elapsed_ms": 23.68,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "_r",
+            "file": "src/requests/auth.py"
+          }
+        },
+        {
+          "query": "HTTP response from the server",
+          "query_type": "natural_language",
+          "expected_symbol": "Response",
+          "expected_file_suffix": "src/requests/models.py",
+          "rank": null,
+          "elapsed_ms": 20.55,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "get_unicode_from_response",
+            "file": "src/requests/utils.py"
+          }
+        },
+        {
+          "query": "HTTP adapter that manages connection pool",
+          "query_type": "natural_language",
+          "expected_symbol": "HTTPAdapter",
+          "expected_file_suffix": "src/requests/adapters.py",
+          "rank": null,
+          "elapsed_ms": 25.91,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "build_connection_pool_key_attributes",
+            "file": "src/requests/adapters.py"
+          }
+        },
+        {
+          "query": "basic authentication for HTTP requests",
+          "query_type": "natural_language",
+          "expected_symbol": "HTTPBasicAuth",
+          "expected_file_suffix": "src/requests/auth.py",
+          "rank": null,
+          "elapsed_ms": 23.22,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "_r",
+            "file": "src/requests/auth.py"
+          }
+        },
+        {
+          "query": "digest authentication scheme",
+          "query_type": "natural_language",
+          "expected_symbol": "HTTPDigestAuth",
+          "expected_file_suffix": "src/requests/auth.py",
+          "rank": 1,
+          "elapsed_ms": 15.2,
+          "candidate_count": 20,
+          "top_candidate": {
+            "name": "HTTPDigestAuth",
+            "file": "src/requests/auth.py"
+          }
+        },
+        {
+          "query": "proxy authentication for requests",
+          "query_type": "natural_language",
+          "expected_symbol": "HTTPProxyAuth",
+          "expected_file_suffix": "src/requests/auth.py",
+          "rank": 14,
+          "elapsed_ms": 19.84,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "_r",
+            "file": "src/requests/auth.py"
+          }
+        },
+        {
+          "query": "cookie jar that stores cookies across requests",
+          "query_type": "natural_language",
+          "expected_symbol": "RequestsCookieJar",
+          "expected_file_suffix": "src/requests/cookies.py",
+          "rank": 2,
+          "elapsed_ms": 17.66,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "_r",
+            "file": "src/requests/auth.py"
+          }
+        },
+        {
+          "query": "create a cookie from name and value",
+          "query_type": "natural_language",
+          "expected_symbol": "create_cookie",
+          "expected_file_suffix": "src/requests/cookies.py",
+          "rank": 1,
+          "elapsed_ms": 20.02,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "create_cookie",
+            "file": "src/requests/cookies.py"
+          }
+        },
+        {
+          "query": "extract cookies from HTTP response",
+          "query_type": "natural_language",
+          "expected_symbol": "extract_cookies_to_jar",
+          "expected_file_suffix": "src/requests/cookies.py",
+          "rank": 2,
+          "elapsed_ms": 23.23,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "_r",
+            "file": "src/requests/auth.py"
+          }
+        },
+        {
+          "query": "merge two cookie jars together",
+          "query_type": "natural_language",
+          "expected_symbol": "merge_cookies",
+          "expected_file_suffix": "src/requests/cookies.py",
+          "rank": 1,
+          "elapsed_ms": 19.09,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "merge_cookies",
+            "file": "src/requests/cookies.py"
+          }
+        },
+        {
+          "query": "build cookie jar from a dictionary",
+          "query_type": "natural_language",
+          "expected_symbol": "cookiejar_from_dict",
+          "expected_file_suffix": "src/requests/cookies.py",
+          "rank": 2,
+          "elapsed_ms": 20.92,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "dict_from_cookiejar",
+            "file": "src/requests/utils.py"
+          }
+        },
+        {
+          "query": "http session",
+          "query_type": "short_phrase",
+          "expected_symbol": "Session",
+          "expected_file_suffix": "src/requests/sessions.py",
+          "rank": 3,
+          "elapsed_ms": 16.09,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "HTTPError",
+            "file": "src/requests/exceptions.py"
+          }
+        },
+        {
+          "query": "prepared request",
+          "query_type": "short_phrase",
+          "expected_symbol": "PreparedRequest",
+          "expected_file_suffix": "src/requests/models.py",
+          "rank": 6,
+          "elapsed_ms": 16.55,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "prepared_request",
+            "file": "src/requests/sessions.py"
+          }
+        },
+        {
+          "query": "http adapter",
+          "query_type": "short_phrase",
+          "expected_symbol": "HTTPAdapter",
+          "expected_file_suffix": "src/requests/adapters.py",
+          "rank": 1,
+          "elapsed_ms": 16.89,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "HTTPAdapter",
+            "file": "src/requests/adapters.py"
+          }
+        },
+        {
+          "query": "cookie jar",
+          "query_type": "short_phrase",
+          "expected_symbol": "RequestsCookieJar",
+          "expected_file_suffix": "src/requests/cookies.py",
+          "rank": 2,
+          "elapsed_ms": 15.79,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "_copy_cookie_jar",
+            "file": "src/requests/cookies.py"
+          }
+        },
+        {
+          "query": "basic auth",
+          "query_type": "short_phrase",
+          "expected_symbol": "HTTPBasicAuth",
+          "expected_file_suffix": "src/requests/auth.py",
+          "rank": 2,
+          "elapsed_ms": 17.39,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "_basic_auth_str",
+            "file": "src/requests/auth.py"
+          }
+        },
+        {
+          "query": "Session",
+          "query_type": "identifier",
+          "expected_symbol": "Session",
+          "expected_file_suffix": "src/requests/sessions.py",
+          "rank": 1,
+          "elapsed_ms": 16.83,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "Session",
+            "file": "src/requests/sessions.py"
+          }
+        },
+        {
+          "query": "HTTPAdapter",
+          "query_type": "identifier",
+          "expected_symbol": "HTTPAdapter",
+          "expected_file_suffix": "src/requests/adapters.py",
+          "rank": 1,
+          "elapsed_ms": 13.31,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "HTTPAdapter",
+            "file": "src/requests/adapters.py"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context",
+      "mrr": 0.5837009803921568,
+      "acc1": 0.4166666666666667,
+      "acc3": 0.7083333333333334,
+      "acc5": 0.75,
+      "avg_elapsed_ms": 113.21041666666667,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 1.0,
+          "acc1": 1.0,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 13.845
+        },
+        "natural_language": {
+          "count": 17,
+          "mrr": 0.6147058823529411,
+          "acc1": 0.47058823529411764,
+          "acc3": 0.7058823529411765,
+          "acc5": 0.7647058823529411,
+          "avg_elapsed_ms": 124.42352941176469
+        },
+        "short_phrase": {
+          "count": 5,
+          "mrr": 0.31176470588235294,
+          "acc1": 0.0,
+          "acc3": 0.6,
+          "acc5": 0.6,
+          "avg_elapsed_ms": 114.832
+        }
+      },
+      "rows": [
+        {
+          "query": "send HTTP GET request to a URL",
+          "query_type": "natural_language",
+          "expected_symbol": "get",
+          "expected_file_suffix": "src/requests/api.py",
+          "rank": 1,
+          "elapsed_ms": 127.55,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "get",
+            "file": "src/requests/api.py"
+          }
+        },
+        {
+          "query": "send HTTP POST request with JSON body",
+          "query_type": "natural_language",
+          "expected_symbol": "post",
+          "expected_file_suffix": "src/requests/api.py",
+          "rank": 2,
+          "elapsed_ms": 120.62,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "body",
+            "file": "src/requests/models.py"
+          }
+        },
+        {
+          "query": "send HTTP request with custom method",
+          "query_type": "natural_language",
+          "expected_symbol": "request",
+          "expected_file_suffix": "src/requests/api.py",
+          "rank": 1,
+          "elapsed_ms": 125.4,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "request",
+            "file": "src/requests/api.py"
+          }
+        },
+        {
+          "query": "delete resource over HTTP",
+          "query_type": "natural_language",
+          "expected_symbol": "delete",
+          "expected_file_suffix": "src/requests/api.py",
+          "rank": 1,
+          "elapsed_ms": 121.94,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "delete",
+            "file": "src/requests/api.py"
+          }
+        },
+        {
+          "query": "send HTTP PATCH request to update resource",
+          "query_type": "natural_language",
+          "expected_symbol": "patch",
+          "expected_file_suffix": "src/requests/api.py",
+          "rank": 1,
+          "elapsed_ms": 126.89,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "patch",
+            "file": "src/requests/api.py"
+          }
+        },
+        {
+          "query": "HTTP session object that reuses connections",
+          "query_type": "natural_language",
+          "expected_symbol": "Session",
+          "expected_file_suffix": "src/requests/sessions.py",
+          "rank": 2,
+          "elapsed_ms": 131.73,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "session",
+            "file": "src/requests/sessions.py"
+          }
+        },
+        {
+          "query": "prepare HTTP request before sending it",
+          "query_type": "natural_language",
+          "expected_symbol": "PreparedRequest",
+          "expected_file_suffix": "src/requests/models.py",
+          "rank": 12,
+          "elapsed_ms": 125.98,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "prepare_method",
+            "file": "src/requests/models.py"
+          }
+        },
+        {
+          "query": "HTTP response from the server",
+          "query_type": "natural_language",
+          "expected_symbol": "Response",
+          "expected_file_suffix": "src/requests/models.py",
+          "rank": 15,
+          "elapsed_ms": 122.24,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "response",
+            "file": "src/requests/adapters.py"
+          }
+        },
+        {
+          "query": "HTTP adapter that manages connection pool",
+          "query_type": "natural_language",
+          "expected_symbol": "HTTPAdapter",
+          "expected_file_suffix": "src/requests/adapters.py",
+          "rank": null,
+          "elapsed_ms": 126.13,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "init_poolmanager",
+            "file": "src/requests/adapters.py"
+          }
+        },
+        {
+          "query": "basic authentication for HTTP requests",
+          "query_type": "natural_language",
+          "expected_symbol": "HTTPBasicAuth",
+          "expected_file_suffix": "src/requests/auth.py",
+          "rank": 1,
+          "elapsed_ms": 125.38,
+          "candidate_count": 33,
+          "top_candidate": {
+            "name": "HTTPBasicAuth",
+            "file": "src/requests/auth.py"
+          }
+        },
+        {
+          "query": "digest authentication scheme",
+          "query_type": "natural_language",
+          "expected_symbol": "HTTPDigestAuth",
+          "expected_file_suffix": "src/requests/auth.py",
+          "rank": 4,
+          "elapsed_ms": 115.73,
+          "candidate_count": 20,
+          "top_candidate": {
+            "name": "expected_digest",
+            "file": "tests/test_lowlevel.py"
+          }
+        },
+        {
+          "query": "proxy authentication for requests",
+          "query_type": "natural_language",
+          "expected_symbol": "HTTPProxyAuth",
+          "expected_file_suffix": "src/requests/auth.py",
+          "rank": 2,
+          "elapsed_ms": 119.86,
+          "candidate_count": 33,
+          "top_candidate": {
+            "name": "test_proxy_auth",
+            "file": "tests/test_requests.py"
+          }
+        },
+        {
+          "query": "cookie jar that stores cookies across requests",
+          "query_type": "natural_language",
+          "expected_symbol": "RequestsCookieJar",
+          "expected_file_suffix": "src/requests/cookies.py",
+          "rank": 20,
+          "elapsed_ms": 123.23,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "extract_cookies_to_jar",
+            "file": "src/requests/cookies.py"
+          }
+        },
+        {
+          "query": "create a cookie from name and value",
+          "query_type": "natural_language",
+          "expected_symbol": "create_cookie",
+          "expected_file_suffix": "src/requests/cookies.py",
+          "rank": 1,
+          "elapsed_ms": 125.99,
+          "candidate_count": 34,
+          "top_candidate": {
+            "name": "create_cookie",
+            "file": "src/requests/cookies.py"
+          }
+        },
+        {
+          "query": "extract cookies from HTTP response",
+          "query_type": "natural_language",
+          "expected_symbol": "extract_cookies_to_jar",
+          "expected_file_suffix": "src/requests/cookies.py",
+          "rank": 1,
+          "elapsed_ms": 127.46,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "extract_cookies_to_jar",
+            "file": "src/requests/cookies.py"
+          }
+        },
+        {
+          "query": "merge two cookie jars together",
+          "query_type": "natural_language",
+          "expected_symbol": "merge_cookies",
+          "expected_file_suffix": "src/requests/cookies.py",
+          "rank": 1,
+          "elapsed_ms": 129.48,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "merge_cookies",
+            "file": "src/requests/cookies.py"
+          }
+        },
+        {
+          "query": "build cookie jar from a dictionary",
+          "query_type": "natural_language",
+          "expected_symbol": "cookiejar_from_dict",
+          "expected_file_suffix": "src/requests/cookies.py",
+          "rank": 2,
+          "elapsed_ms": 119.59,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "dict_from_cookiejar",
+            "file": "src/requests/utils.py"
+          }
+        },
+        {
+          "query": "http session",
+          "query_type": "short_phrase",
+          "expected_symbol": "Session",
+          "expected_file_suffix": "src/requests/sessions.py",
+          "rank": 2,
+          "elapsed_ms": 115.9,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "session",
+            "file": "src/requests/sessions.py"
+          }
+        },
+        {
+          "query": "prepared request",
+          "query_type": "short_phrase",
+          "expected_symbol": "PreparedRequest",
+          "expected_file_suffix": "src/requests/models.py",
+          "rank": 6,
+          "elapsed_ms": 112.02,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "prepare",
+            "file": "src/requests/models.py"
+          }
+        },
+        {
+          "query": "http adapter",
+          "query_type": "short_phrase",
+          "expected_symbol": "HTTPAdapter",
+          "expected_file_suffix": "src/requests/adapters.py",
+          "rank": 2,
+          "elapsed_ms": 116.23,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "adapter",
+            "file": "tests/test_requests.py"
+          }
+        },
+        {
+          "query": "cookie jar",
+          "query_type": "short_phrase",
+          "expected_symbol": "RequestsCookieJar",
+          "expected_file_suffix": "src/requests/cookies.py",
+          "rank": 17,
+          "elapsed_ms": 114.97,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "jar",
+            "file": "tests/test_requests.py"
+          }
+        },
+        {
+          "query": "basic auth",
+          "query_type": "short_phrase",
+          "expected_symbol": "HTTPBasicAuth",
+          "expected_file_suffix": "src/requests/auth.py",
+          "rank": 3,
+          "elapsed_ms": 115.04,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "authstr",
+            "file": "src/requests/auth.py"
+          }
+        },
+        {
+          "query": "Session",
+          "query_type": "identifier",
+          "expected_symbol": "Session",
+          "expected_file_suffix": "src/requests/sessions.py",
+          "rank": 1,
+          "elapsed_ms": 14.81,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "Session",
+            "file": "src/requests/sessions.py"
+          }
+        },
+        {
+          "query": "HTTPAdapter",
+          "query_type": "identifier",
+          "expected_symbol": "HTTPAdapter",
+          "expected_file_suffix": "src/requests/adapters.py",
+          "rank": 1,
+          "elapsed_ms": 12.88,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "HTTPAdapter",
+            "file": "src/requests/adapters.py"
+          }
+        }
+      ]
+    }
+  ],
+  "hybrid_uplift": {
+    "mrr_delta": 0.18919753062554917,
+    "acc1_delta": 0.16666666666666669,
+    "acc3_delta": 0.20833333333333337,
+    "acc5_delta": 0.25
+  },
+  "hybrid_uplift_by_query_type": {
+    "identifier": {
+      "mrr_delta": 0.0,
+      "acc1_delta": 0.0,
+      "acc3_delta": 0.0,
+      "acc5_delta": 0.0
+    },
+    "natural_language": {
+      "mrr_delta": 0.3224657179765538,
+      "acc1_delta": 0.2941176470588235,
+      "acc3_delta": 0.35294117647058826,
+      "acc5_delta": 0.41176470588235287
+    },
+    "short_phrase": {
+      "mrr_delta": -0.18823529411764706,
+      "acc1_delta": -0.2,
+      "acc3_delta": -0.20000000000000007,
+      "acc5_delta": -0.20000000000000007
+    }
+  }
+}

--- a/benchmarks/embedding-quality-v1.6-flip-ripgrep-default-on.json
+++ b/benchmarks/embedding-quality-v1.6-flip-ripgrep-default-on.json
@@ -1,0 +1,1097 @@
+{
+  "project": "/tmp/ripgrep-ext",
+  "benchmark_project": "/var/folders/z0/0tcbss795xsdp75jmr_t9_kh0000gn/T/codelens-embed-quality-96wpnuml/ripgrep-ext",
+  "isolated_copy": true,
+  "binary": "/Users/bagjaeseog/codelens-mcp-plugin/target/release/codelens-mcp",
+  "embedding_model": "MiniLM-L12-CodeSearchNet-INT8",
+  "runtime_model": {
+    "model_dir": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch",
+    "model_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/model.onnx",
+    "config_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/config.json",
+    "sha256": "ef1d1e9cfa72e4929f5b9faea17d8704b23a2530aadebf0d464a4cc7750920b3",
+    "size_bytes": 34000281,
+    "num_hidden_layers": 12,
+    "hidden_size": 384
+  },
+  "dataset_path": "/Users/bagjaeseog/codelens-mcp-plugin/benchmarks/embedding-quality-dataset-ripgrep.json",
+  "dataset_size": 24,
+  "ranking_cutoff": 10,
+  "metric_labels": {
+    "mrr": "MRR@10",
+    "acc1": "Acc@1",
+    "acc3": "Acc@3",
+    "acc5": "Acc@5"
+  },
+  "methods": [
+    {
+      "method": "semantic_search",
+      "mrr": 0.3972222222222222,
+      "acc1": 0.20833333333333334,
+      "acc3": 0.5833333333333334,
+      "acc5": 0.625,
+      "avg_elapsed_ms": 346.89124999999996,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 0.75,
+          "acc1": 0.5,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 123.15
+        },
+        "natural_language": {
+          "count": 17,
+          "mrr": 0.38431372549019605,
+          "acc1": 0.17647058823529413,
+          "acc3": 0.5882352941176471,
+          "acc5": 0.6470588235294118,
+          "avg_elapsed_ms": 412.2029411764706
+        },
+        "short_phrase": {
+          "count": 5,
+          "mrr": 0.3,
+          "acc1": 0.2,
+          "acc3": 0.4,
+          "acc5": 0.4,
+          "avg_elapsed_ms": 214.32799999999997
+        }
+      },
+      "rows": [
+        {
+          "query": "build regex matcher from pattern string",
+          "query_type": "natural_language",
+          "expected_symbol": "build",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 2,
+          "elapsed_ms": 210.55,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "build",
+            "file": "crates/pcre2/src/matcher.rs"
+          }
+        },
+        {
+          "query": "case insensitive regex matching",
+          "query_type": "natural_language",
+          "expected_symbol": "case_insensitive",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 202.21,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "case_insensitive",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "match multiple regex patterns at once",
+          "query_type": "natural_language",
+          "expected_symbol": "build_many",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": null,
+          "elapsed_ms": 190.78,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "matcher",
+            "file": "crates/regex/src/lib.rs"
+          }
+        },
+        {
+          "query": "ignore whitespace inside regex pattern",
+          "query_type": "natural_language",
+          "expected_symbol": "ignore_whitespace",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 207.08,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "ignore_whitespace",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "match a whole line only not substring",
+          "query_type": "natural_language",
+          "expected_symbol": "whole_line",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 2,
+          "elapsed_ms": 794.21,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "whole_line",
+            "file": "crates/pcre2/src/matcher.rs"
+          }
+        },
+        {
+          "query": "treat patterns as fixed strings not regex",
+          "query_type": "natural_language",
+          "expected_symbol": "fixed_strings",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 2,
+          "elapsed_ms": 1396.01,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "is_fixed_strings",
+            "file": "crates/regex/src/config.rs"
+          }
+        },
+        {
+          "query": "set regex memory size limit",
+          "query_type": "natural_language",
+          "expected_symbol": "size_limit",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": null,
+          "elapsed_ms": 846.6,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "set_before",
+            "file": "crates/core/flags/lowargs.rs"
+          }
+        },
+        {
+          "query": "search file content for regex matches",
+          "query_type": "natural_language",
+          "expected_symbol": "search_file",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": null,
+          "elapsed_ms": 539.6,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "search",
+            "file": "crates/core/main.rs"
+          }
+        },
+        {
+          "query": "search file by path on the filesystem",
+          "query_type": "natural_language",
+          "expected_symbol": "search_path",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": 5,
+          "elapsed_ms": 249.74,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "search_path",
+            "file": "crates/core/search.rs"
+          }
+        },
+        {
+          "query": "search an input reader line by line",
+          "query_type": "natural_language",
+          "expected_symbol": "search_reader",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": 2,
+          "elapsed_ms": 241.73,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "search_reader",
+            "file": "crates/core/search.rs"
+          }
+        },
+        {
+          "query": "walk directory tree respecting gitignore rules",
+          "query_type": "natural_language",
+          "expected_symbol": "WalkBuilder",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": 2,
+          "elapsed_ms": 253.21,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "walkdir_is_dir",
+            "file": "crates/ignore/src/walk.rs"
+          }
+        },
+        {
+          "query": "build parallel directory traversal",
+          "query_type": "natural_language",
+          "expected_symbol": "build_parallel",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": 1,
+          "elapsed_ms": 374.17,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "build_parallel",
+            "file": "crates/ignore/src/walk.rs"
+          }
+        },
+        {
+          "query": "parallel directory walker across threads",
+          "query_type": "natural_language",
+          "expected_symbol": "WalkParallel",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": null,
+          "elapsed_ms": 166.98,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "walk_collect_entries_parallel",
+            "file": "crates/ignore/src/walk.rs"
+          }
+        },
+        {
+          "query": "check if a path matches gitignore rules",
+          "query_type": "natural_language",
+          "expected_symbol": "Gitignore",
+          "expected_file_suffix": "crates/ignore/src/gitignore.rs",
+          "rank": 3,
+          "elapsed_ms": 326.24,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "gitignore",
+            "file": "crates/ignore/src/lib.rs"
+          }
+        },
+        {
+          "query": "build set of glob patterns for matching",
+          "query_type": "natural_language",
+          "expected_symbol": "GlobSetBuilder",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": null,
+          "elapsed_ms": 309.93,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "GlobMatcher",
+            "file": "crates/globset/src/glob.rs"
+          }
+        },
+        {
+          "query": "match file path against multiple glob patterns",
+          "query_type": "natural_language",
+          "expected_symbol": "GlobSet",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": null,
+          "elapsed_ms": 322.93,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "matched",
+            "file": "crates/ignore/src/gitignore.rs"
+          }
+        },
+        {
+          "query": "escape glob special characters in a string",
+          "query_type": "natural_language",
+          "expected_symbol": "escape",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": 2,
+          "elapsed_ms": 375.48,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "char_to_escaped_literal",
+            "file": "crates/globset/src/glob.rs"
+          }
+        },
+        {
+          "query": "regex builder",
+          "query_type": "short_phrase",
+          "expected_symbol": "RegexMatcherBuilder",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 395.14,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "RegexMatcherBuilder",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "file searcher",
+          "query_type": "short_phrase",
+          "expected_symbol": "Searcher",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": null,
+          "elapsed_ms": 237.96,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "search_file",
+            "file": "crates/searcher/src/searcher/mod.rs"
+          }
+        },
+        {
+          "query": "directory walker",
+          "query_type": "short_phrase",
+          "expected_symbol": "Walk",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": null,
+          "elapsed_ms": 134.71,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "name",
+            "file": ".github/workflows/release.yml"
+          }
+        },
+        {
+          "query": "gitignore builder",
+          "query_type": "short_phrase",
+          "expected_symbol": "GitignoreBuilder",
+          "expected_file_suffix": "crates/ignore/src/gitignore.rs",
+          "rank": 2,
+          "elapsed_ms": 136.73,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "gitignore",
+            "file": "crates/ignore/src/lib.rs"
+          }
+        },
+        {
+          "query": "standard printer",
+          "query_type": "short_phrase",
+          "expected_symbol": "Standard",
+          "expected_file_suffix": "crates/printer/src/standard.rs",
+          "rank": null,
+          "elapsed_ms": 167.1,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "printer_standard",
+            "file": "crates/core/flags/hiargs.rs"
+          }
+        },
+        {
+          "query": "RegexMatcher",
+          "query_type": "identifier",
+          "expected_symbol": "RegexMatcher",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 2,
+          "elapsed_ms": 121.12,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "RegexMatcher",
+            "file": "crates/searcher/src/testutil.rs"
+          }
+        },
+        {
+          "query": "GlobSet",
+          "query_type": "identifier",
+          "expected_symbol": "GlobSet",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": 1,
+          "elapsed_ms": 125.18,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "GlobSet",
+            "file": "crates/globset/src/lib.rs"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context_no_semantic",
+      "mrr": 0.38453930328930325,
+      "acc1": 0.2916666666666667,
+      "acc3": 0.375,
+      "acc5": 0.5416666666666666,
+      "avg_elapsed_ms": 23.979583333333334,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 0.625,
+          "acc1": 0.5,
+          "acc3": 0.5,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 18.305
+        },
+        "natural_language": {
+          "count": 17,
+          "mrr": 0.3546437222907811,
+          "acc1": 0.29411764705882354,
+          "acc3": 0.35294117647058826,
+          "acc5": 0.4117647058823529,
+          "avg_elapsed_ms": 25.90294117647059
+        },
+        "short_phrase": {
+          "count": 5,
+          "mrr": 0.39,
+          "acc1": 0.2,
+          "acc3": 0.4,
+          "acc5": 0.8,
+          "avg_elapsed_ms": 19.71
+        }
+      },
+      "rows": [
+        {
+          "query": "build regex matcher from pattern string",
+          "query_type": "natural_language",
+          "expected_symbol": "build",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": null,
+          "elapsed_ms": 29.3,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "from_pattern",
+            "file": "crates/regex/src/ast.rs"
+          }
+        },
+        {
+          "query": "case insensitive regex matching",
+          "query_type": "natural_language",
+          "expected_symbol": "case_insensitive",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 24.98,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "case_insensitive",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "match multiple regex patterns at once",
+          "query_type": "natural_language",
+          "expected_symbol": "build_many",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": null,
+          "elapsed_ms": 25.56,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "regex",
+            "file": "crates/regex/src/error.rs"
+          }
+        },
+        {
+          "query": "ignore whitespace inside regex pattern",
+          "query_type": "natural_language",
+          "expected_symbol": "ignore_whitespace",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 27.68,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "ignore_whitespace",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "match a whole line only not substring",
+          "query_type": "natural_language",
+          "expected_symbol": "whole_line",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 2,
+          "elapsed_ms": 26.73,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "whole_line",
+            "file": "crates/pcre2/src/matcher.rs"
+          }
+        },
+        {
+          "query": "treat patterns as fixed strings not regex",
+          "query_type": "natural_language",
+          "expected_symbol": "fixed_strings",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 26.41,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "fixed_strings",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "set regex memory size limit",
+          "query_type": "natural_language",
+          "expected_symbol": "size_limit",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 25.39,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "size_limit",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "search file content for regex matches",
+          "query_type": "natural_language",
+          "expected_symbol": "search_file",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": null,
+          "elapsed_ms": 28.17,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "build_format",
+            "file": "crates/printer/src/hyperlink/mod.rs"
+          }
+        },
+        {
+          "query": "search file by path on the filesystem",
+          "query_type": "natural_language",
+          "expected_symbol": "search_path",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": null,
+          "elapsed_ms": 27.29,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "path",
+            "file": "crates/ignore/src/gitignore.rs"
+          }
+        },
+        {
+          "query": "search an input reader line by line",
+          "query_type": "natural_language",
+          "expected_symbol": "search_reader",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": 4,
+          "elapsed_ms": 28.47,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "by_line",
+            "file": "crates/searcher/src/testutil.rs"
+          }
+        },
+        {
+          "query": "walk directory tree respecting gitignore rules",
+          "query_type": "natural_language",
+          "expected_symbol": "WalkBuilder",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": 11,
+          "elapsed_ms": 28.06,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "Gitignore",
+            "file": "crates/ignore/src/gitignore.rs"
+          }
+        },
+        {
+          "query": "build parallel directory traversal",
+          "query_type": "natural_language",
+          "expected_symbol": "build_parallel",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": 1,
+          "elapsed_ms": 21.79,
+          "candidate_count": 21,
+          "top_candidate": {
+            "name": "build_parallel",
+            "file": "crates/ignore/src/walk.rs"
+          }
+        },
+        {
+          "query": "parallel directory walker across threads",
+          "query_type": "natural_language",
+          "expected_symbol": "WalkParallel",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": 9,
+          "elapsed_ms": 22.2,
+          "candidate_count": 13,
+          "top_candidate": {
+            "name": "build_parallel",
+            "file": "crates/ignore/src/walk.rs"
+          }
+        },
+        {
+          "query": "check if a path matches gitignore rules",
+          "query_type": "natural_language",
+          "expected_symbol": "Gitignore",
+          "expected_file_suffix": "crates/ignore/src/gitignore.rs",
+          "rank": 13,
+          "elapsed_ms": 25.65,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "nmatches",
+            "file": "crates/globset/src/glob.rs"
+          }
+        },
+        {
+          "query": "build set of glob patterns for matching",
+          "query_type": "natural_language",
+          "expected_symbol": "GlobSetBuilder",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": null,
+          "elapsed_ms": 25.8,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "build",
+            "file": "crates/globset/src/glob.rs"
+          }
+        },
+        {
+          "query": "match file path against multiple glob patterns",
+          "query_type": "natural_language",
+          "expected_symbol": "GlobSet",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": null,
+          "elapsed_ms": 22.08,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "GlobMatcher",
+            "file": "crates/globset/src/glob.rs"
+          }
+        },
+        {
+          "query": "escape glob special characters in a string",
+          "query_type": "natural_language",
+          "expected_symbol": "escape",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": null,
+          "elapsed_ms": 24.79,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "Glob",
+            "file": "crates/globset/src/glob.rs"
+          }
+        },
+        {
+          "query": "regex builder",
+          "query_type": "short_phrase",
+          "expected_symbol": "RegexMatcherBuilder",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 2,
+          "elapsed_ms": 19.7,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "regex",
+            "file": "crates/regex/src/error.rs"
+          }
+        },
+        {
+          "query": "file searcher",
+          "query_type": "short_phrase",
+          "expected_symbol": "Searcher",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": 4,
+          "elapsed_ms": 20.82,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "search_file",
+            "file": "crates/searcher/src/searcher/mod.rs"
+          }
+        },
+        {
+          "query": "directory walker",
+          "query_type": "short_phrase",
+          "expected_symbol": "Walk",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": null,
+          "elapsed_ms": 18.05,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "working-directory",
+            "file": ".github/workflows/ci.yml"
+          }
+        },
+        {
+          "query": "gitignore builder",
+          "query_type": "short_phrase",
+          "expected_symbol": "GitignoreBuilder",
+          "expected_file_suffix": "crates/ignore/src/gitignore.rs",
+          "rank": 1,
+          "elapsed_ms": 19.9,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "GitignoreBuilder",
+            "file": "crates/ignore/src/gitignore.rs"
+          }
+        },
+        {
+          "query": "standard printer",
+          "query_type": "short_phrase",
+          "expected_symbol": "Standard",
+          "expected_file_suffix": "crates/printer/src/standard.rs",
+          "rank": 5,
+          "elapsed_ms": 20.08,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "printer_standard",
+            "file": "crates/core/flags/hiargs.rs"
+          }
+        },
+        {
+          "query": "RegexMatcher",
+          "query_type": "identifier",
+          "expected_symbol": "RegexMatcher",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 4,
+          "elapsed_ms": 17.58,
+          "candidate_count": 7,
+          "top_candidate": {
+            "name": "RegexMatcher",
+            "file": "crates/matcher/tests/util.rs"
+          }
+        },
+        {
+          "query": "GlobSet",
+          "query_type": "identifier",
+          "expected_symbol": "GlobSet",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": 1,
+          "elapsed_ms": 19.03,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "GlobSet",
+            "file": "crates/globset/src/lib.rs"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context",
+      "mrr": 0.5291666666666667,
+      "acc1": 0.3333333333333333,
+      "acc3": 0.6666666666666666,
+      "acc5": 0.7916666666666666,
+      "avg_elapsed_ms": 114.98166666666667,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 0.625,
+          "acc1": 0.5,
+          "acc3": 0.5,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 18.42
+        },
+        "natural_language": {
+          "count": 17,
+          "mrr": 0.5539215686274509,
+          "acc1": 0.35294117647058826,
+          "acc3": 0.7058823529411765,
+          "acc5": 0.7647058823529411,
+          "avg_elapsed_ms": 125.52823529411765
+        },
+        "short_phrase": {
+          "count": 5,
+          "mrr": 0.4066666666666666,
+          "acc1": 0.2,
+          "acc3": 0.6,
+          "acc5": 0.8,
+          "avg_elapsed_ms": 117.748
+        }
+      },
+      "rows": [
+        {
+          "query": "build regex matcher from pattern string",
+          "query_type": "natural_language",
+          "expected_symbol": "build",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 124.8,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "build",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "case insensitive regex matching",
+          "query_type": "natural_language",
+          "expected_symbol": "case_insensitive",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 122.72,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "case_insensitive",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "match multiple regex patterns at once",
+          "query_type": "natural_language",
+          "expected_symbol": "build_many",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": null,
+          "elapsed_ms": 126.62,
+          "candidate_count": 35,
+          "top_candidate": {
+            "name": "matcher",
+            "file": "crates/regex/src/lib.rs"
+          }
+        },
+        {
+          "query": "ignore whitespace inside regex pattern",
+          "query_type": "natural_language",
+          "expected_symbol": "ignore_whitespace",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 131.58,
+          "candidate_count": 34,
+          "top_candidate": {
+            "name": "ignore_whitespace",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "match a whole line only not substring",
+          "query_type": "natural_language",
+          "expected_symbol": "whole_line",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 2,
+          "elapsed_ms": 125.79,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "whole_line",
+            "file": "crates/pcre2/src/matcher.rs"
+          }
+        },
+        {
+          "query": "treat patterns as fixed strings not regex",
+          "query_type": "natural_language",
+          "expected_symbol": "fixed_strings",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 2,
+          "elapsed_ms": 125.47,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "is_fixed_strings",
+            "file": "crates/regex/src/config.rs"
+          }
+        },
+        {
+          "query": "set regex memory size limit",
+          "query_type": "natural_language",
+          "expected_symbol": "size_limit",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 125.76,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "size_limit",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "search file content for regex matches",
+          "query_type": "natural_language",
+          "expected_symbol": "search_file",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": 1,
+          "elapsed_ms": 126.01,
+          "candidate_count": 33,
+          "top_candidate": {
+            "name": "search_file",
+            "file": "crates/searcher/src/searcher/mod.rs"
+          }
+        },
+        {
+          "query": "search file by path on the filesystem",
+          "query_type": "natural_language",
+          "expected_symbol": "search_path",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": 4,
+          "elapsed_ms": 125.05,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "search_file",
+            "file": "crates/searcher/src/searcher/mod.rs"
+          }
+        },
+        {
+          "query": "search an input reader line by line",
+          "query_type": "natural_language",
+          "expected_symbol": "search_reader",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": 2,
+          "elapsed_ms": 130.54,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "search_reader",
+            "file": "crates/core/search.rs"
+          }
+        },
+        {
+          "query": "walk directory tree respecting gitignore rules",
+          "query_type": "natural_language",
+          "expected_symbol": "WalkBuilder",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": 2,
+          "elapsed_ms": 129.55,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "walkdir_is_dir",
+            "file": "crates/ignore/src/walk.rs"
+          }
+        },
+        {
+          "query": "build parallel directory traversal",
+          "query_type": "natural_language",
+          "expected_symbol": "build_parallel",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": 1,
+          "elapsed_ms": 124.59,
+          "candidate_count": 21,
+          "top_candidate": {
+            "name": "build_parallel",
+            "file": "crates/ignore/src/walk.rs"
+          }
+        },
+        {
+          "query": "parallel directory walker across threads",
+          "query_type": "natural_language",
+          "expected_symbol": "WalkParallel",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": 6,
+          "elapsed_ms": 124.86,
+          "candidate_count": 13,
+          "top_candidate": {
+            "name": "ParallelVisitor",
+            "file": "crates/ignore/src/walk.rs"
+          }
+        },
+        {
+          "query": "check if a path matches gitignore rules",
+          "query_type": "natural_language",
+          "expected_symbol": "Gitignore",
+          "expected_file_suffix": "crates/ignore/src/gitignore.rs",
+          "rank": 2,
+          "elapsed_ms": 123.51,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "gitignore",
+            "file": "crates/ignore/src/lib.rs"
+          }
+        },
+        {
+          "query": "build set of glob patterns for matching",
+          "query_type": "natural_language",
+          "expected_symbol": "GlobSetBuilder",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": null,
+          "elapsed_ms": 124.64,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "compile_matcher",
+            "file": "crates/globset/src/glob.rs"
+          }
+        },
+        {
+          "query": "match file path against multiple glob patterns",
+          "query_type": "natural_language",
+          "expected_symbol": "GlobSet",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": null,
+          "elapsed_ms": 119.69,
+          "candidate_count": 33,
+          "top_candidate": {
+            "name": "MatchStrategy",
+            "file": "crates/globset/src/glob.rs"
+          }
+        },
+        {
+          "query": "escape glob special characters in a string",
+          "query_type": "natural_language",
+          "expected_symbol": "escape",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": 2,
+          "elapsed_ms": 122.8,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "char_to_escaped_literal",
+            "file": "crates/globset/src/glob.rs"
+          }
+        },
+        {
+          "query": "regex builder",
+          "query_type": "short_phrase",
+          "expected_symbol": "RegexMatcherBuilder",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 1,
+          "elapsed_ms": 117.14,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "RegexMatcherBuilder",
+            "file": "crates/regex/src/matcher.rs"
+          }
+        },
+        {
+          "query": "file searcher",
+          "query_type": "short_phrase",
+          "expected_symbol": "Searcher",
+          "expected_file_suffix": "crates/searcher/src/searcher/mod.rs",
+          "rank": 5,
+          "elapsed_ms": 120.83,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "search_file",
+            "file": "crates/searcher/src/searcher/mod.rs"
+          }
+        },
+        {
+          "query": "directory walker",
+          "query_type": "short_phrase",
+          "expected_symbol": "Walk",
+          "expected_file_suffix": "crates/ignore/src/walk.rs",
+          "rank": null,
+          "elapsed_ms": 114.84,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "working-directory",
+            "file": ".github/workflows/ci.yml"
+          }
+        },
+        {
+          "query": "gitignore builder",
+          "query_type": "short_phrase",
+          "expected_symbol": "GitignoreBuilder",
+          "expected_file_suffix": "crates/ignore/src/gitignore.rs",
+          "rank": 2,
+          "elapsed_ms": 117.52,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "gitignore",
+            "file": "crates/ignore/src/lib.rs"
+          }
+        },
+        {
+          "query": "standard printer",
+          "query_type": "short_phrase",
+          "expected_symbol": "Standard",
+          "expected_file_suffix": "crates/printer/src/standard.rs",
+          "rank": 3,
+          "elapsed_ms": 118.41,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "printer_standard",
+            "file": "crates/core/flags/hiargs.rs"
+          }
+        },
+        {
+          "query": "RegexMatcher",
+          "query_type": "identifier",
+          "expected_symbol": "RegexMatcher",
+          "expected_file_suffix": "crates/regex/src/matcher.rs",
+          "rank": 4,
+          "elapsed_ms": 17.57,
+          "candidate_count": 7,
+          "top_candidate": {
+            "name": "RegexMatcher",
+            "file": "crates/matcher/tests/util.rs"
+          }
+        },
+        {
+          "query": "GlobSet",
+          "query_type": "identifier",
+          "expected_symbol": "GlobSet",
+          "expected_file_suffix": "crates/globset/src/lib.rs",
+          "rank": 1,
+          "elapsed_ms": 19.27,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "GlobSet",
+            "file": "crates/globset/src/lib.rs"
+          }
+        }
+      ]
+    }
+  ],
+  "hybrid_uplift": {
+    "mrr_delta": 0.14462736337736343,
+    "acc1_delta": 0.04166666666666663,
+    "acc3_delta": 0.29166666666666663,
+    "acc5_delta": 0.25
+  },
+  "hybrid_uplift_by_query_type": {
+    "identifier": {
+      "mrr_delta": 0.0,
+      "acc1_delta": 0.0,
+      "acc3_delta": 0.0,
+      "acc5_delta": 0.0
+    },
+    "natural_language": {
+      "mrr_delta": 0.19927784633666978,
+      "acc1_delta": 0.05882352941176472,
+      "acc3_delta": 0.35294117647058826,
+      "acc5_delta": 0.3529411764705882
+    },
+    "short_phrase": {
+      "mrr_delta": 0.016666666666666607,
+      "acc1_delta": 0.0,
+      "acc3_delta": 0.19999999999999996,
+      "acc5_delta": 0.0
+    }
+  }
+}

--- a/crates/codelens-engine/src/embedding/mod.rs
+++ b/crates/codelens-engine/src/embedding/mod.rs
@@ -1856,23 +1856,32 @@ fn nl_tokens_enabled() -> bool {
     auto_hint_should_enable()
 }
 
-/// Return true when v1.5 Phase 2j auto-detection mode is enabled via
-/// `CODELENS_EMBED_HINT_AUTO=1` (or `true`/`yes`/`on`).
+/// Return true when v1.5 Phase 2j auto-detection mode is enabled.
 ///
-/// Phase 2j accepts the measured reality that the v1.5 opt-in stack is
-/// Rust-optimised (§8.2–§8.10): three Rust datasets win at +2.4 % /
-/// +7.1 % / +15.2 % relative hybrid MRR, one Python dataset loses at
-/// −15.2 %, and the Phase 2h / 2i filter refinements only recover
-/// ~8 % of the Python regression. Rather than ship a global default
-/// that is right half the time, Phase 2j flips Phase 2b / 2c / 2e
-/// on or off based on the project's dominant language — auto-enabled
-/// for `rust`, `cpp`, `c`, `go`, `java`, `kotlin`, `scala`, `cs` and
-/// disabled for everything else.
+/// **v1.6.0 default change (§8.14)**: this returns `true` by default.
+/// Users opt **out** with `CODELENS_EMBED_HINT_AUTO=0` (or `false` /
+/// `no` / `off`). The previous v1.5.x behaviour was the other way
+/// around — default OFF, opt in with `=1`. The flip ships as part of
+/// v1.6.0 after the five-dataset measurement (§8.7, §8.8, §8.13,
+/// §8.11, §8.12) validated:
+///
+/// 1. Rust / C / C++ / Go / Java / Kotlin / Scala / C# projects hit
+///    the §8.7 stacked arm (+2.4 % to +15.2 % hybrid MRR).
+/// 2. TypeScript / JavaScript projects hit the §8.13 stacked arm
+///    (+7.3 % hybrid MRR on `facebook/jest`).
+/// 3. Python projects hit the §8.8 baseline (no change) — the
+///    §8.11 language gate + §8.12 MCP auto-set means Python is
+///    auto-detected and the stack stays OFF without user action.
+/// 4. Ruby / PHP / Lua / shell / untested-dynamic projects fall
+///    through to the conservative default-off branch (same as
+///    Python behaviour — no regression).
 ///
 /// The dominant language is supplied by the MCP tool layer via the
-/// `CODELENS_EMBED_HINT_AUTO_LANG` env var (set once per process on
-/// `activate_project` / `index_embeddings`). The engine only reads
-/// the env var — it does not walk the filesystem itself.
+/// `CODELENS_EMBED_HINT_AUTO_LANG` env var, which is set
+/// automatically on startup (`main.rs`) and on MCP
+/// `activate_project` calls by `compute_dominant_language` (§8.12).
+/// The engine only reads the env var — it does not walk the
+/// filesystem itself.
 ///
 /// Explicit `CODELENS_EMBED_HINT_INCLUDE_COMMENTS=1` /
 /// `CODELENS_EMBED_HINT_INCLUDE_API_CALLS=1` /
@@ -1880,8 +1889,12 @@ fn nl_tokens_enabled() -> bool {
 /// always win over the auto decision — users who want to force a
 /// configuration still can, the auto mode is a better default, not
 /// a lock-in.
+///
+/// **Opt-out**: set `CODELENS_EMBED_HINT_AUTO=0` to restore v1.5.x
+/// behaviour (no auto-detection, all three Phase 2 gates default
+/// off unless their individual env vars are set).
 pub(super) fn auto_hint_mode_enabled() -> bool {
-    parse_bool_env("CODELENS_EMBED_HINT_AUTO").unwrap_or(false)
+    parse_bool_env("CODELENS_EMBED_HINT_AUTO").unwrap_or(true)
 }
 
 /// Return the language tag supplied by the MCP tool layer via
@@ -2609,6 +2622,14 @@ mod tests {
     /// Serialize tests that load the fastembed ONNX model to avoid file lock contention.
     static MODEL_LOCK: Mutex<()> = Mutex::new(());
 
+    /// Serialize tests that mutate `CODELENS_EMBED_HINT_*` env vars.
+    /// The v1.6.0 default flip (§8.14) exposed a pre-existing race where
+    /// parallel env-var mutating tests interfere with each other — the
+    /// old `unwrap_or(false)` default happened to mask the race most of
+    /// the time, but `unwrap_or(true)` no longer does. All tests that
+    /// read or mutate `CODELENS_EMBED_HINT_*` should take this lock.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
     macro_rules! skip_without_embedding_model {
         () => {
             if !super::embedding_model_assets_available() {
@@ -2954,6 +2975,7 @@ fn route_request() {
 
     #[test]
     fn extract_nl_tokens_gated_off_by_default() {
+        let _env_guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         // Default: no env, no NL tokens regardless of body content.
         let previous = std::env::var("CODELENS_EMBED_HINT_INCLUDE_COMMENTS").ok();
         unsafe {
@@ -2975,18 +2997,54 @@ fn skip_things() {
     }
 
     #[test]
-    fn auto_hint_mode_gated_off_by_default() {
+    fn auto_hint_mode_defaults_on_unless_explicit_off() {
+        let _env_guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        // v1.6.0 flip (§8.14): default-ON semantics.
+        //
+        // Case 1: env var unset → default ON (the v1.6.0 flip).
+        // Case 2: env var="0" (or "false"/"no"/"off") → explicit OFF
+        //   (opt-out preserved).
+        // Case 3: env var="1" (or "true"/"yes"/"on") → explicit ON
+        //   (still works — explicit always wins).
         let previous = std::env::var("CODELENS_EMBED_HINT_AUTO").ok();
+
+        // Case 1: unset → ON (flip)
         unsafe {
             std::env::remove_var("CODELENS_EMBED_HINT_AUTO");
         }
-        let enabled = super::auto_hint_mode_enabled();
+        let default_enabled = super::auto_hint_mode_enabled();
+        assert!(
+            default_enabled,
+            "v1.6.0 default flip: auto hint mode should be ON when env unset"
+        );
+
+        // Case 2: explicit OFF
         unsafe {
-            if let Some(value) = previous {
-                std::env::set_var("CODELENS_EMBED_HINT_AUTO", value);
+            std::env::set_var("CODELENS_EMBED_HINT_AUTO", "0");
+        }
+        let explicit_off = super::auto_hint_mode_enabled();
+        assert!(
+            !explicit_off,
+            "explicit CODELENS_EMBED_HINT_AUTO=0 must still disable (opt-out escape hatch)"
+        );
+
+        // Case 3: explicit ON
+        unsafe {
+            std::env::set_var("CODELENS_EMBED_HINT_AUTO", "1");
+        }
+        let explicit_on = super::auto_hint_mode_enabled();
+        assert!(
+            explicit_on,
+            "explicit CODELENS_EMBED_HINT_AUTO=1 must still enable"
+        );
+
+        // Restore
+        unsafe {
+            match previous {
+                Some(v) => std::env::set_var("CODELENS_EMBED_HINT_AUTO", v),
+                None => std::env::remove_var("CODELENS_EMBED_HINT_AUTO"),
             }
         }
-        assert!(!enabled, "auto hint mode gate leaked");
     }
 
     #[test]
@@ -3036,17 +3094,20 @@ fn skip_things() {
 
     #[test]
     fn auto_hint_should_enable_requires_both_gate_and_supported_lang() {
+        let _env_guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let prev_auto = std::env::var("CODELENS_EMBED_HINT_AUTO").ok();
         let prev_lang = std::env::var("CODELENS_EMBED_HINT_AUTO_LANG").ok();
 
-        // Case 1: gate off → never enable, regardless of language
+        // Case 1: gate explicitly off → never enable, regardless of language.
+        // v1.6.0 flip (§8.14): `unset` now means default-ON, so to test
+        // "gate off" we must set the env var to an explicit "0".
         unsafe {
-            std::env::remove_var("CODELENS_EMBED_HINT_AUTO");
+            std::env::set_var("CODELENS_EMBED_HINT_AUTO", "0");
             std::env::set_var("CODELENS_EMBED_HINT_AUTO_LANG", "rust");
         }
         assert!(
             !super::auto_hint_should_enable(),
-            "gate-off with lang=rust must stay disabled"
+            "gate-off (explicit =0) with lang=rust must stay disabled"
         );
 
         // Case 2: gate on, supported language → enable
@@ -3094,6 +3155,7 @@ fn skip_things() {
 
     #[test]
     fn nl_tokens_enabled_explicit_env_wins_over_auto() {
+        let _env_guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let prev_explicit = std::env::var("CODELENS_EMBED_HINT_INCLUDE_COMMENTS").ok();
         let prev_auto = std::env::var("CODELENS_EMBED_HINT_AUTO").ok();
         let prev_lang = std::env::var("CODELENS_EMBED_HINT_AUTO_LANG").ok();
@@ -3161,6 +3223,7 @@ fn skip_things() {
 
     #[test]
     fn strict_comments_gated_off_by_default() {
+        let _env_guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let previous = std::env::var("CODELENS_EMBED_HINT_STRICT_COMMENTS").ok();
         unsafe {
             std::env::remove_var("CODELENS_EMBED_HINT_STRICT_COMMENTS");
@@ -3210,6 +3273,7 @@ fn skip_things() {
 
     #[test]
     fn strict_comments_filters_meta_annotations_during_extraction() {
+        let _env_guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let previous = std::env::var("CODELENS_EMBED_HINT_STRICT_COMMENTS").ok();
         unsafe {
             std::env::set_var("CODELENS_EMBED_HINT_STRICT_COMMENTS", "1");
@@ -3252,6 +3316,7 @@ fn handle_request() {
 
     #[test]
     fn strict_comments_is_orthogonal_to_strict_literals() {
+        let _env_guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         // Enabling strict_comments must NOT affect the Pass-2 literal path.
         // A format-specifier literal should still pass through Pass 2
         // when the literal filter is off, regardless of the comment gate.
@@ -3293,6 +3358,7 @@ fn handle() {
 
     #[test]
     fn strict_literal_filter_gated_off_by_default() {
+        let _env_guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let previous = std::env::var("CODELENS_EMBED_HINT_STRICT_LITERALS").ok();
         unsafe {
             std::env::remove_var("CODELENS_EMBED_HINT_STRICT_LITERALS");
@@ -3345,6 +3411,7 @@ fn handle() {
 
     #[test]
     fn strict_mode_rejects_format_and_error_literals_during_extraction() {
+        let _env_guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         // The env gate is bypassed by calling the inner function directly,
         // BUT the inner function still reads the strict-literal env var.
         // So we have to set it explicitly for this test.
@@ -3390,6 +3457,7 @@ fn handle_request() {
 
     #[test]
     fn strict_mode_leaves_comments_untouched() {
+        let _env_guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         // Comments (Pass 1) should NOT be filtered by the strict flag —
         // the §8.8 post-mortem identified string literals as the
         // regression source, not comments.
@@ -3457,6 +3525,7 @@ fn do_work() {
 
     #[test]
     fn extract_api_calls_gated_off_by_default() {
+        let _env_guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         // Default: no env, no API-call hint regardless of body content.
         let previous = std::env::var("CODELENS_EMBED_HINT_INCLUDE_API_CALLS").ok();
         unsafe {

--- a/crates/codelens-mcp/src/tools/session/project_ops.rs
+++ b/crates/codelens-mcp/src/tools/session/project_ops.rs
@@ -455,13 +455,21 @@ pub fn query_project(state: &AppState, arguments: &serde_json::Value) -> ToolRes
 /// no known-extension files at all), we leave the env var unset and the
 /// engine falls through to the conservative default (stack OFF).
 pub fn auto_set_embed_hint_lang(project_path: &std::path::Path) {
+    // v1.6.0 flip (§8.14): default-ON semantics. Unset env means "auto
+    // mode ON", explicit `CODELENS_EMBED_HINT_AUTO=0`/`false`/`no`/`off`
+    // is the opt-out. Must stay in lock-step with the engine's
+    // `auto_hint_mode_enabled()` in `crates/codelens-engine/src/embedding/mod.rs`.
     let auto_hint_gate_enabled = std::env::var("CODELENS_EMBED_HINT_AUTO")
         .ok()
         .map(|v| {
             let lowered = v.trim().to_ascii_lowercase();
-            matches!(lowered.as_str(), "1" | "true" | "yes" | "on")
+            match lowered.as_str() {
+                "1" | "true" | "yes" | "on" => true,
+                "0" | "false" | "no" | "off" => false,
+                _ => true, // unknown value → fall through to default-on
+            }
         })
-        .unwrap_or(false);
+        .unwrap_or(true);
     let user_forced_lang = std::env::var("CODELENS_EMBED_HINT_AUTO_LANG").is_ok();
     if !auto_hint_gate_enabled || user_forced_lang {
         return;

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1457,7 +1457,65 @@ Measurement artefacts: `benchmarks/embedding-quality-v1.5-phase3c-jest-{baseline
 
 ---
 
-> > > > > > > f5a5765 (feat(engine): Phase 3c — JS/TS validation on facebook/jest, add ts/js to language_supports_nl_stack)
+### §8.14 — v1.6.0 default flip: `CODELENS_EMBED_HINT_AUTO=1` becomes the default
+
+**Hypothesis** (from §8.11 / §8.12 / §8.13 "v1.6.0 default flip readiness"): after the five-dataset measurement arc (§8.2 / §8.4 / §8.6 / §8.7 / §8.8 / §8.13), with Phase 2j engine gating (§8.11) and MCP auto-set follow-up (§8.12) landed, there are no remaining blockers to flipping `auto_hint_mode_enabled()` default from `false` to `true`. Users of Rust / C / C++ / Go / Java / Kotlin / Scala / C# / TypeScript / JavaScript projects will get the measurement-validated stacked arm without setting any env var, and users of Python / Ruby / PHP / Lua / shell / unknown-language projects will get the §8.8 baseline behaviour via the conservative default-off branch of `language_supports_nl_stack`. The flip is the culmination of the §8.1 cAST-revert-methodology → §8.13 Phase 3c arc, shipping what the measurement matrix explicitly justified.
+
+**Implementation** (one-line change + two-line test semantics reversal, covered by eight acceptance criteria):
+
+1. **Engine** — `crates/codelens-engine/src/embedding/mod.rs:1897` `parse_bool_env("CODELENS_EMBED_HINT_AUTO").unwrap_or(false)` → `unwrap_or(true)`. Doc-comment above the function updated to document the opt-out semantics.
+2. **MCP helper** — `crates/codelens-mcp/src/tools/session/project_ops.rs:auto_set_embed_hint_lang` had its own inline env-var parser that was still `.unwrap_or(false)`. This must stay in lock-step with the engine gate or the MCP layer short-circuits before computing dominant language, leaving `CODELENS_EMBED_HINT_AUTO_LANG` unset and the engine's `auto_hint_should_enable()` falling through to the "no language tag" conservative-off branch. Mirrored the engine's default-true behaviour with an explicit match on `1/true/yes/on` vs `0/false/no/off`, with unknown values falling through to default-on.
+3. **Engine unit tests** — renamed `auto_hint_mode_gated_off_by_default` → `auto_hint_mode_defaults_on_unless_explicit_off`. Body expanded from one assertion (env-unset → false) to three cases: env-unset → true (the flip), explicit `=0` → false (opt-out preserved), explicit `=1` → true (explicit always wins). Also updated `auto_hint_should_enable_requires_both_gate_and_supported_lang` Case 1 to use `set_var("0")` instead of `remove_var` — the old test was ambiguous under the flipped semantics (is "unset" the gate-off case, or the default-on case?). Under v1.6.0 semantics, "gate off" means `explicit =0`.
+4. **Env-var race hardening** — the flip surfaced a latent race condition in the test suite. Previously, `unwrap_or(false)` meant that if two parallel env-mutating tests interfered, both tests would often still observe "off" for the unset case, masking the race. Under `unwrap_or(true)`, an interfering test setting `AUTO=1` now visibly collides with a test expecting the default path. Added a module-static `ENV_LOCK: Mutex<()>` pattern (mirroring the existing `MODEL_LOCK` for fastembed ONNX tests) and wrapped the eleven `CODELENS_EMBED_HINT_*`-mutating test functions with `let _env_guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());` as their first line. Engine test count unchanged at 257 — one test was renamed and expanded, no new tests created.
+
+**Measurement** — replay the Phase 2j follow-up (§8.12) benchmarks with **no** `CODELENS_EMBED_HINT_*` env vars set at all, confirming that the flip alone suffices to reach bit-identical parity with the hand-configured measurements.
+
+| Dataset           |              Expected (from §8.12) | v1.6.0 flip actual |      Δ |
+| ----------------- | ---------------------------------: | -----------------: | -----: |
+| ripgrep (Rust)    |  0.5291666666666667 (§8.7 stacked) | 0.5291666666666667 | 0.0000 |
+| requests (Python) | 0.5837009803921568 (§8.8 baseline) | 0.5837009803921568 | 0.0000 |
+
+**Bit-identical to the tenth decimal**. The flip + MCP helper change produces exactly the same results as explicit `CODELENS_EMBED_HINT_AUTO=1 CODELENS_EMBED_HINT_AUTO_LANG=rust` (§8.12 ripgrep-mcpauto) and `CODELENS_EMBED_HINT_AUTO=1 CODELENS_EMBED_HINT_AUTO_LANG=python` (§8.12 requests-mcpauto). The three-step flip (engine gate + MCP helper + test semantics) is verified end-to-end with no user action beyond upgrading the binary.
+
+**Reproduce** (note — zero env vars except `CODELENS_RANK_SPARSE_*` tuning which lives outside the auto-gate):
+
+```bash
+# ripgrep — no AUTO, no AUTO_LANG — the flip does all the work
+CODELENS_MODEL_DIR=$(pwd)/crates/codelens-engine/models \
+CODELENS_RANK_SPARSE_THRESHOLD=40 \
+CODELENS_RANK_SPARSE_MAX=40 \
+CODELENS_BIN=./target/release/codelens-mcp \
+python3 benchmarks/embedding-quality.py /tmp/ripgrep-ext --isolated-copy \
+  --dataset benchmarks/embedding-quality-dataset-ripgrep.json \
+  --output benchmarks/embedding-quality-v1.6-flip-ripgrep-default-on.json
+
+# requests — no env — the flip auto-detects Python and holds the stack OFF
+CODELENS_MODEL_DIR=$(pwd)/crates/codelens-engine/models \
+CODELENS_RANK_SPARSE_THRESHOLD=40 \
+CODELENS_RANK_SPARSE_MAX=40 \
+CODELENS_BIN=./target/release/codelens-mcp \
+python3 benchmarks/embedding-quality.py /tmp/requests-ext --isolated-copy \
+  --dataset benchmarks/embedding-quality-dataset-requests.json \
+  --output benchmarks/embedding-quality-v1.6-flip-requests-default-on.json
+```
+
+**Migration note** (for v1.5.x users upgrading to v1.6.0):
+
+- **Most users**: no action required. A supported-language project (Rust/C/C++/Go/Java/Kotlin/Scala/C#/TS/JS) will silently start producing the stacked results. A Python project will silently stay on baseline behaviour via the language gate. Any project whose `language_supports_nl_stack` classification is "unknown" (Ruby, PHP, Lua, shell, …) will also stay on baseline — the conservative default-off branch catches everything the allow-list does not explicitly cover.
+- **v1.5.x users who had explicit `CODELENS_EMBED_HINT_AUTO=1`**: no change, explicit always wins, behaviour identical.
+- **v1.5.x users who had explicit `CODELENS_EMBED_HINT_INCLUDE_COMMENTS=1` / `CODELENS_EMBED_HINT_INCLUDE_API_CALLS=1` / `CODELENS_RANK_SPARSE_TERM_WEIGHT=1`**: no change, per-gate explicit wins over the auto decision (explicit-first-then-auto rule preserved from §8.11).
+- **Opt-out escape hatch**: set `CODELENS_EMBED_HINT_AUTO=0` to restore v1.5.x default-off semantics for the whole auto pipeline. Also accepts `false`, `no`, `off` (case-insensitive).
+- **Python / JS / TS users who want to force the stack ON despite the language gate**: set each of the three explicit env vars (`CODELENS_EMBED_HINT_INCLUDE_COMMENTS=1`, `CODELENS_EMBED_HINT_INCLUDE_API_CALLS=1`, `CODELENS_RANK_SPARSE_TERM_WEIGHT=1`) plus `CODELENS_RANK_SPARSE_THRESHOLD=40` `CODELENS_RANK_SPARSE_MAX=40` to bypass the gate. Not recommended for Python based on §8.8 measurement.
+
+**Limitations**:
+
+1. **Process-scoped env var**. `auto_set_embed_hint_lang` exports `CODELENS_EMBED_HINT_AUTO_LANG` for the rest of the process. Switching projects mid-session via the `activate_project` MCP tool re-runs the helper, but because `user_forced_lang` short-circuits when the env var is already set, **switching from a Rust project to a Python project mid-session still sees the Rust language tag**. This was an acknowledged follow-up limitation from §8.12 and is unchanged by the flip. Restart the server to pick up a language change.
+2. **No Phase 3d evidence yet**. JS/TS classification rests on a single external-repo measurement (§8.13 `facebook/jest`). A Phase 3d follow-up on `microsoft/typescript` or `microsoft/vscode` is still open and would firm up the evidence for users with very large TS monorepos.
+3. **Test race exposed, not eliminated for all future env-var tests**. New tests that mutate `CODELENS_EMBED_HINT_*` env vars must remember to take `ENV_LOCK` or they will see race conditions against the existing eleven tests. A clippy lint or helper macro would be a nicer long-term fix.
+
+**Artefacts**: `benchmarks/embedding-quality-v1.6-flip-{ripgrep,requests}-default-on.json`. Both files are bit-identical to their `§8.12 phase2j-*-mcpauto.json` counterparts — readers can verify with `diff` if they want to confirm the parity claim independently.
+
+---
 
 ## 9. See Also
 


### PR DESCRIPTION
## Summary

After the five-dataset measurement arc (§8.2–§8.13), Phase 2j engine gate (§8.11), and MCP auto-set follow-up (§8.12), this PR flips `auto_hint_mode_enabled()` default from `false` → `true`. Supported-language projects (Rust / C / C++ / Go / Java / Kotlin / Scala / C# / TypeScript / JavaScript) silently gain the §8.7 / §8.13 stacked behaviour; Python / Ruby / PHP / Lua / shell / unknown-language projects silently stay on baseline via the §8.11 language gate.

**Zero env vars required for the common case.** Users who want to opt out set `CODELENS_EMBED_HINT_AUTO=0`.

## Changes

| File | Change |
|---|---|
| `crates/codelens-engine/src/embedding/mod.rs` | `auto_hint_mode_enabled()` → `unwrap_or(true)`. Doc-comment updated. |
| `crates/codelens-mcp/src/tools/session/project_ops.rs` | `auto_set_embed_hint_lang` helper flipped in lock-step with engine — its own inline env parser was still `unwrap_or(false)`, which broke the flip by short-circuiting before `compute_dominant_language`. |
| `crates/codelens-engine/src/embedding/mod.rs` (tests) | Renamed `auto_hint_mode_gated_off_by_default` → `auto_hint_mode_defaults_on_unless_explicit_off`. Three-case assertion (unset → on, `=0` → off, `=1` → on). Updated `auto_hint_should_enable_requires_both_gate_and_supported_lang` Case 1 to use explicit `=0`. |
| `crates/codelens-engine/src/embedding/mod.rs` (tests) | Added `ENV_LOCK: Mutex<()>` and wrapped eleven `CODELENS_EMBED_HINT_*`-mutating test functions — the flip exposed a latent parallel-test race that the old `unwrap_or(false)` default had been masking. |
| `benchmarks/embedding-quality-v1.6-flip-{ripgrep,requests}-default-on.json` | Bit-identical verification artefacts. |
| `docs/benchmarks.md §8.14` | Full write-up. |
| `CHANGELOG.md [Unreleased]` | New `[Changed]` entry with migration note. |

## Measurement verification (bit-identical parity)

Replayed §8.12 benchmarks with **zero** `CODELENS_EMBED_HINT_*` env vars set (only Phase 2e tuning `SPARSE_THRESHOLD=40` / `SPARSE_MAX=40`):

| Dataset           | Expected (§8.12 target)              | v1.6.0 flip actual     | Δ      |
| ----------------- | -----------------------------------: | ---------------------: | -----: |
| ripgrep (Rust)    | 0.5291666666666667 (§8.7 stacked)    | **0.5291666666666667** | 0.0000 |
| requests (Python) | 0.5837009803921568 (§8.8 baseline)   | **0.5837009803921568** | 0.0000 |

Bit-identical to the tenth decimal. The flip produces exactly the same results as explicit `CODELENS_EMBED_HINT_AUTO=1` + `CODELENS_EMBED_HINT_AUTO_LANG=rust/python`, but with zero configuration.

## Migration note for v1.5.x users

- **Most users**: no action. Supported-language projects silently gain stacked behaviour. Python/other projects silently stay on baseline via §8.11 language gate + `language_supports_nl_stack` conservative default-off branch.
- **Opt-out**: `CODELENS_EMBED_HINT_AUTO=0` restores v1.5.x default-off semantics. Also accepts `false` / `no` / `off` (case-insensitive).
- **Per-gate explicit overrides still win** (`CODELENS_EMBED_HINT_INCLUDE_COMMENTS=1` / `_API_CALLS=1` / `CODELENS_RANK_SPARSE_TERM_WEIGHT=1`) — explicit-first-then-auto rule from §8.11 preserved.
- **Python users who want to force the stack ON despite the language gate**: set the three explicit per-gate env vars plus the sparse tuning knobs. Not recommended based on §8.8 measurement.

## v1.6.0 as a `[Changed]` entry

Ships as `[Changed]`, not `[Added]` — this is a default behaviour change. Users upgrading must read the migration note. Semantic versioning matches: v1.5.x → v1.6.0 for the backwards-compatible-with-opt-out default change.

## Test plan

- [x] `cargo test -p codelens-engine` — 257 passed (test count unchanged; one renamed + expanded, `ENV_LOCK` race hardening in 11 tests)
- [x] `cargo test -p codelens-mcp` — 148 passed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo build --release -p codelens-mcp`
- [x] Measurement: ripgrep with zero env vars → 0.5291666666666667 (bit-identical to §8.7 stacked / §8.12 ripgrep-mcpauto)
- [x] Measurement: requests with zero env vars → 0.5837009803921568 (bit-identical to §8.8 baseline / §8.12 requests-mcpauto)

## Dependency chain

This PR is the culmination of the §8.1–§8.13 measurement arc:
- §8.7 Phase 3a (Rust ripgrep) — PR #9
- §8.8 Phase 3b (Python requests) — PR (same)
- §8.9 Phase 2h / §8.10 Phase 2i filter refinements — PRs #23, #24
- §8.11 Phase 2j language gate — PR #25
- §8.12 Phase 2j MCP auto-set follow-up — PR #26 (merged)
- §8.13 Phase 3c JS/TS validation on jest — PR #27 (merged)
- **§8.14 v1.6.0 default flip — this PR**

🤖 Generated with [Claude Code](https://claude.com/claude-code)