### PR TITLE
Phase 3d: second JS/TS dataset on microsoft/typescript — strong evidence tier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Measured (Phase 3d — JS/TS evidence upgrade via `microsoft/typescript`)
+
+Second external-repo measurement for the JS/TS branch of `language_supports_nl_stack`. §8.13 Phase 3c added `ts` / `typescript` / `tsx` / `js` / `javascript` / `jsx` based on a single dataset (`facebook/jest`, +7.3 % hybrid MRR, 24 queries) and explicitly labelled the evidence "single-dataset moderate confidence". Phase 3d replays the methodology on **`microsoft/typescript`** (the TypeScript compiler itself), upgrading the evidence tier to **"two-dataset strong confidence"**.
+
+- **Target**: `/tmp/typescript/src` — 709 production `.ts` source files (1.9 × jest's 380), spanning compiler / services / server / jsTyping / harness. `/tests` (50 k+ fixture files) deliberately excluded — fixtures would bias the index toward intentional syntax errors.
+- **Dataset**: 34 hand-built queries in `benchmarks/embedding-quality-dataset-typescript.json` (42 % larger than jest). 26 NL + 6 short_phrase + 2 identifier. Spans five compiler subsystems: pipeline (createProgram, createSourceFile, createScanner, createPrinter, createTypeChecker, forEachChild, getLineStarts), diagnostics (getSyntacticDiagnostics, getSemanticDiagnostics, getSuggestionDiagnostics), language service (createLanguageService, getCompletionsAtPosition, getDefinitionAtPosition, findReferences, getCodeFixesAtPosition), editor server (getRenameInfo, getFormattingEditsForRange, getOutliningSpans, getSignatureHelpItems), and core types (SyntaxKind, SourceFile, NodeFlags, FlowFlags, ScriptTarget, ModuleKind, TypeChecker).
+- **Four-arm A/B result**:
+
+  | arm         |   hybrid MRR |        Δ rel | NL sub-MRR |   sh sub-MRR | id sub-MRR |
+  | ----------- | -----------: | -----------: | ---------: | -----------: | ---------: |
+  | baseline    |     0.098355 |            — |   0.019644 |     0.138889 |   1.000000 |
+  | 2e only     |     0.088551 |  **−10.0 %** |   0.019644 |     0.083333 |   1.000000 |
+  | 2b+2c only  |     0.200980 | **+104.3 %** |   0.153846 |     0.138889 |   1.000000 |
+  | **stacked** | **0.200980** | **+104.3 %** |   0.153846 | **0.138889** |   1.000000 |
+
+- **Largest relative lift any external-repo measurement has produced**: +104.3 %. Compare to ripgrep (+15.2 %), jest (+7.3 %), Rust 436-query (+7.1 %), Rust 89-query (+2.4 %). Absolute lift +0.103 is comparable to ripgrep's +0.070, but on a smaller baseline (0.098 vs 0.459). Phase 2e is **−10.0 %** alone (first explicitly negative Phase 2e measurement on any dataset), and stacked = 2b+2c-only because Phase 2e contributes zero signal on top.
+- **Per-query decomposition — zero regressions**: 34 total queries → **6 improvements / 0 regressions / 28 unchanged** under the stacked arm. All six improvements move a baseline ranking toward rank 1 (`getLineStarts` 6→2, `getSyntacticDiagnostics` 10→1, `getSuggestionDiagnostics` 15→3, `createLanguageService` 23→6, `SourceFile` 14→1, `ModuleKind` 16→1). The 20 NL queries that stay `None` in both arms are retrieval failures (candidate pool never includes the target) — unfixable by any v1.5 re-ranking knob, a model-level issue for Phase 2d.
+- **Why so much larger than jest?** Three compounding factors: (1) low baseline floor (0.098 vs jest's 0.155) makes relative gains look dramatic; (2) TypeScript compiler files are enormous (`checker.ts` ~50 k lines, `parser.ts` ~10 k) and baseline `extract_leading_doc` captures only the first few lines — Phase 2b recovers signal from hundreds of lines of JSDoc and inline comments that the baseline missed by construction; (3) TypeScript is heavily JSDoc-annotated, and Phase 2b's comment extractor normalizes these into NL-shaped tokens that embed well against natural-language queries.
+- **Reader guidance**: treat jest and TypeScript as a **range**, not a single number. v1.5 stack lift on TS/JS is somewhere between **+7.3 % (jest) and +104 % (TypeScript)**, with the actual lift depending on file size distribution and JSDoc density. A typical Next.js app with short files will land near jest; a compiler / language server / editor extension with heavy docs will land near TypeScript.
+- **Updated six-dataset matrix**:
+
+  | Dataset                       | Language  | baseline MRR | stacked MRR |      Δ abs |        Δ rel |
+  | ----------------------------- | --------- | -----------: | ----------: | ---------: | -----------: |
+  | 89-query self                 | Rust      |        0.572 |       0.586 |     +0.014 |       +2.4 % |
+  | 436-query self                | Rust      |       0.0476 |      0.0510 |    +0.0034 |       +7.1 % |
+  | ripgrep external              | Rust      |        0.459 |       0.529 |     +0.070 |      +15.2 % |
+  | requests external             | Python    |        0.584 |       0.495 |     −0.089 |      −15.2 % |
+  | jest external                 | TS/JS     |        0.155 |       0.166 |     +0.011 |       +7.3 % |
+  | **typescript external (new)** | **TS/JS** |    **0.098** |   **0.201** | **+0.103** | **+104.3 %** |
+
+  Pattern: 5 positive : 1 negative across three measurement-backed language families. JS/TS classification upgraded to **two-dataset strong confidence**.
+
+- **No code changes in this phase**. `language_supports_nl_stack` already contains the JS/TS entries from §8.13; Phase 3d is pure measurement + documentation. The §8.13 "Limitations acknowledged" item ("Still only one TS dataset, Phase 3d on microsoft/typescript would firm up the evidence") is now resolved.
+- **Artefacts**: `benchmarks/embedding-quality-v1.6-phase3d-typescript-{baseline,2e-only,2b2c-only,stacked}.json`. Dataset: `benchmarks/embedding-quality-dataset-typescript.json`. Full §8.15 write-up with per-query rank tables, large-lift attribution, and limitations in [`docs/benchmarks.md` §8.15](docs/benchmarks.md).
+
 ## [1.6.0] — 2026-04-12
 
 ### Release summary

--- a/benchmarks/embedding-quality-dataset-typescript.json
+++ b/benchmarks/embedding-quality-dataset-typescript.json
@@ -1,0 +1,206 @@
+[
+  {
+    "query": "create a TypeScript program from source files and options",
+    "expected_symbol": "createProgram",
+    "expected_file_suffix": "compiler/program.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "parse a TypeScript source file into an AST",
+    "expected_symbol": "createSourceFile",
+    "expected_file_suffix": "compiler/parser.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "tokenize TypeScript source code into a stream",
+    "expected_symbol": "createScanner",
+    "expected_file_suffix": "compiler/scanner.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "print a TypeScript AST back to source text",
+    "expected_symbol": "createPrinter",
+    "expected_file_suffix": "compiler/emitter.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "build a type checker for a program",
+    "expected_symbol": "createTypeChecker",
+    "expected_file_suffix": "compiler/checker.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "visit every child node of an AST node",
+    "expected_symbol": "forEachChild",
+    "expected_file_suffix": "compiler/parser.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "get line start offsets in a source file",
+    "expected_symbol": "getLineStarts",
+    "expected_file_suffix": "compiler/scanner.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "get syntactic diagnostics from a program",
+    "expected_symbol": "getSyntacticDiagnostics",
+    "expected_file_suffix": "compiler/program.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "get semantic diagnostics for type errors",
+    "expected_symbol": "getSemanticDiagnostics",
+    "expected_file_suffix": "compiler/program.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "get suggestion diagnostics for code quality hints",
+    "expected_symbol": "getSuggestionDiagnostics",
+    "expected_file_suffix": "compiler/program.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "create a language service for editor integration",
+    "expected_symbol": "createLanguageService",
+    "expected_file_suffix": "services/services.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "get autocomplete suggestions at a cursor position",
+    "expected_symbol": "getCompletionsAtPosition",
+    "expected_file_suffix": "services/completions.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "find the definition site of a symbol at a position",
+    "expected_symbol": "getDefinitionAtPosition",
+    "expected_file_suffix": "services/services.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "find all references to a symbol in the project",
+    "expected_symbol": "findReferences",
+    "expected_file_suffix": "services/services.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "compute automatic code fixes for diagnostics",
+    "expected_symbol": "getCodeFixesAtPosition",
+    "expected_file_suffix": "services/services.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "rename a symbol and find all its occurrences",
+    "expected_symbol": "getRenameInfo",
+    "expected_file_suffix": "server/session.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "format a source range according to style rules",
+    "expected_symbol": "getFormattingEditsForRange",
+    "expected_file_suffix": "server/session.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "compute collapsible regions for an outline view",
+    "expected_symbol": "getOutliningSpans",
+    "expected_file_suffix": "server/session.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "provide parameter hints while typing a function call",
+    "expected_symbol": "getSignatureHelpItems",
+    "expected_file_suffix": "server/session.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "enum of every TypeScript AST node kind",
+    "expected_symbol": "SyntaxKind",
+    "expected_file_suffix": "compiler/types.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "interface that represents a parsed source file",
+    "expected_symbol": "SourceFile",
+    "expected_file_suffix": "compiler/types.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "flags describing properties of an AST node",
+    "expected_symbol": "NodeFlags",
+    "expected_file_suffix": "compiler/types.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "enum of control flow analysis states",
+    "expected_symbol": "FlowFlags",
+    "expected_file_suffix": "compiler/types.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "emit target ECMAScript version",
+    "expected_symbol": "ScriptTarget",
+    "expected_file_suffix": "compiler/types.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "module system kind for output code",
+    "expected_symbol": "ModuleKind",
+    "expected_file_suffix": "compiler/types.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "top-level type checker interface",
+    "expected_symbol": "TypeChecker",
+    "expected_file_suffix": "compiler/types.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "create a scanner",
+    "expected_symbol": "createScanner",
+    "expected_file_suffix": "compiler/scanner.ts",
+    "query_type": "short_phrase"
+  },
+  {
+    "query": "create a source file",
+    "expected_symbol": "createSourceFile",
+    "expected_file_suffix": "compiler/parser.ts",
+    "query_type": "short_phrase"
+  },
+  {
+    "query": "language service",
+    "expected_symbol": "createLanguageService",
+    "expected_file_suffix": "services/services.ts",
+    "query_type": "short_phrase"
+  },
+  {
+    "query": "type checker",
+    "expected_symbol": "createTypeChecker",
+    "expected_file_suffix": "compiler/checker.ts",
+    "query_type": "short_phrase"
+  },
+  {
+    "query": "rename info",
+    "expected_symbol": "getRenameInfo",
+    "expected_file_suffix": "server/session.ts",
+    "query_type": "short_phrase"
+  },
+  {
+    "query": "completions at position",
+    "expected_symbol": "getCompletionsAtPosition",
+    "expected_file_suffix": "services/completions.ts",
+    "query_type": "short_phrase"
+  },
+  {
+    "query": "SyntaxKind",
+    "expected_symbol": "SyntaxKind",
+    "expected_file_suffix": "compiler/types.ts",
+    "query_type": "identifier"
+  },
+  {
+    "query": "TypeChecker",
+    "expected_symbol": "TypeChecker",
+    "expected_file_suffix": "compiler/types.ts",
+    "query_type": "identifier"
+  }
+]

--- a/benchmarks/embedding-quality-v1.6-phase3d-typescript-2b2c-only.json
+++ b/benchmarks/embedding-quality-v1.6-phase3d-typescript-2b2c-only.json
@@ -1,0 +1,1487 @@
+{
+  "project": "/tmp/typescript/src",
+  "benchmark_project": "/var/folders/z0/0tcbss795xsdp75jmr_t9_kh0000gn/T/codelens-embed-quality-5avl1m8u/src",
+  "isolated_copy": true,
+  "binary": "/Users/bagjaeseog/codelens-mcp-plugin/target/release/codelens-mcp",
+  "embedding_model": "MiniLM-L12-CodeSearchNet-INT8",
+  "runtime_model": {
+    "model_dir": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch",
+    "model_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/model.onnx",
+    "config_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/config.json",
+    "sha256": "ef1d1e9cfa72e4929f5b9faea17d8704b23a2530aadebf0d464a4cc7750920b3",
+    "size_bytes": 34000281,
+    "num_hidden_layers": 12,
+    "hidden_size": 384
+  },
+  "dataset_path": "/Users/bagjaeseog/codelens-mcp-plugin/benchmarks/embedding-quality-dataset-typescript.json",
+  "dataset_size": 34,
+  "ranking_cutoff": 10,
+  "metric_labels": {
+    "mrr": "MRR@10",
+    "acc1": "Acc@1",
+    "acc3": "Acc@3",
+    "acc5": "Acc@5"
+  },
+  "methods": [
+    {
+      "method": "semantic_search",
+      "mrr": 0.17091503267973857,
+      "acc1": 0.14705882352941177,
+      "acc3": 0.17647058823529413,
+      "acc5": 0.17647058823529413,
+      "avg_elapsed_ms": 912.6270588235294,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 1.0,
+          "acc1": 1.0,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 255.57
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.06581196581196581,
+          "acc1": 0.038461538461538464,
+          "acc3": 0.07692307692307693,
+          "acc5": 0.07692307692307693,
+          "avg_elapsed_ms": 1030.8507692307692
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.35000000000000003,
+          "acc1": 0.3333333333333333,
+          "acc3": 0.3333333333333333,
+          "acc5": 0.3333333333333333,
+          "avg_elapsed_ms": 619.3433333333334
+        }
+      },
+      "rows": [
+        {
+          "query": "create a TypeScript program from source files and options",
+          "query_type": "natural_language",
+          "expected_symbol": "createProgram",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": null,
+          "elapsed_ms": 772.57,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "createError",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "parse a TypeScript source file into an AST",
+          "query_type": "natural_language",
+          "expected_symbol": "createSourceFile",
+          "expected_file_suffix": "compiler/parser.ts",
+          "rank": null,
+          "elapsed_ms": 1253.09,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "parseSourceFile",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "tokenize TypeScript source code into a stream",
+          "query_type": "natural_language",
+          "expected_symbol": "createScanner",
+          "expected_file_suffix": "compiler/scanner.ts",
+          "rank": null,
+          "elapsed_ms": 1009.48,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "codeActionForFix",
+            "file": "services/codefixes/importFixes.ts"
+          }
+        },
+        {
+          "query": "print a TypeScript AST back to source text",
+          "query_type": "natural_language",
+          "expected_symbol": "createPrinter",
+          "expected_file_suffix": "compiler/emitter.ts",
+          "rank": null,
+          "elapsed_ms": 1287.42,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "consumeCurrentOperator",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "build a type checker for a program",
+          "query_type": "natural_language",
+          "expected_symbol": "createTypeChecker",
+          "expected_file_suffix": "compiler/checker.ts",
+          "rank": null,
+          "elapsed_ms": 932.99,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "check",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "visit every child node of an AST node",
+          "query_type": "natural_language",
+          "expected_symbol": "forEachChild",
+          "expected_file_suffix": "compiler/parser.ts",
+          "rank": null,
+          "elapsed_ms": 1270.9,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "visit",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "get line start offsets in a source file",
+          "query_type": "natural_language",
+          "expected_symbol": "getLineStarts",
+          "expected_file_suffix": "compiler/scanner.ts",
+          "rank": 2,
+          "elapsed_ms": 1064.86,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getLineStarts",
+            "file": "services/services.ts"
+          }
+        },
+        {
+          "query": "get syntactic diagnostics from a program",
+          "query_type": "natural_language",
+          "expected_symbol": "getSyntacticDiagnostics",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": 1,
+          "elapsed_ms": 976.96,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getSyntacticDiagnostics",
+            "file": "compiler/program.ts"
+          }
+        },
+        {
+          "query": "get semantic diagnostics for type errors",
+          "query_type": "natural_language",
+          "expected_symbol": "getSemanticDiagnostics",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": null,
+          "elapsed_ms": 1063.43,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getAccessorDeclarationTypeVisibilityError",
+            "file": "compiler/transformers/declarations/diagnostics.ts"
+          }
+        },
+        {
+          "query": "get suggestion diagnostics for code quality hints",
+          "query_type": "natural_language",
+          "expected_symbol": "getSuggestionDiagnostics",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": 10,
+          "elapsed_ms": 607.34,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getSuggestion",
+            "file": "services/codefixes/fixNaNEquality.ts"
+          }
+        },
+        {
+          "query": "create a language service for editor integration",
+          "query_type": "natural_language",
+          "expected_symbol": "createLanguageService",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 1088.41,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "createReturnTypeOfSignatureDeclaration",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "get autocomplete suggestions at a cursor position",
+          "query_type": "natural_language",
+          "expected_symbol": "getCompletionsAtPosition",
+          "expected_file_suffix": "services/completions.ts",
+          "rank": null,
+          "elapsed_ms": 925.55,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getRecommendedCompletion",
+            "file": "services/completions.ts"
+          }
+        },
+        {
+          "query": "find the definition site of a symbol at a position",
+          "query_type": "natural_language",
+          "expected_symbol": "getDefinitionAtPosition",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 1306.13,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "symbolAtLocation",
+            "file": "harness/fourslashInterfaceImpl.ts"
+          }
+        },
+        {
+          "query": "find all references to a symbol in the project",
+          "query_type": "natural_language",
+          "expected_symbol": "findReferences",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 1080.86,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getReferencedSymbolsForModule",
+            "file": "services/findAllReferences.ts"
+          }
+        },
+        {
+          "query": "compute automatic code fixes for diagnostics",
+          "query_type": "natural_language",
+          "expected_symbol": "getCodeFixesAtPosition",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 1046.43,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "computeModuleSpecifiers",
+            "file": "compiler/moduleSpecifiers.ts"
+          }
+        },
+        {
+          "query": "rename a symbol and find all its occurrences",
+          "query_type": "natural_language",
+          "expected_symbol": "getRenameInfo",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 770.56,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "symbol",
+            "file": "services/rename.ts"
+          }
+        },
+        {
+          "query": "format a source range according to style rules",
+          "query_type": "natural_language",
+          "expected_symbol": "getFormattingEditsForRange",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 1068.46,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "formatRange",
+            "file": "harness/fourslashImpl.ts"
+          }
+        },
+        {
+          "query": "compute collapsible regions for an outline view",
+          "query_type": "natural_language",
+          "expected_symbol": "getOutliningSpans",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 1054.03,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "formatEnum",
+            "file": "compiler/debug.ts"
+          }
+        },
+        {
+          "query": "provide parameter hints while typing a function call",
+          "query_type": "natural_language",
+          "expected_symbol": "getSignatureHelpItems",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 597.25,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "addParameterHints",
+            "file": "services/inlayHints.ts"
+          }
+        },
+        {
+          "query": "enum of every TypeScript AST node kind",
+          "query_type": "natural_language",
+          "expected_symbol": "SyntaxKind",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 1317.51,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "asterisk",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "interface that represents a parsed source file",
+          "query_type": "natural_language",
+          "expected_symbol": "SourceFile",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 1342.22,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "parseDoStatement",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "flags describing properties of an AST node",
+          "query_type": "natural_language",
+          "expected_symbol": "NodeFlags",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 1176.34,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "flags",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "enum of control flow analysis states",
+          "query_type": "natural_language",
+          "expected_symbol": "FlowFlags",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 926.12,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "State",
+            "file": "harness/fourslashImpl.ts"
+          }
+        },
+        {
+          "query": "emit target ECMAScript version",
+          "query_type": "natural_language",
+          "expected_symbol": "ScriptTarget",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 816.25,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "createImplementsDiagnostics",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "module system kind for output code",
+          "query_type": "natural_language",
+          "expected_symbol": "ModuleKind",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": 9,
+          "elapsed_ms": 1040.75,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "evaluate",
+            "file": "harness/evaluatorImpl.ts"
+          }
+        },
+        {
+          "query": "top-level type checker interface",
+          "query_type": "natural_language",
+          "expected_symbol": "TypeChecker",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 1006.21,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "check",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "create a scanner",
+          "query_type": "short_phrase",
+          "expected_symbol": "createScanner",
+          "expected_file_suffix": "compiler/scanner.ts",
+          "rank": 10,
+          "elapsed_ms": 562.23,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "scanner",
+            "file": "services/utilities.ts"
+          }
+        },
+        {
+          "query": "create a source file",
+          "query_type": "short_phrase",
+          "expected_symbol": "createSourceFile",
+          "expected_file_suffix": "compiler/parser.ts",
+          "rank": 1,
+          "elapsed_ms": 1090.58,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "createSourceFile",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "language service",
+          "query_type": "short_phrase",
+          "expected_symbol": "createLanguageService",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 741.53,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "LanguageServiceMode",
+            "file": "services/types.ts"
+          }
+        },
+        {
+          "query": "type checker",
+          "query_type": "short_phrase",
+          "expected_symbol": "createTypeChecker",
+          "expected_file_suffix": "compiler/checker.ts",
+          "rank": null,
+          "elapsed_ms": 399.96,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "checker",
+            "file": "services/utilities.ts"
+          }
+        },
+        {
+          "query": "rename info",
+          "query_type": "short_phrase",
+          "expected_symbol": "getRenameInfo",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 387.67,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "renameInfo",
+            "file": "services/rename.ts"
+          }
+        },
+        {
+          "query": "completions at position",
+          "query_type": "short_phrase",
+          "expected_symbol": "getCompletionsAtPosition",
+          "expected_file_suffix": "services/completions.ts",
+          "rank": 1,
+          "elapsed_ms": 534.09,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getCompletionsAtPosition",
+            "file": "services/completions.ts"
+          }
+        },
+        {
+          "query": "SyntaxKind",
+          "query_type": "identifier",
+          "expected_symbol": "SyntaxKind",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": 1,
+          "elapsed_ms": 257.51,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "SyntaxKind",
+            "file": "compiler/types.ts"
+          }
+        },
+        {
+          "query": "TypeChecker",
+          "query_type": "identifier",
+          "expected_symbol": "TypeChecker",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": 1,
+          "elapsed_ms": 253.63,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "TypeChecker",
+            "file": "compiler/types.ts"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context_no_semantic",
+      "mrr": 0.1201155462184874,
+      "acc1": 0.08823529411764706,
+      "acc3": 0.11764705882352941,
+      "acc5": 0.17647058823529413,
+      "avg_elapsed_ms": 156.56117647058824,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 1.0,
+          "acc1": 1.0,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 78.95
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.012843406593406595,
+          "acc1": 0.0,
+          "acc3": 0.0,
+          "acc5": 0.038461538461538464,
+          "avg_elapsed_ms": 173.7303846153846
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.2916666666666667,
+          "acc1": 0.16666666666666666,
+          "acc3": 0.3333333333333333,
+          "acc5": 0.5,
+          "avg_elapsed_ms": 108.03166666666668
+        }
+      },
+      "rows": [
+        {
+          "query": "create a TypeScript program from source files and options",
+          "query_type": "natural_language",
+          "expected_symbol": "createProgram",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": 16,
+          "elapsed_ms": 125.44,
+          "candidate_count": 18,
+          "top_candidate": {
+            "name": "shouldProgramCreateNewSourceFiles",
+            "file": "compiler/program.ts"
+          }
+        },
+        {
+          "query": "parse a TypeScript source file into an AST",
+          "query_type": "natural_language",
+          "expected_symbol": "createSourceFile",
+          "expected_file_suffix": "compiler/parser.ts",
+          "rank": 14,
+          "elapsed_ms": 215.97,
+          "candidate_count": 20,
+          "top_candidate": {
+            "name": "parseSourceFileWorker",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "tokenize TypeScript source code into a stream",
+          "query_type": "natural_language",
+          "expected_symbol": "createScanner",
+          "expected_file_suffix": "compiler/scanner.ts",
+          "rank": null,
+          "elapsed_ms": 172.98,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "SourceMapSpanWithDecodeErrors",
+            "file": "harness/sourceMapRecorder.ts"
+          }
+        },
+        {
+          "query": "print a TypeScript AST back to source text",
+          "query_type": "natural_language",
+          "expected_symbol": "createPrinter",
+          "expected_file_suffix": "compiler/emitter.ts",
+          "rank": null,
+          "elapsed_ms": 197.88,
+          "candidate_count": 21,
+          "top_candidate": {
+            "name": "isBacktrackingSourcePosition",
+            "file": "compiler/sourcemap.ts"
+          }
+        },
+        {
+          "query": "build a type checker for a program",
+          "query_type": "natural_language",
+          "expected_symbol": "createTypeChecker",
+          "expected_file_suffix": "compiler/checker.ts",
+          "rank": null,
+          "elapsed_ms": 185.84,
+          "candidate_count": 19,
+          "top_candidate": {
+            "name": "getWidenedLiteralLikeTypeForContextualType",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "visit every child node of an AST node",
+          "query_type": "natural_language",
+          "expected_symbol": "forEachChild",
+          "expected_file_suffix": "compiler/parser.ts",
+          "rank": null,
+          "elapsed_ms": 205.31,
+          "candidate_count": 20,
+          "top_candidate": {
+            "name": "visitExistingNodeTreeSymbols",
+            "file": "compiler/expressionToTypeNode.ts"
+          }
+        },
+        {
+          "query": "get line start offsets in a source file",
+          "query_type": "natural_language",
+          "expected_symbol": "getLineStarts",
+          "expected_file_suffix": "compiler/scanner.ts",
+          "rank": null,
+          "elapsed_ms": 167.08,
+          "candidate_count": 21,
+          "top_candidate": {
+            "name": "getParsedCommandLineOfConfigFile",
+            "file": "compiler/commandLineParser.ts"
+          }
+        },
+        {
+          "query": "get syntactic diagnostics from a program",
+          "query_type": "natural_language",
+          "expected_symbol": "getSyntacticDiagnostics",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": null,
+          "elapsed_ms": 149.06,
+          "candidate_count": 21,
+          "top_candidate": {
+            "name": "getCombinedDiagnostics",
+            "file": "compiler/programDiagnostics.ts"
+          }
+        },
+        {
+          "query": "get semantic diagnostics for type errors",
+          "query_type": "natural_language",
+          "expected_symbol": "getSemanticDiagnostics",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": null,
+          "elapsed_ms": 169.69,
+          "candidate_count": 18,
+          "top_candidate": {
+            "name": "serializeReturnTypeForSignature",
+            "file": "compiler/expressionToTypeNode.ts"
+          }
+        },
+        {
+          "query": "get suggestion diagnostics for code quality hints",
+          "query_type": "natural_language",
+          "expected_symbol": "getSuggestionDiagnostics",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": null,
+          "elapsed_ms": 112.05,
+          "candidate_count": 19,
+          "top_candidate": {
+            "name": "createGetSymbolAccessibilityDiagnosticForNode",
+            "file": "compiler/transformers/declarations/diagnostics.ts"
+          }
+        },
+        {
+          "query": "create a language service for editor integration",
+          "query_type": "natural_language",
+          "expected_symbol": "createLanguageService",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 210.26,
+          "candidate_count": 20,
+          "top_candidate": {
+            "name": "onUpdateLanguageServiceStateForProject",
+            "file": "server/editorServices.ts"
+          }
+        },
+        {
+          "query": "get autocomplete suggestions at a cursor position",
+          "query_type": "natural_language",
+          "expected_symbol": "getCompletionsAtPosition",
+          "expected_file_suffix": "services/completions.ts",
+          "rank": null,
+          "elapsed_ms": 145.99,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "getMoveToRefactoringFileSuggestions",
+            "file": "harness/client.ts"
+          }
+        },
+        {
+          "query": "find the definition site of a symbol at a position",
+          "query_type": "natural_language",
+          "expected_symbol": "getDefinitionAtPosition",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 198.04,
+          "candidate_count": 18,
+          "top_candidate": {
+            "name": "getDefinitionFromSymbol",
+            "file": "services/goToDefinition.ts"
+          }
+        },
+        {
+          "query": "find all references to a symbol in the project",
+          "query_type": "natural_language",
+          "expected_symbol": "findReferences",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 170.52,
+          "candidate_count": 17,
+          "top_candidate": {
+            "name": "findOwnConstructorReferences",
+            "file": "services/findAllReferences.ts"
+          }
+        },
+        {
+          "query": "compute automatic code fixes for diagnostics",
+          "query_type": "natural_language",
+          "expected_symbol": "getCodeFixesAtPosition",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 165.14,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "codeFixes",
+            "file": "harness/fourslashImpl.ts"
+          }
+        },
+        {
+          "query": "rename a symbol and find all its occurrences",
+          "query_type": "natural_language",
+          "expected_symbol": "getRenameInfo",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 139.74,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "getRefactorEditsToExtractSymbol",
+            "file": "services/refactors/extractSymbol.ts"
+          }
+        },
+        {
+          "query": "format a source range according to style rules",
+          "query_type": "natural_language",
+          "expected_symbol": "getFormattingEditsForRange",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 174.3,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "SourceMapGeneratorOptions",
+            "file": "compiler/sourcemap.ts"
+          }
+        },
+        {
+          "query": "compute collapsible regions for an outline view",
+          "query_type": "natural_language",
+          "expected_symbol": "getOutliningSpans",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 176.08,
+          "candidate_count": 19,
+          "top_candidate": {
+            "name": "transformConstructorBodyWorker",
+            "file": "compiler/transformers/classFields.ts"
+          }
+        },
+        {
+          "query": "provide parameter hints while typing a function call",
+          "query_type": "natural_language",
+          "expected_symbol": "getSignatureHelpItems",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 113.43,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "addParameterHints",
+            "file": "services/inlayHints.ts"
+          }
+        },
+        {
+          "query": "enum of every TypeScript AST node kind",
+          "query_type": "natural_language",
+          "expected_symbol": "SyntaxKind",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 211.35,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "visitExistingNodeTreeSymbolsWorker",
+            "file": "compiler/expressionToTypeNode.ts"
+          }
+        },
+        {
+          "query": "interface that represents a parsed source file",
+          "query_type": "natural_language",
+          "expected_symbol": "SourceFile",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 225.75,
+          "candidate_count": 21,
+          "top_candidate": {
+            "name": "parseSourceFileWorker",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "flags describing properties of an AST node",
+          "query_type": "natural_language",
+          "expected_symbol": "NodeFlags",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 187.72,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "getUsageInfoRangeForPasteEdits",
+            "file": "services/pasteEdits.ts"
+          }
+        },
+        {
+          "query": "enum of control flow analysis states",
+          "query_type": "natural_language",
+          "expected_symbol": "FlowFlags",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 154.82,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "saveFlowAnalysisDisabled",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "emit target ECMAScript version",
+          "query_type": "natural_language",
+          "expected_symbol": "ScriptTarget",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 152.71,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "transformECMAScriptModule",
+            "file": "compiler/transformers/module/esnextAnd2015.ts"
+          }
+        },
+        {
+          "query": "module system kind for output code",
+          "query_type": "natural_language",
+          "expected_symbol": "ModuleKind",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 169.79,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "transformSystemModule",
+            "file": "compiler/transformers/module/system.ts"
+          }
+        },
+        {
+          "query": "top-level type checker interface",
+          "query_type": "natural_language",
+          "expected_symbol": "TypeChecker",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": 5,
+          "elapsed_ms": 220.05,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "isNonGenericTopLevelType",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "create a scanner",
+          "query_type": "short_phrase",
+          "expected_symbol": "createScanner",
+          "expected_file_suffix": "compiler/scanner.ts",
+          "rank": 1,
+          "elapsed_ms": 109.25,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "createScanner",
+            "file": "compiler/scanner.ts"
+          }
+        },
+        {
+          "query": "create a source file",
+          "query_type": "short_phrase",
+          "expected_symbol": "createSourceFile",
+          "expected_file_suffix": "compiler/parser.ts",
+          "rank": 6,
+          "elapsed_ms": 127.96,
+          "candidate_count": 19,
+          "top_candidate": {
+            "name": "createSourceFileWithText",
+            "file": "testRunner/unittests/helpers.ts"
+          }
+        },
+        {
+          "query": "language service",
+          "query_type": "short_phrase",
+          "expected_symbol": "createLanguageService",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 92.23,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "LanguageServiceAdapter",
+            "file": "harness/harnessLanguageService.ts"
+          }
+        },
+        {
+          "query": "type checker",
+          "query_type": "short_phrase",
+          "expected_symbol": "createTypeChecker",
+          "expected_file_suffix": "compiler/checker.ts",
+          "rank": 3,
+          "elapsed_ms": 111.83,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "TypeChecker",
+            "file": "compiler/types.ts"
+          }
+        },
+        {
+          "query": "rename info",
+          "query_type": "short_phrase",
+          "expected_symbol": "getRenameInfo",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 92.95,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "getRenameInfoError",
+            "file": "services/rename.ts"
+          }
+        },
+        {
+          "query": "completions at position",
+          "query_type": "short_phrase",
+          "expected_symbol": "getCompletionsAtPosition",
+          "expected_file_suffix": "services/completions.ts",
+          "rank": 4,
+          "elapsed_ms": 113.97,
+          "candidate_count": 21,
+          "top_candidate": {
+            "name": "getJsDocTagAtPosition",
+            "file": "services/completions.ts"
+          }
+        },
+        {
+          "query": "SyntaxKind",
+          "query_type": "identifier",
+          "expected_symbol": "SyntaxKind",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": 1,
+          "elapsed_ms": 79.61,
+          "candidate_count": 20,
+          "top_candidate": {
+            "name": "SyntaxKind",
+            "file": "compiler/types.ts"
+          }
+        },
+        {
+          "query": "TypeChecker",
+          "query_type": "identifier",
+          "expected_symbol": "TypeChecker",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": 1,
+          "elapsed_ms": 78.29,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "TypeChecker",
+            "file": "compiler/types.ts"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context",
+      "mrr": 0.20098039215686272,
+      "acc1": 0.14705882352941177,
+      "acc3": 0.23529411764705882,
+      "acc5": 0.23529411764705882,
+      "avg_elapsed_ms": 279.39382352941175,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 1.0,
+          "acc1": 1.0,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 77.33000000000001
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.15384615384615385,
+          "acc1": 0.11538461538461539,
+          "acc3": 0.19230769230769232,
+          "acc5": 0.19230769230769232,
+          "avg_elapsed_ms": 304.9153846153846
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.13888888888888887,
+          "acc1": 0.0,
+          "acc3": 0.16666666666666666,
+          "acc5": 0.16666666666666666,
+          "avg_elapsed_ms": 236.155
+        }
+      },
+      "rows": [
+        {
+          "query": "create a TypeScript program from source files and options",
+          "query_type": "natural_language",
+          "expected_symbol": "createProgram",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": null,
+          "elapsed_ms": 257.59,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "getCreateSourceFileOptions",
+            "file": "compiler/program.ts"
+          }
+        },
+        {
+          "query": "parse a TypeScript source file into an AST",
+          "query_type": "natural_language",
+          "expected_symbol": "createSourceFile",
+          "expected_file_suffix": "compiler/parser.ts",
+          "rank": null,
+          "elapsed_ms": 351.69,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "parseParenthesizedType",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "tokenize TypeScript source code into a stream",
+          "query_type": "natural_language",
+          "expected_symbol": "createScanner",
+          "expected_file_suffix": "compiler/scanner.ts",
+          "rank": null,
+          "elapsed_ms": 304.48,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "token",
+            "file": "services/codefixes/fixAddModuleReferTypeMissingTypeof.ts"
+          }
+        },
+        {
+          "query": "print a TypeScript AST back to source text",
+          "query_type": "natural_language",
+          "expected_symbol": "createPrinter",
+          "expected_file_suffix": "compiler/emitter.ts",
+          "rank": null,
+          "elapsed_ms": 334.8,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "fromString",
+            "file": "services/types.ts"
+          }
+        },
+        {
+          "query": "build a type checker for a program",
+          "query_type": "natural_language",
+          "expected_symbol": "createTypeChecker",
+          "expected_file_suffix": "compiler/checker.ts",
+          "rank": null,
+          "elapsed_ms": 322.75,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "checker",
+            "file": "services/utilities.ts"
+          }
+        },
+        {
+          "query": "visit every child node of an AST node",
+          "query_type": "natural_language",
+          "expected_symbol": "forEachChild",
+          "expected_file_suffix": "compiler/parser.ts",
+          "rank": null,
+          "elapsed_ms": 337.4,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "visit",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "get line start offsets in a source file",
+          "query_type": "natural_language",
+          "expected_symbol": "getLineStarts",
+          "expected_file_suffix": "compiler/scanner.ts",
+          "rank": 2,
+          "elapsed_ms": 300.39,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "getLineStarts",
+            "file": "services/services.ts"
+          }
+        },
+        {
+          "query": "get syntactic diagnostics from a program",
+          "query_type": "natural_language",
+          "expected_symbol": "getSyntacticDiagnostics",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": 1,
+          "elapsed_ms": 281.64,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "getSyntacticDiagnostics",
+            "file": "compiler/program.ts"
+          }
+        },
+        {
+          "query": "get semantic diagnostics for type errors",
+          "query_type": "natural_language",
+          "expected_symbol": "getSemanticDiagnostics",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": null,
+          "elapsed_ms": 299.95,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "errorType",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "get suggestion diagnostics for code quality hints",
+          "query_type": "natural_language",
+          "expected_symbol": "getSuggestionDiagnostics",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": 3,
+          "elapsed_ms": 246.04,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "suggestion",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "create a language service for editor integration",
+          "query_type": "natural_language",
+          "expected_symbol": "createLanguageService",
+          "expected_file_suffix": "services/services.ts",
+          "rank": 6,
+          "elapsed_ms": 307.82,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "EditorOptions",
+            "file": "services/types.ts"
+          }
+        },
+        {
+          "query": "get autocomplete suggestions at a cursor position",
+          "query_type": "natural_language",
+          "expected_symbol": "getCompletionsAtPosition",
+          "expected_file_suffix": "services/completions.ts",
+          "rank": null,
+          "elapsed_ms": 285.49,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "getRecommendedCompletion",
+            "file": "services/completions.ts"
+          }
+        },
+        {
+          "query": "find the definition site of a symbol at a position",
+          "query_type": "natural_language",
+          "expected_symbol": "getDefinitionAtPosition",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 335.98,
+          "candidate_count": 21,
+          "top_candidate": {
+            "name": "symbol",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "find all references to a symbol in the project",
+          "query_type": "natural_language",
+          "expected_symbol": "findReferences",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 306.9,
+          "candidate_count": 17,
+          "top_candidate": {
+            "name": "getReferencedSymbolsForModule",
+            "file": "services/findAllReferences.ts"
+          }
+        },
+        {
+          "query": "compute automatic code fixes for diagnostics",
+          "query_type": "natural_language",
+          "expected_symbol": "getCodeFixesAtPosition",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 292.35,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "getFixInfosWithoutDiagnostic",
+            "file": "services/codefixes/importFixes.ts"
+          }
+        },
+        {
+          "query": "rename a symbol and find all its occurrences",
+          "query_type": "natural_language",
+          "expected_symbol": "getRenameInfo",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 270.49,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "symbol",
+            "file": "services/rename.ts"
+          }
+        },
+        {
+          "query": "format a source range according to style rules",
+          "query_type": "natural_language",
+          "expected_symbol": "getFormattingEditsForRange",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 305.16,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "formatRange",
+            "file": "harness/fourslashImpl.ts"
+          }
+        },
+        {
+          "query": "compute collapsible regions for an outline view",
+          "query_type": "natural_language",
+          "expected_symbol": "getOutliningSpans",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 308.2,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "region",
+            "file": "services/outliningElementsCollector.ts"
+          }
+        },
+        {
+          "query": "provide parameter hints while typing a function call",
+          "query_type": "natural_language",
+          "expected_symbol": "getSignatureHelpItems",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 239.93,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "hintText",
+            "file": "services/inlayHints.ts"
+          }
+        },
+        {
+          "query": "enum of every TypeScript AST node kind",
+          "query_type": "natural_language",
+          "expected_symbol": "SyntaxKind",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 345.58,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "Extension",
+            "file": "compiler/types.ts"
+          }
+        },
+        {
+          "query": "interface that represents a parsed source file",
+          "query_type": "natural_language",
+          "expected_symbol": "SourceFile",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": 1,
+          "elapsed_ms": 355.32,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "SourceFile",
+            "file": "compiler/types.ts"
+          }
+        },
+        {
+          "query": "flags describing properties of an AST node",
+          "query_type": "natural_language",
+          "expected_symbol": "NodeFlags",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 312.16,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "flags",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "enum of control flow analysis states",
+          "query_type": "natural_language",
+          "expected_symbol": "FlowFlags",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 280.93,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "State",
+            "file": "harness/fourslashImpl.ts"
+          }
+        },
+        {
+          "query": "emit target ECMAScript version",
+          "query_type": "natural_language",
+          "expected_symbol": "ScriptTarget",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 289.78,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "EmitHint",
+            "file": "compiler/types.ts"
+          }
+        },
+        {
+          "query": "module system kind for output code",
+          "query_type": "natural_language",
+          "expected_symbol": "ModuleKind",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": 1,
+          "elapsed_ms": 307.05,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "ModuleKind",
+            "file": "compiler/types.ts"
+          }
+        },
+        {
+          "query": "top-level type checker interface",
+          "query_type": "natural_language",
+          "expected_symbol": "TypeChecker",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 347.93,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "check",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "create a scanner",
+          "query_type": "short_phrase",
+          "expected_symbol": "createScanner",
+          "expected_file_suffix": "compiler/scanner.ts",
+          "rank": 6,
+          "elapsed_ms": 243.37,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "scanner",
+            "file": "services/utilities.ts"
+          }
+        },
+        {
+          "query": "create a source file",
+          "query_type": "short_phrase",
+          "expected_symbol": "createSourceFile",
+          "expected_file_suffix": "compiler/parser.ts",
+          "rank": 6,
+          "elapsed_ms": 263.76,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "sourceFile",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "language service",
+          "query_type": "short_phrase",
+          "expected_symbol": "createLanguageService",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 219.88,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "LanguageServiceMode",
+            "file": "services/types.ts"
+          }
+        },
+        {
+          "query": "type checker",
+          "query_type": "short_phrase",
+          "expected_symbol": "createTypeChecker",
+          "expected_file_suffix": "compiler/checker.ts",
+          "rank": null,
+          "elapsed_ms": 241.16,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "checker",
+            "file": "services/utilities.ts"
+          }
+        },
+        {
+          "query": "rename info",
+          "query_type": "short_phrase",
+          "expected_symbol": "getRenameInfo",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 218.77,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "renameInfo",
+            "file": "services/rename.ts"
+          }
+        },
+        {
+          "query": "completions at position",
+          "query_type": "short_phrase",
+          "expected_symbol": "getCompletionsAtPosition",
+          "expected_file_suffix": "services/completions.ts",
+          "rank": 2,
+          "elapsed_ms": 229.99,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "completionData",
+            "file": "services/completions.ts"
+          }
+        },
+        {
+          "query": "SyntaxKind",
+          "query_type": "identifier",
+          "expected_symbol": "SyntaxKind",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": 1,
+          "elapsed_ms": 76.62,
+          "candidate_count": 20,
+          "top_candidate": {
+            "name": "SyntaxKind",
+            "file": "compiler/types.ts"
+          }
+        },
+        {
+          "query": "TypeChecker",
+          "query_type": "identifier",
+          "expected_symbol": "TypeChecker",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": 1,
+          "elapsed_ms": 78.04,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "TypeChecker",
+            "file": "compiler/types.ts"
+          }
+        }
+      ]
+    }
+  ],
+  "hybrid_uplift": {
+    "mrr_delta": 0.08086484593837533,
+    "acc1_delta": 0.058823529411764705,
+    "acc3_delta": 0.11764705882352941,
+    "acc5_delta": 0.05882352941176469
+  },
+  "hybrid_uplift_by_query_type": {
+    "identifier": {
+      "mrr_delta": 0.0,
+      "acc1_delta": 0.0,
+      "acc3_delta": 0.0,
+      "acc5_delta": 0.0
+    },
+    "natural_language": {
+      "mrr_delta": 0.14100274725274725,
+      "acc1_delta": 0.11538461538461539,
+      "acc3_delta": 0.19230769230769232,
+      "acc5_delta": 0.15384615384615385
+    },
+    "short_phrase": {
+      "mrr_delta": -0.15277777777777782,
+      "acc1_delta": -0.16666666666666666,
+      "acc3_delta": -0.16666666666666666,
+      "acc5_delta": -0.33333333333333337
+    }
+  }
+}

