### PR TITLE
Phase 4d: single-instance port guard for HTTP transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added (Phase 4d — single-instance port guard for HTTP transport)
+
+Closes the duplicate-launcher failure mode that Phase 4c's structured logging **made visible but did not resolve**. Phase 4c observability confirmed two launchers racing on port 7837 (`project_source="MCP_PROJECT_DIR"` and `project_source="CLI path"`, 27 μs apart). The `CLI path` source maps to the launchd user agent `com.bagjaeseog.codelens-mcp.http.plist` (`RunAtLoad+KeepAlive`), while the `MCP_PROJECT_DIR` source is not tracked to any persistent config. Since source elimination is impossible without project-wide user-config policy, Phase 4d adds an **application-level single-instance guarantee** instead: whoever loses the race exits gracefully (`exit 0`) with a structured marker, leaving the existing daemon undisturbed.
+
+- **`port_is_occupied()` helper in `transport_http.rs`**: probes `127.0.0.1:<port>` via `TcpStream::connect` with a 200 ms timeout. `Ok(Ok(_))` → port is occupied (something is listening). `Ok(Err(_))` (typically `ConnectionRefused`) → port is free. Timeout → treat as free (conservative — the actual `bind` call will catch any real conflict). Pure async, no extra dependencies.
+- **Pre-bind probe in `run_http()`**: the HTTP server entry point now probes the target port before even constructing the axum router. Occupied port → skip to `emit_existing_instance_exit()`. Free port → normal bind + serve path.
+- **Bind-time AddrInUse fallback**: a short race window exists between the probe and the actual `bind()` call where a second instance could claim the port. We catch that specific error (`std::io::ErrorKind::AddrInUse` from the `bind` result) and re-route it through the same graceful exit path. Double-safety — whichever detection fires first wins.
+- **`emit_existing_instance_exit()` → `exit 0`**: logs a structured `warn!` with `port`, `project_root`, `git_sha`, `daemon_started_at`, and a new `existing_instance_detected=true` discriminator field, then calls `std::process::exit(0)`. The `exit 0` is deliberate so a suitably configured launchd user agent (`KeepAlive.SuccessfulExit=false`) will respect the graceful termination and **not** trigger a retry loop. If the plist is not yet updated, launchd will keep retrying but each retry hits the same graceful exit — worst case is log noise, not a spin.
+- **Smoke test on running daemon (verified end-to-end)**: launched a second `codelens-mcp --transport http --port 7837` against a live daemon (PID 33970). Result:
+  ```
+  WARN CODELENS_SESSION_START pid=53608 ... git_sha=b60a1d5 ...
+  WARN another CodeLens MCP daemon is already listening on this port —
+       deferring to existing instance (exit 0) port=7837
+       existing_instance_detected=true ...
+  exit code: 0
+  ```
+  The second process detected the existing listener in **376 μs** (between startup banner and graceful exit), emitted the structured marker, and exited cleanly. The existing daemon (PID 33970) kept serving uninterrupted. Phase 4c's `project_source=MCP_PROJECT_DIR` vs `project_source=CLI path` race (the bug that motivated this phase) is now a no-op: whichever process reaches the port first keeps it, the other emits one log line and exits.
+- **Three new unit tests** in `transport_http::single_instance_guard_tests`:
+  - `port_is_occupied_returns_false_for_empty_port` — bind `127.0.0.1:0` to reserve an ephemeral port, drop the listener, probe should return false (normal startup path)
+  - `port_is_occupied_returns_true_for_live_listener` — bind a real listener, spawn an accept loop, probe should return true (duplicate-detection path)
+  - `port_is_occupied_handles_port_zero_gracefully` — port 0 is a reserved wildcard, probe should return false without panicking (edge case)
+
+  MCP test count (`--features http`): 198 → **201** (+3). Default-feature count unchanged at 155 (the tests are `#[cfg(feature = "http")]`-gated).
+
+- **launchd plist migration note** (user action required, not done in this PR): for the graceful-exit path to prevent launchd retry loops, `~/Library/LaunchAgents/com.bagjaeseog.codelens-mcp.http.plist` should be updated from `<key>KeepAlive</key><true/>` to a dict form with `SuccessfulExit=false`:
+
+  ```xml
+  <key>KeepAlive</key>
+  <dict>
+      <key>SuccessfulExit</key>
+      <false/>
+  </dict>
+  ```
+
+  Followed by `launchctl unload ~/Library/LaunchAgents/com.bagjaeseog.codelens-mcp.http.plist && launchctl load ~/Library/LaunchAgents/com.bagjaeseog.codelens-mcp.http.plist`. This is documented but **not automated** — system-level config changes are out of scope for a Rust PR and should be approved explicitly by the user after reviewing the PR.
+
+- **No API breakage**: no JSON payload changes, no public function signatures changed. The `run_http` function returns the same `Result<()>` with the same normal path; the only difference is that `std::process::exit(0)` may now be called from within the function body under the specific "port occupied" condition. Callers that expected `run_http` to always return are a theoretical concern, but there are no such callers in-tree (the function is the final leaf in `main.rs`'s http branch).
+
 ### Added (Phase 4c — HTTP startup banner, structured bind errors, docs stale fixes)
 
 Operational observability layer improvements. Phase 4a/4b made `get_capabilities` an accurate runtime truth source, but debuggers looking at append-only daemon logs (e.g. `~/.codex/codelens-http.log` under launchd) still had no single-line session boundary. Phase 4c closes the gap for log readers the same way Phase 4b closed it for `get_capabilities` callers.

--- a/crates/codelens-mcp/src/server/transport_http.rs
+++ b/crates/codelens-mcp/src/server/transport_http.rs
@@ -86,10 +86,72 @@ async fn server_card_handler(State(state): State<Arc<AppState>>) -> impl IntoRes
     )
 }
 
