### PR TITLE
docs(bench): Phase 3d cleanup — index typescript dataset + §8.15 semantic/hybrid decomposition

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -120,6 +120,13 @@ python3 benchmarks/embedding-quality.py . \
   - `short_phrase`
   - `natural_language`
 
+외부 저장소 follow-up 데이터셋 (v1.5 / v1.6 phase 측정용):
+
+- `benchmarks/embedding-quality-dataset-typescript.json`
+  - `microsoft/typescript` 34-query TS/JS dataset (Phase 3d, landed)
+  - 4-arm A/B 측정 완료 — 전체 결과와 해석은 `docs/benchmarks.md` §8.15 참조
+  - arm별 결과 파일: `benchmarks/embedding-quality-v1.6-phase3d-typescript-{baseline,2e-only,2b2c-only,stacked}.json`
+
 리포트는 전체 평균 외에 질의 유형별 MRR / Acc@k와 hybrid uplift도 같이 보여준다.
 
 현재 정책:

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1574,6 +1574,17 @@ Total: 6 improved, 0 regressed, 28 unchanged — 6 : 0 positive : negative ratio
 
 **Zero regressions.** This is a cleaner signal than jest's 7 : 1 — every baseline ranking either stayed put or moved closer to rank 1. The 20 NL queries that remain `None` in both arms (e.g. `createProgram`, `getCompletionsAtPosition`, `getRenameInfo`) are cases where the CodeSearchNet-INT8 embedding + lexical signal combined cannot find the target at all within the top 10 candidates — these are **retrieval failures**, not ranking failures, and they are by definition unfixable by Phase 2b/2c/2e since those knobs re-rank existing candidates rather than expanding the candidate pool. A larger `max_results` cap (beyond 10) might help some of them, but that is outside the v1.5 stack's scope.
 
+**Where the lift actually comes from (semantic vs hybrid decomposition)**:
+
+A subtlety worth flagging: the `semantic_search` aggregate MRR on this dataset is **identical across all four arms** (0.170915 to 16 decimal digits — baseline, 2e-only, 2b+2c-only, and stacked all produce the same number). The entire +104 % hybrid lift lives in `get_ranked_context`, which moves from **0.0984 → 0.2010** under Phase 2b+2c. Pure `get_ranked_context_no_semantic` (lexical-only) is also unchanged between baseline and 2b+2c. So Phase 2b+2c is not discovering new candidates that semantic missed — it is changing how the hybrid re-ranker combines the existing semantic and lexical evidence.
+
+Two concrete per-query patterns illustrate the mechanism:
+
+- **`getSyntacticDiagnostics`** — `semantic_search` rank is **1 in every arm**, but baseline `get_ranked_context` demotes it to rank **10** and only under Phase 2b+2c does hybrid rank recover to **1** (Δ MRR +0.900). Here the top hit was sitting in the semantic result set the whole time; the hybrid re-ranker was actively suppressing it, and Phase 2b's NL-token body extraction tips the lexical agreement just enough for the re-ranker to stop demoting it.
+- **`SourceFile`** — `semantic_search` rank is **`None` in every arm** (the target never enters the top 10 on semantic alone), yet hybrid rank moves from **14 → 1** under Phase 2b+2c (Δ MRR +0.929). Here the hybrid candidate pool is broader than semantic's, and Phase 2b/2c enrich the embedded text for chunks that the re-ranker was previously scoring below rank 10.
+
+So the Phase 3d lift is best characterised as "the hybrid re-ranker recovering cases that it previously down-weighted" rather than "the retrieval layer finding new answers". This is consistent with Phase 2b/2c being index-time extractors that affect the embedding input but not the `semantic_search` top-k ordering at the aggregate level on this particular dataset.
+
 **Why is the lift so much larger on TypeScript than on jest or ripgrep?**
 
 Three compounding factors:


### PR DESCRIPTION
## Summary

Follow-up cleanup after Phase 3d landing (PR #33, commit 516ce29). Two minimal doc edits, no code changes, no new datasets:

1. **`benchmarks/README.md`** — adds an "외부 저장소 follow-up 데이터셋" subsection indexing `benchmarks/embedding-quality-dataset-typescript.json` and pointing to `docs/benchmarks.md` §8.15. Before this, the typescript dataset existed on disk and in §8.15 but was not listed in the benchmark README catalogue.

2. **`docs/benchmarks.md` §8.15** — adds a "Where the lift actually comes from (semantic vs hybrid decomposition)" paragraph explaining why the +104 % lift does *not* show up in `semantic_search` aggregate MRR. On this dataset:
   - `semantic_search` aggregate MRR is **identical across all four arms** (0.170915 to 16 decimal digits — baseline, 2e-only, 2b+2c-only, stacked)
   - `get_ranked_context_no_semantic` (lexical-only) is unchanged between baseline and 2b+2c
   - The entire +104 % lift lives in `get_ranked_context` (hybrid), which moves 0.0984 → 0.2010 under Phase 2b+2c only

   So Phase 2b+2c is not finding new candidates — it is changing how the hybrid re-ranker combines the existing semantic and lexical evidence.

   Two per-query patterns illustrate the mechanism:
   - **`getSyntacticDiagnostics`**: semantic rank 1 in every arm, but hybrid rank 10 → 1 under 2b+2c (re-ranker was suppressing semantic's top hit)
   - **`SourceFile`**: semantic rank `None` in every arm, hybrid rank 14 → 1 (hybrid's broader candidate pool plus enriched lexical text lifts a target semantic alone never finds)

## Test plan

- [x] `git diff --stat` shows exactly 2 files changed, 18 insertions, 0 deletions
- [x] Numbers in the new §8.15 paragraph cross-checked against the four result JSON files (`benchmarks/embedding-quality-v1.6-phase3d-typescript-{baseline,2e-only,2b2c-only,stacked}.json`)
- [x] Per-query ranks for `getSyntacticDiagnostics` / `SourceFile` verified from `rows` field in the result files
- [x] No code or measurement changes — documentation-only cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)