--- a/benchmarks/embedding-quality-v1.6-phase3d-typescript-2e-only.json
+++ b/benchmarks/embedding-quality-v1.6-phase3d-typescript-2e-only.json
@@ -1,0 +1,1487 @@
+{
+  "project": "/tmp/typescript/src",
+  "benchmark_project": "/var/folders/z0/0tcbss795xsdp75jmr_t9_kh0000gn/T/codelens-embed-quality-rgvw_ogb/src",
+  "isolated_copy": true,
+  "binary": "/Users/bagjaeseog/codelens-mcp-plugin/target/release/codelens-mcp",
+  "embedding_model": "MiniLM-L12-CodeSearchNet-INT8",
+  "runtime_model": {
+    "model_dir": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch",
+    "model_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/model.onnx",
+    "config_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/config.json",
+    "sha256": "ef1d1e9cfa72e4929f5b9faea17d8704b23a2530aadebf0d464a4cc7750920b3",
+    "size_bytes": 34000281,
+    "num_hidden_layers": 12,
+    "hidden_size": 384
+  },
+  "dataset_path": "/Users/bagjaeseog/codelens-mcp-plugin/benchmarks/embedding-quality-dataset-typescript.json",
+  "dataset_size": 34,
+  "ranking_cutoff": 10,
+  "metric_labels": {
+    "mrr": "MRR@10",
+    "acc1": "Acc@1",
+    "acc3": "Acc@3",
+    "acc5": "Acc@5"
+  },
+  "methods": [
+    {
+      "method": "semantic_search",
+      "mrr": 0.17091503267973857,
+      "acc1": 0.14705882352941177,
+      "acc3": 0.17647058823529413,
+      "acc5": 0.17647058823529413,
+      "avg_elapsed_ms": 895.3602941176471,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 1.0,
+          "acc1": 1.0,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 245.32999999999998
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.06581196581196581,
+          "acc1": 0.038461538461538464,
+          "acc3": 0.07692307692307693,
+          "acc5": 0.07692307692307693,
+          "avg_elapsed_ms": 1044.5753846153846
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.35000000000000003,
+          "acc1": 0.3333333333333333,
+          "acc3": 0.3333333333333333,
+          "acc5": 0.3333333333333333,
+          "avg_elapsed_ms": 465.43833333333333
+        }
+      },
+      "rows": [
+        {
+          "query": "create a TypeScript program from source files and options",
+          "query_type": "natural_language",
+          "expected_symbol": "createProgram",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": null,
+          "elapsed_ms": 752.33,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "createError",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "parse a TypeScript source file into an AST",
+          "query_type": "natural_language",
+          "expected_symbol": "createSourceFile",
+          "expected_file_suffix": "compiler/parser.ts",
+          "rank": null,
+          "elapsed_ms": 1308.17,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "parseSourceFile",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "tokenize TypeScript source code into a stream",
+          "query_type": "natural_language",
+          "expected_symbol": "createScanner",
+          "expected_file_suffix": "compiler/scanner.ts",
+          "rank": null,
+          "elapsed_ms": 1089.73,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "codeActionForFix",
+            "file": "services/codefixes/importFixes.ts"
+          }
+        },
+        {
+          "query": "print a TypeScript AST back to source text",
+          "query_type": "natural_language",
+          "expected_symbol": "createPrinter",
+          "expected_file_suffix": "compiler/emitter.ts",
+          "rank": null,
+          "elapsed_ms": 1244.63,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "consumeCurrentOperator",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "build a type checker for a program",
+          "query_type": "natural_language",
+          "expected_symbol": "createTypeChecker",
+          "expected_file_suffix": "compiler/checker.ts",
+          "rank": null,
+          "elapsed_ms": 915.17,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "check",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "visit every child node of an AST node",
+          "query_type": "natural_language",
+          "expected_symbol": "forEachChild",
+          "expected_file_suffix": "compiler/parser.ts",
+          "rank": null,
+          "elapsed_ms": 1234.8,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "visit",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "get line start offsets in a source file",
+          "query_type": "natural_language",
+          "expected_symbol": "getLineStarts",
+          "expected_file_suffix": "compiler/scanner.ts",
+          "rank": 2,
+          "elapsed_ms": 1003.4,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getLineStarts",
+            "file": "services/services.ts"
+          }
+        },
+        {
+          "query": "get syntactic diagnostics from a program",
+          "query_type": "natural_language",
+          "expected_symbol": "getSyntacticDiagnostics",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": 1,
+          "elapsed_ms": 878.88,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getSyntacticDiagnostics",
+            "file": "compiler/program.ts"
+          }
+        },
+        {
+          "query": "get semantic diagnostics for type errors",
+          "query_type": "natural_language",
+          "expected_symbol": "getSemanticDiagnostics",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": null,
+          "elapsed_ms": 1161.93,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getAccessorDeclarationTypeVisibilityError",
+            "file": "compiler/transformers/declarations/diagnostics.ts"
+          }
+        },
+        {
+          "query": "get suggestion diagnostics for code quality hints",
+          "query_type": "natural_language",
+          "expected_symbol": "getSuggestionDiagnostics",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": 10,
+          "elapsed_ms": 1410.99,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getSuggestion",
+            "file": "services/codefixes/fixNaNEquality.ts"
+          }
+        },
+        {
+          "query": "create a language service for editor integration",
+          "query_type": "natural_language",
+          "expected_symbol": "createLanguageService",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 1176.5,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "createReturnTypeOfSignatureDeclaration",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "get autocomplete suggestions at a cursor position",
+          "query_type": "natural_language",
+          "expected_symbol": "getCompletionsAtPosition",
+          "expected_file_suffix": "services/completions.ts",
+          "rank": null,
+          "elapsed_ms": 914.38,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getRecommendedCompletion",
+            "file": "services/completions.ts"
+          }
+        },
+        {
+          "query": "find the definition site of a symbol at a position",
+          "query_type": "natural_language",
+          "expected_symbol": "getDefinitionAtPosition",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 1269.79,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "symbolAtLocation",
+            "file": "harness/fourslashInterfaceImpl.ts"
+          }
+        },
+        {
+          "query": "find all references to a symbol in the project",
+          "query_type": "natural_language",
+          "expected_symbol": "findReferences",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 1027.09,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getReferencedSymbolsForModule",
+            "file": "services/findAllReferences.ts"
+          }
+        },
+        {
+          "query": "compute automatic code fixes for diagnostics",
+          "query_type": "natural_language",
+          "expected_symbol": "getCodeFixesAtPosition",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 1006.3,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "computeModuleSpecifiers",
+            "file": "compiler/moduleSpecifiers.ts"
+          }
+        },
+        {
+          "query": "rename a symbol and find all its occurrences",
+          "query_type": "natural_language",
+          "expected_symbol": "getRenameInfo",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 737.53,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "symbol",
+            "file": "services/rename.ts"
+          }
+        },
+        {
+          "query": "format a source range according to style rules",
+          "query_type": "natural_language",
+          "expected_symbol": "getFormattingEditsForRange",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 1020.92,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "formatRange",
+            "file": "harness/fourslashImpl.ts"
+          }
+        },
+        {
+          "query": "compute collapsible regions for an outline view",
+          "query_type": "natural_language",
+          "expected_symbol": "getOutliningSpans",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 1014.1,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "formatEnum",
+            "file": "compiler/debug.ts"
+          }
+        },
+        {
+          "query": "provide parameter hints while typing a function call",
+          "query_type": "natural_language",
+          "expected_symbol": "getSignatureHelpItems",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 570.56,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "addParameterHints",
+            "file": "services/inlayHints.ts"
+          }
+        },
+        {
+          "query": "enum of every TypeScript AST node kind",
+          "query_type": "natural_language",
+          "expected_symbol": "SyntaxKind",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 1288.47,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "asterisk",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "interface that represents a parsed source file",
+          "query_type": "natural_language",
+          "expected_symbol": "SourceFile",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 1275.79,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "parseDoStatement",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "flags describing properties of an AST node",
+          "query_type": "natural_language",
+          "expected_symbol": "NodeFlags",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 1130.95,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "flags",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "enum of control flow analysis states",
+          "query_type": "natural_language",
+          "expected_symbol": "FlowFlags",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 887.33,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "State",
+            "file": "harness/fourslashImpl.ts"
+          }
+        },
+        {
+          "query": "emit target ECMAScript version",
+          "query_type": "natural_language",
+          "expected_symbol": "ScriptTarget",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 767.03,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "createImplementsDiagnostics",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "module system kind for output code",
+          "query_type": "natural_language",
+          "expected_symbol": "ModuleKind",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": 9,
+          "elapsed_ms": 1045.81,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "evaluate",
+            "file": "harness/evaluatorImpl.ts"
+          }
+        },
+        {
+          "query": "top-level type checker interface",
+          "query_type": "natural_language",
+          "expected_symbol": "TypeChecker",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 1026.38,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "check",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "create a scanner",
+          "query_type": "short_phrase",
+          "expected_symbol": "createScanner",
+          "expected_file_suffix": "compiler/scanner.ts",
+          "rank": 10,
+          "elapsed_ms": 532.3,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "scanner",
+            "file": "services/utilities.ts"
+          }
+        },
+        {
+          "query": "create a source file",
+          "query_type": "short_phrase",
+          "expected_symbol": "createSourceFile",
+          "expected_file_suffix": "compiler/parser.ts",
+          "rank": 1,
+          "elapsed_ms": 659.19,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "createSourceFile",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "language service",
+          "query_type": "short_phrase",
+          "expected_symbol": "createLanguageService",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 356.98,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "LanguageServiceMode",
+            "file": "services/types.ts"
+          }
+        },
+        {
+          "query": "type checker",
+          "query_type": "short_phrase",
+          "expected_symbol": "createTypeChecker",
+          "expected_file_suffix": "compiler/checker.ts",
+          "rank": null,
+          "elapsed_ms": 379.54,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "checker",
+            "file": "services/utilities.ts"
+          }
+        },
+        {
+          "query": "rename info",
+          "query_type": "short_phrase",
+          "expected_symbol": "getRenameInfo",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 354.25,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "renameInfo",
+            "file": "services/rename.ts"
+          }
+        },
+        {
+          "query": "completions at position",
+          "query_type": "short_phrase",
+          "expected_symbol": "getCompletionsAtPosition",
+          "expected_file_suffix": "services/completions.ts",
+          "rank": 1,
+          "elapsed_ms": 510.37,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getCompletionsAtPosition",
+            "file": "services/completions.ts"
+          }
+        },
+        {
+          "query": "SyntaxKind",
+          "query_type": "identifier",
+          "expected_symbol": "SyntaxKind",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": 1,
+          "elapsed_ms": 247.52,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "SyntaxKind",
+            "file": "compiler/types.ts"
+          }
+        },
+        {
+          "query": "TypeChecker",
+          "query_type": "identifier",
+          "expected_symbol": "TypeChecker",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": 1,
+          "elapsed_ms": 243.14,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "TypeChecker",
+            "file": "compiler/types.ts"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context_no_semantic",
+      "mrr": 0.1397233893557423,
+      "acc1": 0.11764705882352941,
+      "acc3": 0.11764705882352941,
+      "acc5": 0.17647058823529413,
+      "avg_elapsed_ms": 145.89235294117648,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 1.0,
+          "acc1": 1.0,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 74.12
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.012843406593406595,
+          "acc1": 0.0,
+          "acc3": 0.0,
+          "acc5": 0.038461538461538464,
+          "avg_elapsed_ms": 161.9480769230769
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.40277777777777773,
+          "acc1": 0.3333333333333333,
+          "acc3": 0.3333333333333333,
+          "acc5": 0.5,
+          "avg_elapsed_ms": 100.24166666666667
+        }
+      },
+      "rows": [
+        {
+          "query": "create a TypeScript program from source files and options",
+          "query_type": "natural_language",
+          "expected_symbol": "createProgram",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": 16,
+          "elapsed_ms": 116.61,
+          "candidate_count": 18,
+          "top_candidate": {
+            "name": "shouldProgramCreateNewSourceFiles",
+            "file": "compiler/program.ts"
+          }
+        },
+        {
+          "query": "parse a TypeScript source file into an AST",
+          "query_type": "natural_language",
+          "expected_symbol": "createSourceFile",
+          "expected_file_suffix": "compiler/parser.ts",
+          "rank": 14,
+          "elapsed_ms": 200.71,
+          "candidate_count": 20,
+          "top_candidate": {
+            "name": "parseSourceFileWorker",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "tokenize TypeScript source code into a stream",
+          "query_type": "natural_language",
+          "expected_symbol": "createScanner",
+          "expected_file_suffix": "compiler/scanner.ts",
+          "rank": null,
+          "elapsed_ms": 163.82,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "SourceMapSpanWithDecodeErrors",
+            "file": "harness/sourceMapRecorder.ts"
+          }
+        },
+        {
+          "query": "print a TypeScript AST back to source text",
+          "query_type": "natural_language",
+          "expected_symbol": "createPrinter",
+          "expected_file_suffix": "compiler/emitter.ts",
+          "rank": null,
+          "elapsed_ms": 190.58,
+          "candidate_count": 21,
+          "top_candidate": {
+            "name": "isBacktrackingSourcePosition",
+            "file": "compiler/sourcemap.ts"
+          }
+        },
+        {
+          "query": "build a type checker for a program",
+          "query_type": "natural_language",
+          "expected_symbol": "createTypeChecker",
+          "expected_file_suffix": "compiler/checker.ts",
+          "rank": null,
+          "elapsed_ms": 180.82,
+          "candidate_count": 19,
+          "top_candidate": {
+            "name": "getWidenedLiteralLikeTypeForContextualType",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "visit every child node of an AST node",
+          "query_type": "natural_language",
+          "expected_symbol": "forEachChild",
+          "expected_file_suffix": "compiler/parser.ts",
+          "rank": null,
+          "elapsed_ms": 195.67,
+          "candidate_count": 20,
+          "top_candidate": {
+            "name": "visitExistingNodeTreeSymbols",
+            "file": "compiler/expressionToTypeNode.ts"
+          }
+        },
+        {
+          "query": "get line start offsets in a source file",
+          "query_type": "natural_language",
+          "expected_symbol": "getLineStarts",
+          "expected_file_suffix": "compiler/scanner.ts",
+          "rank": null,
+          "elapsed_ms": 159.34,
+          "candidate_count": 21,
+          "top_candidate": {
+            "name": "getParsedCommandLineOfConfigFile",
+            "file": "compiler/commandLineParser.ts"
+          }
+        },
+        {
+          "query": "get syntactic diagnostics from a program",
+          "query_type": "natural_language",
+          "expected_symbol": "getSyntacticDiagnostics",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": null,
+          "elapsed_ms": 140.81,
+          "candidate_count": 21,
+          "top_candidate": {
+            "name": "getCombinedDiagnostics",
+            "file": "compiler/programDiagnostics.ts"
+          }
+        },
+        {
+          "query": "get semantic diagnostics for type errors",
+          "query_type": "natural_language",
+          "expected_symbol": "getSemanticDiagnostics",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": null,
+          "elapsed_ms": 157.6,
+          "candidate_count": 18,
+          "top_candidate": {
+            "name": "serializeReturnTypeForSignature",
+            "file": "compiler/expressionToTypeNode.ts"
+          }
+        },
+        {
+          "query": "get suggestion diagnostics for code quality hints",
+          "query_type": "natural_language",
+          "expected_symbol": "getSuggestionDiagnostics",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": null,
+          "elapsed_ms": 107.93,
+          "candidate_count": 19,
+          "top_candidate": {
+            "name": "createGetSymbolAccessibilityDiagnosticForNode",
+            "file": "compiler/transformers/declarations/diagnostics.ts"
+          }
+        },
+        {
+          "query": "create a language service for editor integration",
+          "query_type": "natural_language",
+          "expected_symbol": "createLanguageService",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 163.53,
+          "candidate_count": 20,
+          "top_candidate": {
+            "name": "onUpdateLanguageServiceStateForProject",
+            "file": "server/editorServices.ts"
+          }
+        },
+        {
+          "query": "get autocomplete suggestions at a cursor position",
+          "query_type": "natural_language",
+          "expected_symbol": "getCompletionsAtPosition",
+          "expected_file_suffix": "services/completions.ts",
+          "rank": null,
+          "elapsed_ms": 140.74,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "getMoveToRefactoringFileSuggestions",
+            "file": "harness/client.ts"
+          }
+        },
+        {
+          "query": "find the definition site of a symbol at a position",
+          "query_type": "natural_language",
+          "expected_symbol": "getDefinitionAtPosition",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 185.65,
+          "candidate_count": 18,
+          "top_candidate": {
+            "name": "getDefinitionFromSymbol",
+            "file": "services/goToDefinition.ts"
+          }
+        },
+        {
+          "query": "find all references to a symbol in the project",
+          "query_type": "natural_language",
+          "expected_symbol": "findReferences",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 160.55,
+          "candidate_count": 17,
+          "top_candidate": {
+            "name": "findOwnConstructorReferences",
+            "file": "services/findAllReferences.ts"
+          }
+        },
+        {
+          "query": "compute automatic code fixes for diagnostics",
+          "query_type": "natural_language",
+          "expected_symbol": "getCodeFixesAtPosition",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 157.1,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "codeFixes",
+            "file": "harness/fourslashImpl.ts"
+          }
+        },
+        {
+          "query": "rename a symbol and find all its occurrences",
+          "query_type": "natural_language",
+          "expected_symbol": "getRenameInfo",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 131.99,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "getRenameInfoForModule",
+            "file": "services/rename.ts"
+          }
+        },
+        {
+          "query": "format a source range according to style rules",
+          "query_type": "natural_language",
+          "expected_symbol": "getFormattingEditsForRange",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 160.86,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "SourceMapGeneratorOptions",
+            "file": "compiler/sourcemap.ts"
+          }
+        },
+        {
+          "query": "compute collapsible regions for an outline view",
+          "query_type": "natural_language",
+          "expected_symbol": "getOutliningSpans",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 160.44,
+          "candidate_count": 19,
+          "top_candidate": {
+            "name": "transformConstructorBodyWorker",
+            "file": "compiler/transformers/classFields.ts"
+          }
+        },
+        {
+          "query": "provide parameter hints while typing a function call",
+          "query_type": "natural_language",
+          "expected_symbol": "getSignatureHelpItems",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 106.47,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "addParameterHints",
+            "file": "services/inlayHints.ts"
+          }
+        },
+        {
+          "query": "enum of every TypeScript AST node kind",
+          "query_type": "natural_language",
+          "expected_symbol": "SyntaxKind",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 196.07,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "visitExistingNodeTreeSymbolsWorker",
+            "file": "compiler/expressionToTypeNode.ts"
+          }
+        },
+        {
+          "query": "interface that represents a parsed source file",
+          "query_type": "natural_language",
+          "expected_symbol": "SourceFile",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 204.8,
+          "candidate_count": 21,
+          "top_candidate": {
+            "name": "parseSourceFileWorker",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "flags describing properties of an AST node",
+          "query_type": "natural_language",
+          "expected_symbol": "NodeFlags",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 175.45,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "getUsageInfoRangeForPasteEdits",
+            "file": "services/pasteEdits.ts"
+          }
+        },
+        {
+          "query": "enum of control flow analysis states",
+          "query_type": "natural_language",
+          "expected_symbol": "FlowFlags",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 144.58,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "saveFlowAnalysisDisabled",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "emit target ECMAScript version",
+          "query_type": "natural_language",
+          "expected_symbol": "ScriptTarget",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 145.28,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "transformECMAScriptModule",
+            "file": "compiler/transformers/module/esnextAnd2015.ts"
+          }
+        },
+        {
+          "query": "module system kind for output code",
+          "query_type": "natural_language",
+          "expected_symbol": "ModuleKind",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 155.6,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "transformSystemModule",
+            "file": "compiler/transformers/module/system.ts"
+          }
+        },
+        {
+          "query": "top-level type checker interface",
+          "query_type": "natural_language",
+          "expected_symbol": "TypeChecker",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": 5,
+          "elapsed_ms": 207.65,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "isNonGenericTopLevelType",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "create a scanner",
+          "query_type": "short_phrase",
+          "expected_symbol": "createScanner",
+          "expected_file_suffix": "compiler/scanner.ts",
+          "rank": 1,
+          "elapsed_ms": 101.67,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "createScanner",
+            "file": "compiler/scanner.ts"
+          }
+        },
+        {
+          "query": "create a source file",
+          "query_type": "short_phrase",
+          "expected_symbol": "createSourceFile",
+          "expected_file_suffix": "compiler/parser.ts",
+          "rank": 6,
+          "elapsed_ms": 118.57,
+          "candidate_count": 19,
+          "top_candidate": {
+            "name": "createSourceFileWithText",
+            "file": "testRunner/unittests/helpers.ts"
+          }
+        },
+        {
+          "query": "language service",
+          "query_type": "short_phrase",
+          "expected_symbol": "createLanguageService",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 86.74,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "LanguageServiceAdapter",
+            "file": "harness/harnessLanguageService.ts"
+          }
+        },
+        {
+          "query": "type checker",
+          "query_type": "short_phrase",
+          "expected_symbol": "createTypeChecker",
+          "expected_file_suffix": "compiler/checker.ts",
+          "rank": 1,
+          "elapsed_ms": 103.48,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "createTypeChecker",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "rename info",
+          "query_type": "short_phrase",
+          "expected_symbol": "getRenameInfo",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 87.09,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "getRenameInfoError",
+            "file": "services/rename.ts"
+          }
+        },
+        {
+          "query": "completions at position",
+          "query_type": "short_phrase",
+          "expected_symbol": "getCompletionsAtPosition",
+          "expected_file_suffix": "services/completions.ts",
+          "rank": 4,
+          "elapsed_ms": 103.9,
+          "candidate_count": 21,
+          "top_candidate": {
+            "name": "getJsDocTagAtPosition",
+            "file": "services/completions.ts"
+          }
+        },
+        {
+          "query": "SyntaxKind",
+          "query_type": "identifier",
+          "expected_symbol": "SyntaxKind",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": 1,
+          "elapsed_ms": 72.97,
+          "candidate_count": 20,
+          "top_candidate": {
+            "name": "SyntaxKind",
+            "file": "compiler/types.ts"
+          }
+        },
+        {
+          "query": "TypeChecker",
+          "query_type": "identifier",
+          "expected_symbol": "TypeChecker",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": 1,
+          "elapsed_ms": 75.27,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "TypeChecker",
+            "file": "compiler/types.ts"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context",
+      "mrr": 0.08855118134210206,
+      "acc1": 0.058823529411764705,
+      "acc3": 0.058823529411764705,
+      "acc5": 0.058823529411764705,
+      "avg_elapsed_ms": 266.0329411764706,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 1.0,
+          "acc1": 1.0,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 77.16499999999999
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.019643852524287304,
+          "acc1": 0.0,
+          "acc3": 0.0,
+          "acc5": 0.0,
+          "avg_elapsed_ms": 289.53076923076924
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.08333333333333333,
+          "acc1": 0.0,
+          "acc3": 0.0,
+          "acc5": 0.0,
+          "avg_elapsed_ms": 227.165
+        }
+      },
+      "rows": [
+        {
+          "query": "create a TypeScript program from source files and options",
+          "query_type": "natural_language",
+          "expected_symbol": "createProgram",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": null,
+          "elapsed_ms": 238.07,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "optionsForFile",
+            "file": "compiler/program.ts"
+          }
+        },
+        {
+          "query": "parse a TypeScript source file into an AST",
+          "query_type": "natural_language",
+          "expected_symbol": "createSourceFile",
+          "expected_file_suffix": "compiler/parser.ts",
+          "rank": null,
+          "elapsed_ms": 357.09,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "parseParenthesizedType",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "tokenize TypeScript source code into a stream",
+          "query_type": "natural_language",
+          "expected_symbol": "createScanner",
+          "expected_file_suffix": "compiler/scanner.ts",
+          "rank": null,
+          "elapsed_ms": 289.18,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "token",
+            "file": "services/utilities.ts"
+          }
+        },
+        {
+          "query": "print a TypeScript AST back to source text",
+          "query_type": "natural_language",
+          "expected_symbol": "createPrinter",
+          "expected_file_suffix": "compiler/emitter.ts",
+          "rank": null,
+          "elapsed_ms": 314.91,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "print",
+            "file": "compiler/emitter.ts"
+          }
+        },
+        {
+          "query": "build a type checker for a program",
+          "query_type": "natural_language",
+          "expected_symbol": "createTypeChecker",
+          "expected_file_suffix": "compiler/checker.ts",
+          "rank": null,
+          "elapsed_ms": 307.11,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "check",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "visit every child node of an AST node",
+          "query_type": "natural_language",
+          "expected_symbol": "forEachChild",
+          "expected_file_suffix": "compiler/parser.ts",
+          "rank": null,
+          "elapsed_ms": 325.93,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "visit",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "get line start offsets in a source file",
+          "query_type": "natural_language",
+          "expected_symbol": "getLineStarts",
+          "expected_file_suffix": "compiler/scanner.ts",
+          "rank": 6,
+          "elapsed_ms": 285.28,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "offsetStart",
+            "file": "harness/fourslashImpl.ts"
+          }
+        },
+        {
+          "query": "get syntactic diagnostics from a program",
+          "query_type": "natural_language",
+          "expected_symbol": "getSyntacticDiagnostics",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": 10,
+          "elapsed_ms": 261.77,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "getSyntacticDiagnosticsForFile",
+            "file": "compiler/program.ts"
+          }
+        },
+        {
+          "query": "get semantic diagnostics for type errors",
+          "query_type": "natural_language",
+          "expected_symbol": "getSemanticDiagnostics",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": null,
+          "elapsed_ms": 283.76,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "isErrorType",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "get suggestion diagnostics for code quality hints",
+          "query_type": "natural_language",
+          "expected_symbol": "getSuggestionDiagnostics",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": 15,
+          "elapsed_ms": 231.3,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "getSuggestion",
+            "file": "services/codefixes/fixNaNEquality.ts"
+          }
+        },
+        {
+          "query": "create a language service for editor integration",
+          "query_type": "natural_language",
+          "expected_symbol": "createLanguageService",
+          "expected_file_suffix": "services/services.ts",
+          "rank": 23,
+          "elapsed_ms": 286.9,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "EditorOptions",
+            "file": "services/types.ts"
+          }
+        },
+        {
+          "query": "get autocomplete suggestions at a cursor position",
+          "query_type": "natural_language",
+          "expected_symbol": "getCompletionsAtPosition",
+          "expected_file_suffix": "services/completions.ts",
+          "rank": null,
+          "elapsed_ms": 266.14,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "suggestion",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "find the definition site of a symbol at a position",
+          "query_type": "natural_language",
+          "expected_symbol": "getDefinitionAtPosition",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 319.33,
+          "candidate_count": 21,
+          "top_candidate": {
+            "name": "symbol",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "find all references to a symbol in the project",
+          "query_type": "natural_language",
+          "expected_symbol": "findReferences",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 278.51,
+          "candidate_count": 17,
+          "top_candidate": {
+            "name": "getReferencedSymbolsForModule",
+            "file": "services/findAllReferences.ts"
+          }
+        },
+        {
+          "query": "compute automatic code fixes for diagnostics",
+          "query_type": "natural_language",
+          "expected_symbol": "getCodeFixesAtPosition",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 273.71,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "fixes",
+            "file": "harness/fourslashImpl.ts"
+          }
+        },
+        {
+          "query": "rename a symbol and find all its occurrences",
+          "query_type": "natural_language",
+          "expected_symbol": "getRenameInfo",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 251.15,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "symbol",
+            "file": "services/rename.ts"
+          }
+        },
+        {
+          "query": "format a source range according to style rules",
+          "query_type": "natural_language",
+          "expected_symbol": "getFormattingEditsForRange",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 282.42,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "sourceIndex",
+            "file": "compiler/sourcemap.ts"
+          }
+        },
+        {
+          "query": "compute collapsible regions for an outline view",
+          "query_type": "natural_language",
+          "expected_symbol": "getOutliningSpans",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 288.51,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "regions",
+            "file": "services/outliningElementsCollector.ts"
+          }
+        },
+        {
+          "query": "provide parameter hints while typing a function call",
+          "query_type": "natural_language",
+          "expected_symbol": "getSignatureHelpItems",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 242.39,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "hints",
+            "file": "harness/fourslashImpl.ts"
+          }
+        },
+        {
+          "query": "enum of every TypeScript AST node kind",
+          "query_type": "natural_language",
+          "expected_symbol": "SyntaxKind",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 330.47,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "enumType",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "interface that represents a parsed source file",
+          "query_type": "natural_language",
+          "expected_symbol": "SourceFile",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": 14,
+          "elapsed_ms": 338.49,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "parseSourceFile",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "flags describing properties of an AST node",
+          "query_type": "natural_language",
+          "expected_symbol": "NodeFlags",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 302.35,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "flags",
+            "file": "compiler/factory/nodeFactory.ts"
+          }
+        },
+        {
+          "query": "enum of control flow analysis states",
+          "query_type": "natural_language",
+          "expected_symbol": "FlowFlags",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 275.35,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "States",
+            "file": "compiler/utilities.ts"
+          }
+        },
+        {
+          "query": "emit target ECMAScript version",
+          "query_type": "natural_language",
+          "expected_symbol": "ScriptTarget",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 274.86,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "emit",
+            "file": "compiler/tsbuildPublic.ts"
+          }
+        },
+        {
+          "query": "module system kind for output code",
+          "query_type": "natural_language",
+          "expected_symbol": "ModuleKind",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": 16,
+          "elapsed_ms": 288.23,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "kind",
+            "file": "services/codefixes/fixAwaitInSyncFunction.ts"
+          }
+        },
+        {
+          "query": "top-level type checker interface",
+          "query_type": "natural_language",
+          "expected_symbol": "TypeChecker",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 334.59,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "checkTypeLiteral",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "create a scanner",
+          "query_type": "short_phrase",
+          "expected_symbol": "createScanner",
+          "expected_file_suffix": "compiler/scanner.ts",
+          "rank": 6,
+          "elapsed_ms": 230.52,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "scanner",
+            "file": "services/utilities.ts"
+          }
+        },
+        {
+          "query": "create a source file",
+          "query_type": "short_phrase",
+          "expected_symbol": "createSourceFile",
+          "expected_file_suffix": "compiler/parser.ts",
+          "rank": 6,
+          "elapsed_ms": 243.25,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "sourceFile",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "language service",
+          "query_type": "short_phrase",
+          "expected_symbol": "createLanguageService",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 211.43,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "LanguageServiceAdapter",
+            "file": "harness/harnessLanguageService.ts"
+          }
+        },
+        {
+          "query": "type checker",
+          "query_type": "short_phrase",
+          "expected_symbol": "createTypeChecker",
+          "expected_file_suffix": "compiler/checker.ts",
+          "rank": null,
+          "elapsed_ms": 228.51,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "checkTypes",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "rename info",
+          "query_type": "short_phrase",
+          "expected_symbol": "getRenameInfo",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 212.86,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "renameInfo",
+            "file": "services/rename.ts"
+          }
+        },
+        {
+          "query": "completions at position",
+          "query_type": "short_phrase",
+          "expected_symbol": "getCompletionsAtPosition",
+          "expected_file_suffix": "services/completions.ts",
+          "rank": 6,
+          "elapsed_ms": 236.42,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "completionData",
+            "file": "services/completions.ts"
+          }
+        },
+        {
+          "query": "SyntaxKind",
+          "query_type": "identifier",
+          "expected_symbol": "SyntaxKind",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": 1,
+          "elapsed_ms": 76.41,
+          "candidate_count": 20,
+          "top_candidate": {
+            "name": "SyntaxKind",
+            "file": "compiler/types.ts"
+          }
+        },
+        {
+          "query": "TypeChecker",
+          "query_type": "identifier",
+          "expected_symbol": "TypeChecker",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": 1,
+          "elapsed_ms": 77.92,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "TypeChecker",
+            "file": "compiler/types.ts"
+          }
+        }
+      ]
+    }
+  ],
+  "hybrid_uplift": {
+    "mrr_delta": -0.05117220801364024,
+    "acc1_delta": -0.058823529411764705,
+    "acc3_delta": -0.058823529411764705,
+    "acc5_delta": -0.11764705882352942
+  },
+  "hybrid_uplift_by_query_type": {
+    "identifier": {
+      "mrr_delta": 0.0,
+      "acc1_delta": 0.0,
+      "acc3_delta": 0.0,
+      "acc5_delta": 0.0
+    },
+    "natural_language": {
+      "mrr_delta": 0.00680044593088071,
+      "acc1_delta": 0.0,
+      "acc3_delta": 0.0,
+      "acc5_delta": -0.038461538461538464
+    },
+    "short_phrase": {
+      "mrr_delta": -0.3194444444444444,
+      "acc1_delta": -0.3333333333333333,
+      "acc3_delta": -0.3333333333333333,
+      "acc5_delta": -0.5
+    }
+  }
+}