+/// Phase 4d (§single-instance guard): probe the target port before
+/// attempting to bind. Returns `true` if the port is already
+/// accepting connections, which we interpret as "another CodeLens
+/// MCP daemon is already live here — defer to it".
+///
+/// Uses a short 200 ms connect timeout so startup doesn't stall on
+/// weird network states. `ConnectionRefused` (the normal "nothing is
+/// listening" response from the kernel) is the happy path and
+/// returns `false`. Any other error (timeout, permission denied,
+/// network unreachable) is also treated as "port is free" —
+/// conservative, since the actual `bind` call will still catch a
+/// real bind conflict.
+async fn port_is_occupied(port: u16) -> bool {
+    use tokio::net::TcpStream;
+    use tokio::time::{Duration, timeout};
+    let addr = format!("127.0.0.1:{port}");
+    match timeout(Duration::from_millis(200), TcpStream::connect(&addr)).await {
+        // Successful connect within 200 ms → something is listening.
+        Ok(Ok(_stream)) => true,
+        // Any error (ConnectionRefused, etc.) → port is free.
+        Ok(Err(_)) => false,
+        // Timeout → treat as free (bind will catch a real conflict).
+        Err(_) => false,
+    }
+}
+
+/// Phase 4d (§single-instance guard): log and exit 0 when we detect
+/// an existing instance. `std::process::exit(0)` is deliberate — it
+/// tells launchd (configured with `KeepAlive.SuccessfulExit=false`)
+/// that this invocation is a normal termination and should **not**
+/// trigger an automatic retry. If the user's launchd config does
+/// not yet carry that key, launchd will keep retrying but each retry
+/// will hit the same exit 0 path until the existing instance dies
+/// naturally — so the worst case is log noise, not a spin.
+fn emit_existing_instance_exit(
+    port: u16,
+    project_root: String,
+    daemon_started_at: &str,
+) -> ! {
+    tracing::warn!(
+        port,
+        project_root = %project_root,
+        git_sha = crate::build_info::BUILD_GIT_SHA,
+        daemon_started_at = daemon_started_at,
+        existing_instance_detected = true,
+        "another CodeLens MCP daemon is already listening on this port — deferring to existing instance (exit 0)"
+    );
+    std::process::exit(0);
+}
+
 /// Start the HTTP server with Streamable HTTP transport.
 #[tokio::main]
 pub(crate) async fn run_http(state: Arc<AppState>, port: u16) -> Result<()> {
     state.metrics().record_transport_session("http");
+
+    // Phase 4d §single-instance guard: probe before bind. Catches
+    // the common duplicate-launcher case (two launchd-style sources
+    // racing for the same port) with a sub-second check instead of
+    // letting both processes reach `bind()` and stack bind errors
+    // in the append-only daemon log.
+    if port_is_occupied(port).await {
+        let project_root = state.current_project_scope();
+        let daemon_started_at = state.daemon_started_at().to_string();
+        emit_existing_instance_exit(port, project_root, &daemon_started_at);
+    }
+
     let app = build_router(state.clone());
 
     // Session cleanup background task
@@ -110,17 +172,37 @@ pub(crate) async fn run_http(state: Arc<AppState>, port: u16) -> Result<()> {
     let addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));
     tracing::info!("CodeLens MCP HTTP server listening on http://{addr}/mcp");
 
