### PR TITLE
chore(release): v1.6.0 — language-gated default flip + Phase 4 reporting/observability epic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0] — 2026-04-12
+
+### Release summary
+
+Closes the Phase 2j → 3c → v1.6.0 flip → 4a–4d arc. Five themes:
+
+1. **Language-gated v1.5 stack is now the default** (Phase 2j + Phase 2j follow-up + v1.6.0 default flip, §8.11 / §8.12 / §8.14). `CODELENS_EMBED_HINT_AUTO=1` is the default behaviour; supported-language projects (Rust / C / C++ / Go / Java / Kotlin / Scala / C# / TypeScript / JavaScript) silently gain the §8.7 / §8.13 stacked-arm results, Python / Ruby / PHP / Lua / shell / unknown-language projects silently stay on the §8.8 baseline via the language gate. Opt-out: set `CODELENS_EMBED_HINT_AUTO=0`. Five datasets measurement-validated (4 positive : 1 Python negative).
+2. **TypeScript / JavaScript are measurement-validated** (Phase 3c, §8.13). One external-repo A/B on `facebook/jest` with 24 hand-built queries, `+7.3%` relative hybrid MRR over baseline, 7 : 1 per-query positive : negative ratio. Added `ts` / `typescript` / `tsx` / `js` / `javascript` / `jsx` to `language_supports_nl_stack`. Evidence tier acknowledged — single-dataset, moderate confidence — Phase 3d on `microsoft/typescript` remains open.
+3. **Filter-refinement experiments merged as negative results** (Phase 2h partial, Phase 2i rejected, §8.9 / §8.10). Phase 2h strict literal filter recovered ~8% of the Python regression on `requests`; Phase 2i strict comment filter closed an additional 0%. The negative results are shipped as opt-in knobs anyway so future contributors can bisect and so Rust users who want defensive safety nets can enable them at zero cost.
+4. **Capability reporting is now truthful** (Phase 4a / 4b, §capability-reporting). `get_capabilities` no longer lies about semantic search ("call index_embeddings first" → four-way decomposition with `status` field) or about LSP availability (daemon PATH fallback via `/opt/homebrew/bin`, `~/.cargo/bin`, `~/.fnm/aliases/default/bin`, etc. plus `CODELENS_LSP_PATH_EXTRA`). `PLANNER_READONLY` and `BUILDER_MINIMAL` surfaces now expose `semantic_search` + `index_embeddings` so the Codex surface is in lock-step with the engine's actual capabilities. Binary build metadata (`binary_version`, `binary_git_sha`, `binary_build_time`, `daemon_started_at`) is added to the capability payload so downstream tooling can detect a stale running daemon in a single tool call.
+5. **HTTP transport is operationally observable and single-instance safe** (Phase 4c / 4d, §observability). Single-line `CODELENS_SESSION_START` marker at `warn!` level gives append-only daemon logs (launchd / systemd) an explicit session boundary with pid / port / project_root / project_source / surface / build-identity / daemon_started_at. HTTP bind and serve failures now carry structured tracing fields (port / project_root / git_sha / daemon_started_at) for the same reason. On top of that, `run_http()` now probes the target port before `bind()` and gracefully exits `0` on duplicate detection with `existing_instance_detected=true`, catching the two-launcher race that Phase 4c observability made visible in the first place. Smoke test: **376 μs** from second-launcher startup banner to graceful exit 0; existing daemon uninterrupted.
+
+Test totals at release:
+
+| Suite                              |   Count |
+| ---------------------------------- | ------: |
+| `codelens-engine`                  |     257 |
+| `codelens-mcp` (default)           |     155 |
+| `codelens-mcp` (`--features http`) | **201** |
+
+All `cargo clippy --all-targets --features http -- -D warnings` clean. Release binary builds cleanly for both default and http feature sets.
+
+**Opt-out / migration notes** for v1.5.x users:
+
+- **Most users**: no action required. Supported-language projects silently gain the Phase 2j stack. Python / Ruby / PHP / Lua / shell / unknown-language projects silently stay on baseline.
+- **v1.5.x users who had `CODELENS_EMBED_HINT_AUTO=1` explicit**: no change, explicit always wins.
+- **Restore v1.5.x default-off semantics**: set `CODELENS_EMBED_HINT_AUTO=0` (also accepts `false` / `no` / `off`).
+- **Per-gate explicit overrides still win**: `CODELENS_EMBED_HINT_INCLUDE_COMMENTS`, `_API_CALLS`, `CODELENS_RANK_SPARSE_TERM_WEIGHT` all take precedence over the auto decision — same explicit-first-then-auto rule as §8.11.
+- **launchd user agent users** (the Phase 4d reader audience): if you use `~/Library/LaunchAgents/com.bagjaeseog.codelens-mcp.http.plist` or similar, update `<key>KeepAlive</key><true/>` to a dict with `<key>SuccessfulExit</key><false/>` so launchd respects the Phase 4d graceful-exit path and does not trigger a retry loop on duplicate detection. See §8.14 / Phase 4d write-up for the full plist snippet.
+
+---
+
 ### Added (Phase 4d — single-instance port guard for HTTP transport)
 
 Closes the duplicate-launcher failure mode that Phase 4c's structured logging **made visible but did not resolve**. Phase 4c observability confirmed two launchers racing on port 7837 (`project_source="MCP_PROJECT_DIR"` and `project_source="CLI path"`, 27 μs apart). The `CLI path` source maps to the launchd user agent `com.bagjaeseog.codelens-mcp.http.plist` (`RunAtLoad+KeepAlive`), while the `MCP_PROJECT_DIR` source is not tracked to any persistent config. Since source elimination is impossible without project-wide user-config policy, Phase 4d adds an **application-level single-instance guarantee** instead: whoever loses the race exits gracefully (`exit 0`) with a structured marker, leaving the existing daemon undisturbed.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,7 +265,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "codelens-engine"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -328,7 +328,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-mcp"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "Apache-2.0"
-version = "1.5.0"
+version = "1.6.0"
 description = "Pure Rust MCP server for code intelligence — 89 tools (+6 semantic), 25 languages, tree-sitter-first, 50-87% fewer tokens"
 repository = "https://github.com/mupozg823/codelens-mcp-plugin"
 homepage = "https://github.com/mupozg823/codelens-mcp-plugin"


### PR DESCRIPTION
## Summary

Version bump `1.5.0 → 1.6.0`. Closes the Phase 2j → 3c → v1.6.0 flip → 4a–4d work arc that started in PR #25 and lands as 8 merged PRs worth of changes.

## Commits in v1.6.0 (since v1.5.0)

| PR | Commit | Phase |
|---|---|---|
| #25 | `6782b11` | Phase 2j — language-gated auto-detection (opt-in) |
| #26 | `9909674` | Phase 2j follow-up — MCP auto-set of `CODELENS_EMBED_HINT_AUTO_LANG` |
| #27 | `fc97c0a` | Phase 3c — JS/TS validation on facebook/jest |
| #28 | `fde683e` | v1.6.0 default flip — `CODELENS_EMBED_HINT_AUTO=1` default |
| #29 | `5a3082c` | Phase 4a — capability reporting correctness + LSP daemon PATH |
| #29 | `179a263` | Phase 4b — binary build metadata in `get_capabilities` |
| #30 | `375b3fe` | Phase 4c — HTTP startup banner + structured errors + docs |
| #31 | `20572c1` | Phase 4d — single-instance port guard for HTTP transport |

Plus documentation-only commits from Phase 2d design briefs, Phase 3a/3b external-repo validation narratives, Phase 2h/2i filter experiments (all previously merged in the 1.5.x cycle but consolidated in the [1.6.0] CHANGELOG entry for release-note readers).

## Five themes

### 1. Language-gated v1.5 stack is the default (§8.11 / §8.12 / §8.14)

`CODELENS_EMBED_HINT_AUTO=1` is now the default behaviour. Supported-language projects (Rust / C / C++ / Go / Java / Kotlin / Scala / C# / TypeScript / JavaScript) silently gain the §8.7 / §8.13 stacked-arm results. Python / Ruby / PHP / Lua / shell / unknown-language projects silently stay on the §8.8 baseline via the language gate. Opt-out: `CODELENS_EMBED_HINT_AUTO=0`. **Five datasets measurement-validated** (4 positive : 1 Python negative).

### 2. TypeScript / JavaScript measurement-validated (§8.13)

One external-repo A/B on `facebook/jest` with 24 hand-built queries. **+7.3% relative hybrid MRR over baseline**, 7 : 1 per-query positive : negative ratio. Added `ts` / `typescript` / `tsx` / `js` / `javascript` / `jsx` to `language_supports_nl_stack`. Evidence tier: single-dataset, moderate confidence. Phase 3d on `microsoft/typescript` remains open as a follow-up.

### 3. Filter-refinement experiments merged as negative results (§8.9 / §8.10)

Phase 2h strict literal filter recovered ~8% of the §8.8 Python regression. Phase 2i strict comment filter closed an additional 0%. Both shipped as opt-in knobs so future contributors can bisect and so Rust users who want defensive safety nets can enable them at zero cost.

### 4. Capability reporting is now truthful (Phase 4a / 4b)

- `get_capabilities` no longer lies about semantic search (\"call index_embeddings first\" → 4-way `SemanticSearchStatus` decomposition with structured `status` field)
- LSP availability detection handles launchd-slim daemon PATH (`/opt/homebrew/bin`, `~/.cargo/bin`, `~/.fnm/aliases/default/bin`, `~/.nvm/versions/node/current/bin`, plus `CODELENS_LSP_PATH_EXTRA` override)
- `PLANNER_READONLY` and `BUILDER_MINIMAL` surfaces expose `semantic_search` + `index_embeddings` so Codex surface matches engine capability
- Binary build metadata (`binary_version`, `binary_git_sha`, `binary_build_time`, `daemon_started_at`) in capability payload for stale-daemon detection

### 5. HTTP transport: observable + single-instance safe (Phase 4c / 4d)

- `CODELENS_SESSION_START` marker at `warn!` level (visible under default `CODELENS_LOG=warn`) gives append-only daemon logs (launchd / systemd) an explicit session boundary with pid / port / project_root / project_source / surface / build-identity / daemon_started_at
- HTTP `bind` and `serve` failures carry structured `tracing` fields (port / project_root / git_sha / daemon_started_at)
- `run_http()` probes target port before `bind()` and gracefully exits `0` on duplicate detection with `existing_instance_detected=true`
- Smoke test: **376 μs** from second-launcher startup banner to graceful exit 0, existing daemon uninterrupted

## Test totals at release

| Suite | Count |
|---|---|
| `codelens-engine` | **257** |
| `codelens-mcp` (default features) | **155** |
| `codelens-mcp` (`--features http`) | **201** |
| `cargo clippy --all-targets --features http -- -D warnings` | clean |
| `cargo build --release -p codelens-mcp --features http` | ok |

## Migration (v1.5.x → v1.6.0)

- **Most users**: no action required. Supported-language projects silently gain the Phase 2j stack. Python / Ruby / PHP / Lua / shell / unknown-language projects silently stay on baseline.
- **v1.5.x users with `CODELENS_EMBED_HINT_AUTO=1` explicit**: no change, explicit always wins.
- **Restore v1.5.x default-off semantics**: set `CODELENS_EMBED_HINT_AUTO=0` (also accepts `false` / `no` / `off`).
- **Per-gate explicit overrides still win**: `CODELENS_EMBED_HINT_INCLUDE_COMMENTS`, `_API_CALLS`, `CODELENS_RANK_SPARSE_TERM_WEIGHT` all take precedence.
- **launchd user agent users** (for Phase 4d graceful-exit path): update `<key>KeepAlive</key><true/>` to a dict with `<key>SuccessfulExit</key><false/>` and `launchctl unload + load`. See §8.14 / Phase 4d write-up for the full plist snippet.

## Post-merge action plan

After this PR merges to main, create a git tag `v1.6.0` from the merge commit and push to origin. The tag produces a GitHub release automatically (if the repo has that workflow).

## Test plan

- [x] `cargo test -p codelens-engine` — 257 passed
- [x] `cargo test -p codelens-mcp` — 155 passed (default features)
- [x] `cargo test -p codelens-mcp --features http` — **201** passed
- [x] `cargo clippy --all-targets --features http -- -D warnings` — clean
- [x] `cargo build --release -p codelens-mcp --features http`
- [x] Cargo.toml workspace version 1.5.0 → 1.6.0 (verified via `cargo check` output `Compiling codelens-mcp v1.6.0`)
- [x] CHANGELOG.md `[Unreleased]` empty section preserved, new `[1.6.0] — 2026-04-12` section with five-theme summary + migration notes added above prior `[1.5.0]` entry
- [x] All 8 constituent PRs (#25, #26, #27, #28, #29, #30, #31) previously merged to main; this PR is the pure release-metadata bump on top

🤖 Generated with [Claude Code](https://claude.com/claude-code)