--- a/benchmarks/embedding-quality-v1.6-phase3d-typescript-baseline.json
+++ b/benchmarks/embedding-quality-v1.6-phase3d-typescript-baseline.json
@@ -1,0 +1,1487 @@
+{
+  "project": "/tmp/typescript/src",
+  "benchmark_project": "/var/folders/z0/0tcbss795xsdp75jmr_t9_kh0000gn/T/codelens-embed-quality-1spcdfwm/src",
+  "isolated_copy": true,
+  "binary": "/Users/bagjaeseog/codelens-mcp-plugin/target/release/codelens-mcp",
+  "embedding_model": "MiniLM-L12-CodeSearchNet-INT8",
+  "runtime_model": {
+    "model_dir": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch",
+    "model_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/model.onnx",
+    "config_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/config.json",
+    "sha256": "ef1d1e9cfa72e4929f5b9faea17d8704b23a2530aadebf0d464a4cc7750920b3",
+    "size_bytes": 34000281,
+    "num_hidden_layers": 12,
+    "hidden_size": 384
+  },
+  "dataset_path": "/Users/bagjaeseog/codelens-mcp-plugin/benchmarks/embedding-quality-dataset-typescript.json",
+  "dataset_size": 34,
+  "ranking_cutoff": 10,
+  "metric_labels": {
+    "mrr": "MRR@10",
+    "acc1": "Acc@1",
+    "acc3": "Acc@3",
+    "acc5": "Acc@5"
+  },
+  "methods": [
+    {
+      "method": "semantic_search",
+      "mrr": 0.17091503267973857,
+      "acc1": 0.14705882352941177,
+      "acc3": 0.17647058823529413,
+      "acc5": 0.17647058823529413,
+      "avg_elapsed_ms": 972.1638235294117,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 1.0,
+          "acc1": 1.0,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 254.925
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.06581196581196581,
+          "acc1": 0.038461538461538464,
+          "acc3": 0.07692307692307693,
+          "acc5": 0.07692307692307693,
+          "avg_elapsed_ms": 1140.573076923077
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.35000000000000003,
+          "acc1": 0.3333333333333333,
+          "acc3": 0.3333333333333333,
+          "acc5": 0.3333333333333333,
+          "avg_elapsed_ms": 481.46999999999997
+        }
+      },
+      "rows": [
+        {
+          "query": "create a TypeScript program from source files and options",
+          "query_type": "natural_language",
+          "expected_symbol": "createProgram",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": null,
+          "elapsed_ms": 2011.76,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "createError",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "parse a TypeScript source file into an AST",
+          "query_type": "natural_language",
+          "expected_symbol": "createSourceFile",
+          "expected_file_suffix": "compiler/parser.ts",
+          "rank": null,
+          "elapsed_ms": 1241.62,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "parseSourceFile",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "tokenize TypeScript source code into a stream",
+          "query_type": "natural_language",
+          "expected_symbol": "createScanner",
+          "expected_file_suffix": "compiler/scanner.ts",
+          "rank": null,
+          "elapsed_ms": 1007.71,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "codeActionForFix",
+            "file": "services/codefixes/importFixes.ts"
+          }
+        },
+        {
+          "query": "print a TypeScript AST back to source text",
+          "query_type": "natural_language",
+          "expected_symbol": "createPrinter",
+          "expected_file_suffix": "compiler/emitter.ts",
+          "rank": null,
+          "elapsed_ms": 1224.78,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "consumeCurrentOperator",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "build a type checker for a program",
+          "query_type": "natural_language",
+          "expected_symbol": "createTypeChecker",
+          "expected_file_suffix": "compiler/checker.ts",
+          "rank": null,
+          "elapsed_ms": 894.5,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "check",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "visit every child node of an AST node",
+          "query_type": "natural_language",
+          "expected_symbol": "forEachChild",
+          "expected_file_suffix": "compiler/parser.ts",
+          "rank": null,
+          "elapsed_ms": 1235.48,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "visit",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "get line start offsets in a source file",
+          "query_type": "natural_language",
+          "expected_symbol": "getLineStarts",
+          "expected_file_suffix": "compiler/scanner.ts",
+          "rank": 2,
+          "elapsed_ms": 1014.45,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getLineStarts",
+            "file": "services/services.ts"
+          }
+        },
+        {
+          "query": "get syntactic diagnostics from a program",
+          "query_type": "natural_language",
+          "expected_symbol": "getSyntacticDiagnostics",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": 1,
+          "elapsed_ms": 877.39,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getSyntacticDiagnostics",
+            "file": "compiler/program.ts"
+          }
+        },
+        {
+          "query": "get semantic diagnostics for type errors",
+          "query_type": "natural_language",
+          "expected_symbol": "getSemanticDiagnostics",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": null,
+          "elapsed_ms": 1238.65,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getAccessorDeclarationTypeVisibilityError",
+            "file": "compiler/transformers/declarations/diagnostics.ts"
+          }
+        },
+        {
+          "query": "get suggestion diagnostics for code quality hints",
+          "query_type": "natural_language",
+          "expected_symbol": "getSuggestionDiagnostics",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": 10,
+          "elapsed_ms": 1269.2,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getSuggestion",
+            "file": "services/codefixes/fixNaNEquality.ts"
+          }
+        },
+        {
+          "query": "create a language service for editor integration",
+          "query_type": "natural_language",
+          "expected_symbol": "createLanguageService",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 1366.24,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "createReturnTypeOfSignatureDeclaration",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "get autocomplete suggestions at a cursor position",
+          "query_type": "natural_language",
+          "expected_symbol": "getCompletionsAtPosition",
+          "expected_file_suffix": "services/completions.ts",
+          "rank": null,
+          "elapsed_ms": 908.14,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getRecommendedCompletion",
+            "file": "services/completions.ts"
+          }
+        },
+        {
+          "query": "find the definition site of a symbol at a position",
+          "query_type": "natural_language",
+          "expected_symbol": "getDefinitionAtPosition",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 1273.27,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "symbolAtLocation",
+            "file": "harness/fourslashInterfaceImpl.ts"
+          }
+        },
+        {
+          "query": "find all references to a symbol in the project",
+          "query_type": "natural_language",
+          "expected_symbol": "findReferences",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 1049.24,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getReferencedSymbolsForModule",
+            "file": "services/findAllReferences.ts"
+          }
+        },
+        {
+          "query": "compute automatic code fixes for diagnostics",
+          "query_type": "natural_language",
+          "expected_symbol": "getCodeFixesAtPosition",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 1006.19,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "computeModuleSpecifiers",
+            "file": "compiler/moduleSpecifiers.ts"
+          }
+        },
+        {
+          "query": "rename a symbol and find all its occurrences",
+          "query_type": "natural_language",
+          "expected_symbol": "getRenameInfo",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 737.97,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "symbol",
+            "file": "services/rename.ts"
+          }
+        },
+        {
+          "query": "format a source range according to style rules",
+          "query_type": "natural_language",
+          "expected_symbol": "getFormattingEditsForRange",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 1034.32,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "formatRange",
+            "file": "harness/fourslashImpl.ts"
+          }
+        },
+        {
+          "query": "compute collapsible regions for an outline view",
+          "query_type": "natural_language",
+          "expected_symbol": "getOutliningSpans",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 1001.75,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "formatEnum",
+            "file": "compiler/debug.ts"
+          }
+        },
+        {
+          "query": "provide parameter hints while typing a function call",
+          "query_type": "natural_language",
+          "expected_symbol": "getSignatureHelpItems",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 559.32,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "addParameterHints",
+            "file": "services/inlayHints.ts"
+          }
+        },
+        {
+          "query": "enum of every TypeScript AST node kind",
+          "query_type": "natural_language",
+          "expected_symbol": "SyntaxKind",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 1243.21,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "asterisk",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "interface that represents a parsed source file",
+          "query_type": "natural_language",
+          "expected_symbol": "SourceFile",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 1270.93,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "parseDoStatement",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "flags describing properties of an AST node",
+          "query_type": "natural_language",
+          "expected_symbol": "NodeFlags",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 1110.43,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "flags",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "enum of control flow analysis states",
+          "query_type": "natural_language",
+          "expected_symbol": "FlowFlags",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 897.08,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "State",
+            "file": "harness/fourslashImpl.ts"
+          }
+        },
+        {
+          "query": "emit target ECMAScript version",
+          "query_type": "natural_language",
+          "expected_symbol": "ScriptTarget",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 759.3,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "createImplementsDiagnostics",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "module system kind for output code",
+          "query_type": "natural_language",
+          "expected_symbol": "ModuleKind",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": 9,
+          "elapsed_ms": 1219.72,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "evaluate",
+            "file": "harness/evaluatorImpl.ts"
+          }
+        },
+        {
+          "query": "top-level type checker interface",
+          "query_type": "natural_language",
+          "expected_symbol": "TypeChecker",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 2202.25,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "check",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "create a scanner",
+          "query_type": "short_phrase",
+          "expected_symbol": "createScanner",
+          "expected_file_suffix": "compiler/scanner.ts",
+          "rank": 10,
+          "elapsed_ms": 545.0,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "scanner",
+            "file": "services/utilities.ts"
+          }
+        },
+        {
+          "query": "create a source file",
+          "query_type": "short_phrase",
+          "expected_symbol": "createSourceFile",
+          "expected_file_suffix": "compiler/parser.ts",
+          "rank": 1,
+          "elapsed_ms": 682.68,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "createSourceFile",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "language service",
+          "query_type": "short_phrase",
+          "expected_symbol": "createLanguageService",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 367.14,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "LanguageServiceMode",
+            "file": "services/types.ts"
+          }
+        },
+        {
+          "query": "type checker",
+          "query_type": "short_phrase",
+          "expected_symbol": "createTypeChecker",
+          "expected_file_suffix": "compiler/checker.ts",
+          "rank": null,
+          "elapsed_ms": 386.98,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "checker",
+            "file": "services/utilities.ts"
+          }
+        },
+        {
+          "query": "rename info",
+          "query_type": "short_phrase",
+          "expected_symbol": "getRenameInfo",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 376.02,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "renameInfo",
+            "file": "services/rename.ts"
+          }
+        },
+        {
+          "query": "completions at position",
+          "query_type": "short_phrase",
+          "expected_symbol": "getCompletionsAtPosition",
+          "expected_file_suffix": "services/completions.ts",
+          "rank": 1,
+          "elapsed_ms": 531.0,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getCompletionsAtPosition",
+            "file": "services/completions.ts"
+          }
+        },
+        {
+          "query": "SyntaxKind",
+          "query_type": "identifier",
+          "expected_symbol": "SyntaxKind",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": 1,
+          "elapsed_ms": 256.5,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "SyntaxKind",
+            "file": "compiler/types.ts"
+          }
+        },
+        {
+          "query": "TypeChecker",
+          "query_type": "identifier",
+          "expected_symbol": "TypeChecker",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": 1,
+          "elapsed_ms": 253.35,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "TypeChecker",
+            "file": "compiler/types.ts"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context_no_semantic",
+      "mrr": 0.1201155462184874,
+      "acc1": 0.08823529411764706,
+      "acc3": 0.11764705882352941,
+      "acc5": 0.17647058823529413,
+      "avg_elapsed_ms": 148.43558823529412,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 1.0,
+          "acc1": 1.0,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 74.95
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.012843406593406595,
+          "acc1": 0.0,
+          "acc3": 0.0,
+          "acc5": 0.038461538461538464,
+          "avg_elapsed_ms": 164.55923076923077
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.2916666666666667,
+          "acc1": 0.16666666666666666,
+          "acc3": 0.3333333333333333,
+          "acc5": 0.5,
+          "avg_elapsed_ms": 103.06166666666667
+        }
+      },
+      "rows": [
+        {
+          "query": "create a TypeScript program from source files and options",
+          "query_type": "natural_language",
+          "expected_symbol": "createProgram",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": 16,
+          "elapsed_ms": 124.65,
+          "candidate_count": 18,
+          "top_candidate": {
+            "name": "shouldProgramCreateNewSourceFiles",
+            "file": "compiler/program.ts"
+          }
+        },
+        {
+          "query": "parse a TypeScript source file into an AST",
+          "query_type": "natural_language",
+          "expected_symbol": "createSourceFile",
+          "expected_file_suffix": "compiler/parser.ts",
+          "rank": 14,
+          "elapsed_ms": 204.52,
+          "candidate_count": 20,
+          "top_candidate": {
+            "name": "parseSourceFileWorker",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "tokenize TypeScript source code into a stream",
+          "query_type": "natural_language",
+          "expected_symbol": "createScanner",
+          "expected_file_suffix": "compiler/scanner.ts",
+          "rank": null,
+          "elapsed_ms": 166.73,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "SourceMapSpanWithDecodeErrors",
+            "file": "harness/sourceMapRecorder.ts"
+          }
+        },
+        {
+          "query": "print a TypeScript AST back to source text",
+          "query_type": "natural_language",
+          "expected_symbol": "createPrinter",
+          "expected_file_suffix": "compiler/emitter.ts",
+          "rank": null,
+          "elapsed_ms": 211.87,
+          "candidate_count": 21,
+          "top_candidate": {
+            "name": "isBacktrackingSourcePosition",
+            "file": "compiler/sourcemap.ts"
+          }
+        },
+        {
+          "query": "build a type checker for a program",
+          "query_type": "natural_language",
+          "expected_symbol": "createTypeChecker",
+          "expected_file_suffix": "compiler/checker.ts",
+          "rank": null,
+          "elapsed_ms": 181.56,
+          "candidate_count": 19,
+          "top_candidate": {
+            "name": "getWidenedLiteralLikeTypeForContextualType",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "visit every child node of an AST node",
+          "query_type": "natural_language",
+          "expected_symbol": "forEachChild",
+          "expected_file_suffix": "compiler/parser.ts",
+          "rank": null,
+          "elapsed_ms": 196.22,
+          "candidate_count": 20,
+          "top_candidate": {
+            "name": "visitExistingNodeTreeSymbols",
+            "file": "compiler/expressionToTypeNode.ts"
+          }
+        },
+        {
+          "query": "get line start offsets in a source file",
+          "query_type": "natural_language",
+          "expected_symbol": "getLineStarts",
+          "expected_file_suffix": "compiler/scanner.ts",
+          "rank": null,
+          "elapsed_ms": 161.72,
+          "candidate_count": 21,
+          "top_candidate": {
+            "name": "getParsedCommandLineOfConfigFile",
+            "file": "compiler/commandLineParser.ts"
+          }
+        },
+        {
+          "query": "get syntactic diagnostics from a program",
+          "query_type": "natural_language",
+          "expected_symbol": "getSyntacticDiagnostics",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": null,
+          "elapsed_ms": 142.15,
+          "candidate_count": 21,
+          "top_candidate": {
+            "name": "getCombinedDiagnostics",
+            "file": "compiler/programDiagnostics.ts"
+          }
+        },
+        {
+          "query": "get semantic diagnostics for type errors",
+          "query_type": "natural_language",
+          "expected_symbol": "getSemanticDiagnostics",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": null,
+          "elapsed_ms": 161.82,
+          "candidate_count": 18,
+          "top_candidate": {
+            "name": "serializeReturnTypeForSignature",
+            "file": "compiler/expressionToTypeNode.ts"
+          }
+        },
+        {
+          "query": "get suggestion diagnostics for code quality hints",
+          "query_type": "natural_language",
+          "expected_symbol": "getSuggestionDiagnostics",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": null,
+          "elapsed_ms": 106.03,
+          "candidate_count": 19,
+          "top_candidate": {
+            "name": "createGetSymbolAccessibilityDiagnosticForNode",
+            "file": "compiler/transformers/declarations/diagnostics.ts"
+          }
+        },
+        {
+          "query": "create a language service for editor integration",
+          "query_type": "natural_language",
+          "expected_symbol": "createLanguageService",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 168.15,
+          "candidate_count": 20,
+          "top_candidate": {
+            "name": "onUpdateLanguageServiceStateForProject",
+            "file": "server/editorServices.ts"
+          }
+        },
+        {
+          "query": "get autocomplete suggestions at a cursor position",
+          "query_type": "natural_language",
+          "expected_symbol": "getCompletionsAtPosition",
+          "expected_file_suffix": "services/completions.ts",
+          "rank": null,
+          "elapsed_ms": 142.72,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "getMoveToRefactoringFileSuggestions",
+            "file": "harness/client.ts"
+          }
+        },
+        {
+          "query": "find the definition site of a symbol at a position",
+          "query_type": "natural_language",
+          "expected_symbol": "getDefinitionAtPosition",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 189.73,
+          "candidate_count": 18,
+          "top_candidate": {
+            "name": "getDefinitionFromSymbol",
+            "file": "services/goToDefinition.ts"
+          }
+        },
+        {
+          "query": "find all references to a symbol in the project",
+          "query_type": "natural_language",
+          "expected_symbol": "findReferences",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 160.15,
+          "candidate_count": 17,
+          "top_candidate": {
+            "name": "findOwnConstructorReferences",
+            "file": "services/findAllReferences.ts"
+          }
+        },
+        {
+          "query": "compute automatic code fixes for diagnostics",
+          "query_type": "natural_language",
+          "expected_symbol": "getCodeFixesAtPosition",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 154.83,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "codeFixes",
+            "file": "harness/fourslashImpl.ts"
+          }
+        },
+        {
+          "query": "rename a symbol and find all its occurrences",
+          "query_type": "natural_language",
+          "expected_symbol": "getRenameInfo",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 130.34,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "getRefactorEditsToExtractSymbol",
+            "file": "services/refactors/extractSymbol.ts"
+          }
+        },
+        {
+          "query": "format a source range according to style rules",
+          "query_type": "natural_language",
+          "expected_symbol": "getFormattingEditsForRange",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 161.04,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "SourceMapGeneratorOptions",
+            "file": "compiler/sourcemap.ts"
+          }
+        },
+        {
+          "query": "compute collapsible regions for an outline view",
+          "query_type": "natural_language",
+          "expected_symbol": "getOutliningSpans",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 168.54,
+          "candidate_count": 19,
+          "top_candidate": {
+            "name": "transformConstructorBodyWorker",
+            "file": "compiler/transformers/classFields.ts"
+          }
+        },
+        {
+          "query": "provide parameter hints while typing a function call",
+          "query_type": "natural_language",
+          "expected_symbol": "getSignatureHelpItems",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 108.0,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "addParameterHints",
+            "file": "services/inlayHints.ts"
+          }
+        },
+        {
+          "query": "enum of every TypeScript AST node kind",
+          "query_type": "natural_language",
+          "expected_symbol": "SyntaxKind",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 196.0,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "visitExistingNodeTreeSymbolsWorker",
+            "file": "compiler/expressionToTypeNode.ts"
+          }
+        },
+        {
+          "query": "interface that represents a parsed source file",
+          "query_type": "natural_language",
+          "expected_symbol": "SourceFile",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 206.25,
+          "candidate_count": 21,
+          "top_candidate": {
+            "name": "parseSourceFileWorker",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "flags describing properties of an AST node",
+          "query_type": "natural_language",
+          "expected_symbol": "NodeFlags",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 177.9,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "getUsageInfoRangeForPasteEdits",
+            "file": "services/pasteEdits.ts"
+          }
+        },
+        {
+          "query": "enum of control flow analysis states",
+          "query_type": "natural_language",
+          "expected_symbol": "FlowFlags",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 149.58,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "saveFlowAnalysisDisabled",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "emit target ECMAScript version",
+          "query_type": "natural_language",
+          "expected_symbol": "ScriptTarget",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 142.89,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "transformECMAScriptModule",
+            "file": "compiler/transformers/module/esnextAnd2015.ts"
+          }
+        },
+        {
+          "query": "module system kind for output code",
+          "query_type": "natural_language",
+          "expected_symbol": "ModuleKind",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 158.46,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "transformSystemModule",
+            "file": "compiler/transformers/module/system.ts"
+          }
+        },
+        {
+          "query": "top-level type checker interface",
+          "query_type": "natural_language",
+          "expected_symbol": "TypeChecker",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": 5,
+          "elapsed_ms": 206.69,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "isNonGenericTopLevelType",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "create a scanner",
+          "query_type": "short_phrase",
+          "expected_symbol": "createScanner",
+          "expected_file_suffix": "compiler/scanner.ts",
+          "rank": 1,
+          "elapsed_ms": 105.35,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "createScanner",
+            "file": "compiler/scanner.ts"
+          }
+        },
+        {
+          "query": "create a source file",
+          "query_type": "short_phrase",
+          "expected_symbol": "createSourceFile",
+          "expected_file_suffix": "compiler/parser.ts",
+          "rank": 6,
+          "elapsed_ms": 120.77,
+          "candidate_count": 19,
+          "top_candidate": {
+            "name": "createSourceFileWithText",
+            "file": "testRunner/unittests/helpers.ts"
+          }
+        },
+        {
+          "query": "language service",
+          "query_type": "short_phrase",
+          "expected_symbol": "createLanguageService",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 89.82,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "LanguageServiceAdapter",
+            "file": "harness/harnessLanguageService.ts"
+          }
+        },
+        {
+          "query": "type checker",
+          "query_type": "short_phrase",
+          "expected_symbol": "createTypeChecker",
+          "expected_file_suffix": "compiler/checker.ts",
+          "rank": 3,
+          "elapsed_ms": 106.34,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "TypeChecker",
+            "file": "compiler/types.ts"
+          }
+        },
+        {
+          "query": "rename info",
+          "query_type": "short_phrase",
+          "expected_symbol": "getRenameInfo",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 88.92,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "getRenameInfoError",
+            "file": "services/rename.ts"
+          }
+        },
+        {
+          "query": "completions at position",
+          "query_type": "short_phrase",
+          "expected_symbol": "getCompletionsAtPosition",
+          "expected_file_suffix": "services/completions.ts",
+          "rank": 4,
+          "elapsed_ms": 107.17,
+          "candidate_count": 21,
+          "top_candidate": {
+            "name": "getJsDocTagAtPosition",
+            "file": "services/completions.ts"
+          }
+        },
+        {
+          "query": "SyntaxKind",
+          "query_type": "identifier",
+          "expected_symbol": "SyntaxKind",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": 1,
+          "elapsed_ms": 75.5,
+          "candidate_count": 20,
+          "top_candidate": {
+            "name": "SyntaxKind",
+            "file": "compiler/types.ts"
+          }
+        },
+        {
+          "query": "TypeChecker",
+          "query_type": "identifier",
+          "expected_symbol": "TypeChecker",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": 1,
+          "elapsed_ms": 74.4,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "TypeChecker",
+            "file": "compiler/types.ts"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context",
+      "mrr": 0.0983551029107295,
+      "acc1": 0.058823529411764705,
+      "acc3": 0.08823529411764706,
+      "acc5": 0.08823529411764706,
+      "avg_elapsed_ms": 263.56382352941176,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 1.0,
+          "acc1": 1.0,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 81.315
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.019643852524287304,
+          "acc1": 0.0,
+          "acc3": 0.0,
+          "acc5": 0.0,
+          "avg_elapsed_ms": 284.3876923076923
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.13888888888888887,
+          "acc1": 0.0,
+          "acc3": 0.16666666666666666,
+          "acc5": 0.16666666666666666,
+          "avg_elapsed_ms": 234.07666666666668
+        }
+      },
+      "rows": [
+        {
+          "query": "create a TypeScript program from source files and options",
+          "query_type": "natural_language",
+          "expected_symbol": "createProgram",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": null,
+          "elapsed_ms": 269.23,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "optionsForFile",
+            "file": "compiler/program.ts"
+          }
+        },
+        {
+          "query": "parse a TypeScript source file into an AST",
+          "query_type": "natural_language",
+          "expected_symbol": "createSourceFile",
+          "expected_file_suffix": "compiler/parser.ts",
+          "rank": null,
+          "elapsed_ms": 367.82,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "parseParenthesizedType",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "tokenize TypeScript source code into a stream",
+          "query_type": "natural_language",
+          "expected_symbol": "createScanner",
+          "expected_file_suffix": "compiler/scanner.ts",
+          "rank": null,
+          "elapsed_ms": 298.03,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "token",
+            "file": "services/utilities.ts"
+          }
+        },
+        {
+          "query": "print a TypeScript AST back to source text",
+          "query_type": "natural_language",
+          "expected_symbol": "createPrinter",
+          "expected_file_suffix": "compiler/emitter.ts",
+          "rank": null,
+          "elapsed_ms": 305.1,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "print",
+            "file": "compiler/emitter.ts"
+          }
+        },
+        {
+          "query": "build a type checker for a program",
+          "query_type": "natural_language",
+          "expected_symbol": "createTypeChecker",
+          "expected_file_suffix": "compiler/checker.ts",
+          "rank": null,
+          "elapsed_ms": 299.83,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "check",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "visit every child node of an AST node",
+          "query_type": "natural_language",
+          "expected_symbol": "forEachChild",
+          "expected_file_suffix": "compiler/parser.ts",
+          "rank": null,
+          "elapsed_ms": 311.05,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "visit",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "get line start offsets in a source file",
+          "query_type": "natural_language",
+          "expected_symbol": "getLineStarts",
+          "expected_file_suffix": "compiler/scanner.ts",
+          "rank": 6,
+          "elapsed_ms": 276.79,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "offsetStart",
+            "file": "harness/fourslashImpl.ts"
+          }
+        },
+        {
+          "query": "get syntactic diagnostics from a program",
+          "query_type": "natural_language",
+          "expected_symbol": "getSyntacticDiagnostics",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": 10,
+          "elapsed_ms": 291.95,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "getSyntacticDiagnosticsForFile",
+            "file": "compiler/program.ts"
+          }
+        },
+        {
+          "query": "get semantic diagnostics for type errors",
+          "query_type": "natural_language",
+          "expected_symbol": "getSemanticDiagnostics",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": null,
+          "elapsed_ms": 274.91,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "isErrorType",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "get suggestion diagnostics for code quality hints",
+          "query_type": "natural_language",
+          "expected_symbol": "getSuggestionDiagnostics",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": 15,
+          "elapsed_ms": 232.94,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "getSuggestion",
+            "file": "services/codefixes/fixNaNEquality.ts"
+          }
+        },
+        {
+          "query": "create a language service for editor integration",
+          "query_type": "natural_language",
+          "expected_symbol": "createLanguageService",
+          "expected_file_suffix": "services/services.ts",
+          "rank": 23,
+          "elapsed_ms": 283.2,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "EditorOptions",
+            "file": "services/types.ts"
+          }
+        },
+        {
+          "query": "get autocomplete suggestions at a cursor position",
+          "query_type": "natural_language",
+          "expected_symbol": "getCompletionsAtPosition",
+          "expected_file_suffix": "services/completions.ts",
+          "rank": null,
+          "elapsed_ms": 263.01,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "suggestion",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "find the definition site of a symbol at a position",
+          "query_type": "natural_language",
+          "expected_symbol": "getDefinitionAtPosition",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 297.78,
+          "candidate_count": 21,
+          "top_candidate": {
+            "name": "symbol",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "find all references to a symbol in the project",
+          "query_type": "natural_language",
+          "expected_symbol": "findReferences",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 272.63,
+          "candidate_count": 17,
+          "top_candidate": {
+            "name": "getReferencedSymbolsForModule",
+            "file": "services/findAllReferences.ts"
+          }
+        },
+        {
+          "query": "compute automatic code fixes for diagnostics",
+          "query_type": "natural_language",
+          "expected_symbol": "getCodeFixesAtPosition",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 274.33,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "fixes",
+            "file": "harness/fourslashImpl.ts"
+          }
+        },
+        {
+          "query": "rename a symbol and find all its occurrences",
+          "query_type": "natural_language",
+          "expected_symbol": "getRenameInfo",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 251.92,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "symbol",
+            "file": "services/rename.ts"
+          }
+        },
+        {
+          "query": "format a source range according to style rules",
+          "query_type": "natural_language",
+          "expected_symbol": "getFormattingEditsForRange",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 272.56,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "sourceIndex",
+            "file": "compiler/sourcemap.ts"
+          }
+        },
+        {
+          "query": "compute collapsible regions for an outline view",
+          "query_type": "natural_language",
+          "expected_symbol": "getOutliningSpans",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 280.87,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "regions",
+            "file": "services/outliningElementsCollector.ts"
+          }
+        },
+        {
+          "query": "provide parameter hints while typing a function call",
+          "query_type": "natural_language",
+          "expected_symbol": "getSignatureHelpItems",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 225.55,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "hints",
+            "file": "harness/fourslashImpl.ts"
+          }
+        },
+        {
+          "query": "enum of every TypeScript AST node kind",
+          "query_type": "natural_language",
+          "expected_symbol": "SyntaxKind",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 307.26,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "enumType",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "interface that represents a parsed source file",
+          "query_type": "natural_language",
+          "expected_symbol": "SourceFile",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": 14,
+          "elapsed_ms": 319.12,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "parseSourceFile",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "flags describing properties of an AST node",
+          "query_type": "natural_language",
+          "expected_symbol": "NodeFlags",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 293.86,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "flags",
+            "file": "compiler/factory/nodeFactory.ts"
+          }
+        },
+        {
+          "query": "enum of control flow analysis states",
+          "query_type": "natural_language",
+          "expected_symbol": "FlowFlags",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 266.03,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "States",
+            "file": "compiler/utilities.ts"
+          }
+        },
+        {
+          "query": "emit target ECMAScript version",
+          "query_type": "natural_language",
+          "expected_symbol": "ScriptTarget",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 261.97,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "emit",
+            "file": "compiler/tsbuildPublic.ts"
+          }
+        },
+        {
+          "query": "module system kind for output code",
+          "query_type": "natural_language",
+          "expected_symbol": "ModuleKind",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": 16,
+          "elapsed_ms": 273.69,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "kind",
+            "file": "services/codefixes/fixAwaitInSyncFunction.ts"
+          }
+        },
+        {
+          "query": "top-level type checker interface",
+          "query_type": "natural_language",
+          "expected_symbol": "TypeChecker",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 322.65,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "checkTypeLiteral",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "create a scanner",
+          "query_type": "short_phrase",
+          "expected_symbol": "createScanner",
+          "expected_file_suffix": "compiler/scanner.ts",
+          "rank": 6,
+          "elapsed_ms": 217.81,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "scanner",
+            "file": "services/utilities.ts"
+          }
+        },
+        {
+          "query": "create a source file",
+          "query_type": "short_phrase",
+          "expected_symbol": "createSourceFile",
+          "expected_file_suffix": "compiler/parser.ts",
+          "rank": 6,
+          "elapsed_ms": 235.61,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "sourceFile",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "language service",
+          "query_type": "short_phrase",
+          "expected_symbol": "createLanguageService",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 218.82,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "LanguageServiceAdapter",
+            "file": "harness/harnessLanguageService.ts"
+          }
+        },
+        {
+          "query": "type checker",
+          "query_type": "short_phrase",
+          "expected_symbol": "createTypeChecker",
+          "expected_file_suffix": "compiler/checker.ts",
+          "rank": null,
+          "elapsed_ms": 231.42,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "checkTypes",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "rename info",
+          "query_type": "short_phrase",
+          "expected_symbol": "getRenameInfo",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 264.0,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "renameInfo",
+            "file": "services/rename.ts"
+          }
+        },
+        {
+          "query": "completions at position",
+          "query_type": "short_phrase",
+          "expected_symbol": "getCompletionsAtPosition",
+          "expected_file_suffix": "services/completions.ts",
+          "rank": 2,
+          "elapsed_ms": 236.8,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "completionData",
+            "file": "services/completions.ts"
+          }
+        },
+        {
+          "query": "SyntaxKind",
+          "query_type": "identifier",
+          "expected_symbol": "SyntaxKind",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": 1,
+          "elapsed_ms": 79.58,
+          "candidate_count": 20,
+          "top_candidate": {
+            "name": "SyntaxKind",
+            "file": "compiler/types.ts"
+          }
+        },
+        {
+          "query": "TypeChecker",
+          "query_type": "identifier",
+          "expected_symbol": "TypeChecker",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": 1,
+          "elapsed_ms": 83.05,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "TypeChecker",
+            "file": "compiler/types.ts"
+          }
+        }
+      ]
+    }
+  ],
+  "hybrid_uplift": {
+    "mrr_delta": -0.021760443307757893,
+    "acc1_delta": -0.02941176470588236,
+    "acc3_delta": -0.029411764705882346,
+    "acc5_delta": -0.08823529411764706
+  },
+  "hybrid_uplift_by_query_type": {
+    "identifier": {
+      "mrr_delta": 0.0,
+      "acc1_delta": 0.0,
+      "acc3_delta": 0.0,
+      "acc5_delta": 0.0
+    },
+    "natural_language": {
+      "mrr_delta": 0.00680044593088071,
+      "acc1_delta": 0.0,
+      "acc3_delta": 0.0,
+      "acc5_delta": -0.038461538461538464
+    },
+    "short_phrase": {
+      "mrr_delta": -0.15277777777777782,
+      "acc1_delta": -0.16666666666666666,
+      "acc3_delta": -0.16666666666666666,
+      "acc5_delta": -0.33333333333333337
+    }
+  }
+}