-    let listener = tokio::net::TcpListener::bind(addr).await.map_err(|error| {
-        tracing::error!(
-            port,
-            project_root = %state.current_project_scope(),
-            git_sha = crate::build_info::BUILD_GIT_SHA,
-            daemon_started_at = state.daemon_started_at(),
-            error = %error,
-            "failed to bind CodeLens MCP HTTP listener"
-        );
-        error
-    })?;
+    // Phase 4d §single-instance guard: even with pre-probe, a
+    // race window exists where a second instance bound the port
+    // between our probe and our bind. `bind` will then fail with
+    // `AddrInUse`. We catch that specific error and re-route to
+    // the same graceful exit 0 path.
+    let listener = match tokio::net::TcpListener::bind(addr).await {
+        Ok(listener) => listener,
+        Err(error) if error.kind() == std::io::ErrorKind::AddrInUse => {
+            let project_root = state.current_project_scope();
+            let daemon_started_at = state.daemon_started_at().to_string();
+            tracing::warn!(
+                port,
+                project_root = %project_root,
+                git_sha = crate::build_info::BUILD_GIT_SHA,
+                daemon_started_at = %daemon_started_at,
+                "bind raced with existing instance (AddrInUse after probe) — deferring"
+            );
+            emit_existing_instance_exit(port, project_root, &daemon_started_at);
+        }
+        Err(error) => {
+            tracing::error!(
+                port,
+                project_root = %state.current_project_scope(),
+                git_sha = crate::build_info::BUILD_GIT_SHA,
+                daemon_started_at = state.daemon_started_at(),
+                error = %error,
+                "failed to bind CodeLens MCP HTTP listener"
+            );
+            return Err(error.into());
+        }
+    };
     axum::serve(listener, app).await.map_err(|error| {
         tracing::error!(
             port,
@@ -298,4 +380,78 @@ async fn mcp_delete_handler(State(state): State<Arc<AppState>>, headers: HeaderM
         tracing::debug!(session_id = id, "session terminated by client");
     }
     StatusCode::NO_CONTENT
+}
+
+// ── Phase 4d: single-instance port guard tests ─────────────────────
+
+#[cfg(test)]
+mod single_instance_guard_tests {
+    use super::port_is_occupied;
+
+    /// Pick a port that's almost certainly free by binding 127.0.0.1:0
+    /// (let the kernel choose) and returning the allocated number.
+    /// The listener is dropped before we return, so by the time the
+    /// caller probes, the port is definitely free.
+    async fn reserve_free_port() -> u16 {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("kernel should hand out a free ephemeral port");
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+        port
+    }
+
+    /// Phase 4d AC3: an empty port must be reported as not-occupied.
+    /// This is the normal startup path — daemon probes, sees nothing,
+    /// proceeds to bind.
+    #[tokio::test]
+    async fn port_is_occupied_returns_false_for_empty_port() {
+        let port = reserve_free_port().await;
+        assert!(
+            !port_is_occupied(port).await,
+            "empty port {port} must be reported as not-occupied"
+        );
+    }
+
+    /// Phase 4d AC1: a port with a live listener must be reported as
+    /// occupied. This is the single-instance trigger — a second
+    /// launcher probing the same port must detect the existing
+    /// daemon before calling `bind()`.
+    #[tokio::test]
+    async fn port_is_occupied_returns_true_for_live_listener() {
+        // Bind a real listener on an ephemeral port.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("kernel should hand out a free ephemeral port");
+        let port = listener.local_addr().unwrap().port();
+
+        // Spawn a minimal accept loop so the probe's TcpStream::connect
+        // actually succeeds rather than hitting a race against the
+        // kernel's accept queue. We just accept and immediately drop —
+        // the probe only cares about the initial 3-way handshake.
+        let accept_handle = tokio::spawn(async move {
+            if let Ok((stream, _)) = listener.accept().await {
+                drop(stream);
+            }
+        });
+
+        assert!(
+            port_is_occupied(port).await,
+            "live listener on port {port} must be reported as occupied"
+        );
+
+        // Clean up the spawned accept task.
+        accept_handle.abort();
+    }
+
+    /// Phase 4d AC1 edge case: unreachable ports (e.g. port 0, which
+    /// is a reserved wildcard) should not panic and should return
+    /// false so normal startup proceeds. The probe is conservative
+    /// by design — bind will catch any real problem.
+    #[tokio::test]
+    async fn port_is_occupied_handles_port_zero_gracefully() {
+        // Port 0 is reserved and unbindable via TcpStream::connect.
+        // Should return false (not-occupied) without panicking.
+        let _ = port_is_occupied(0).await;
+    }
 }


### PR DESCRIPTION
## Summary

Closes the duplicate-launcher failure mode that Phase 4c's structured logging **made visible but did not resolve**. Phase 4c observability confirmed two launchers racing on port 7837 (`project_source="MCP_PROJECT_DIR"` and `project_source="CLI path"`, 27 μs apart in the log). Source elimination is impossible without project-wide user-config policy, so Phase 4d adds an **application-level single-instance guarantee** instead: whoever loses the race exits gracefully with `exit 0`, leaving the existing daemon undisturbed.

## The problem (Phase 4c discovery)

Two consecutive log markers from `~/.codex/codelens-http.log`:
```
19:54:16.953415Z  WARN CODELENS_SESSION_START pid=33890 ... project_source="MCP_PROJECT_DIR" ...
19:54:16.953442Z  WARN CODELENS_SESSION_START pid=33883 ... project_source="CLI path" ...
19:54:16.954671Z ERROR failed to bind CodeLens MCP HTTP listener port=7837 ... Address already in use
```

Two distinct launcher sources bound for the same port within 27 μs of each other. One lost the `bind()` race and exited with an anonymous error. Phase 4c made this visible; Phase 4d makes the loser's exit **graceful** and **non-disruptive**.

## Implementation

### Pre-bind port probe

```rust
async fn port_is_occupied(port: u16) -> bool {
    let addr = format!("127.0.0.1:{port}");
    match timeout(Duration::from_millis(200), TcpStream::connect(&addr)).await {
        Ok(Ok(_stream)) => true,   // something is listening
        Ok(Err(_)) => false,       // ConnectionRefused → port free
        Err(_) => false,           // timeout → treat as free
    }
}
```

Called from `run_http()` **before** constructing the axum router. Pure async, no new dependencies.

### Bind-time AddrInUse fallback (race safety)

A short window exists between probe and actual `bind()`. If a second instance claims the port in that window, the `bind()` call fails with `ErrorKind::AddrInUse`. We catch that specific error and re-route through the same graceful exit path. **Double-safety**: whichever detection fires first wins.

### Graceful exit 0

```rust
fn emit_existing_instance_exit(port, project_root, daemon_started_at) -> ! {
    tracing::warn!(
        port, project_root, git_sha, daemon_started_at,
        existing_instance_detected = true,
        "another CodeLens MCP daemon is already listening on this port —
         deferring to existing instance (exit 0)"
    );
    std::process::exit(0);
}
```

`exit 0` is deliberate so launchd with `KeepAlive.SuccessfulExit=false` respects the graceful termination and **does not** trigger retry. Without that plist update, launchd keeps retrying but each retry hits the same graceful exit — worst case is log noise, not a spin.

## Smoke test (verified end-to-end on live daemon)

Launched a second `codelens-mcp --transport http --port 7837` against a live daemon (PID 33970):

```
WARN CODELENS_SESSION_START pid=53608 ... git_sha=b60a1d5 ...
WARN another CodeLens MCP daemon is already listening on this port —
     deferring to existing instance (exit 0) port=7837
     existing_instance_detected=true ...
exit code: 0
```

**376 μs** between startup banner and graceful exit. Existing daemon (PID 33970) kept serving uninterrupted.

## Tests

Three new unit tests in `transport_http::single_instance_guard_tests`:

| Test | Scenario |
|---|---|
| `port_is_occupied_returns_false_for_empty_port` | Normal startup path — probe detects no listener, proceed |
| `port_is_occupied_returns_true_for_live_listener` | Duplicate detection — probe detects listener, trigger exit 0 |
| `port_is_occupied_handles_port_zero_gracefully` | Edge case — reserved port 0 should not panic |

| Suite | Before | After |
|---|---|---|
| `codelens-engine` | 257 | 257 (unchanged) |
| `codelens-mcp` (default features) | 155 | 155 (unchanged — tests are http-gated) |
| `codelens-mcp` (`--features http`) | 198 | **201** (+3) |
| `cargo clippy --all-targets --features http -- -D warnings` | clean | clean |

## launchd plist migration note (user action required, NOT in this PR)

For launchd to respect the graceful-exit path and stop retry loops, update `~/Library/LaunchAgents/com.bagjaeseog.codelens-mcp.http.plist`:

```xml
<!-- OLD -->
<key>KeepAlive</key>
<true/>

<!-- NEW -->
<key>KeepAlive</key>
<dict>
    <key>SuccessfulExit</key>
    <false/>
</dict>
```

Then reload:
```bash
launchctl unload ~/Library/LaunchAgents/com.bagjaeseog.codelens-mcp.http.plist
launchctl load ~/Library/LaunchAgents/com.bagjaeseog.codelens-mcp.http.plist
```

**This PR does NOT automate the plist change** — system-level config changes require explicit user approval. Without it, Phase 4d still works (graceful exit on every duplicate), but launchd may keep retrying until the existing daemon dies.

## No API breakage

- No JSON payload changes
- No public function signature changes
- `run_http()` may now call `std::process::exit(0)` under the specific "port occupied" condition; the only in-tree caller (`main.rs` http branch) is a leaf that exits after `run_http()` anyway

## Relationship to prior PRs

- Builds on PR #30 (Phase 4c) which added the observability that revealed the bug
- Builds on PR #29 (Phase 4a + 4b) which added the capability-reporting accuracy baseline
- Completes the Phase 4 series: Phase 4a (fix reporting) → 4b (detect stale daemon) → 4c (observe duplicate launchers) → **4d (prevent duplicate launchers)**

## Test plan

- [x] `cargo test -p codelens-engine` — 257 passed
- [x] `cargo test -p codelens-mcp` — 155 passed (default)
- [x] `cargo test -p codelens-mcp --features http` — **201** passed (+3)
- [x] `cargo clippy --all-targets --features http -- -D warnings` — clean
- [x] `cargo build --release -p codelens-mcp --features http`
- [x] Smoke test: second daemon launch on occupied port → graceful exit 0 in 376 μs, existing daemon undisturbed

🤖 Generated with [Claude Code](https://claude.com/claude-code)