--- a/benchmarks/embedding-quality-v1.6-phase3d-typescript-stacked.json
+++ b/benchmarks/embedding-quality-v1.6-phase3d-typescript-stacked.json
@@ -1,0 +1,1487 @@
+{
+  "project": "/tmp/typescript/src",
+  "benchmark_project": "/var/folders/z0/0tcbss795xsdp75jmr_t9_kh0000gn/T/codelens-embed-quality-e8smp5dt/src",
+  "isolated_copy": true,
+  "binary": "/Users/bagjaeseog/codelens-mcp-plugin/target/release/codelens-mcp",
+  "embedding_model": "MiniLM-L12-CodeSearchNet-INT8",
+  "runtime_model": {
+    "model_dir": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch",
+    "model_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/model.onnx",
+    "config_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/config.json",
+    "sha256": "ef1d1e9cfa72e4929f5b9faea17d8704b23a2530aadebf0d464a4cc7750920b3",
+    "size_bytes": 34000281,
+    "num_hidden_layers": 12,
+    "hidden_size": 384
+  },
+  "dataset_path": "/Users/bagjaeseog/codelens-mcp-plugin/benchmarks/embedding-quality-dataset-typescript.json",
+  "dataset_size": 34,
+  "ranking_cutoff": 10,
+  "metric_labels": {
+    "mrr": "MRR@10",
+    "acc1": "Acc@1",
+    "acc3": "Acc@3",
+    "acc5": "Acc@5"
+  },
+  "methods": [
+    {
+      "method": "semantic_search",
+      "mrr": 0.17091503267973857,
+      "acc1": 0.14705882352941177,
+      "acc3": 0.17647058823529413,
+      "acc5": 0.17647058823529413,
+      "avg_elapsed_ms": 916.9673529411765,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 1.0,
+          "acc1": 1.0,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 248.755
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.06581196581196581,
+          "acc1": 0.038461538461538464,
+          "acc3": 0.07692307692307693,
+          "acc5": 0.07692307692307693,
+          "avg_elapsed_ms": 1069.916923076923
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.35000000000000003,
+          "acc1": 0.3333333333333333,
+          "acc3": 0.3333333333333333,
+          "acc5": 0.3333333333333333,
+          "avg_elapsed_ms": 476.92333333333335
+        }
+      },
+      "rows": [
+        {
+          "query": "create a TypeScript program from source files and options",
+          "query_type": "natural_language",
+          "expected_symbol": "createProgram",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": null,
+          "elapsed_ms": 798.26,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "createError",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "parse a TypeScript source file into an AST",
+          "query_type": "natural_language",
+          "expected_symbol": "createSourceFile",
+          "expected_file_suffix": "compiler/parser.ts",
+          "rank": null,
+          "elapsed_ms": 1469.97,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "parseSourceFile",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "tokenize TypeScript source code into a stream",
+          "query_type": "natural_language",
+          "expected_symbol": "createScanner",
+          "expected_file_suffix": "compiler/scanner.ts",
+          "rank": null,
+          "elapsed_ms": 2060.61,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "codeActionForFix",
+            "file": "services/codefixes/importFixes.ts"
+          }
+        },
+        {
+          "query": "print a TypeScript AST back to source text",
+          "query_type": "natural_language",
+          "expected_symbol": "createPrinter",
+          "expected_file_suffix": "compiler/emitter.ts",
+          "rank": null,
+          "elapsed_ms": 1278.63,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "consumeCurrentOperator",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "build a type checker for a program",
+          "query_type": "natural_language",
+          "expected_symbol": "createTypeChecker",
+          "expected_file_suffix": "compiler/checker.ts",
+          "rank": null,
+          "elapsed_ms": 931.03,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "check",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "visit every child node of an AST node",
+          "query_type": "natural_language",
+          "expected_symbol": "forEachChild",
+          "expected_file_suffix": "compiler/parser.ts",
+          "rank": null,
+          "elapsed_ms": 1311.82,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "visit",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "get line start offsets in a source file",
+          "query_type": "natural_language",
+          "expected_symbol": "getLineStarts",
+          "expected_file_suffix": "compiler/scanner.ts",
+          "rank": 2,
+          "elapsed_ms": 1218.18,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getLineStarts",
+            "file": "services/services.ts"
+          }
+        },
+        {
+          "query": "get syntactic diagnostics from a program",
+          "query_type": "natural_language",
+          "expected_symbol": "getSyntacticDiagnostics",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": 1,
+          "elapsed_ms": 949.5,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getSyntacticDiagnostics",
+            "file": "compiler/program.ts"
+          }
+        },
+        {
+          "query": "get semantic diagnostics for type errors",
+          "query_type": "natural_language",
+          "expected_symbol": "getSemanticDiagnostics",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": null,
+          "elapsed_ms": 1024.38,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getAccessorDeclarationTypeVisibilityError",
+            "file": "compiler/transformers/declarations/diagnostics.ts"
+          }
+        },
+        {
+          "query": "get suggestion diagnostics for code quality hints",
+          "query_type": "natural_language",
+          "expected_symbol": "getSuggestionDiagnostics",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": 10,
+          "elapsed_ms": 570.52,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getSuggestion",
+            "file": "services/codefixes/fixNaNEquality.ts"
+          }
+        },
+        {
+          "query": "create a language service for editor integration",
+          "query_type": "natural_language",
+          "expected_symbol": "createLanguageService",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 1020.84,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "createReturnTypeOfSignatureDeclaration",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "get autocomplete suggestions at a cursor position",
+          "query_type": "natural_language",
+          "expected_symbol": "getCompletionsAtPosition",
+          "expected_file_suffix": "services/completions.ts",
+          "rank": null,
+          "elapsed_ms": 903.41,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getRecommendedCompletion",
+            "file": "services/completions.ts"
+          }
+        },
+        {
+          "query": "find the definition site of a symbol at a position",
+          "query_type": "natural_language",
+          "expected_symbol": "getDefinitionAtPosition",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 1303.4,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "symbolAtLocation",
+            "file": "harness/fourslashInterfaceImpl.ts"
+          }
+        },
+        {
+          "query": "find all references to a symbol in the project",
+          "query_type": "natural_language",
+          "expected_symbol": "findReferences",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 1047.6,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getReferencedSymbolsForModule",
+            "file": "services/findAllReferences.ts"
+          }
+        },
+        {
+          "query": "compute automatic code fixes for diagnostics",
+          "query_type": "natural_language",
+          "expected_symbol": "getCodeFixesAtPosition",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 1030.35,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "computeModuleSpecifiers",
+            "file": "compiler/moduleSpecifiers.ts"
+          }
+        },
+        {
+          "query": "rename a symbol and find all its occurrences",
+          "query_type": "natural_language",
+          "expected_symbol": "getRenameInfo",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 740.18,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "symbol",
+            "file": "services/rename.ts"
+          }
+        },
+        {
+          "query": "format a source range according to style rules",
+          "query_type": "natural_language",
+          "expected_symbol": "getFormattingEditsForRange",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 1035.8,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "formatRange",
+            "file": "harness/fourslashImpl.ts"
+          }
+        },
+        {
+          "query": "compute collapsible regions for an outline view",
+          "query_type": "natural_language",
+          "expected_symbol": "getOutliningSpans",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 1048.4,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "formatEnum",
+            "file": "compiler/debug.ts"
+          }
+        },
+        {
+          "query": "provide parameter hints while typing a function call",
+          "query_type": "natural_language",
+          "expected_symbol": "getSignatureHelpItems",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 591.86,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "addParameterHints",
+            "file": "services/inlayHints.ts"
+          }
+        },
+        {
+          "query": "enum of every TypeScript AST node kind",
+          "query_type": "natural_language",
+          "expected_symbol": "SyntaxKind",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 1317.88,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "asterisk",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "interface that represents a parsed source file",
+          "query_type": "natural_language",
+          "expected_symbol": "SourceFile",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 1292.84,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "parseDoStatement",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "flags describing properties of an AST node",
+          "query_type": "natural_language",
+          "expected_symbol": "NodeFlags",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 1148.97,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "flags",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "enum of control flow analysis states",
+          "query_type": "natural_language",
+          "expected_symbol": "FlowFlags",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 916.78,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "State",
+            "file": "harness/fourslashImpl.ts"
+          }
+        },
+        {
+          "query": "emit target ECMAScript version",
+          "query_type": "natural_language",
+          "expected_symbol": "ScriptTarget",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 780.31,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "createImplementsDiagnostics",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "module system kind for output code",
+          "query_type": "natural_language",
+          "expected_symbol": "ModuleKind",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": 9,
+          "elapsed_ms": 1038.52,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "evaluate",
+            "file": "harness/evaluatorImpl.ts"
+          }
+        },
+        {
+          "query": "top-level type checker interface",
+          "query_type": "natural_language",
+          "expected_symbol": "TypeChecker",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 987.8,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "check",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "create a scanner",
+          "query_type": "short_phrase",
+          "expected_symbol": "createScanner",
+          "expected_file_suffix": "compiler/scanner.ts",
+          "rank": 10,
+          "elapsed_ms": 532.03,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "scanner",
+            "file": "services/utilities.ts"
+          }
+        },
+        {
+          "query": "create a source file",
+          "query_type": "short_phrase",
+          "expected_symbol": "createSourceFile",
+          "expected_file_suffix": "compiler/parser.ts",
+          "rank": 1,
+          "elapsed_ms": 675.53,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "createSourceFile",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "language service",
+          "query_type": "short_phrase",
+          "expected_symbol": "createLanguageService",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 369.59,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "LanguageServiceMode",
+            "file": "services/types.ts"
+          }
+        },
+        {
+          "query": "type checker",
+          "query_type": "short_phrase",
+          "expected_symbol": "createTypeChecker",
+          "expected_file_suffix": "compiler/checker.ts",
+          "rank": null,
+          "elapsed_ms": 379.12,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "checker",
+            "file": "services/utilities.ts"
+          }
+        },
+        {
+          "query": "rename info",
+          "query_type": "short_phrase",
+          "expected_symbol": "getRenameInfo",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 380.42,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "renameInfo",
+            "file": "services/rename.ts"
+          }
+        },
+        {
+          "query": "completions at position",
+          "query_type": "short_phrase",
+          "expected_symbol": "getCompletionsAtPosition",
+          "expected_file_suffix": "services/completions.ts",
+          "rank": 1,
+          "elapsed_ms": 524.85,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getCompletionsAtPosition",
+            "file": "services/completions.ts"
+          }
+        },
+        {
+          "query": "SyntaxKind",
+          "query_type": "identifier",
+          "expected_symbol": "SyntaxKind",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": 1,
+          "elapsed_ms": 248.87,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "SyntaxKind",
+            "file": "compiler/types.ts"
+          }
+        },
+        {
+          "query": "TypeChecker",
+          "query_type": "identifier",
+          "expected_symbol": "TypeChecker",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": 1,
+          "elapsed_ms": 248.64,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "TypeChecker",
+            "file": "compiler/types.ts"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context_no_semantic",
+      "mrr": 0.1397233893557423,
+      "acc1": 0.11764705882352941,
+      "acc3": 0.11764705882352941,
+      "acc5": 0.17647058823529413,
+      "avg_elapsed_ms": 154.53117647058824,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 1.0,
+          "acc1": 1.0,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 78.61
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.012843406593406595,
+          "acc1": 0.0,
+          "acc3": 0.0,
+          "acc5": 0.038461538461538464,
+          "avg_elapsed_ms": 170.1053846153846
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.40277777777777773,
+          "acc1": 0.3333333333333333,
+          "acc3": 0.3333333333333333,
+          "acc5": 0.5,
+          "avg_elapsed_ms": 112.35000000000001
+        }
+      },
+      "rows": [
+        {
+          "query": "create a TypeScript program from source files and options",
+          "query_type": "natural_language",
+          "expected_symbol": "createProgram",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": 16,
+          "elapsed_ms": 125.54,
+          "candidate_count": 18,
+          "top_candidate": {
+            "name": "shouldProgramCreateNewSourceFiles",
+            "file": "compiler/program.ts"
+          }
+        },
+        {
+          "query": "parse a TypeScript source file into an AST",
+          "query_type": "natural_language",
+          "expected_symbol": "createSourceFile",
+          "expected_file_suffix": "compiler/parser.ts",
+          "rank": 14,
+          "elapsed_ms": 215.78,
+          "candidate_count": 20,
+          "top_candidate": {
+            "name": "parseSourceFileWorker",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "tokenize TypeScript source code into a stream",
+          "query_type": "natural_language",
+          "expected_symbol": "createScanner",
+          "expected_file_suffix": "compiler/scanner.ts",
+          "rank": null,
+          "elapsed_ms": 176.57,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "SourceMapSpanWithDecodeErrors",
+            "file": "harness/sourceMapRecorder.ts"
+          }
+        },
+        {
+          "query": "print a TypeScript AST back to source text",
+          "query_type": "natural_language",
+          "expected_symbol": "createPrinter",
+          "expected_file_suffix": "compiler/emitter.ts",
+          "rank": null,
+          "elapsed_ms": 200.61,
+          "candidate_count": 21,
+          "top_candidate": {
+            "name": "isBacktrackingSourcePosition",
+            "file": "compiler/sourcemap.ts"
+          }
+        },
+        {
+          "query": "build a type checker for a program",
+          "query_type": "natural_language",
+          "expected_symbol": "createTypeChecker",
+          "expected_file_suffix": "compiler/checker.ts",
+          "rank": null,
+          "elapsed_ms": 187.03,
+          "candidate_count": 19,
+          "top_candidate": {
+            "name": "getWidenedLiteralLikeTypeForContextualType",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "visit every child node of an AST node",
+          "query_type": "natural_language",
+          "expected_symbol": "forEachChild",
+          "expected_file_suffix": "compiler/parser.ts",
+          "rank": null,
+          "elapsed_ms": 208.57,
+          "candidate_count": 20,
+          "top_candidate": {
+            "name": "visitExistingNodeTreeSymbols",
+            "file": "compiler/expressionToTypeNode.ts"
+          }
+        },
+        {
+          "query": "get line start offsets in a source file",
+          "query_type": "natural_language",
+          "expected_symbol": "getLineStarts",
+          "expected_file_suffix": "compiler/scanner.ts",
+          "rank": null,
+          "elapsed_ms": 170.89,
+          "candidate_count": 21,
+          "top_candidate": {
+            "name": "getParsedCommandLineOfConfigFile",
+            "file": "compiler/commandLineParser.ts"
+          }
+        },
+        {
+          "query": "get syntactic diagnostics from a program",
+          "query_type": "natural_language",
+          "expected_symbol": "getSyntacticDiagnostics",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": null,
+          "elapsed_ms": 151.88,
+          "candidate_count": 21,
+          "top_candidate": {
+            "name": "getCombinedDiagnostics",
+            "file": "compiler/programDiagnostics.ts"
+          }
+        },
+        {
+          "query": "get semantic diagnostics for type errors",
+          "query_type": "natural_language",
+          "expected_symbol": "getSemanticDiagnostics",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": null,
+          "elapsed_ms": 165.78,
+          "candidate_count": 18,
+          "top_candidate": {
+            "name": "serializeReturnTypeForSignature",
+            "file": "compiler/expressionToTypeNode.ts"
+          }
+        },
+        {
+          "query": "get suggestion diagnostics for code quality hints",
+          "query_type": "natural_language",
+          "expected_symbol": "getSuggestionDiagnostics",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": null,
+          "elapsed_ms": 106.99,
+          "candidate_count": 19,
+          "top_candidate": {
+            "name": "createGetSymbolAccessibilityDiagnosticForNode",
+            "file": "compiler/transformers/declarations/diagnostics.ts"
+          }
+        },
+        {
+          "query": "create a language service for editor integration",
+          "query_type": "natural_language",
+          "expected_symbol": "createLanguageService",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 174.28,
+          "candidate_count": 20,
+          "top_candidate": {
+            "name": "onUpdateLanguageServiceStateForProject",
+            "file": "server/editorServices.ts"
+          }
+        },
+        {
+          "query": "get autocomplete suggestions at a cursor position",
+          "query_type": "natural_language",
+          "expected_symbol": "getCompletionsAtPosition",
+          "expected_file_suffix": "services/completions.ts",
+          "rank": null,
+          "elapsed_ms": 152.83,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "getMoveToRefactoringFileSuggestions",
+            "file": "harness/client.ts"
+          }
+        },
+        {
+          "query": "find the definition site of a symbol at a position",
+          "query_type": "natural_language",
+          "expected_symbol": "getDefinitionAtPosition",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 194.79,
+          "candidate_count": 18,
+          "top_candidate": {
+            "name": "getDefinitionFromSymbol",
+            "file": "services/goToDefinition.ts"
+          }
+        },
+        {
+          "query": "find all references to a symbol in the project",
+          "query_type": "natural_language",
+          "expected_symbol": "findReferences",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 165.85,
+          "candidate_count": 17,
+          "top_candidate": {
+            "name": "findOwnConstructorReferences",
+            "file": "services/findAllReferences.ts"
+          }
+        },
+        {
+          "query": "compute automatic code fixes for diagnostics",
+          "query_type": "natural_language",
+          "expected_symbol": "getCodeFixesAtPosition",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 164.86,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "codeFixes",
+            "file": "harness/fourslashImpl.ts"
+          }
+        },
+        {
+          "query": "rename a symbol and find all its occurrences",
+          "query_type": "natural_language",
+          "expected_symbol": "getRenameInfo",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 137.78,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "getRenameInfoForModule",
+            "file": "services/rename.ts"
+          }
+        },
+        {
+          "query": "format a source range according to style rules",
+          "query_type": "natural_language",
+          "expected_symbol": "getFormattingEditsForRange",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 163.43,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "SourceMapGeneratorOptions",
+            "file": "compiler/sourcemap.ts"
+          }
+        },
+        {
+          "query": "compute collapsible regions for an outline view",
+          "query_type": "natural_language",
+          "expected_symbol": "getOutliningSpans",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 164.89,
+          "candidate_count": 19,
+          "top_candidate": {
+            "name": "transformConstructorBodyWorker",
+            "file": "compiler/transformers/classFields.ts"
+          }
+        },
+        {
+          "query": "provide parameter hints while typing a function call",
+          "query_type": "natural_language",
+          "expected_symbol": "getSignatureHelpItems",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 120.62,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "addParameterHints",
+            "file": "services/inlayHints.ts"
+          }
+        },
+        {
+          "query": "enum of every TypeScript AST node kind",
+          "query_type": "natural_language",
+          "expected_symbol": "SyntaxKind",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 208.03,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "visitExistingNodeTreeSymbolsWorker",
+            "file": "compiler/expressionToTypeNode.ts"
+          }
+        },
+        {
+          "query": "interface that represents a parsed source file",
+          "query_type": "natural_language",
+          "expected_symbol": "SourceFile",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 207.96,
+          "candidate_count": 21,
+          "top_candidate": {
+            "name": "parseSourceFileWorker",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "flags describing properties of an AST node",
+          "query_type": "natural_language",
+          "expected_symbol": "NodeFlags",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 178.8,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "getUsageInfoRangeForPasteEdits",
+            "file": "services/pasteEdits.ts"
+          }
+        },
+        {
+          "query": "enum of control flow analysis states",
+          "query_type": "natural_language",
+          "expected_symbol": "FlowFlags",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 154.65,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "saveFlowAnalysisDisabled",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "emit target ECMAScript version",
+          "query_type": "natural_language",
+          "expected_symbol": "ScriptTarget",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 152.79,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "transformECMAScriptModule",
+            "file": "compiler/transformers/module/esnextAnd2015.ts"
+          }
+        },
+        {
+          "query": "module system kind for output code",
+          "query_type": "natural_language",
+          "expected_symbol": "ModuleKind",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 162.62,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "transformSystemModule",
+            "file": "compiler/transformers/module/system.ts"
+          }
+        },
+        {
+          "query": "top-level type checker interface",
+          "query_type": "natural_language",
+          "expected_symbol": "TypeChecker",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": 5,
+          "elapsed_ms": 208.92,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "isNonGenericTopLevelType",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "create a scanner",
+          "query_type": "short_phrase",
+          "expected_symbol": "createScanner",
+          "expected_file_suffix": "compiler/scanner.ts",
+          "rank": 1,
+          "elapsed_ms": 106.28,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "createScanner",
+            "file": "compiler/scanner.ts"
+          }
+        },
+        {
+          "query": "create a source file",
+          "query_type": "short_phrase",
+          "expected_symbol": "createSourceFile",
+          "expected_file_suffix": "compiler/parser.ts",
+          "rank": 6,
+          "elapsed_ms": 121.32,
+          "candidate_count": 19,
+          "top_candidate": {
+            "name": "createSourceFileWithText",
+            "file": "testRunner/unittests/helpers.ts"
+          }
+        },
+        {
+          "query": "language service",
+          "query_type": "short_phrase",
+          "expected_symbol": "createLanguageService",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 89.66,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "LanguageServiceAdapter",
+            "file": "harness/harnessLanguageService.ts"
+          }
+        },
+        {
+          "query": "type checker",
+          "query_type": "short_phrase",
+          "expected_symbol": "createTypeChecker",
+          "expected_file_suffix": "compiler/checker.ts",
+          "rank": 1,
+          "elapsed_ms": 108.09,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "createTypeChecker",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "rename info",
+          "query_type": "short_phrase",
+          "expected_symbol": "getRenameInfo",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 137.45,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "getRenameInfoError",
+            "file": "services/rename.ts"
+          }
+        },
+        {
+          "query": "completions at position",
+          "query_type": "short_phrase",
+          "expected_symbol": "getCompletionsAtPosition",
+          "expected_file_suffix": "services/completions.ts",
+          "rank": 4,
+          "elapsed_ms": 111.3,
+          "candidate_count": 21,
+          "top_candidate": {
+            "name": "getJsDocTagAtPosition",
+            "file": "services/completions.ts"
+          }
+        },
+        {
+          "query": "SyntaxKind",
+          "query_type": "identifier",
+          "expected_symbol": "SyntaxKind",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": 1,
+          "elapsed_ms": 77.44,
+          "candidate_count": 20,
+          "top_candidate": {
+            "name": "SyntaxKind",
+            "file": "compiler/types.ts"
+          }
+        },
+        {
+          "query": "TypeChecker",
+          "query_type": "identifier",
+          "expected_symbol": "TypeChecker",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": 1,
+          "elapsed_ms": 79.78,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "TypeChecker",
+            "file": "compiler/types.ts"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context",
+      "mrr": 0.20098039215686272,
+      "acc1": 0.14705882352941177,
+      "acc3": 0.23529411764705882,
+      "acc5": 0.23529411764705882,
+      "avg_elapsed_ms": 270.01176470588234,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 1.0,
+          "acc1": 1.0,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 79.74000000000001
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.15384615384615385,
+          "acc1": 0.11538461538461539,
+          "acc3": 0.19230769230769232,
+          "acc5": 0.19230769230769232,
+          "avg_elapsed_ms": 293.28076923076924
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.13888888888888887,
+          "acc1": 0.0,
+          "acc3": 0.16666666666666666,
+          "acc5": 0.16666666666666666,
+          "avg_elapsed_ms": 232.60333333333332
+        }
+      },
+      "rows": [
+        {
+          "query": "create a TypeScript program from source files and options",
+          "query_type": "natural_language",
+          "expected_symbol": "createProgram",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": null,
+          "elapsed_ms": 252.85,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "getCreateSourceFileOptions",
+            "file": "compiler/program.ts"
+          }
+        },
+        {
+          "query": "parse a TypeScript source file into an AST",
+          "query_type": "natural_language",
+          "expected_symbol": "createSourceFile",
+          "expected_file_suffix": "compiler/parser.ts",
+          "rank": null,
+          "elapsed_ms": 327.24,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "parseParenthesizedType",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "tokenize TypeScript source code into a stream",
+          "query_type": "natural_language",
+          "expected_symbol": "createScanner",
+          "expected_file_suffix": "compiler/scanner.ts",
+          "rank": null,
+          "elapsed_ms": 296.9,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "token",
+            "file": "services/codefixes/fixAddModuleReferTypeMissingTypeof.ts"
+          }
+        },
+        {
+          "query": "print a TypeScript AST back to source text",
+          "query_type": "natural_language",
+          "expected_symbol": "createPrinter",
+          "expected_file_suffix": "compiler/emitter.ts",
+          "rank": null,
+          "elapsed_ms": 315.62,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "fromString",
+            "file": "services/types.ts"
+          }
+        },
+        {
+          "query": "build a type checker for a program",
+          "query_type": "natural_language",
+          "expected_symbol": "createTypeChecker",
+          "expected_file_suffix": "compiler/checker.ts",
+          "rank": null,
+          "elapsed_ms": 313.9,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "checker",
+            "file": "services/utilities.ts"
+          }
+        },
+        {
+          "query": "visit every child node of an AST node",
+          "query_type": "natural_language",
+          "expected_symbol": "forEachChild",
+          "expected_file_suffix": "compiler/parser.ts",
+          "rank": null,
+          "elapsed_ms": 323.64,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "visit",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "get line start offsets in a source file",
+          "query_type": "natural_language",
+          "expected_symbol": "getLineStarts",
+          "expected_file_suffix": "compiler/scanner.ts",
+          "rank": 2,
+          "elapsed_ms": 287.84,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "getLineStarts",
+            "file": "services/services.ts"
+          }
+        },
+        {
+          "query": "get syntactic diagnostics from a program",
+          "query_type": "natural_language",
+          "expected_symbol": "getSyntacticDiagnostics",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": 1,
+          "elapsed_ms": 262.53,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "getSyntacticDiagnostics",
+            "file": "compiler/program.ts"
+          }
+        },
+        {
+          "query": "get semantic diagnostics for type errors",
+          "query_type": "natural_language",
+          "expected_symbol": "getSemanticDiagnostics",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": null,
+          "elapsed_ms": 285.22,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "errorType",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "get suggestion diagnostics for code quality hints",
+          "query_type": "natural_language",
+          "expected_symbol": "getSuggestionDiagnostics",
+          "expected_file_suffix": "compiler/program.ts",
+          "rank": 3,
+          "elapsed_ms": 230.15,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "suggestion",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "create a language service for editor integration",
+          "query_type": "natural_language",
+          "expected_symbol": "createLanguageService",
+          "expected_file_suffix": "services/services.ts",
+          "rank": 6,
+          "elapsed_ms": 288.54,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "EditorOptions",
+            "file": "services/types.ts"
+          }
+        },
+        {
+          "query": "get autocomplete suggestions at a cursor position",
+          "query_type": "natural_language",
+          "expected_symbol": "getCompletionsAtPosition",
+          "expected_file_suffix": "services/completions.ts",
+          "rank": null,
+          "elapsed_ms": 278.75,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "getRecommendedCompletion",
+            "file": "services/completions.ts"
+          }
+        },
+        {
+          "query": "find the definition site of a symbol at a position",
+          "query_type": "natural_language",
+          "expected_symbol": "getDefinitionAtPosition",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 312.62,
+          "candidate_count": 21,
+          "top_candidate": {
+            "name": "symbol",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "find all references to a symbol in the project",
+          "query_type": "natural_language",
+          "expected_symbol": "findReferences",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 293.27,
+          "candidate_count": 17,
+          "top_candidate": {
+            "name": "getReferencedSymbolsForModule",
+            "file": "services/findAllReferences.ts"
+          }
+        },
+        {
+          "query": "compute automatic code fixes for diagnostics",
+          "query_type": "natural_language",
+          "expected_symbol": "getCodeFixesAtPosition",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 319.2,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "getFixInfosWithoutDiagnostic",
+            "file": "services/codefixes/importFixes.ts"
+          }
+        },
+        {
+          "query": "rename a symbol and find all its occurrences",
+          "query_type": "natural_language",
+          "expected_symbol": "getRenameInfo",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 256.04,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "symbol",
+            "file": "services/rename.ts"
+          }
+        },
+        {
+          "query": "format a source range according to style rules",
+          "query_type": "natural_language",
+          "expected_symbol": "getFormattingEditsForRange",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 290.33,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "formatRange",
+            "file": "harness/fourslashImpl.ts"
+          }
+        },
+        {
+          "query": "compute collapsible regions for an outline view",
+          "query_type": "natural_language",
+          "expected_symbol": "getOutliningSpans",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 295.86,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "region",
+            "file": "services/outliningElementsCollector.ts"
+          }
+        },
+        {
+          "query": "provide parameter hints while typing a function call",
+          "query_type": "natural_language",
+          "expected_symbol": "getSignatureHelpItems",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 237.78,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "hintText",
+            "file": "services/inlayHints.ts"
+          }
+        },
+        {
+          "query": "enum of every TypeScript AST node kind",
+          "query_type": "natural_language",
+          "expected_symbol": "SyntaxKind",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 330.29,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "Extension",
+            "file": "compiler/types.ts"
+          }
+        },
+        {
+          "query": "interface that represents a parsed source file",
+          "query_type": "natural_language",
+          "expected_symbol": "SourceFile",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": 1,
+          "elapsed_ms": 342.73,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "SourceFile",
+            "file": "compiler/types.ts"
+          }
+        },
+        {
+          "query": "flags describing properties of an AST node",
+          "query_type": "natural_language",
+          "expected_symbol": "NodeFlags",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 308.1,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "flags",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "enum of control flow analysis states",
+          "query_type": "natural_language",
+          "expected_symbol": "FlowFlags",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 276.38,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "State",
+            "file": "harness/fourslashImpl.ts"
+          }
+        },
+        {
+          "query": "emit target ECMAScript version",
+          "query_type": "natural_language",
+          "expected_symbol": "ScriptTarget",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 275.9,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "EmitHint",
+            "file": "compiler/types.ts"
+          }
+        },
+        {
+          "query": "module system kind for output code",
+          "query_type": "natural_language",
+          "expected_symbol": "ModuleKind",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": 1,
+          "elapsed_ms": 288.31,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "ModuleKind",
+            "file": "compiler/types.ts"
+          }
+        },
+        {
+          "query": "top-level type checker interface",
+          "query_type": "natural_language",
+          "expected_symbol": "TypeChecker",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": null,
+          "elapsed_ms": 335.31,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "check",
+            "file": "compiler/checker.ts"
+          }
+        },
+        {
+          "query": "create a scanner",
+          "query_type": "short_phrase",
+          "expected_symbol": "createScanner",
+          "expected_file_suffix": "compiler/scanner.ts",
+          "rank": 6,
+          "elapsed_ms": 235.65,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "scanner",
+            "file": "services/utilities.ts"
+          }
+        },
+        {
+          "query": "create a source file",
+          "query_type": "short_phrase",
+          "expected_symbol": "createSourceFile",
+          "expected_file_suffix": "compiler/parser.ts",
+          "rank": 6,
+          "elapsed_ms": 253.35,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "sourceFile",
+            "file": "compiler/parser.ts"
+          }
+        },
+        {
+          "query": "language service",
+          "query_type": "short_phrase",
+          "expected_symbol": "createLanguageService",
+          "expected_file_suffix": "services/services.ts",
+          "rank": null,
+          "elapsed_ms": 211.33,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "LanguageServiceMode",
+            "file": "services/types.ts"
+          }
+        },
+        {
+          "query": "type checker",
+          "query_type": "short_phrase",
+          "expected_symbol": "createTypeChecker",
+          "expected_file_suffix": "compiler/checker.ts",
+          "rank": null,
+          "elapsed_ms": 237.35,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "checker",
+            "file": "services/utilities.ts"
+          }
+        },
+        {
+          "query": "rename info",
+          "query_type": "short_phrase",
+          "expected_symbol": "getRenameInfo",
+          "expected_file_suffix": "server/session.ts",
+          "rank": null,
+          "elapsed_ms": 219.46,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "renameInfo",
+            "file": "services/rename.ts"
+          }
+        },
+        {
+          "query": "completions at position",
+          "query_type": "short_phrase",
+          "expected_symbol": "getCompletionsAtPosition",
+          "expected_file_suffix": "services/completions.ts",
+          "rank": 2,
+          "elapsed_ms": 238.48,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "completionData",
+            "file": "services/completions.ts"
+          }
+        },
+        {
+          "query": "SyntaxKind",
+          "query_type": "identifier",
+          "expected_symbol": "SyntaxKind",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": 1,
+          "elapsed_ms": 80.42,
+          "candidate_count": 20,
+          "top_candidate": {
+            "name": "SyntaxKind",
+            "file": "compiler/types.ts"
+          }
+        },
+        {
+          "query": "TypeChecker",
+          "query_type": "identifier",
+          "expected_symbol": "TypeChecker",
+          "expected_file_suffix": "compiler/types.ts",
+          "rank": 1,
+          "elapsed_ms": 79.06,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "TypeChecker",
+            "file": "compiler/types.ts"
+          }
+        }
+      ]
+    }
+  ],
+  "hybrid_uplift": {
+    "mrr_delta": 0.061257002801120425,
+    "acc1_delta": 0.02941176470588236,
+    "acc3_delta": 0.11764705882352941,
+    "acc5_delta": 0.05882352941176469
+  },
+  "hybrid_uplift_by_query_type": {
+    "identifier": {
+      "mrr_delta": 0.0,
+      "acc1_delta": 0.0,
+      "acc3_delta": 0.0,
+      "acc5_delta": 0.0
+    },
+    "natural_language": {
+      "mrr_delta": 0.14100274725274725,
+      "acc1_delta": 0.11538461538461539,
+      "acc3_delta": 0.19230769230769232,
+      "acc5_delta": 0.15384615384615385
+    },
+    "short_phrase": {
+      "mrr_delta": -0.26388888888888884,
+      "acc1_delta": -0.3333333333333333,
+      "acc3_delta": -0.16666666666666666,
+      "acc5_delta": -0.33333333333333337
+    }
+  }
+}

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -14,8 +14,8 @@ This document is the authoritative source for CodeLens's public performance clai
 | Token reduction vs Read/Grep (total, structured tasks)  | **6.1x (84% fewer tokens)** | `benchmarks/token-efficiency.py`      |
 | Token reduction on best single task (context retrieval) | **167x**                    | `benchmarks/token-efficiency.py`      |
 | Workflow profile compression (planner/reviewer)         | **15-16x**                  | `benchmarks/token-efficiency.py`      |
-| Search quality, hybrid (MRR)                            | **0.664**                   | `benchmarks/embedding-quality.py`     |
-| Search quality, hybrid (Accuracy@5)                     | **0.775**                   | `benchmarks/embedding-quality.py`     |
+| Search quality, hybrid (MRR)                            | **0.573**                   | `benchmarks/embedding-quality.py`     |
+| Search quality, hybrid (Accuracy@5)                     | **0.660**                   | `benchmarks/embedding-quality.py`     |
 | Cold start (no LSP)                                     | **~12 ms**                  | `target/release/codelens-mcp` startup |
 
 All token counts use **tiktoken `cl100k_base`** — the same tokenizer used by Claude and GPT-4 — so "tokens saved" maps directly to "prompt budget saved."
@@ -86,23 +86,25 @@ The compression ratio grows when agents would otherwise expand raw graph data (i
 - **MRR** (Mean Reciprocal Rank) — `1/rank` of the correct answer, averaged. Higher is better. `1.0` means always rank-1.
 - **Accuracy@k** — fraction of queries where the correct symbol lands in the top-k results.
 
-**Result snapshot** (2026-04-11, 89 queries, hybrid ranking on):
+**Result snapshot** (2026-04-11, 89 queries, hybrid ranking on, post-path-fix apples-to-apples baseline):
 
 | Method                         |       MRR | Acc@1 | Acc@5 | Latency |
 | ------------------------------ | --------: | ----: | ----: | ------: |
-| `semantic_search`              |     0.598 | 0.539 | 0.663 |  574 ms |
-| `get_ranked_context` (lexical) |     0.604 | 0.528 | 0.697 |  168 ms |
-| `get_ranked_context` (hybrid)  | **0.664** | 0.584 | 0.775 |  265 ms |
+| `semantic_search`              |     0.528 | 0.480 | 0.570 |  247 ms |
+| `get_ranked_context` (lexical) |     0.492 | 0.420 | 0.600 |   32 ms |
+| `get_ranked_context` (hybrid)  | **0.573** | 0.510 | 0.660 |  102 ms |
 
 **By query type (hybrid)**:
 
 | Query type         |   MRR | Count | Notes                                          |
 | ------------------ | ----: | ----: | ---------------------------------------------- |
-| `identifier`       | 0.960 |    25 | Near-perfect — FTS5 dominates                  |
-| `short_phrase`     | 0.676 |     9 | Good — hybrid helps                            |
-| `natural_language` | 0.528 |    55 | Weakest — structural target for future ML work |
+| `identifier`       | 0.800 |    25 | Near-perfect enough — lexical path dominates   |
+| `short_phrase`     | 0.559 |     9 | Hybrid helps, but the sample is still small    |
+| `natural_language` | 0.472 |    55 | Weakest — primary retrieval quality bottleneck |
 
-Identifier queries hit a lexical fast path (FTS5 + jaro_winkler). Natural-language queries rely on the bundled MiniLM-L12-CodeSearchNet INT8 model. The NL gap is the current weakness we track — see [docs/architecture.md §8 Key Metrics](architecture.md#8-key-metrics) for the improvement trajectory.
+Identifier queries hit a lexical fast path (FTS5 + jaro_winkler). Natural-language queries rely on the bundled MiniLM-L12-CodeSearchNet INT8 model plus the MCP-layer hybrid merge. The NL gap is the current weakness we track — see [docs/architecture.md §8 Key Metrics](architecture.md#8-key-metrics) for the current critical paths.
+
+> **Authoritative baseline rule**: the numbers above are the current regression baseline for this repo because they use the post-rename dataset whose file suffixes match the current `crates/codelens-engine/...` paths. The older `0.664` hybrid MRR snapshot remains historically useful, but it is not the apples-to-apples baseline for future comparisons.
 
 ### Re-running
 
@@ -117,15 +119,15 @@ Use `--isolated-copy` to avoid index pollution when the script mutates the worki
 
 ## 5. Per-Operation Latency (Real-Time Budget)
 
-| Operation              | Latency                              | Method                    |
-| ---------------------- | ------------------------------------ | ------------------------- |
-| `find_symbol`          | < 1 ms                               | SQLite FTS5               |
-| `get_symbols_overview` | < 1 ms                               | Cached                    |
-| `get_ranked_context`   | ~265 ms (hybrid) / ~168 ms (lexical) | 4-signal + semantic blend |
-| `get_impact_analysis`  | ~1 ms                                | Graph cache (petgraph)    |
-| `semantic_search`      | ~574 ms                              | Warm embedding pool       |
-| `onboard_project`      | ~21 ms                               | Composite workflow        |
-| Cold start             | ~12 ms                               | No LSP boot               |
+| Operation              | Latency                             | Method                    |
+| ---------------------- | ----------------------------------- | ------------------------- |
+| `find_symbol`          | < 1 ms                              | SQLite FTS5               |
+| `get_symbols_overview` | < 1 ms                              | Cached                    |
+| `get_ranked_context`   | ~102 ms (hybrid) / ~32 ms (lexical) | 4-signal + semantic blend |
+| `get_impact_analysis`  | ~1 ms                               | Graph cache (petgraph)    |
+| `semantic_search`      | ~247 ms                             | Warm embedding pool       |
+| `onboard_project`      | ~21 ms                              | Composite workflow        |
+| Cold start             | ~12 ms                              | No LSP boot               |
 
 Measurement harness: `benchmarks/embedding-runtime.py` (latency distribution) and `benchmarks/token-efficiency.py` (workflow scenarios). Both write JSON results.
 
@@ -168,7 +170,7 @@ All three scripts are deterministic given the same input repo and binary. Result
 The 89-query dataset targets symbols that actually exist in this repo. Cross-repo generalization is a separate question we do not currently claim. Use your own project to verify the numbers before relying on them in production.
 
 **Why hybrid ranking?**
-Pure semantic search (MRR 0.598) and pure lexical search (MRR 0.604) are roughly tied. Hybrid blending takes the best of both — identifier queries stay lexical-first, natural-language queries get semantic boosting — and lifts MRR to 0.664 with only +100 ms latency.
+Pure semantic search (MRR 0.528) and pure lexical search (MRR 0.492) are in the same ballpark. Hybrid blending takes the best of both — identifier queries stay lexical-first, natural-language queries get semantic boosting — and lifts MRR to 0.573 with about +70 ms over the lexical-only path.
 
 **What we don't measure (yet)**
 
@@ -1455,6 +1457,8 @@ With §8.13 shipping, the `CODELENS_EMBED_HINT_AUTO=1` default is the right beha
 
 Measurement artefacts: `benchmarks/embedding-quality-v1.5-phase3c-jest-{baseline,2e-only,2b2c-only,stacked}.json`. Dataset: `benchmarks/embedding-quality-dataset-jest.json`.
 
+**Phase 3d follow-up scaffolding**: the larger TypeScript follow-up assets now live in-repo as `benchmarks/embedding-quality-dataset-typescript.json` (34 hand-built queries, split 26 natural_language / 6 short_phrase / 2 identifier against `microsoft/typescript`) plus the baseline-only snapshot `benchmarks/embedding-quality-v1.6-phase3d-typescript-baseline.json`. This does **not** mean Phase 3d is complete; it means the input dataset and baseline artefact are now versioned so the future full four-arm A/B can be reproduced instead of rebuilt from scratch.
+
 ---
 
 ### §8.14 — v1.6.0 default flip: `CODELENS_EMBED_HINT_AUTO=1` becomes the default
@@ -1514,6 +1518,140 @@ python3 benchmarks/embedding-quality.py /tmp/requests-ext --isolated-copy \
 3. **Test race exposed, not eliminated for all future env-var tests**. New tests that mutate `CODELENS_EMBED_HINT_*` env vars must remember to take `ENV_LOCK` or they will see race conditions against the existing eleven tests. A clippy lint or helper macro would be a nicer long-term fix.
 
 **Artefacts**: `benchmarks/embedding-quality-v1.6-flip-{ripgrep,requests}-default-on.json`. Both files are bit-identical to their `§8.12 phase2j-*-mcpauto.json` counterparts — readers can verify with `diff` if they want to confirm the parity claim independently.
+
+---
+
+### §8.15 — Phase 3d: second JS/TS dataset on `microsoft/typescript`
+
+**Hypothesis** (from §8.13 "Limitations acknowledged"): §8.13 added `ts` / `typescript` / `tsx` / `js` / `javascript` / `jsx` to `language_supports_nl_stack` based on a single external-repo measurement (`facebook/jest`, +7.3 % hybrid MRR, 24 queries, 7 : 1 per-query ratio). That was explicitly labelled "moderate confidence" because one dataset could still be a lucky pick. Phase 3d replays the methodology on a second, substantially larger TypeScript codebase — the TypeScript compiler itself — to firm up the evidence tier from "single-dataset moderate" to "two-dataset strong".
+
+**Target repo**: `microsoft/TypeScript` (depth-1 shallow clone, ~2 GB, 81 366 working-tree files of which 709 are `.ts` source files under `src/`). The working-tree file count is dominated by `/tests`, which contains 50 k+ test fixtures that the compiler uses for its conformance suite. We benchmark against **`/tmp/typescript/src`** specifically — the production compiler / services / server source, not the fixture tree. This keeps the indexed corpus at 709 files (1.9 × jest's 380) and the symbol space focused on TypeScript's own public API rather than a haystack of intentional syntax errors from the test corpus.
+
+**Dataset**: 34 hand-built queries in `benchmarks/embedding-quality-dataset-typescript.json`, spanning the five major compiler subsystems:
+
+| Subsystem                   | Example queries                                                                                                             | Count |
+| --------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ----: |
+| Compiler pipeline           | `createProgram`, `createSourceFile`, `createScanner`, `createPrinter`, `createTypeChecker`, `forEachChild`, `getLineStarts` |     7 |
+| Diagnostics                 | `getSyntacticDiagnostics`, `getSemanticDiagnostics`, `getSuggestionDiagnostics`                                             |     3 |
+| Language service            | `createLanguageService`, `getCompletionsAtPosition`, `getDefinitionAtPosition`, `findReferences`, `getCodeFixesAtPosition`  |     5 |
+| Editor server (`tsserver`)  | `getRenameInfo`, `getFormattingEditsForRange`, `getOutliningSpans`, `getSignatureHelpItems`                                 |     4 |
+| Core types                  | `SyntaxKind`, `SourceFile`, `NodeFlags`, `FlowFlags`, `ScriptTarget`, `ModuleKind`, `TypeChecker`                           |     7 |
+| Short phrases + identifiers | `create a scanner`, `SyntaxKind`, `TypeChecker`, …                                                                          |     8 |
+
+Total: 26 NL + 6 short_phrase + 2 identifier = **34 queries** (42 % larger than the Phase 3c jest dataset).
+
+**Measurement**:
+
+| arm         |   hybrid MRR | Δ abs vs baseline |        Δ rel | NL sub-MRR | short sub-MRR | identifier sub-MRR |
+| ----------- | -----------: | ----------------: | -----------: | ---------: | ------------: | -----------------: |
+| baseline    |     0.098355 |                 — |            — |   0.019644 |      0.138889 |           1.000000 |
+| 2e only     |     0.088551 |           −0.0098 |      −10.0 % |   0.019644 |      0.083333 |           1.000000 |
+| 2b+2c only  |     0.200980 |           +0.1026 | **+104.3 %** |   0.153846 |      0.138889 |           1.000000 |
+| **stacked** | **0.200980** |           +0.1026 | **+104.3 %** |   0.153846 |  **0.138889** |           1.000000 |
+
+Phase 2b+2c alone gives the **entire lift** (+104.3 % hybrid MRR relative, +0.134 absolute on NL sub-MRR — an **8× NL improvement** from 0.020 → 0.154). Phase 2e alone is **−10.0 %** (sparse term weighting is actively harmful on TypeScript because the large compiler files dilute the coverage ratio). Stacked = 2b+2c-only because 2e contributes zero signal on top of 2b+2c.
+
+This is the **largest relative lift the v1.5 stack has produced on any external repo** — jest was +7.3 %, ripgrep was +15.2 %, Rust 436-query self was +7.1 %, Rust 89-query self was +2.4 %. TypeScript's +104 % puts the v1.5 stack from "NL retrieval works some of the time" (baseline MRR 0.098) to "NL retrieval works about as well as it does on ripgrep" (stacked MRR 0.201).
+
+**Per-query decomposition** (the validating evidence):
+
+```
+NL queries (26 total, stacked vs baseline):
+  6 improved, 0 regressed, 20 unchanged
+    getLineStarts         6 → 2    (Δ MRR +0.333)
+    getSyntacticDiagnostics 10 → 1 (Δ MRR +0.900)
+    getSuggestionDiagnostics 15 → 3 (Δ MRR +0.267)
+    createLanguageService 23 → 6   (Δ MRR +0.123)
+    SourceFile            14 → 1   (Δ MRR +0.929)
+    ModuleKind            16 → 1   (Δ MRR +0.938)
+    sum Δ MRR              ≈ +3.49
+
+short_phrase queries (6 total): 0 improved, 0 regressed (identical output)
+identifier queries (2 total, SyntaxKind + TypeChecker): both rank-1 in every arm
+
+Total: 6 improved, 0 regressed, 28 unchanged — 6 : 0 positive : negative ratio.
+```
+
+**Zero regressions.** This is a cleaner signal than jest's 7 : 1 — every baseline ranking either stayed put or moved closer to rank 1. The 20 NL queries that remain `None` in both arms (e.g. `createProgram`, `getCompletionsAtPosition`, `getRenameInfo`) are cases where the CodeSearchNet-INT8 embedding + lexical signal combined cannot find the target at all within the top 10 candidates — these are **retrieval failures**, not ranking failures, and they are by definition unfixable by Phase 2b/2c/2e since those knobs re-rank existing candidates rather than expanding the candidate pool. A larger `max_results` cap (beyond 10) might help some of them, but that is outside the v1.5 stack's scope.
+
+**Why is the lift so much larger on TypeScript than on jest or ripgrep?**
+
+Three compounding factors:
+
+1. **Baseline floor is very low** (0.098 vs jest's 0.155 vs ripgrep's 0.459). Percentage gains on a low baseline look dramatic; the absolute lift (+0.103) is comparable to ripgrep's absolute lift (+0.070) but on a smaller denominator.
+2. **TypeScript compiler files are enormous**. `checker.ts` is ~50 000 lines; `parser.ts` is ~10 000. When the baseline `extract_leading_doc` captures only the first ~3 lines of a function, and the function body covers hundreds of lines of domain-specific description in comments and string literals, Phase 2b (`extract_nl_tokens` from full body) recovers signal that the baseline missed by construction.
+3. **JSDoc prevalence**. TypeScript's own source is heavily JSDoc-annotated (every public API has `@param`, `@returns`, `@remarks`). Phase 2b's comment extractor normalizes these into NL-shaped tokens that embed well against natural-language queries, much more so than ripgrep's Rust doc comments (which are more technical) or jest's object-literal matcher bodies (which are mostly runtime checks with few comments).
+
+So the signal is real but the magnitude is a function of TypeScript's specific "giant files + JSDoc-heavy" code style. On a more typical TS codebase (a Next.js app with short files and sparse comments), the lift would probably be closer to jest's +7.3 % than to +104 %. Readers should treat the two external-repo results as a **range** rather than a single number: **+7.3 % (jest) to +104 % (TypeScript)**, with the actual lift depending on file size distribution and JSDoc density.
+
+**Reproduce**:
+
+```bash
+# Clone only the subtree we benchmark against
+git clone --depth=1 https://github.com/microsoft/TypeScript.git /tmp/typescript
+
+# Arm 1: baseline (no env flags)
+CODELENS_MODEL_DIR=$(pwd)/crates/codelens-engine/models \
+CODELENS_BIN=./target/release/codelens-mcp \
+python3 benchmarks/embedding-quality.py /tmp/typescript/src --isolated-copy \
+  --dataset benchmarks/embedding-quality-dataset-typescript.json \
+  --output benchmarks/embedding-quality-v1.6-phase3d-typescript-baseline.json
+
+# Arm 2: Phase 2e only
+CODELENS_RANK_SPARSE_TERM_WEIGHT=1 \
+CODELENS_RANK_SPARSE_THRESHOLD=40 \
+CODELENS_RANK_SPARSE_MAX=40 \
+CODELENS_MODEL_DIR=$(pwd)/crates/codelens-engine/models \
+python3 benchmarks/embedding-quality.py /tmp/typescript/src --isolated-copy \
+  --dataset benchmarks/embedding-quality-dataset-typescript.json \
+  --output benchmarks/embedding-quality-v1.6-phase3d-typescript-2e-only.json
+
+# Arm 3: Phase 2b + 2c only
+CODELENS_EMBED_HINT_INCLUDE_COMMENTS=1 \
+CODELENS_EMBED_HINT_INCLUDE_API_CALLS=1 \
+CODELENS_MODEL_DIR=$(pwd)/crates/codelens-engine/models \
+python3 benchmarks/embedding-quality.py /tmp/typescript/src --isolated-copy \
+  --dataset benchmarks/embedding-quality-dataset-typescript.json \
+  --output benchmarks/embedding-quality-v1.6-phase3d-typescript-2b2c-only.json
+
+# Arm 4: stacked
+CODELENS_EMBED_HINT_INCLUDE_COMMENTS=1 \
+CODELENS_EMBED_HINT_INCLUDE_API_CALLS=1 \
+CODELENS_RANK_SPARSE_TERM_WEIGHT=1 \
+CODELENS_RANK_SPARSE_THRESHOLD=40 \
+CODELENS_RANK_SPARSE_MAX=40 \
+CODELENS_MODEL_DIR=$(pwd)/crates/codelens-engine/models \
+python3 benchmarks/embedding-quality.py /tmp/typescript/src --isolated-copy \
+  --dataset benchmarks/embedding-quality-dataset-typescript.json \
+  --output benchmarks/embedding-quality-v1.6-phase3d-typescript-stacked.json
+```
+
+**Updated six-dataset baseline matrix**:
+
+| Dataset                              | Language  | baseline MRR | stacked MRR |      Δ abs |        Δ rel |
+| ------------------------------------ | --------- | -----------: | ----------: | ---------: | -----------: |
+| 89-query self                        | Rust      |        0.572 |       0.586 |     +0.014 |       +2.4 % |
+| 436-query self                       | Rust      |       0.0476 |      0.0510 |    +0.0034 |       +7.1 % |
+| ripgrep external                     | Rust      |        0.459 |       0.529 |     +0.070 |      +15.2 % |
+| requests external                    | Python    |        0.584 |       0.495 |     −0.089 |      −15.2 % |
+| jest external                        | TS/JS     |        0.155 |       0.166 |     +0.011 |       +7.3 % |
+| **typescript external (new, §8.15)** | **TS/JS** |    **0.098** |   **0.201** | **+0.103** | **+104.3 %** |
+
+Pattern: **5 positive (Rust / Rust / Rust / TS-JS / TS-JS) : 1 negative (Python)**, with TypeScript producing the largest relative lift in the matrix. The `language_supports_nl_stack` classification of `ts` / `typescript` / `tsx` / `js` / `javascript` / `jsx` is now backed by **two independent external-repo measurements** with consistent direction (both positive, 6 : 0 and 7 : 1 per-query ratios respectively). Evidence tier: **"two-dataset strong confidence"**, up from §8.13's "single-dataset moderate confidence".
+
+\*\*Implications for v1.6.x`:
+
+- The JS/TS branch of `CODELENS_EMBED_HINT_AUTO=1` default-on behaviour is now empirically on even firmer ground. Users with large TS projects (compilers, language servers, editor extensions) are likely to see the largest quality gains from flipping `AUTO=1` on.
+- **Phase 2e remains the weakest of the three knobs**. §8.12 measured Phase 2e as positive on ripgrep, Phase 3c measured it as +1.3 % marginal on jest, and §8.15 measures it as **−10.0 %** on TypeScript (the first explicitly negative measurement on the sparse re-ranker alone). The stack's lift comes almost entirely from Phase 2b + 2c on JS/TS. A future Phase 2m could consider dropping Phase 2e from the auto-on set for JS/TS while keeping it on for Rust — but that's a two-axis gate complication deferred until a user actually hits the problem.
+- **No code changes required by this phase**. Phase 3d is a pure measurement update. `language_supports_nl_stack` already contains the JS/TS entries from §8.13; §8.15 only upgrades their evidence tier in the documentation.
+
+**Limitations acknowledged**:
+
+1. **Still only two TS datasets**. Jest is matcher-heavy object-literal code; TypeScript is a large compiler with heavy JSDoc. Both are positive, but both are unrepresentative of a typical app codebase (small-to-medium TS with React / Next.js / Node patterns). A Phase 3e on a typical app repo (e.g. `vercel/next.js` or `facebook/react` internals) would cover the remaining population.
+2. **20 / 26 NL queries remain `None` in both arms**. These are retrieval failures, not ranking failures — the candidate pool never includes the target. The v1.5 stack does not address retrieval failures; that's an embedding-model issue, not a ranking one, and belongs to Phase 2d (model swap).
+3. **TypeScript `src/` is not the full repo**. Benchmarking against `/src` (709 files) excludes the `/tests` fixture tree (50 k+ files). A user who actually points CodeLens at the full TypeScript checkout will get `/tests` in their embedding index, which will shift the NL results toward test fixtures. This is a user-facing reality, but benchmarking the production codebase in isolation is the scientifically cleaner choice.
+
+**Artefacts**: `benchmarks/embedding-quality-v1.6-phase3d-typescript-{baseline,2e-only,2b2c-only,stacked}.json`. Dataset: `benchmarks/embedding-quality-dataset-typescript.json`.
 
 ---
 


### PR DESCRIPTION
## Summary

Upgrades the JS/TS evidence tier in `language_supports_nl_stack` from **"single-dataset moderate confidence"** (§8.13 Phase 3c on `facebook/jest`, one 24-query dataset) to **"two-dataset strong confidence"** by replaying the four-arm A/B methodology on a second, substantially larger TypeScript codebase — **the TypeScript compiler itself**.

**No code changes.** Pure measurement + documentation. `language_supports_nl_stack` already contains the JS/TS entries from §8.13; this PR resolves the "Still only one TS dataset" item from §8.13's Limitations acknowledged.

## Target

- **Repo**: `microsoft/TypeScript` (depth-1 shallow clone)
- **Benchmark root**: `/tmp/typescript/src` — 709 production `.ts` source files (1.9× jest's 380)
- **Subsystems**: compiler / services / server / jsTyping / harness
- **Excluded**: `/tests` (50k+ fixture files — would bias the index toward intentional syntax errors)

## Dataset

34 hand-built queries (42% larger than jest's 24):

| Subsystem | Queries | Count |
|---|---|---:|
| Compiler pipeline | `createProgram`, `createSourceFile`, `createScanner`, `createPrinter`, `createTypeChecker`, `forEachChild`, `getLineStarts` | 7 |
| Diagnostics | `getSyntacticDiagnostics`, `getSemanticDiagnostics`, `getSuggestionDiagnostics` | 3 |
| Language service | `createLanguageService`, `getCompletionsAtPosition`, `getDefinitionAtPosition`, `findReferences`, `getCodeFixesAtPosition` | 5 |
| Editor server (`tsserver`) | `getRenameInfo`, `getFormattingEditsForRange`, `getOutliningSpans`, `getSignatureHelpItems` | 4 |
| Core types | `SyntaxKind`, `SourceFile`, `NodeFlags`, `FlowFlags`, `ScriptTarget`, `ModuleKind`, `TypeChecker` | 7 |
| Short phrases + identifiers | `create a scanner`, `SyntaxKind`, `TypeChecker`, … | 8 |

26 NL + 6 short_phrase + 2 identifier = **34 queries**.

## Four-arm A/B result

| arm | hybrid MRR | Δ rel | NL sub-MRR | short sub-MRR | identifier sub-MRR |
|---|---:|---:|---:|---:|---:|
| baseline | 0.098355 | — | 0.019644 | 0.138889 | 1.000000 |
| 2e only | 0.088551 | **−10.0 %** | 0.019644 | 0.083333 | 1.000000 |
| 2b+2c only | 0.200980 | **+104.3 %** | 0.153846 | 0.138889 | 1.000000 |
| **stacked** | **0.200980** | **+104.3 %** | 0.153846 | **0.138889** | 1.000000 |

**Largest relative lift any external-repo measurement has produced.** Compare: ripgrep +15.2 %, jest +7.3 %, Rust 436-query +7.1 %, Rust 89-query +2.4 %.

**Phase 2e alone is −10.0 %** — the first explicitly negative Phase 2e measurement on any dataset. Stacked = 2b+2c-only because Phase 2e contributes zero signal on top of 2b+2c.

## Per-query decomposition — zero regressions

**6 improvements / 0 regressions / 28 unchanged** under the stacked arm:

| Symbol | baseline rank | stacked rank | ΔMRR |
|---|---:|---:|---:|
| `getLineStarts` | 6 | 2 | +0.333 |
| `getSyntacticDiagnostics` | 10 | 1 | +0.900 |
| `getSuggestionDiagnostics` | 15 | 3 | +0.267 |
| `createLanguageService` | 23 | 6 | +0.123 |
| `SourceFile` | 14 | 1 | +0.929 |
| `ModuleKind` | 16 | 1 | +0.938 |

All six improvements move a baseline ranking toward rank 1. The 20 NL queries that stay `None` in both arms are **retrieval failures** (candidate pool never includes the target), unfixable by any v1.5 re-ranking knob — a model-level issue for Phase 2d.

## Why so much larger than jest?

Three compounding factors:

1. **Low baseline floor** (0.098 vs jest's 0.155). Absolute lift +0.103 is comparable to ripgrep's +0.070, but on a smaller denominator.
2. **TypeScript compiler files are enormous** (`checker.ts` ~50k lines, `parser.ts` ~10k). Baseline `extract_leading_doc` captures only the first few lines — Phase 2b recovers signal from hundreds of lines of JSDoc and inline comments that the baseline missed by construction.
3. **TypeScript is heavily JSDoc-annotated**. Phase 2b's comment extractor normalizes these into NL-shaped tokens that embed well against natural-language queries.

**Reader guidance**: treat jest and TypeScript as a **range**, not a single number. v1.5 stack lift on TS/JS is somewhere between **+7.3 % (jest)** and **+104 % (TypeScript)**, depending on file size distribution and JSDoc density.

## Updated six-dataset matrix

| Dataset | Language | baseline | stacked | Δ rel |
|---|---|---:|---:|---:|
| 89-query self | Rust | 0.572 | 0.586 | +2.4 % |
| 436-query self | Rust | 0.0476 | 0.0510 | +7.1 % |
| ripgrep external | Rust | 0.459 | 0.529 | +15.2 % |
| requests external | Python | 0.584 | 0.495 | −15.2 % |
| jest external | TS/JS | 0.155 | 0.166 | +7.3 % |
| **typescript external (new)** | **TS/JS** | **0.098** | **0.201** | **+104.3 %** |

**Pattern: 5 positive : 1 negative across three measurement-backed language families.** JS/TS classification upgraded to **two-dataset strong confidence**.

## Limitations acknowledged

1. **Still only two TS datasets**. Jest is matcher-heavy object-literal code; TypeScript is a large compiler with heavy JSDoc. Both are positive, but both are unrepresentative of a typical app codebase (small-to-medium TS with React / Next.js / Node patterns). A Phase 3e on a typical app repo would cover the remaining population.
2. **20 / 26 NL queries remain `None`** in both arms — retrieval failures, not ranking failures. Unfixable by v1.5 re-ranking; belongs to Phase 2d (model swap).
3. **Benchmark excludes `/tests`** fixture tree. A user who points CodeLens at the full TypeScript checkout gets `/tests` in their embedding index — this PR measures production code in isolation, the scientifically cleaner choice.

## Implications for v1.6.x

- JS/TS branch of `CODELENS_EMBED_HINT_AUTO=1` default-on behaviour is now empirically on firmer ground. Users with large TS projects (compilers, language servers, editor extensions) are likely to see the largest quality gains.
- Phase 2e remains the weakest of the three knobs. §8.12 measured Phase 2e as positive on ripgrep, Phase 3c as +1.3 % marginal on jest, and §8.15 as **−10.0 %** on TypeScript. A future Phase 2m could consider dropping Phase 2e from the auto-on set for JS/TS while keeping it on for Rust — but that's a two-axis gate complication deferred until a user actually hits the problem.

## Test plan

- [x] `cargo test -p codelens-engine` — 257 passed (unchanged, no code change)
- [x] `cargo test -p codelens-mcp` — 155 passed (unchanged)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] Four-arm measurement on `/tmp/typescript/src` — artefacts at `benchmarks/embedding-quality-v1.6-phase3d-typescript-{baseline,2e-only,2b2c-only,stacked}.json`
- [x] Per-query rank analysis — 6 improved / 0 regressed / 28 unchanged
- [x] Full §8.15 write-up with reproduce instructions

## Relationship to prior PRs

- Follows v1.6.0 release (PR #32, merged `fb4a173`)
- Resolves §8.13 Phase 3c's "single-dataset moderate confidence" limitation
- Zero code changes — this is documentation + benchmark artefacts only

🤖 Generated with [Claude Code](https://claude.com/claude-code)