### PR TITLE
docs(bench): Phase 3e — third JS/TS dataset on vercel/next.js (null result on typical app)

### DIFF
--- a/benchmarks/embedding-quality-dataset-next-js.json
+++ b/benchmarks/embedding-quality-dataset-next-js.json
@@ -1,0 +1,206 @@
+[
+  {
+    "query": "get the current request headers in a server component",
+    "expected_symbol": "headers",
+    "expected_file_suffix": "server/request/headers.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "read cookies in a server component",
+    "expected_symbol": "cookies",
+    "expected_file_suffix": "server/request/cookies.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "check if draft mode is enabled",
+    "expected_symbol": "draftMode",
+    "expected_file_suffix": "server/request/draft-mode.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "revalidate a cached path on demand",
+    "expected_symbol": "revalidatePath",
+    "expected_file_suffix": "server/web/spec-extension/revalidate.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "invalidate cached data by tag",
+    "expected_symbol": "revalidateTag",
+    "expected_file_suffix": "server/web/spec-extension/revalidate.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "cache the result of a server-side function",
+    "expected_symbol": "unstable_cache",
+    "expected_file_suffix": "server/web/spec-extension/unstable-cache.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "return a 404 from a server component",
+    "expected_symbol": "notFound",
+    "expected_file_suffix": "client/components/not-found.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "permanently redirect to a new URL",
+    "expected_symbol": "permanentRedirect",
+    "expected_file_suffix": "client/components/redirect.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "get the current URL search params in a client component",
+    "expected_symbol": "useSearchParams",
+    "expected_file_suffix": "client/components/navigation.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "read the current pathname in a client component",
+    "expected_symbol": "usePathname",
+    "expected_file_suffix": "client/components/navigation.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "access dynamic route params",
+    "expected_symbol": "useParams",
+    "expected_file_suffix": "client/components/navigation.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "use the router for programmatic navigation",
+    "expected_symbol": "useRouter",
+    "expected_file_suffix": "client/compat/router.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "custom Request class with helpers for Next.js",
+    "expected_symbol": "NextRequest",
+    "expected_file_suffix": "server/web/spec-extension/request.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "Next.js Response helper with cookies and redirects",
+    "expected_symbol": "NextResponse",
+    "expected_file_suffix": "server/web/spec-extension/response.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "load Next.js user config from disk",
+    "expected_symbol": "loadConfig",
+    "expected_file_suffix": "server/config.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "gather trace output files for the build",
+    "expected_symbol": "collectBuildTraces",
+    "expected_file_suffix": "build/collect-build-traces.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "start the Next.js HTTP server",
+    "expected_symbol": "startServer",
+    "expected_file_suffix": "server/lib/start-server.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "check if a route contains dynamic segments",
+    "expected_symbol": "isDynamicRoute",
+    "expected_file_suffix": "shared/lib/router/utils/is-dynamic.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "build a regex that matches a route pattern",
+    "expected_symbol": "getRouteRegex",
+    "expected_file_suffix": "shared/lib/router/utils/route-regex.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "get a matcher function for a route",
+    "expected_symbol": "getRouteMatcher",
+    "expected_file_suffix": "shared/lib/router/utils/route-matcher.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "add the configured basePath to a URL",
+    "expected_symbol": "addBasePath",
+    "expected_file_suffix": "client/add-base-path.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "substitute dynamic segments into the as path",
+    "expected_symbol": "interpolateAs",
+    "expected_file_suffix": "shared/lib/router/utils/interpolate-as.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "normalize an app-router path format",
+    "expected_symbol": "normalizeAppPath",
+    "expected_file_suffix": "shared/lib/router/utils/app-paths.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "check if a URL is a local in-app URL",
+    "expected_symbol": "isLocalURL",
+    "expected_file_suffix": "shared/lib/router/utils/is-local-url.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "format a URL object back to a string",
+    "expected_symbol": "formatUrl",
+    "expected_file_suffix": "shared/lib/router/utils/format-url.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "check if a path already has the base path prefix",
+    "expected_symbol": "hasBasePath",
+    "expected_file_suffix": "client/has-base-path.ts",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "revalidate path",
+    "expected_symbol": "revalidatePath",
+    "expected_file_suffix": "server/web/spec-extension/revalidate.ts",
+    "query_type": "short_phrase"
+  },
+  {
+    "query": "next request",
+    "expected_symbol": "NextRequest",
+    "expected_file_suffix": "server/web/spec-extension/request.ts",
+    "query_type": "short_phrase"
+  },
+  {
+    "query": "use search params",
+    "expected_symbol": "useSearchParams",
+    "expected_file_suffix": "client/components/navigation.ts",
+    "query_type": "short_phrase"
+  },
+  {
+    "query": "get route regex",
+    "expected_symbol": "getRouteRegex",
+    "expected_file_suffix": "shared/lib/router/utils/route-regex.ts",
+    "query_type": "short_phrase"
+  },
+  {
+    "query": "load config",
+    "expected_symbol": "loadConfig",
+    "expected_file_suffix": "server/config.ts",
+    "query_type": "short_phrase"
+  },
+  {
+    "query": "start server",
+    "expected_symbol": "startServer",
+    "expected_file_suffix": "server/lib/start-server.ts",
+    "query_type": "short_phrase"
+  },
+  {
+    "query": "NextRequest",
+    "expected_symbol": "NextRequest",
+    "expected_file_suffix": "server/web/spec-extension/request.ts",
+    "query_type": "identifier"
+  },
+  {
+    "query": "useSearchParams",
+    "expected_symbol": "useSearchParams",
+    "expected_file_suffix": "client/components/navigation.ts",
+    "query_type": "identifier"
+  }
+]

--- a/benchmarks/embedding-quality-v1.6-phase3e-next-js-2b2c-only.json
+++ b/benchmarks/embedding-quality-v1.6-phase3e-next-js-2b2c-only.json
@@ -1,0 +1,1487 @@
+{
+  "project": "/tmp/next-js/packages/next/src",
+  "benchmark_project": "/var/folders/z0/0tcbss795xsdp75jmr_t9_kh0000gn/T/codelens-embed-quality-x41q_hdx/src",
+  "isolated_copy": true,
+  "binary": "/Users/bagjaeseog/codelens-mcp-plugin/target/release/codelens-mcp",
+  "embedding_model": "MiniLM-L12-CodeSearchNet-INT8",
+  "runtime_model": {
+    "model_dir": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch",
+    "model_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/model.onnx",
+    "config_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/config.json",
+    "sha256": "ef1d1e9cfa72e4929f5b9faea17d8704b23a2530aadebf0d464a4cc7750920b3",
+    "size_bytes": 34000281,
+    "num_hidden_layers": 12,
+    "hidden_size": 384
+  },
+  "dataset_path": "/Users/bagjaeseog/codelens-mcp-plugin/benchmarks/embedding-quality-dataset-next-js.json",
+  "dataset_size": 34,
+  "ranking_cutoff": 10,
+  "metric_labels": {
+    "mrr": "MRR@10",
+    "acc1": "Acc@1",
+    "acc3": "Acc@3",
+    "acc5": "Acc@5"
+  },
+  "methods": [
+    {
+      "method": "semantic_search",
+      "mrr": 0.14640522875816994,
+      "acc1": 0.11764705882352941,
+      "acc3": 0.14705882352941177,
+      "acc5": 0.17647058823529413,
+      "avg_elapsed_ms": 1845.7270588235294,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 1.0,
+          "acc1": 1.0,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 431.69
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.10256410256410256,
+          "acc1": 0.07692307692307693,
+          "acc3": 0.11538461538461539,
+          "acc5": 0.11538461538461539,
+          "avg_elapsed_ms": 2137.878846153846
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.05185185185185185,
+          "acc1": 0.0,
+          "acc3": 0.0,
+          "acc5": 0.16666666666666666,
+          "avg_elapsed_ms": 1051.0816666666667
+        }
+      },
+      "rows": [
+        {
+          "query": "get the current request headers in a server component",
+          "query_type": "natural_language",
+          "expected_symbol": "headers",
+          "expected_file_suffix": "server/request/headers.ts",
+          "rank": null,
+          "elapsed_ms": 2100.59,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "headers",
+            "file": "compiled/@vercel/blob/index.cjs"
+          }
+        },
+        {
+          "query": "read cookies in a server component",
+          "query_type": "natural_language",
+          "expected_symbol": "cookies",
+          "expected_file_suffix": "server/request/cookies.ts",
+          "rank": null,
+          "elapsed_ms": 2295.89,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "read",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "check if draft mode is enabled",
+          "query_type": "natural_language",
+          "expected_symbol": "draftMode",
+          "expected_file_suffix": "server/request/draft-mode.ts",
+          "rank": 6,
+          "elapsed_ms": 1716.01,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "check",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "revalidate a cached path on demand",
+          "query_type": "natural_language",
+          "expected_symbol": "revalidatePath",
+          "expected_file_suffix": "server/web/spec-extension/revalidate.ts",
+          "rank": null,
+          "elapsed_ms": 1728.71,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "read",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "invalidate cached data by tag",
+          "query_type": "natural_language",
+          "expected_symbol": "revalidateTag",
+          "expected_file_suffix": "server/web/spec-extension/revalidate.ts",
+          "rank": null,
+          "elapsed_ms": 1716.76,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "invalidate",
+            "file": "compiled/babel/bundle.js"
+          }
+        },
+        {
+          "query": "cache the result of a server-side function",
+          "query_type": "natural_language",
+          "expected_symbol": "unstable_cache",
+          "expected_file_suffix": "server/web/spec-extension/unstable-cache.ts",
+          "rank": null,
+          "elapsed_ms": 3139.71,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "cachedProperty",
+            "file": "compiled/crypto-browserify/index.js"
+          }
+        },
+        {
+          "query": "return a 404 from a server component",
+          "query_type": "natural_language",
+          "expected_symbol": "notFound",
+          "expected_file_suffix": "client/components/not-found.ts",
+          "rank": null,
+          "elapsed_ms": 2594.42,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "rename",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "permanently redirect to a new URL",
+          "query_type": "natural_language",
+          "expected_symbol": "permanentRedirect",
+          "expected_file_suffix": "client/components/redirect.ts",
+          "rank": 1,
+          "elapsed_ms": 1718.28,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "permanentRedirect",
+            "file": "client/components/redirect.ts"
+          }
+        },
+        {
+          "query": "get the current URL search params in a client component",
+          "query_type": "natural_language",
+          "expected_symbol": "useSearchParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": null,
+          "elapsed_ms": 2077.23,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "searchParams",
+            "file": "client/components/client-page.tsx"
+          }
+        },
+        {
+          "query": "read the current pathname in a client component",
+          "query_type": "natural_language",
+          "expected_symbol": "usePathname",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": null,
+          "elapsed_ms": 2782.06,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "pathname",
+            "file": "client/dev/on-demand-entries-client.ts"
+          }
+        },
+        {
+          "query": "access dynamic route params",
+          "query_type": "natural_language",
+          "expected_symbol": "useParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": null,
+          "elapsed_ms": 2151.19,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "parseDynamicParamFromURLPart",
+            "file": "client/route-params.ts"
+          }
+        },
+        {
+          "query": "use the router for programmatic navigation",
+          "query_type": "natural_language",
+          "expected_symbol": "useRouter",
+          "expected_file_suffix": "client/compat/router.ts",
+          "rank": null,
+          "elapsed_ms": 2793.68,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "Router",
+            "file": "client/components/app-router.tsx"
+          }
+        },
+        {
+          "query": "custom Request class with helpers for Next.js",
+          "query_type": "natural_language",
+          "expected_symbol": "NextRequest",
+          "expected_file_suffix": "server/web/spec-extension/request.ts",
+          "rank": null,
+          "elapsed_ms": 1126.85,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "next",
+            "file": "compiled/crypto-browserify/index.js"
+          }
+        },
+        {
+          "query": "Next.js Response helper with cookies and redirects",
+          "query_type": "natural_language",
+          "expected_symbol": "NextResponse",
+          "expected_file_suffix": "server/web/spec-extension/response.ts",
+          "rank": null,
+          "elapsed_ms": 1123.25,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "next",
+            "file": "compiled/crypto-browserify/index.js"
+          }
+        },
+        {
+          "query": "load Next.js user config from disk",
+          "query_type": "natural_language",
+          "expected_symbol": "loadConfig",
+          "expected_file_suffix": "server/config.ts",
+          "rank": null,
+          "elapsed_ms": 2265.56,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getNextConfig",
+            "file": "cli/next-info.ts"
+          }
+        },
+        {
+          "query": "gather trace output files for the build",
+          "query_type": "natural_language",
+          "expected_symbol": "collectBuildTraces",
+          "expected_file_suffix": "build/collect-build-traces.ts",
+          "rank": null,
+          "elapsed_ms": 1197.46,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "traceMemoryUsage",
+            "file": "lib/memory/trace.ts"
+          }
+        },
+        {
+          "query": "start the Next.js HTTP server",
+          "query_type": "natural_language",
+          "expected_symbol": "startServer",
+          "expected_file_suffix": "server/lib/start-server.ts",
+          "rank": null,
+          "elapsed_ms": 2490.42,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "startServer",
+            "file": "cli/next-dev.ts"
+          }
+        },
+        {
+          "query": "check if a route contains dynamic segments",
+          "query_type": "natural_language",
+          "expected_symbol": "isDynamicRoute",
+          "expected_file_suffix": "shared/lib/router/utils/is-dynamic.ts",
+          "rank": null,
+          "elapsed_ms": 2477.76,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "checkConstraints",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "build a regex that matches a route pattern",
+          "query_type": "natural_language",
+          "expected_symbol": "getRouteRegex",
+          "expected_file_suffix": "shared/lib/router/utils/route-regex.ts",
+          "rank": null,
+          "elapsed_ms": 2767.3,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "buildNamespaceReexport",
+            "file": "compiled/babel-packages/packages-bundle.js"
+          }
+        },
+        {
+          "query": "get a matcher function for a route",
+          "query_type": "natural_language",
+          "expected_symbol": "getRouteMatcher",
+          "expected_file_suffix": "shared/lib/router/utils/route-matcher.ts",
+          "rank": null,
+          "elapsed_ms": 2482.61,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "matchKnownRoute",
+            "file": "client/components/segment-cache/optimistic-routes.ts"
+          }
+        },
+        {
+          "query": "add the configured basePath to a URL",
+          "query_type": "natural_language",
+          "expected_symbol": "addBasePath",
+          "expected_file_suffix": "client/add-base-path.ts",
+          "rank": 1,
+          "elapsed_ms": 2063.03,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "addBasePath",
+            "file": "client/add-base-path.ts"
+          }
+        },
+        {
+          "query": "substitute dynamic segments into the as path",
+          "query_type": "natural_language",
+          "expected_symbol": "interpolateAs",
+          "expected_file_suffix": "shared/lib/router/utils/interpolate-as.ts",
+          "rank": null,
+          "elapsed_ms": 2414.86,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "collectSegmentPaths",
+            "file": "export/index.ts"
+          }
+        },
+        {
+          "query": "normalize an app-router path format",
+          "query_type": "natural_language",
+          "expected_symbol": "normalizeAppPath",
+          "expected_file_suffix": "shared/lib/router/utils/app-paths.ts",
+          "rank": null,
+          "elapsed_ms": 2697.39,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "normalizeParserOptions",
+            "file": "compiled/babel-packages/packages-bundle.js"
+          }
+        },
+        {
+          "query": "check if a URL is a local in-app URL",
+          "query_type": "natural_language",
+          "expected_symbol": "isLocalURL",
+          "expected_file_suffix": "shared/lib/router/utils/is-local-url.ts",
+          "rank": null,
+          "elapsed_ms": 2267.21,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "urlIsLocal",
+            "file": "compiled/@vercel/blob/index.cjs"
+          }
+        },
+        {
+          "query": "format a URL object back to a string",
+          "query_type": "natural_language",
+          "expected_symbol": "formatUrl",
+          "expected_file_suffix": "shared/lib/router/utils/format-url.ts",
+          "rank": null,
+          "elapsed_ms": 2079.66,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "formatStringOrUrl",
+            "file": "client/app-dir/link.tsx"
+          }
+        },
+        {
+          "query": "check if a path already has the base path prefix",
+          "query_type": "natural_language",
+          "expected_symbol": "hasBasePath",
+          "expected_file_suffix": "client/has-base-path.ts",
+          "rank": 2,
+          "elapsed_ms": 1316.96,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "check",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "revalidate path",
+          "query_type": "short_phrase",
+          "expected_symbol": "revalidatePath",
+          "expected_file_suffix": "server/web/spec-extension/revalidate.ts",
+          "rank": 9,
+          "elapsed_ms": 697.91,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "relative",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "next request",
+          "query_type": "short_phrase",
+          "expected_symbol": "NextRequest",
+          "expected_file_suffix": "server/web/spec-extension/request.ts",
+          "rank": null,
+          "elapsed_ms": 679.83,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "nextInfo",
+            "file": "cli/next-info.ts"
+          }
+        },
+        {
+          "query": "use search params",
+          "query_type": "short_phrase",
+          "expected_symbol": "useSearchParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": 5,
+          "elapsed_ms": 1730.8,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "searchParams",
+            "file": "compiled/@vercel/blob/index.cjs"
+          }
+        },
+        {
+          "query": "get route regex",
+          "query_type": "short_phrase",
+          "expected_symbol": "getRouteRegex",
+          "expected_file_suffix": "shared/lib/router/utils/route-regex.ts",
+          "rank": null,
+          "elapsed_ms": 1848.41,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getReturn",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "load config",
+          "query_type": "short_phrase",
+          "expected_symbol": "loadConfig",
+          "expected_file_suffix": "server/config.ts",
+          "rank": null,
+          "elapsed_ms": 675.8,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "load",
+            "file": "compiled/@vercel/og/index.node.js"
+          }
+        },
+        {
+          "query": "start server",
+          "query_type": "short_phrase",
+          "expected_symbol": "startServer",
+          "expected_file_suffix": "server/lib/start-server.ts",
+          "rank": null,
+          "elapsed_ms": 673.74,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "start",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "NextRequest",
+          "query_type": "identifier",
+          "expected_symbol": "NextRequest",
+          "expected_file_suffix": "server/web/spec-extension/request.ts",
+          "rank": 1,
+          "elapsed_ms": 433.87,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "NextRequest",
+            "file": "server/web/spec-extension/request.ts"
+          }
+        },
+        {
+          "query": "useSearchParams",
+          "query_type": "identifier",
+          "expected_symbol": "useSearchParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": 1,
+          "elapsed_ms": 429.51,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "useSearchParams",
+            "file": "client/components/navigation.ts"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context_no_semantic",
+      "mrr": 0.22940513644323435,
+      "acc1": 0.20588235294117646,
+      "acc3": 0.23529411764705882,
+      "acc5": 0.23529411764705882,
+      "avg_elapsed_ms": 281.4491176470588,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 1.0,
+          "acc1": 1.0,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 175.375
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.1444729376230924,
+          "acc1": 0.11538461538461539,
+          "acc3": 0.15384615384615385,
+          "acc5": 0.15384615384615385,
+          "avg_elapsed_ms": 303.4423076923077
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.34057971014492755,
+          "acc1": 0.3333333333333333,
+          "acc3": 0.3333333333333333,
+          "acc5": 0.3333333333333333,
+          "avg_elapsed_ms": 221.50333333333333
+        }
+      },
+      "rows": [
+        {
+          "query": "get the current request headers in a server component",
+          "query_type": "natural_language",
+          "expected_symbol": "headers",
+          "expected_file_suffix": "server/request/headers.ts",
+          "rank": null,
+          "elapsed_ms": 271.74,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "getAccessFallbackHTTPStatus",
+            "file": "client/components/http-access-fallback/http-access-fallback.ts"
+          }
+        },
+        {
+          "query": "read cookies in a server component",
+          "query_type": "natural_language",
+          "expected_symbol": "cookies",
+          "expected_file_suffix": "server/request/cookies.ts",
+          "rank": null,
+          "elapsed_ms": 311.88,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "read",
+            "file": "compiled/babel/bundle.js"
+          }
+        },
+        {
+          "query": "check if draft mode is enabled",
+          "query_type": "natural_language",
+          "expected_symbol": "draftMode",
+          "expected_file_suffix": "server/request/draft-mode.ts",
+          "rank": 21,
+          "elapsed_ms": 271.87,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "_enabled",
+            "file": "compiled/react-dom-experimental/cjs/react-dom-profiling.profiling.js"
+          }
+        },
+        {
+          "query": "revalidate a cached path on demand",
+          "query_type": "natural_language",
+          "expected_symbol": "revalidatePath",
+          "expected_file_suffix": "server/web/spec-extension/revalidate.ts",
+          "rank": null,
+          "elapsed_ms": 270.39,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "_",
+            "file": "compiled/path-to-regexp/index.js"
+          }
+        },
+        {
+          "query": "invalidate cached data by tag",
+          "query_type": "natural_language",
+          "expected_symbol": "revalidateTag",
+          "expected_file_suffix": "server/web/spec-extension/revalidate.ts",
+          "rank": null,
+          "elapsed_ms": 275.7,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "_invalidate",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "cache the result of a server-side function",
+          "query_type": "natural_language",
+          "expected_symbol": "unstable_cache",
+          "expected_file_suffix": "server/web/spec-extension/unstable-cache.ts",
+          "rank": null,
+          "elapsed_ms": 383.83,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "isIdentifier",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "return a 404 from a server component",
+          "query_type": "natural_language",
+          "expected_symbol": "notFound",
+          "expected_file_suffix": "client/components/not-found.ts",
+          "rank": null,
+          "elapsed_ms": 337.88,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "hasReturn",
+            "file": "compiled/babel/bundle.js"
+          }
+        },
+        {
+          "query": "permanently redirect to a new URL",
+          "query_type": "natural_language",
+          "expected_symbol": "permanentRedirect",
+          "expected_file_suffix": "client/components/redirect.ts",
+          "rank": 24,
+          "elapsed_ms": 274.61,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "new_",
+            "file": "compiled/terser/bundle.min.js"
+          }
+        },
+        {
+          "query": "get the current URL search params in a client component",
+          "query_type": "natural_language",
+          "expected_symbol": "useSearchParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": null,
+          "elapsed_ms": 297.54,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "search",
+            "file": "compiled/@vercel/blob/index.cjs"
+          }
+        },
+        {
+          "query": "read the current pathname in a client component",
+          "query_type": "natural_language",
+          "expected_symbol": "usePathname",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": null,
+          "elapsed_ms": 382.48,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "pathname",
+            "file": "shared/lib/router/router.ts"
+          }
+        },
+        {
+          "query": "access dynamic route params",
+          "query_type": "natural_language",
+          "expected_symbol": "useParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": null,
+          "elapsed_ms": 306.26,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "isDynamicRoute",
+            "file": "shared/lib/router/utils/is-dynamic.ts"
+          }
+        },
+        {
+          "query": "use the router for programmatic navigation",
+          "query_type": "natural_language",
+          "expected_symbol": "useRouter",
+          "expected_file_suffix": "client/compat/router.ts",
+          "rank": null,
+          "elapsed_ms": 355.22,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "for_",
+            "file": "compiled/terser/bundle.min.js"
+          }
+        },
+        {
+          "query": "custom Request class with helpers for Next.js",
+          "query_type": "natural_language",
+          "expected_symbol": "NextRequest",
+          "expected_file_suffix": "server/web/spec-extension/request.ts",
+          "rank": null,
+          "elapsed_ms": 230.09,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "for_",
+            "file": "compiled/terser/bundle.min.js"
+          }
+        },
+        {
+          "query": "Next.js Response helper with cookies and redirects",
+          "query_type": "natural_language",
+          "expected_symbol": "NextResponse",
+          "expected_file_suffix": "server/web/spec-extension/response.ts",
+          "rank": null,
+          "elapsed_ms": 231.77,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "Response",
+            "file": "compiled/@vercel/blob/index.cjs"
+          }
+        },
+        {
+          "query": "load Next.js user config from disk",
+          "query_type": "natural_language",
+          "expected_symbol": "loadConfig",
+          "expected_file_suffix": "server/config.ts",
+          "rank": null,
+          "elapsed_ms": 315.17,
+          "candidate_count": 21,
+          "top_candidate": {
+            "name": "isUser",
+            "file": "compiled/babel/bundle.js"
+          }
+        },
+        {
+          "query": "gather trace output files for the build",
+          "query_type": "natural_language",
+          "expected_symbol": "collectBuildTraces",
+          "expected_file_suffix": "build/collect-build-traces.ts",
+          "rank": null,
+          "elapsed_ms": 230.0,
+          "candidate_count": 19,
+          "top_candidate": {
+            "name": "for_",
+            "file": "compiled/terser/bundle.min.js"
+          }
+        },
+        {
+          "query": "start the Next.js HTTP server",
+          "query_type": "natural_language",
+          "expected_symbol": "startServer",
+          "expected_file_suffix": "server/lib/start-server.ts",
+          "rank": null,
+          "elapsed_ms": 336.43,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "Start",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "check if a route contains dynamic segments",
+          "query_type": "natural_language",
+          "expected_symbol": "isDynamicRoute",
+          "expected_file_suffix": "shared/lib/router/utils/is-dynamic.ts",
+          "rank": 1,
+          "elapsed_ms": 328.03,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "isDynamicRoute",
+            "file": "shared/lib/router/utils/is-dynamic.ts"
+          }
+        },
+        {
+          "query": "build a regex that matches a route pattern",
+          "query_type": "natural_language",
+          "expected_symbol": "getRouteRegex",
+          "expected_file_suffix": "shared/lib/router/utils/route-regex.ts",
+          "rank": 1,
+          "elapsed_ms": 351.67,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "getRouteRegex",
+            "file": "shared/lib/router/utils/route-regex.ts"
+          }
+        },
+        {
+          "query": "get a matcher function for a route",
+          "query_type": "natural_language",
+          "expected_symbol": "getRouteMatcher",
+          "expected_file_suffix": "shared/lib/router/utils/route-matcher.ts",
+          "rank": null,
+          "elapsed_ms": 320.57,
+          "candidate_count": 21,
+          "top_candidate": {
+            "name": "for_",
+            "file": "compiled/terser/bundle.min.js"
+          }
+        },
+        {
+          "query": "add the configured basePath to a URL",
+          "query_type": "natural_language",
+          "expected_symbol": "addBasePath",
+          "expected_file_suffix": "client/add-base-path.ts",
+          "rank": 18,
+          "elapsed_ms": 294.07,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "addConfiguredExperimentalFeature",
+            "file": "server/config.ts"
+          }
+        },
+        {
+          "query": "substitute dynamic segments into the as path",
+          "query_type": "natural_language",
+          "expected_symbol": "interpolateAs",
+          "expected_file_suffix": "shared/lib/router/utils/interpolate-as.ts",
+          "rank": null,
+          "elapsed_ms": 324.31,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "inTopLevel",
+            "file": "compiled/babel/bundle.js"
+          }
+        },
+        {
+          "query": "normalize an app-router path format",
+          "query_type": "natural_language",
+          "expected_symbol": "normalizeAppPath",
+          "expected_file_suffix": "shared/lib/router/utils/app-paths.ts",
+          "rank": 1,
+          "elapsed_ms": 348.05,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "normalizeAppPath",
+            "file": "shared/lib/router/utils/app-paths.ts"
+          }
+        },
+        {
+          "query": "check if a URL is a local in-app URL",
+          "query_type": "natural_language",
+          "expected_symbol": "isLocalURL",
+          "expected_file_suffix": "shared/lib/router/utils/is-local-url.ts",
+          "rank": 17,
+          "elapsed_ms": 308.64,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "locale",
+            "file": "shared/lib/router/router.ts"
+          }
+        },
+        {
+          "query": "format a URL object back to a string",
+          "query_type": "natural_language",
+          "expected_symbol": "formatUrl",
+          "expected_file_suffix": "shared/lib/router/utils/format-url.ts",
+          "rank": 19,
+          "elapsed_ms": 292.49,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "Url",
+            "file": "shared/lib/router/router.ts"
+          }
+        },
+        {
+          "query": "check if a path already has the base path prefix",
+          "query_type": "natural_language",
+          "expected_symbol": "hasBasePath",
+          "expected_file_suffix": "client/has-base-path.ts",
+          "rank": 2,
+          "elapsed_ms": 238.81,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "pathHasPrefix",
+            "file": "shared/lib/router/utils/path-has-prefix.ts"
+          }
+        },
+        {
+          "query": "revalidate path",
+          "query_type": "short_phrase",
+          "expected_symbol": "revalidatePath",
+          "expected_file_suffix": "server/web/spec-extension/revalidate.ts",
+          "rank": null,
+          "elapsed_ms": 192.99,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "_",
+            "file": "compiled/path-to-regexp/index.js"
+          }
+        },
+        {
+          "query": "next request",
+          "query_type": "short_phrase",
+          "expected_symbol": "NextRequest",
+          "expected_file_suffix": "server/web/spec-extension/request.ts",
+          "rank": null,
+          "elapsed_ms": 194.37,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "NextRequestAdapter",
+            "file": "server/web/spec-extension/adapters/next-request.ts"
+          }
+        },
+        {
+          "query": "use search params",
+          "query_type": "short_phrase",
+          "expected_symbol": "useSearchParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": 23,
+          "elapsed_ms": 272.38,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "makeErroringSearchParamsForUseCache",
+            "file": "server/request/search-params.ts"
+          }
+        },
+        {
+          "query": "get route regex",
+          "query_type": "short_phrase",
+          "expected_symbol": "getRouteRegex",
+          "expected_file_suffix": "shared/lib/router/utils/route-regex.ts",
+          "rank": 1,
+          "elapsed_ms": 283.02,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "getRouteRegex",
+            "file": "shared/lib/router/utils/route-regex.ts"
+          }
+        },
+        {
+          "query": "load config",
+          "query_type": "short_phrase",
+          "expected_symbol": "loadConfig",
+          "expected_file_suffix": "server/config.ts",
+          "rank": null,
+          "elapsed_ms": 192.98,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "load",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "start server",
+          "query_type": "short_phrase",
+          "expected_symbol": "startServer",
+          "expected_file_suffix": "server/lib/start-server.ts",
+          "rank": 1,
+          "elapsed_ms": 193.28,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "startServer",
+            "file": "server/lib/start-server.ts"
+          }
+        },
+        {
+          "query": "NextRequest",
+          "query_type": "identifier",
+          "expected_symbol": "NextRequest",
+          "expected_file_suffix": "server/web/spec-extension/request.ts",
+          "rank": 1,
+          "elapsed_ms": 175.09,
+          "candidate_count": 17,
+          "top_candidate": {
+            "name": "NextRequest",
+            "file": "server/web/spec-extension/request.ts"
+          }
+        },
+        {
+          "query": "useSearchParams",
+          "query_type": "identifier",
+          "expected_symbol": "useSearchParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": 1,
+          "elapsed_ms": 175.66,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "useSearchParams",
+            "file": "client/components/navigation.ts"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context",
+      "mrr": 0.19785660675753555,
+      "acc1": 0.14705882352941177,
+      "acc3": 0.20588235294117646,
+      "acc5": 0.23529411764705882,
+      "avg_elapsed_ms": 407.8961764705882,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 1.0,
+          "acc1": 1.0,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 369.96999999999997
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.11770992165729008,
+          "acc1": 0.07692307692307693,
+          "acc3": 0.11538461538461539,
+          "acc5": 0.15384615384615385,
+          "avg_elapsed_ms": 423.1430769230769
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.2777777777777778,
+          "acc1": 0.16666666666666666,
+          "acc3": 0.3333333333333333,
+          "acc5": 0.3333333333333333,
+          "avg_elapsed_ms": 354.4683333333333
+        }
+      },
+      "rows": [
+        {
+          "query": "get the current request headers in a server component",
+          "query_type": "natural_language",
+          "expected_symbol": "headers",
+          "expected_file_suffix": "server/request/headers.ts",
+          "rank": null,
+          "elapsed_ms": 511.82,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "headers",
+            "file": "compiled/@vercel/blob/index.cjs"
+          }
+        },
+        {
+          "query": "read cookies in a server component",
+          "query_type": "natural_language",
+          "expected_symbol": "cookies",
+          "expected_file_suffix": "server/request/cookies.ts",
+          "rank": null,
+          "elapsed_ms": 432.96,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "cookies",
+            "file": "compiled/@vercel/blob/index.cjs"
+          }
+        },
+        {
+          "query": "check if draft mode is enabled",
+          "query_type": "natural_language",
+          "expected_symbol": "draftMode",
+          "expected_file_suffix": "server/request/draft-mode.ts",
+          "rank": 21,
+          "elapsed_ms": 387.42,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "_enabled",
+            "file": "compiled/react-dom-experimental/cjs/react-dom-profiling.profiling.js"
+          }
+        },
+        {
+          "query": "revalidate a cached path on demand",
+          "query_type": "natural_language",
+          "expected_symbol": "revalidatePath",
+          "expected_file_suffix": "server/web/spec-extension/revalidate.ts",
+          "rank": null,
+          "elapsed_ms": 385.01,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "cachedProperty",
+            "file": "compiled/crypto-browserify/index.js"
+          }
+        },
+        {
+          "query": "invalidate cached data by tag",
+          "query_type": "natural_language",
+          "expected_symbol": "revalidateTag",
+          "expected_file_suffix": "server/web/spec-extension/revalidate.ts",
+          "rank": null,
+          "elapsed_ms": 383.08,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "invalidate",
+            "file": "compiled/babel/bundle.js"
+          }
+        },
+        {
+          "query": "cache the result of a server-side function",
+          "query_type": "natural_language",
+          "expected_symbol": "unstable_cache",
+          "expected_file_suffix": "server/web/spec-extension/unstable-cache.ts",
+          "rank": null,
+          "elapsed_ms": 488.92,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "cachedProperty",
+            "file": "compiled/crypto-browserify/index.js"
+          }
+        },
+        {
+          "query": "return a 404 from a server component",
+          "query_type": "natural_language",
+          "expected_symbol": "notFound",
+          "expected_file_suffix": "client/components/not-found.ts",
+          "rank": 3,
+          "elapsed_ms": 447.35,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "ServerError",
+            "file": "compiled/raw-body/index.js"
+          }
+        },
+        {
+          "query": "permanently redirect to a new URL",
+          "query_type": "natural_language",
+          "expected_symbol": "permanentRedirect",
+          "expected_file_suffix": "client/components/redirect.ts",
+          "rank": 1,
+          "elapsed_ms": 386.71,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "permanentRedirect",
+            "file": "client/components/redirect.ts"
+          }
+        },
+        {
+          "query": "get the current URL search params in a client component",
+          "query_type": "natural_language",
+          "expected_symbol": "useSearchParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": null,
+          "elapsed_ms": 410.87,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "searchParams",
+            "file": "client/components/client-page.tsx"
+          }
+        },
+        {
+          "query": "read the current pathname in a client component",
+          "query_type": "natural_language",
+          "expected_symbol": "usePathname",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": 11,
+          "elapsed_ms": 469.18,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "pathname",
+            "file": "client/dev/on-demand-entries-client.ts"
+          }
+        },
+        {
+          "query": "access dynamic route params",
+          "query_type": "natural_language",
+          "expected_symbol": "useParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": null,
+          "elapsed_ms": 425.81,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "useDynamicRouteParams",
+            "file": "client/components/navigation.ts"
+          }
+        },
+        {
+          "query": "use the router for programmatic navigation",
+          "query_type": "natural_language",
+          "expected_symbol": "useRouter",
+          "expected_file_suffix": "client/compat/router.ts",
+          "rank": null,
+          "elapsed_ms": 469.63,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "Router",
+            "file": "client/components/app-router.tsx"
+          }
+        },
+        {
+          "query": "custom Request class with helpers for Next.js",
+          "query_type": "natural_language",
+          "expected_symbol": "NextRequest",
+          "expected_file_suffix": "server/web/spec-extension/request.ts",
+          "rank": null,
+          "elapsed_ms": 343.73,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "next",
+            "file": "compiled/crypto-browserify/index.js"
+          }
+        },
+        {
+          "query": "Next.js Response helper with cookies and redirects",
+          "query_type": "natural_language",
+          "expected_symbol": "NextResponse",
+          "expected_file_suffix": "server/web/spec-extension/response.ts",
+          "rank": null,
+          "elapsed_ms": 350.06,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "next",
+            "file": "compiled/crypto-browserify/index.js"
+          }
+        },
+        {
+          "query": "load Next.js user config from disk",
+          "query_type": "natural_language",
+          "expected_symbol": "loadConfig",
+          "expected_file_suffix": "server/config.ts",
+          "rank": null,
+          "elapsed_ms": 429.25,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "nextConfig",
+            "file": "cli/next-typegen.ts"
+          }
+        },
+        {
+          "query": "gather trace output files for the build",
+          "query_type": "natural_language",
+          "expected_symbol": "collectBuildTraces",
+          "expected_file_suffix": "build/collect-build-traces.ts",
+          "rank": null,
+          "elapsed_ms": 346.81,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "makeTrace",
+            "file": "compiled/babel-packages/packages-bundle.js"
+          }
+        },
+        {
+          "query": "start the Next.js HTTP server",
+          "query_type": "natural_language",
+          "expected_symbol": "startServer",
+          "expected_file_suffix": "server/lib/start-server.ts",
+          "rank": null,
+          "elapsed_ms": 457.92,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "startServer",
+            "file": "cli/next-dev.ts"
+          }
+        },
+        {
+          "query": "check if a route contains dynamic segments",
+          "query_type": "natural_language",
+          "expected_symbol": "isDynamicRoute",
+          "expected_file_suffix": "shared/lib/router/utils/is-dynamic.ts",
+          "rank": 6,
+          "elapsed_ms": 480.1,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "doesSegmentNeedDynamicRequest",
+            "file": "client/components/router-reducer/ppr-navigations.ts"
+          }
+        },
+        {
+          "query": "build a regex that matches a route pattern",
+          "query_type": "natural_language",
+          "expected_symbol": "getRouteRegex",
+          "expected_file_suffix": "shared/lib/router/utils/route-regex.ts",
+          "rank": 12,
+          "elapsed_ms": 467.17,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "matchKnownRoute",
+            "file": "client/components/segment-cache/optimistic-routes.ts"
+          }
+        },
+        {
+          "query": "get a matcher function for a route",
+          "query_type": "natural_language",
+          "expected_symbol": "getRouteMatcher",
+          "expected_file_suffix": "shared/lib/router/utils/route-matcher.ts",
+          "rank": null,
+          "elapsed_ms": 437.31,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "match",
+            "file": "client/components/segment-cache/optimistic-routes.ts"
+          }
+        },
+        {
+          "query": "add the configured basePath to a URL",
+          "query_type": "natural_language",
+          "expected_symbol": "addBasePath",
+          "expected_file_suffix": "client/add-base-path.ts",
+          "rank": 5,
+          "elapsed_ms": 406.65,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "baseUrl",
+            "file": "compiled/@vercel/blob/index.cjs"
+          }
+        },
+        {
+          "query": "substitute dynamic segments into the as path",
+          "query_type": "natural_language",
+          "expected_symbol": "interpolateAs",
+          "expected_file_suffix": "shared/lib/router/utils/interpolate-as.ts",
+          "rank": null,
+          "elapsed_ms": 436.57,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "segments",
+            "file": "client/components/router-reducer/compute-changed-path.ts"
+          }
+        },
+        {
+          "query": "normalize an app-router path format",
+          "query_type": "natural_language",
+          "expected_symbol": "normalizeAppPath",
+          "expected_file_suffix": "shared/lib/router/utils/app-paths.ts",
+          "rank": 19,
+          "elapsed_ms": 460.96,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "AppRouter",
+            "file": "client/components/app-router.tsx"
+          }
+        },
+        {
+          "query": "check if a URL is a local in-app URL",
+          "query_type": "natural_language",
+          "expected_symbol": "isLocalURL",
+          "expected_file_suffix": "shared/lib/router/utils/is-local-url.ts",
+          "rank": 19,
+          "elapsed_ms": 422.5,
+          "candidate_count": 34,
+          "top_candidate": {
+            "name": "urlIsLocal",
+            "file": "compiled/@vercel/blob/index.cjs"
+          }
+        },
+        {
+          "query": "format a URL object back to a string",
+          "query_type": "natural_language",
+          "expected_symbol": "formatUrl",
+          "expected_file_suffix": "shared/lib/router/utils/format-url.ts",
+          "rank": 30,
+          "elapsed_ms": 404.74,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "formatStringOrUrl",
+            "file": "client/app-dir/link.tsx"
+          }
+        },
+        {
+          "query": "check if a path already has the base path prefix",
+          "query_type": "natural_language",
+          "expected_symbol": "hasBasePath",
+          "expected_file_suffix": "client/has-base-path.ts",
+          "rank": 1,
+          "elapsed_ms": 359.19,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "hasBasePath",
+            "file": "client/has-base-path.ts"
+          }
+        },
+        {
+          "query": "revalidate path",
+          "query_type": "short_phrase",
+          "expected_symbol": "revalidatePath",
+          "expected_file_suffix": "server/web/spec-extension/revalidate.ts",
+          "rank": null,
+          "elapsed_ms": 310.15,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "revalidatingEntry",
+            "file": "client/components/segment-cache/scheduler.ts"
+          }
+        },
+        {
+          "query": "next request",
+          "query_type": "short_phrase",
+          "expected_symbol": "NextRequest",
+          "expected_file_suffix": "server/web/spec-extension/request.ts",
+          "rank": null,
+          "elapsed_ms": 306.51,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "nextCode",
+            "file": "compiled/@vercel/og/index.node.js"
+          }
+        },
+        {
+          "query": "use search params",
+          "query_type": "short_phrase",
+          "expected_symbol": "useSearchParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": 6,
+          "elapsed_ms": 387.07,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "searchParams",
+            "file": "compiled/@vercel/blob/index.cjs"
+          }
+        },
+        {
+          "query": "get route regex",
+          "query_type": "short_phrase",
+          "expected_symbol": "getRouteRegex",
+          "expected_file_suffix": "shared/lib/router/utils/route-regex.ts",
+          "rank": 2,
+          "elapsed_ms": 404.25,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "regex",
+            "file": "compiled/@modelcontextprotocol/sdk/server/mcp.js"
+          }
+        },
+        {
+          "query": "load config",
+          "query_type": "short_phrase",
+          "expected_symbol": "loadConfig",
+          "expected_file_suffix": "server/config.ts",
+          "rank": null,
+          "elapsed_ms": 401.45,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "load",
+            "file": "compiled/@vercel/og/index.node.js"
+          }
+        },
+        {
+          "query": "start server",
+          "query_type": "short_phrase",
+          "expected_symbol": "startServer",
+          "expected_file_suffix": "server/lib/start-server.ts",
+          "rank": 1,
+          "elapsed_ms": 317.38,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "startServer",
+            "file": "server/lib/start-server.ts"
+          }
+        },
+        {
+          "query": "NextRequest",
+          "query_type": "identifier",
+          "expected_symbol": "NextRequest",
+          "expected_file_suffix": "server/web/spec-extension/request.ts",
+          "rank": 1,
+          "elapsed_ms": 184.14,
+          "candidate_count": 17,
+          "top_candidate": {
+            "name": "NextRequest",
+            "file": "server/web/spec-extension/request.ts"
+          }
+        },
+        {
+          "query": "useSearchParams",
+          "query_type": "identifier",
+          "expected_symbol": "useSearchParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": 1,
+          "elapsed_ms": 555.8,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "useSearchParams",
+            "file": "client/components/navigation.ts"
+          }
+        }
+      ]
+    }
+  ],
+  "hybrid_uplift": {
+    "mrr_delta": -0.031548529685698795,
+    "acc1_delta": -0.05882352941176469,
+    "acc3_delta": -0.02941176470588236,
+    "acc5_delta": 0.0
+  },
+  "hybrid_uplift_by_query_type": {
+    "identifier": {
+      "mrr_delta": 0.0,
+      "acc1_delta": 0.0,
+      "acc3_delta": 0.0,
+      "acc5_delta": 0.0
+    },
+    "natural_language": {
+      "mrr_delta": -0.026763015965802328,
+      "acc1_delta": -0.038461538461538464,
+      "acc3_delta": -0.038461538461538464,
+      "acc5_delta": 0.0
+    },
+    "short_phrase": {
+      "mrr_delta": -0.06280193236714976,
+      "acc1_delta": -0.16666666666666666,
+      "acc3_delta": 0.0,
+      "acc5_delta": 0.0
+    }
+  }
+}

--- a/benchmarks/embedding-quality-v1.6-phase3e-next-js-2e-only.json
+++ b/benchmarks/embedding-quality-v1.6-phase3e-next-js-2e-only.json
@@ -1,0 +1,1487 @@
+{
+  "project": "/tmp/next-js/packages/next/src",
+  "benchmark_project": "/var/folders/z0/0tcbss795xsdp75jmr_t9_kh0000gn/T/codelens-embed-quality-hlaz7ztz/src",
+  "isolated_copy": true,
+  "binary": "/Users/bagjaeseog/codelens-mcp-plugin/target/release/codelens-mcp",
+  "embedding_model": "MiniLM-L12-CodeSearchNet-INT8",
+  "runtime_model": {
+    "model_dir": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch",
+    "model_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/model.onnx",
+    "config_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/config.json",
+    "sha256": "ef1d1e9cfa72e4929f5b9faea17d8704b23a2530aadebf0d464a4cc7750920b3",
+    "size_bytes": 34000281,
+    "num_hidden_layers": 12,
+    "hidden_size": 384
+  },
+  "dataset_path": "/Users/bagjaeseog/codelens-mcp-plugin/benchmarks/embedding-quality-dataset-next-js.json",
+  "dataset_size": 34,
+  "ranking_cutoff": 10,
+  "metric_labels": {
+    "mrr": "MRR@10",
+    "acc1": "Acc@1",
+    "acc3": "Acc@3",
+    "acc5": "Acc@5"
+  },
+  "methods": [
+    {
+      "method": "semantic_search",
+      "mrr": 0.14640522875816994,
+      "acc1": 0.11764705882352941,
+      "acc3": 0.14705882352941177,
+      "acc5": 0.17647058823529413,
+      "avg_elapsed_ms": 1994.595882352941,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 1.0,
+          "acc1": 1.0,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 465.15
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.10256410256410256,
+          "acc1": 0.07692307692307693,
+          "acc3": 0.11538461538461539,
+          "acc5": 0.11538461538461539,
+          "avg_elapsed_ms": 2311.2753846153846
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.05185185185185185,
+          "acc1": 0.0,
+          "acc3": 0.0,
+          "acc5": 0.16666666666666666,
+          "avg_elapsed_ms": 1132.1333333333334
+        }
+      },
+      "rows": [
+        {
+          "query": "get the current request headers in a server component",
+          "query_type": "natural_language",
+          "expected_symbol": "headers",
+          "expected_file_suffix": "server/request/headers.ts",
+          "rank": null,
+          "elapsed_ms": 2228.49,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "headers",
+            "file": "compiled/@vercel/blob/index.cjs"
+          }
+        },
+        {
+          "query": "read cookies in a server component",
+          "query_type": "natural_language",
+          "expected_symbol": "cookies",
+          "expected_file_suffix": "server/request/cookies.ts",
+          "rank": null,
+          "elapsed_ms": 2407.57,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "read",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "check if draft mode is enabled",
+          "query_type": "natural_language",
+          "expected_symbol": "draftMode",
+          "expected_file_suffix": "server/request/draft-mode.ts",
+          "rank": 6,
+          "elapsed_ms": 1891.82,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "check",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "revalidate a cached path on demand",
+          "query_type": "natural_language",
+          "expected_symbol": "revalidatePath",
+          "expected_file_suffix": "server/web/spec-extension/revalidate.ts",
+          "rank": null,
+          "elapsed_ms": 1874.03,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "read",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "invalidate cached data by tag",
+          "query_type": "natural_language",
+          "expected_symbol": "revalidateTag",
+          "expected_file_suffix": "server/web/spec-extension/revalidate.ts",
+          "rank": null,
+          "elapsed_ms": 1862.98,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "invalidate",
+            "file": "compiled/babel/bundle.js"
+          }
+        },
+        {
+          "query": "cache the result of a server-side function",
+          "query_type": "natural_language",
+          "expected_symbol": "unstable_cache",
+          "expected_file_suffix": "server/web/spec-extension/unstable-cache.ts",
+          "rank": null,
+          "elapsed_ms": 3332.5,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "cachedProperty",
+            "file": "compiled/crypto-browserify/index.js"
+          }
+        },
+        {
+          "query": "return a 404 from a server component",
+          "query_type": "natural_language",
+          "expected_symbol": "notFound",
+          "expected_file_suffix": "client/components/not-found.ts",
+          "rank": null,
+          "elapsed_ms": 2800.18,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "rename",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "permanently redirect to a new URL",
+          "query_type": "natural_language",
+          "expected_symbol": "permanentRedirect",
+          "expected_file_suffix": "client/components/redirect.ts",
+          "rank": 1,
+          "elapsed_ms": 1870.45,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "permanentRedirect",
+            "file": "client/components/redirect.ts"
+          }
+        },
+        {
+          "query": "get the current URL search params in a client component",
+          "query_type": "natural_language",
+          "expected_symbol": "useSearchParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": null,
+          "elapsed_ms": 2252.43,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "searchParams",
+            "file": "client/components/client-page.tsx"
+          }
+        },
+        {
+          "query": "read the current pathname in a client component",
+          "query_type": "natural_language",
+          "expected_symbol": "usePathname",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": null,
+          "elapsed_ms": 3042.39,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "pathname",
+            "file": "client/dev/on-demand-entries-client.ts"
+          }
+        },
+        {
+          "query": "access dynamic route params",
+          "query_type": "natural_language",
+          "expected_symbol": "useParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": null,
+          "elapsed_ms": 2336.54,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "parseDynamicParamFromURLPart",
+            "file": "client/route-params.ts"
+          }
+        },
+        {
+          "query": "use the router for programmatic navigation",
+          "query_type": "natural_language",
+          "expected_symbol": "useRouter",
+          "expected_file_suffix": "client/compat/router.ts",
+          "rank": null,
+          "elapsed_ms": 3000.09,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "Router",
+            "file": "client/components/app-router.tsx"
+          }
+        },
+        {
+          "query": "custom Request class with helpers for Next.js",
+          "query_type": "natural_language",
+          "expected_symbol": "NextRequest",
+          "expected_file_suffix": "server/web/spec-extension/request.ts",
+          "rank": null,
+          "elapsed_ms": 1222.29,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "next",
+            "file": "compiled/crypto-browserify/index.js"
+          }
+        },
+        {
+          "query": "Next.js Response helper with cookies and redirects",
+          "query_type": "natural_language",
+          "expected_symbol": "NextResponse",
+          "expected_file_suffix": "server/web/spec-extension/response.ts",
+          "rank": null,
+          "elapsed_ms": 1210.59,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "next",
+            "file": "compiled/crypto-browserify/index.js"
+          }
+        },
+        {
+          "query": "load Next.js user config from disk",
+          "query_type": "natural_language",
+          "expected_symbol": "loadConfig",
+          "expected_file_suffix": "server/config.ts",
+          "rank": null,
+          "elapsed_ms": 2470.55,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getNextConfig",
+            "file": "cli/next-info.ts"
+          }
+        },
+        {
+          "query": "gather trace output files for the build",
+          "query_type": "natural_language",
+          "expected_symbol": "collectBuildTraces",
+          "expected_file_suffix": "build/collect-build-traces.ts",
+          "rank": null,
+          "elapsed_ms": 1346.57,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "traceMemoryUsage",
+            "file": "lib/memory/trace.ts"
+          }
+        },
+        {
+          "query": "start the Next.js HTTP server",
+          "query_type": "natural_language",
+          "expected_symbol": "startServer",
+          "expected_file_suffix": "server/lib/start-server.ts",
+          "rank": null,
+          "elapsed_ms": 2692.2,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "startServer",
+            "file": "cli/next-dev.ts"
+          }
+        },
+        {
+          "query": "check if a route contains dynamic segments",
+          "query_type": "natural_language",
+          "expected_symbol": "isDynamicRoute",
+          "expected_file_suffix": "shared/lib/router/utils/is-dynamic.ts",
+          "rank": null,
+          "elapsed_ms": 2721.23,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "checkConstraints",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "build a regex that matches a route pattern",
+          "query_type": "natural_language",
+          "expected_symbol": "getRouteRegex",
+          "expected_file_suffix": "shared/lib/router/utils/route-regex.ts",
+          "rank": null,
+          "elapsed_ms": 3033.65,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "buildNamespaceReexport",
+            "file": "compiled/babel-packages/packages-bundle.js"
+          }
+        },
+        {
+          "query": "get a matcher function for a route",
+          "query_type": "natural_language",
+          "expected_symbol": "getRouteMatcher",
+          "expected_file_suffix": "shared/lib/router/utils/route-matcher.ts",
+          "rank": null,
+          "elapsed_ms": 2696.51,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "matchKnownRoute",
+            "file": "client/components/segment-cache/optimistic-routes.ts"
+          }
+        },
+        {
+          "query": "add the configured basePath to a URL",
+          "query_type": "natural_language",
+          "expected_symbol": "addBasePath",
+          "expected_file_suffix": "client/add-base-path.ts",
+          "rank": 1,
+          "elapsed_ms": 2221.7,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "addBasePath",
+            "file": "client/add-base-path.ts"
+          }
+        },
+        {
+          "query": "substitute dynamic segments into the as path",
+          "query_type": "natural_language",
+          "expected_symbol": "interpolateAs",
+          "expected_file_suffix": "shared/lib/router/utils/interpolate-as.ts",
+          "rank": null,
+          "elapsed_ms": 2569.75,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "collectSegmentPaths",
+            "file": "export/index.ts"
+          }
+        },
+        {
+          "query": "normalize an app-router path format",
+          "query_type": "natural_language",
+          "expected_symbol": "normalizeAppPath",
+          "expected_file_suffix": "shared/lib/router/utils/app-paths.ts",
+          "rank": null,
+          "elapsed_ms": 2850.94,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "normalizeParserOptions",
+            "file": "compiled/babel-packages/packages-bundle.js"
+          }
+        },
+        {
+          "query": "check if a URL is a local in-app URL",
+          "query_type": "natural_language",
+          "expected_symbol": "isLocalURL",
+          "expected_file_suffix": "shared/lib/router/utils/is-local-url.ts",
+          "rank": null,
+          "elapsed_ms": 2479.96,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "urlIsLocal",
+            "file": "compiled/@vercel/blob/index.cjs"
+          }
+        },
+        {
+          "query": "format a URL object back to a string",
+          "query_type": "natural_language",
+          "expected_symbol": "formatUrl",
+          "expected_file_suffix": "shared/lib/router/utils/format-url.ts",
+          "rank": null,
+          "elapsed_ms": 2230.45,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "formatStringOrUrl",
+            "file": "client/app-dir/link.tsx"
+          }
+        },
+        {
+          "query": "check if a path already has the base path prefix",
+          "query_type": "natural_language",
+          "expected_symbol": "hasBasePath",
+          "expected_file_suffix": "client/has-base-path.ts",
+          "rank": 2,
+          "elapsed_ms": 1447.3,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "check",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "revalidate path",
+          "query_type": "short_phrase",
+          "expected_symbol": "revalidatePath",
+          "expected_file_suffix": "server/web/spec-extension/revalidate.ts",
+          "rank": 9,
+          "elapsed_ms": 732.15,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "relative",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "next request",
+          "query_type": "short_phrase",
+          "expected_symbol": "NextRequest",
+          "expected_file_suffix": "server/web/spec-extension/request.ts",
+          "rank": null,
+          "elapsed_ms": 749.5,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "nextInfo",
+            "file": "cli/next-info.ts"
+          }
+        },
+        {
+          "query": "use search params",
+          "query_type": "short_phrase",
+          "expected_symbol": "useSearchParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": 5,
+          "elapsed_ms": 1899.32,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "searchParams",
+            "file": "compiled/@vercel/blob/index.cjs"
+          }
+        },
+        {
+          "query": "get route regex",
+          "query_type": "short_phrase",
+          "expected_symbol": "getRouteRegex",
+          "expected_file_suffix": "shared/lib/router/utils/route-regex.ts",
+          "rank": null,
+          "elapsed_ms": 1959.48,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getReturn",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "load config",
+          "query_type": "short_phrase",
+          "expected_symbol": "loadConfig",
+          "expected_file_suffix": "server/config.ts",
+          "rank": null,
+          "elapsed_ms": 723.15,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "load",
+            "file": "compiled/@vercel/og/index.node.js"
+          }
+        },
+        {
+          "query": "start server",
+          "query_type": "short_phrase",
+          "expected_symbol": "startServer",
+          "expected_file_suffix": "server/lib/start-server.ts",
+          "rank": null,
+          "elapsed_ms": 729.2,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "start",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "NextRequest",
+          "query_type": "identifier",
+          "expected_symbol": "NextRequest",
+          "expected_file_suffix": "server/web/spec-extension/request.ts",
+          "rank": 1,
+          "elapsed_ms": 468.76,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "NextRequest",
+            "file": "server/web/spec-extension/request.ts"
+          }
+        },
+        {
+          "query": "useSearchParams",
+          "query_type": "identifier",
+          "expected_symbol": "useSearchParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": 1,
+          "elapsed_ms": 461.54,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "useSearchParams",
+            "file": "client/components/navigation.ts"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context_no_semantic",
+      "mrr": 0.23124140006879945,
+      "acc1": 0.20588235294117646,
+      "acc3": 0.23529411764705882,
+      "acc5": 0.23529411764705882,
+      "avg_elapsed_ms": 304.60617647058825,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 1.0,
+          "acc1": 1.0,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 187.575
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.14694388214125056,
+          "acc1": 0.11538461538461539,
+          "acc3": 0.15384615384615385,
+          "acc5": 0.15384615384615385,
+          "avg_elapsed_ms": 328.57884615384614
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.34027777777777773,
+          "acc1": 0.3333333333333333,
+          "acc3": 0.3333333333333333,
+          "acc5": 0.3333333333333333,
+          "avg_elapsed_ms": 239.735
+        }
+      },
+      "rows": [
+        {
+          "query": "get the current request headers in a server component",
+          "query_type": "natural_language",
+          "expected_symbol": "headers",
+          "expected_file_suffix": "server/request/headers.ts",
+          "rank": null,
+          "elapsed_ms": 292.07,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "getAccessFallbackHTTPStatus",
+            "file": "client/components/http-access-fallback/http-access-fallback.ts"
+          }
+        },
+        {
+          "query": "read cookies in a server component",
+          "query_type": "natural_language",
+          "expected_symbol": "cookies",
+          "expected_file_suffix": "server/request/cookies.ts",
+          "rank": null,
+          "elapsed_ms": 338.67,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "read",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "check if draft mode is enabled",
+          "query_type": "natural_language",
+          "expected_symbol": "draftMode",
+          "expected_file_suffix": "server/request/draft-mode.ts",
+          "rank": 16,
+          "elapsed_ms": 297.01,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "_enabled",
+            "file": "compiled/react-dom-experimental/cjs/react-dom-profiling.profiling.js"
+          }
+        },
+        {
+          "query": "revalidate a cached path on demand",
+          "query_type": "natural_language",
+          "expected_symbol": "revalidatePath",
+          "expected_file_suffix": "server/web/spec-extension/revalidate.ts",
+          "rank": null,
+          "elapsed_ms": 296.03,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "_",
+            "file": "compiled/path-to-regexp/index.js"
+          }
+        },
+        {
+          "query": "invalidate cached data by tag",
+          "query_type": "natural_language",
+          "expected_symbol": "revalidateTag",
+          "expected_file_suffix": "server/web/spec-extension/revalidate.ts",
+          "rank": null,
+          "elapsed_ms": 293.51,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "_invalidate",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "cache the result of a server-side function",
+          "query_type": "natural_language",
+          "expected_symbol": "unstable_cache",
+          "expected_file_suffix": "server/web/spec-extension/unstable-cache.ts",
+          "rank": null,
+          "elapsed_ms": 408.85,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "isIdentifier",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "return a 404 from a server component",
+          "query_type": "natural_language",
+          "expected_symbol": "notFound",
+          "expected_file_suffix": "client/components/not-found.ts",
+          "rank": null,
+          "elapsed_ms": 361.61,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "hasReturn",
+            "file": "compiled/babel/bundle.js"
+          }
+        },
+        {
+          "query": "permanently redirect to a new URL",
+          "query_type": "natural_language",
+          "expected_symbol": "permanentRedirect",
+          "expected_file_suffix": "client/components/redirect.ts",
+          "rank": 24,
+          "elapsed_ms": 292.06,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "redirect",
+            "file": "compiled/@vercel/blob/index.cjs"
+          }
+        },
+        {
+          "query": "get the current URL search params in a client component",
+          "query_type": "natural_language",
+          "expected_symbol": "useSearchParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": null,
+          "elapsed_ms": 317.15,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "search",
+            "file": "compiled/@vercel/blob/index.cjs"
+          }
+        },
+        {
+          "query": "read the current pathname in a client component",
+          "query_type": "natural_language",
+          "expected_symbol": "usePathname",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": null,
+          "elapsed_ms": 382.94,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "pathname",
+            "file": "shared/lib/router/router.ts"
+          }
+        },
+        {
+          "query": "access dynamic route params",
+          "query_type": "natural_language",
+          "expected_symbol": "useParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": null,
+          "elapsed_ms": 329.99,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "isDynamicRoute",
+            "file": "shared/lib/router/utils/is-dynamic.ts"
+          }
+        },
+        {
+          "query": "use the router for programmatic navigation",
+          "query_type": "natural_language",
+          "expected_symbol": "useRouter",
+          "expected_file_suffix": "client/compat/router.ts",
+          "rank": null,
+          "elapsed_ms": 385.0,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "for_",
+            "file": "compiled/terser/bundle.min.js"
+          }
+        },
+        {
+          "query": "custom Request class with helpers for Next.js",
+          "query_type": "natural_language",
+          "expected_symbol": "NextRequest",
+          "expected_file_suffix": "server/web/spec-extension/request.ts",
+          "rank": null,
+          "elapsed_ms": 273.04,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "for_",
+            "file": "compiled/terser/bundle.min.js"
+          }
+        },
+        {
+          "query": "Next.js Response helper with cookies and redirects",
+          "query_type": "natural_language",
+          "expected_symbol": "NextResponse",
+          "expected_file_suffix": "server/web/spec-extension/response.ts",
+          "rank": null,
+          "elapsed_ms": 253.65,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "Response",
+            "file": "compiled/@vercel/blob/index.cjs"
+          }
+        },
+        {
+          "query": "load Next.js user config from disk",
+          "query_type": "natural_language",
+          "expected_symbol": "loadConfig",
+          "expected_file_suffix": "server/config.ts",
+          "rank": null,
+          "elapsed_ms": 342.42,
+          "candidate_count": 21,
+          "top_candidate": {
+            "name": "isUser",
+            "file": "compiled/babel/bundle.js"
+          }
+        },
+        {
+          "query": "gather trace output files for the build",
+          "query_type": "natural_language",
+          "expected_symbol": "collectBuildTraces",
+          "expected_file_suffix": "build/collect-build-traces.ts",
+          "rank": null,
+          "elapsed_ms": 252.01,
+          "candidate_count": 19,
+          "top_candidate": {
+            "name": "for_",
+            "file": "compiled/terser/bundle.min.js"
+          }
+        },
+        {
+          "query": "start the Next.js HTTP server",
+          "query_type": "natural_language",
+          "expected_symbol": "startServer",
+          "expected_file_suffix": "server/lib/start-server.ts",
+          "rank": null,
+          "elapsed_ms": 373.82,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "start",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "check if a route contains dynamic segments",
+          "query_type": "natural_language",
+          "expected_symbol": "isDynamicRoute",
+          "expected_file_suffix": "shared/lib/router/utils/is-dynamic.ts",
+          "rank": 1,
+          "elapsed_ms": 354.41,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "isDynamicRoute",
+            "file": "shared/lib/router/utils/is-dynamic.ts"
+          }
+        },
+        {
+          "query": "build a regex that matches a route pattern",
+          "query_type": "natural_language",
+          "expected_symbol": "getRouteRegex",
+          "expected_file_suffix": "shared/lib/router/utils/route-regex.ts",
+          "rank": 1,
+          "elapsed_ms": 379.66,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "getRouteRegex",
+            "file": "shared/lib/router/utils/route-regex.ts"
+          }
+        },
+        {
+          "query": "get a matcher function for a route",
+          "query_type": "natural_language",
+          "expected_symbol": "getRouteMatcher",
+          "expected_file_suffix": "shared/lib/router/utils/route-matcher.ts",
+          "rank": null,
+          "elapsed_ms": 346.92,
+          "candidate_count": 21,
+          "top_candidate": {
+            "name": "for_",
+            "file": "compiled/terser/bundle.min.js"
+          }
+        },
+        {
+          "query": "add the configured basePath to a URL",
+          "query_type": "natural_language",
+          "expected_symbol": "addBasePath",
+          "expected_file_suffix": "client/add-base-path.ts",
+          "rank": 19,
+          "elapsed_ms": 318.61,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "addConfiguredExperimentalFeature",
+            "file": "server/config.ts"
+          }
+        },
+        {
+          "query": "substitute dynamic segments into the as path",
+          "query_type": "natural_language",
+          "expected_symbol": "interpolateAs",
+          "expected_file_suffix": "shared/lib/router/utils/interpolate-as.ts",
+          "rank": null,
+          "elapsed_ms": 351.2,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "inTopLevel",
+            "file": "compiled/babel/bundle.js"
+          }
+        },
+        {
+          "query": "normalize an app-router path format",
+          "query_type": "natural_language",
+          "expected_symbol": "normalizeAppPath",
+          "expected_file_suffix": "shared/lib/router/utils/app-paths.ts",
+          "rank": 1,
+          "elapsed_ms": 373.13,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "normalizeAppPath",
+            "file": "shared/lib/router/utils/app-paths.ts"
+          }
+        },
+        {
+          "query": "check if a URL is a local in-app URL",
+          "query_type": "natural_language",
+          "expected_symbol": "isLocalURL",
+          "expected_file_suffix": "shared/lib/router/utils/is-local-url.ts",
+          "rank": 9,
+          "elapsed_ms": 337.47,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "createAsyncLocalStorage",
+            "file": "server/app-render/async-local-storage.ts"
+          }
+        },
+        {
+          "query": "format a URL object back to a string",
+          "query_type": "natural_language",
+          "expected_symbol": "formatUrl",
+          "expected_file_suffix": "shared/lib/router/utils/format-url.ts",
+          "rank": 19,
+          "elapsed_ms": 315.87,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "Url",
+            "file": "shared/lib/router/router.ts"
+          }
+        },
+        {
+          "query": "check if a path already has the base path prefix",
+          "query_type": "natural_language",
+          "expected_symbol": "hasBasePath",
+          "expected_file_suffix": "client/has-base-path.ts",
+          "rank": 2,
+          "elapsed_ms": 275.95,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "pathHasPrefix",
+            "file": "shared/lib/router/utils/path-has-prefix.ts"
+          }
+        },
+        {
+          "query": "revalidate path",
+          "query_type": "short_phrase",
+          "expected_symbol": "revalidatePath",
+          "expected_file_suffix": "server/web/spec-extension/revalidate.ts",
+          "rank": null,
+          "elapsed_ms": 215.64,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "_",
+            "file": "compiled/path-to-regexp/index.js"
+          }
+        },
+        {
+          "query": "next request",
+          "query_type": "short_phrase",
+          "expected_symbol": "NextRequest",
+          "expected_file_suffix": "server/web/spec-extension/request.ts",
+          "rank": null,
+          "elapsed_ms": 207.77,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "NextRequestAdapter",
+            "file": "server/web/spec-extension/adapters/next-request.ts"
+          }
+        },
+        {
+          "query": "use search params",
+          "query_type": "short_phrase",
+          "expected_symbol": "useSearchParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": 24,
+          "elapsed_ms": 297.79,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "makeErroringSearchParamsForUseCache",
+            "file": "server/request/search-params.ts"
+          }
+        },
+        {
+          "query": "get route regex",
+          "query_type": "short_phrase",
+          "expected_symbol": "getRouteRegex",
+          "expected_file_suffix": "shared/lib/router/utils/route-regex.ts",
+          "rank": 1,
+          "elapsed_ms": 303.55,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "getRouteRegex",
+            "file": "shared/lib/router/utils/route-regex.ts"
+          }
+        },
+        {
+          "query": "load config",
+          "query_type": "short_phrase",
+          "expected_symbol": "loadConfig",
+          "expected_file_suffix": "server/config.ts",
+          "rank": null,
+          "elapsed_ms": 205.15,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "load",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "start server",
+          "query_type": "short_phrase",
+          "expected_symbol": "startServer",
+          "expected_file_suffix": "server/lib/start-server.ts",
+          "rank": 1,
+          "elapsed_ms": 208.51,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "startServer",
+            "file": "server/lib/start-server.ts"
+          }
+        },
+        {
+          "query": "NextRequest",
+          "query_type": "identifier",
+          "expected_symbol": "NextRequest",
+          "expected_file_suffix": "server/web/spec-extension/request.ts",
+          "rank": 1,
+          "elapsed_ms": 188.8,
+          "candidate_count": 17,
+          "top_candidate": {
+            "name": "NextRequest",
+            "file": "server/web/spec-extension/request.ts"
+          }
+        },
+        {
+          "query": "useSearchParams",
+          "query_type": "identifier",
+          "expected_symbol": "useSearchParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": 1,
+          "elapsed_ms": 186.35,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "useSearchParams",
+            "file": "client/components/navigation.ts"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context",
+      "mrr": 0.19620761720219923,
+      "acc1": 0.14705882352941177,
+      "acc3": 0.20588235294117646,
+      "acc5": 0.23529411764705882,
+      "avg_elapsed_ms": 428.5035294117647,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 1.0,
+          "acc1": 1.0,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 182.725
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.11900522722891144,
+          "acc1": 0.07692307692307693,
+          "acc3": 0.11538461538461539,
+          "acc5": 0.15384615384615385,
+          "avg_elapsed_ms": 462.1730769230769
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.26282051282051283,
+          "acc1": 0.16666666666666666,
+          "acc3": 0.3333333333333333,
+          "acc5": 0.3333333333333333,
+          "avg_elapsed_ms": 364.52833333333336
+        }
+      },
+      "rows": [
+        {
+          "query": "get the current request headers in a server component",
+          "query_type": "natural_language",
+          "expected_symbol": "headers",
+          "expected_file_suffix": "server/request/headers.ts",
+          "rank": null,
+          "elapsed_ms": 564.89,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "headers",
+            "file": "compiled/@vercel/blob/index.cjs"
+          }
+        },
+        {
+          "query": "read cookies in a server component",
+          "query_type": "natural_language",
+          "expected_symbol": "cookies",
+          "expected_file_suffix": "server/request/cookies.ts",
+          "rank": null,
+          "elapsed_ms": 465.14,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "cookies",
+            "file": "compiled/@vercel/blob/index.cjs"
+          }
+        },
+        {
+          "query": "check if draft mode is enabled",
+          "query_type": "natural_language",
+          "expected_symbol": "draftMode",
+          "expected_file_suffix": "server/request/draft-mode.ts",
+          "rank": 16,
+          "elapsed_ms": 420.58,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "_enabled",
+            "file": "compiled/react-dom-experimental/cjs/react-dom-profiling.profiling.js"
+          }
+        },
+        {
+          "query": "revalidate a cached path on demand",
+          "query_type": "natural_language",
+          "expected_symbol": "revalidatePath",
+          "expected_file_suffix": "server/web/spec-extension/revalidate.ts",
+          "rank": null,
+          "elapsed_ms": 424.78,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "cachedProperty",
+            "file": "compiled/crypto-browserify/index.js"
+          }
+        },
+        {
+          "query": "invalidate cached data by tag",
+          "query_type": "natural_language",
+          "expected_symbol": "revalidateTag",
+          "expected_file_suffix": "server/web/spec-extension/revalidate.ts",
+          "rank": null,
+          "elapsed_ms": 424.11,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "invalidate",
+            "file": "compiled/babel/bundle.js"
+          }
+        },
+        {
+          "query": "cache the result of a server-side function",
+          "query_type": "natural_language",
+          "expected_symbol": "unstable_cache",
+          "expected_file_suffix": "server/web/spec-extension/unstable-cache.ts",
+          "rank": null,
+          "elapsed_ms": 537.16,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "cachedProperty",
+            "file": "compiled/crypto-browserify/index.js"
+          }
+        },
+        {
+          "query": "return a 404 from a server component",
+          "query_type": "natural_language",
+          "expected_symbol": "notFound",
+          "expected_file_suffix": "client/components/not-found.ts",
+          "rank": 3,
+          "elapsed_ms": 492.49,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "ServerError",
+            "file": "compiled/raw-body/index.js"
+          }
+        },
+        {
+          "query": "permanently redirect to a new URL",
+          "query_type": "natural_language",
+          "expected_symbol": "permanentRedirect",
+          "expected_file_suffix": "client/components/redirect.ts",
+          "rank": 1,
+          "elapsed_ms": 442.23,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "permanentRedirect",
+            "file": "client/components/redirect.ts"
+          }
+        },
+        {
+          "query": "get the current URL search params in a client component",
+          "query_type": "natural_language",
+          "expected_symbol": "useSearchParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": null,
+          "elapsed_ms": 449.21,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "searchParams",
+            "file": "client/components/client-page.tsx"
+          }
+        },
+        {
+          "query": "read the current pathname in a client component",
+          "query_type": "natural_language",
+          "expected_symbol": "usePathname",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": 11,
+          "elapsed_ms": 512.96,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "pathname",
+            "file": "client/dev/on-demand-entries-client.ts"
+          }
+        },
+        {
+          "query": "access dynamic route params",
+          "query_type": "natural_language",
+          "expected_symbol": "useParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": null,
+          "elapsed_ms": 459.84,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "useDynamicRouteParams",
+            "file": "client/components/navigation.ts"
+          }
+        },
+        {
+          "query": "use the router for programmatic navigation",
+          "query_type": "natural_language",
+          "expected_symbol": "useRouter",
+          "expected_file_suffix": "client/compat/router.ts",
+          "rank": null,
+          "elapsed_ms": 511.07,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "Router",
+            "file": "client/components/app-router.tsx"
+          }
+        },
+        {
+          "query": "custom Request class with helpers for Next.js",
+          "query_type": "natural_language",
+          "expected_symbol": "NextRequest",
+          "expected_file_suffix": "server/web/spec-extension/request.ts",
+          "rank": null,
+          "elapsed_ms": 376.5,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "next",
+            "file": "compiled/crypto-browserify/index.js"
+          }
+        },
+        {
+          "query": "Next.js Response helper with cookies and redirects",
+          "query_type": "natural_language",
+          "expected_symbol": "NextResponse",
+          "expected_file_suffix": "server/web/spec-extension/response.ts",
+          "rank": null,
+          "elapsed_ms": 382.06,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "next",
+            "file": "compiled/crypto-browserify/index.js"
+          }
+        },
+        {
+          "query": "load Next.js user config from disk",
+          "query_type": "natural_language",
+          "expected_symbol": "loadConfig",
+          "expected_file_suffix": "server/config.ts",
+          "rank": null,
+          "elapsed_ms": 462.47,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "nextConfig",
+            "file": "cli/next-typegen.ts"
+          }
+        },
+        {
+          "query": "gather trace output files for the build",
+          "query_type": "natural_language",
+          "expected_symbol": "collectBuildTraces",
+          "expected_file_suffix": "build/collect-build-traces.ts",
+          "rank": null,
+          "elapsed_ms": 377.7,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "makeTrace",
+            "file": "compiled/babel-packages/packages-bundle.js"
+          }
+        },
+        {
+          "query": "start the Next.js HTTP server",
+          "query_type": "natural_language",
+          "expected_symbol": "startServer",
+          "expected_file_suffix": "server/lib/start-server.ts",
+          "rank": null,
+          "elapsed_ms": 488.09,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "startServer",
+            "file": "cli/next-dev.ts"
+          }
+        },
+        {
+          "query": "check if a route contains dynamic segments",
+          "query_type": "natural_language",
+          "expected_symbol": "isDynamicRoute",
+          "expected_file_suffix": "shared/lib/router/utils/is-dynamic.ts",
+          "rank": 6,
+          "elapsed_ms": 482.21,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "doesSegmentNeedDynamicRequest",
+            "file": "client/components/router-reducer/ppr-navigations.ts"
+          }
+        },
+        {
+          "query": "build a regex that matches a route pattern",
+          "query_type": "natural_language",
+          "expected_symbol": "getRouteRegex",
+          "expected_file_suffix": "shared/lib/router/utils/route-regex.ts",
+          "rank": 12,
+          "elapsed_ms": 512.33,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "matchKnownRoute",
+            "file": "client/components/segment-cache/optimistic-routes.ts"
+          }
+        },
+        {
+          "query": "get a matcher function for a route",
+          "query_type": "natural_language",
+          "expected_symbol": "getRouteMatcher",
+          "expected_file_suffix": "shared/lib/router/utils/route-matcher.ts",
+          "rank": null,
+          "elapsed_ms": 477.41,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "match",
+            "file": "client/components/segment-cache/optimistic-routes.ts"
+          }
+        },
+        {
+          "query": "add the configured basePath to a URL",
+          "query_type": "natural_language",
+          "expected_symbol": "addBasePath",
+          "expected_file_suffix": "client/add-base-path.ts",
+          "rank": 5,
+          "elapsed_ms": 456.28,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "baseUrl",
+            "file": "compiled/@vercel/blob/index.cjs"
+          }
+        },
+        {
+          "query": "substitute dynamic segments into the as path",
+          "query_type": "natural_language",
+          "expected_symbol": "interpolateAs",
+          "expected_file_suffix": "shared/lib/router/utils/interpolate-as.ts",
+          "rank": null,
+          "elapsed_ms": 485.8,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "segments",
+            "file": "client/components/router-reducer/compute-changed-path.ts"
+          }
+        },
+        {
+          "query": "normalize an app-router path format",
+          "query_type": "natural_language",
+          "expected_symbol": "normalizeAppPath",
+          "expected_file_suffix": "shared/lib/router/utils/app-paths.ts",
+          "rank": 19,
+          "elapsed_ms": 508.94,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "AppRouter",
+            "file": "client/components/app-router.tsx"
+          }
+        },
+        {
+          "query": "check if a URL is a local in-app URL",
+          "query_type": "natural_language",
+          "expected_symbol": "isLocalURL",
+          "expected_file_suffix": "shared/lib/router/utils/is-local-url.ts",
+          "rank": 14,
+          "elapsed_ms": 466.07,
+          "candidate_count": 34,
+          "top_candidate": {
+            "name": "urlIsLocal",
+            "file": "compiled/@vercel/blob/index.cjs"
+          }
+        },
+        {
+          "query": "format a URL object back to a string",
+          "query_type": "natural_language",
+          "expected_symbol": "formatUrl",
+          "expected_file_suffix": "shared/lib/router/utils/format-url.ts",
+          "rank": 30,
+          "elapsed_ms": 446.21,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "formatStringOrUrl",
+            "file": "client/app-dir/link.tsx"
+          }
+        },
+        {
+          "query": "check if a path already has the base path prefix",
+          "query_type": "natural_language",
+          "expected_symbol": "hasBasePath",
+          "expected_file_suffix": "client/has-base-path.ts",
+          "rank": 1,
+          "elapsed_ms": 389.97,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "hasBasePath",
+            "file": "client/has-base-path.ts"
+          }
+        },
+        {
+          "query": "revalidate path",
+          "query_type": "short_phrase",
+          "expected_symbol": "revalidatePath",
+          "expected_file_suffix": "server/web/spec-extension/revalidate.ts",
+          "rank": null,
+          "elapsed_ms": 337.24,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "revalidatingEntry",
+            "file": "client/components/segment-cache/scheduler.ts"
+          }
+        },
+        {
+          "query": "next request",
+          "query_type": "short_phrase",
+          "expected_symbol": "NextRequest",
+          "expected_file_suffix": "server/web/spec-extension/request.ts",
+          "rank": null,
+          "elapsed_ms": 338.26,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "nextCode",
+            "file": "compiled/@vercel/og/index.node.js"
+          }
+        },
+        {
+          "query": "use search params",
+          "query_type": "short_phrase",
+          "expected_symbol": "useSearchParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": 13,
+          "elapsed_ms": 420.68,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "makeUntrackedSearchParams",
+            "file": "client/request/search-params.browser.prod.ts"
+          }
+        },
+        {
+          "query": "get route regex",
+          "query_type": "short_phrase",
+          "expected_symbol": "getRouteRegex",
+          "expected_file_suffix": "shared/lib/router/utils/route-regex.ts",
+          "rank": 2,
+          "elapsed_ms": 441.04,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "regex",
+            "file": "compiled/@modelcontextprotocol/sdk/server/mcp.js"
+          }
+        },
+        {
+          "query": "load config",
+          "query_type": "short_phrase",
+          "expected_symbol": "loadConfig",
+          "expected_file_suffix": "server/config.ts",
+          "rank": null,
+          "elapsed_ms": 324.63,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "load",
+            "file": "compiled/@vercel/og/index.node.js"
+          }
+        },
+        {
+          "query": "start server",
+          "query_type": "short_phrase",
+          "expected_symbol": "startServer",
+          "expected_file_suffix": "server/lib/start-server.ts",
+          "rank": 1,
+          "elapsed_ms": 325.32,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "startServer",
+            "file": "server/lib/start-server.ts"
+          }
+        },
+        {
+          "query": "NextRequest",
+          "query_type": "identifier",
+          "expected_symbol": "NextRequest",
+          "expected_file_suffix": "server/web/spec-extension/request.ts",
+          "rank": 1,
+          "elapsed_ms": 183.53,
+          "candidate_count": 17,
+          "top_candidate": {
+            "name": "NextRequest",
+            "file": "server/web/spec-extension/request.ts"
+          }
+        },
+        {
+          "query": "useSearchParams",
+          "query_type": "identifier",
+          "expected_symbol": "useSearchParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": 1,
+          "elapsed_ms": 181.92,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "useSearchParams",
+            "file": "client/components/navigation.ts"
+          }
+        }
+      ]
+    }
+  ],
+  "hybrid_uplift": {
+    "mrr_delta": -0.03503378286660022,
+    "acc1_delta": -0.05882352941176469,
+    "acc3_delta": -0.02941176470588236,
+    "acc5_delta": 0.0
+  },
+  "hybrid_uplift_by_query_type": {
+    "identifier": {
+      "mrr_delta": 0.0,
+      "acc1_delta": 0.0,
+      "acc3_delta": 0.0,
+      "acc5_delta": 0.0
+    },
+    "natural_language": {
+      "mrr_delta": -0.027938654912339128,
+      "acc1_delta": -0.038461538461538464,
+      "acc3_delta": -0.038461538461538464,
+      "acc5_delta": 0.0
+    },
+    "short_phrase": {
+      "mrr_delta": -0.0774572649572649,
+      "acc1_delta": -0.16666666666666666,
+      "acc3_delta": 0.0,
+      "acc5_delta": 0.0
+    }
+  }
+}

--- a/benchmarks/embedding-quality-v1.6-phase3e-next-js-baseline.json
+++ b/benchmarks/embedding-quality-v1.6-phase3e-next-js-baseline.json
@@ -1,0 +1,1487 @@
+{
+  "project": "/tmp/next-js/packages/next/src",
+  "benchmark_project": "/var/folders/z0/0tcbss795xsdp75jmr_t9_kh0000gn/T/codelens-embed-quality-zibqnhe1/src",
+  "isolated_copy": true,
+  "binary": "/Users/bagjaeseog/codelens-mcp-plugin/target/release/codelens-mcp",
+  "embedding_model": "MiniLM-L12-CodeSearchNet-INT8",
+  "runtime_model": {
+    "model_dir": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch",
+    "model_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/model.onnx",
+    "config_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/config.json",
+    "sha256": "ef1d1e9cfa72e4929f5b9faea17d8704b23a2530aadebf0d464a4cc7750920b3",
+    "size_bytes": 34000281,
+    "num_hidden_layers": 12,
+    "hidden_size": 384
+  },
+  "dataset_path": "/Users/bagjaeseog/codelens-mcp-plugin/benchmarks/embedding-quality-dataset-next-js.json",
+  "dataset_size": 34,
+  "ranking_cutoff": 10,
+  "metric_labels": {
+    "mrr": "MRR@10",
+    "acc1": "Acc@1",
+    "acc3": "Acc@3",
+    "acc5": "Acc@5"
+  },
+  "methods": [
+    {
+      "method": "semantic_search",
+      "mrr": 0.14640522875816994,
+      "acc1": 0.11764705882352941,
+      "acc3": 0.14705882352941177,
+      "acc5": 0.17647058823529413,
+      "avg_elapsed_ms": 1900.9535294117647,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 1.0,
+          "acc1": 1.0,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 447.81
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.10256410256410256,
+          "acc1": 0.07692307692307693,
+          "acc3": 0.11538461538461539,
+          "acc5": 0.11538461538461539,
+          "avg_elapsed_ms": 2203.5003846153845
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.05185185185185185,
+          "acc1": 0.0,
+          "acc3": 0.0,
+          "acc5": 0.16666666666666666,
+          "avg_elapsed_ms": 1074.2983333333334
+        }
+      },
+      "rows": [
+        {
+          "query": "get the current request headers in a server component",
+          "query_type": "natural_language",
+          "expected_symbol": "headers",
+          "expected_file_suffix": "server/request/headers.ts",
+          "rank": null,
+          "elapsed_ms": 2152.09,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "headers",
+            "file": "compiled/@vercel/blob/index.cjs"
+          }
+        },
+        {
+          "query": "read cookies in a server component",
+          "query_type": "natural_language",
+          "expected_symbol": "cookies",
+          "expected_file_suffix": "server/request/cookies.ts",
+          "rank": null,
+          "elapsed_ms": 2354.88,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "read",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "check if draft mode is enabled",
+          "query_type": "natural_language",
+          "expected_symbol": "draftMode",
+          "expected_file_suffix": "server/request/draft-mode.ts",
+          "rank": 6,
+          "elapsed_ms": 1784.87,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "check",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "revalidate a cached path on demand",
+          "query_type": "natural_language",
+          "expected_symbol": "revalidatePath",
+          "expected_file_suffix": "server/web/spec-extension/revalidate.ts",
+          "rank": null,
+          "elapsed_ms": 1787.29,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "read",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "invalidate cached data by tag",
+          "query_type": "natural_language",
+          "expected_symbol": "revalidateTag",
+          "expected_file_suffix": "server/web/spec-extension/revalidate.ts",
+          "rank": null,
+          "elapsed_ms": 1780.03,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "invalidate",
+            "file": "compiled/babel/bundle.js"
+          }
+        },
+        {
+          "query": "cache the result of a server-side function",
+          "query_type": "natural_language",
+          "expected_symbol": "unstable_cache",
+          "expected_file_suffix": "server/web/spec-extension/unstable-cache.ts",
+          "rank": null,
+          "elapsed_ms": 3232.74,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "cachedProperty",
+            "file": "compiled/crypto-browserify/index.js"
+          }
+        },
+        {
+          "query": "return a 404 from a server component",
+          "query_type": "natural_language",
+          "expected_symbol": "notFound",
+          "expected_file_suffix": "client/components/not-found.ts",
+          "rank": null,
+          "elapsed_ms": 2654.47,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "rename",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "permanently redirect to a new URL",
+          "query_type": "natural_language",
+          "expected_symbol": "permanentRedirect",
+          "expected_file_suffix": "client/components/redirect.ts",
+          "rank": 1,
+          "elapsed_ms": 1790.9,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "permanentRedirect",
+            "file": "client/components/redirect.ts"
+          }
+        },
+        {
+          "query": "get the current URL search params in a client component",
+          "query_type": "natural_language",
+          "expected_symbol": "useSearchParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": null,
+          "elapsed_ms": 2144.43,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "searchParams",
+            "file": "client/components/client-page.tsx"
+          }
+        },
+        {
+          "query": "read the current pathname in a client component",
+          "query_type": "natural_language",
+          "expected_symbol": "usePathname",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": null,
+          "elapsed_ms": 2895.28,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "pathname",
+            "file": "client/dev/on-demand-entries-client.ts"
+          }
+        },
+        {
+          "query": "access dynamic route params",
+          "query_type": "natural_language",
+          "expected_symbol": "useParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": null,
+          "elapsed_ms": 2195.77,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "parseDynamicParamFromURLPart",
+            "file": "client/route-params.ts"
+          }
+        },
+        {
+          "query": "use the router for programmatic navigation",
+          "query_type": "natural_language",
+          "expected_symbol": "useRouter",
+          "expected_file_suffix": "client/compat/router.ts",
+          "rank": null,
+          "elapsed_ms": 2838.27,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "Router",
+            "file": "client/components/app-router.tsx"
+          }
+        },
+        {
+          "query": "custom Request class with helpers for Next.js",
+          "query_type": "natural_language",
+          "expected_symbol": "NextRequest",
+          "expected_file_suffix": "server/web/spec-extension/request.ts",
+          "rank": null,
+          "elapsed_ms": 1176.9,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "next",
+            "file": "compiled/crypto-browserify/index.js"
+          }
+        },
+        {
+          "query": "Next.js Response helper with cookies and redirects",
+          "query_type": "natural_language",
+          "expected_symbol": "NextResponse",
+          "expected_file_suffix": "server/web/spec-extension/response.ts",
+          "rank": null,
+          "elapsed_ms": 1197.92,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "next",
+            "file": "compiled/crypto-browserify/index.js"
+          }
+        },
+        {
+          "query": "load Next.js user config from disk",
+          "query_type": "natural_language",
+          "expected_symbol": "loadConfig",
+          "expected_file_suffix": "server/config.ts",
+          "rank": null,
+          "elapsed_ms": 2360.75,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getNextConfig",
+            "file": "cli/next-info.ts"
+          }
+        },
+        {
+          "query": "gather trace output files for the build",
+          "query_type": "natural_language",
+          "expected_symbol": "collectBuildTraces",
+          "expected_file_suffix": "build/collect-build-traces.ts",
+          "rank": null,
+          "elapsed_ms": 1237.93,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "traceMemoryUsage",
+            "file": "lib/memory/trace.ts"
+          }
+        },
+        {
+          "query": "start the Next.js HTTP server",
+          "query_type": "natural_language",
+          "expected_symbol": "startServer",
+          "expected_file_suffix": "server/lib/start-server.ts",
+          "rank": null,
+          "elapsed_ms": 2554.54,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "startServer",
+            "file": "cli/next-dev.ts"
+          }
+        },
+        {
+          "query": "check if a route contains dynamic segments",
+          "query_type": "natural_language",
+          "expected_symbol": "isDynamicRoute",
+          "expected_file_suffix": "shared/lib/router/utils/is-dynamic.ts",
+          "rank": null,
+          "elapsed_ms": 2577.97,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "checkConstraints",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "build a regex that matches a route pattern",
+          "query_type": "natural_language",
+          "expected_symbol": "getRouteRegex",
+          "expected_file_suffix": "shared/lib/router/utils/route-regex.ts",
+          "rank": null,
+          "elapsed_ms": 2858.53,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "buildNamespaceReexport",
+            "file": "compiled/babel-packages/packages-bundle.js"
+          }
+        },
+        {
+          "query": "get a matcher function for a route",
+          "query_type": "natural_language",
+          "expected_symbol": "getRouteMatcher",
+          "expected_file_suffix": "shared/lib/router/utils/route-matcher.ts",
+          "rank": null,
+          "elapsed_ms": 2583.5,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "matchKnownRoute",
+            "file": "client/components/segment-cache/optimistic-routes.ts"
+          }
+        },
+        {
+          "query": "add the configured basePath to a URL",
+          "query_type": "natural_language",
+          "expected_symbol": "addBasePath",
+          "expected_file_suffix": "client/add-base-path.ts",
+          "rank": 1,
+          "elapsed_ms": 2094.93,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "addBasePath",
+            "file": "client/add-base-path.ts"
+          }
+        },
+        {
+          "query": "substitute dynamic segments into the as path",
+          "query_type": "natural_language",
+          "expected_symbol": "interpolateAs",
+          "expected_file_suffix": "shared/lib/router/utils/interpolate-as.ts",
+          "rank": null,
+          "elapsed_ms": 2442.04,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "collectSegmentPaths",
+            "file": "export/index.ts"
+          }
+        },
+        {
+          "query": "normalize an app-router path format",
+          "query_type": "natural_language",
+          "expected_symbol": "normalizeAppPath",
+          "expected_file_suffix": "shared/lib/router/utils/app-paths.ts",
+          "rank": null,
+          "elapsed_ms": 2735.3,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "normalizeParserOptions",
+            "file": "compiled/babel-packages/packages-bundle.js"
+          }
+        },
+        {
+          "query": "check if a URL is a local in-app URL",
+          "query_type": "natural_language",
+          "expected_symbol": "isLocalURL",
+          "expected_file_suffix": "shared/lib/router/utils/is-local-url.ts",
+          "rank": null,
+          "elapsed_ms": 2359.9,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "urlIsLocal",
+            "file": "compiled/@vercel/blob/index.cjs"
+          }
+        },
+        {
+          "query": "format a URL object back to a string",
+          "query_type": "natural_language",
+          "expected_symbol": "formatUrl",
+          "expected_file_suffix": "shared/lib/router/utils/format-url.ts",
+          "rank": null,
+          "elapsed_ms": 2123.37,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "formatStringOrUrl",
+            "file": "client/app-dir/link.tsx"
+          }
+        },
+        {
+          "query": "check if a path already has the base path prefix",
+          "query_type": "natural_language",
+          "expected_symbol": "hasBasePath",
+          "expected_file_suffix": "client/has-base-path.ts",
+          "rank": 2,
+          "elapsed_ms": 1376.41,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "check",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "revalidate path",
+          "query_type": "short_phrase",
+          "expected_symbol": "revalidatePath",
+          "expected_file_suffix": "server/web/spec-extension/revalidate.ts",
+          "rank": 9,
+          "elapsed_ms": 711.78,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "relative",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "next request",
+          "query_type": "short_phrase",
+          "expected_symbol": "NextRequest",
+          "expected_file_suffix": "server/web/spec-extension/request.ts",
+          "rank": null,
+          "elapsed_ms": 710.38,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "nextInfo",
+            "file": "cli/next-info.ts"
+          }
+        },
+        {
+          "query": "use search params",
+          "query_type": "short_phrase",
+          "expected_symbol": "useSearchParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": 5,
+          "elapsed_ms": 1767.89,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "searchParams",
+            "file": "compiled/@vercel/blob/index.cjs"
+          }
+        },
+        {
+          "query": "get route regex",
+          "query_type": "short_phrase",
+          "expected_symbol": "getRouteRegex",
+          "expected_file_suffix": "shared/lib/router/utils/route-regex.ts",
+          "rank": null,
+          "elapsed_ms": 1871.38,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getReturn",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "load config",
+          "query_type": "short_phrase",
+          "expected_symbol": "loadConfig",
+          "expected_file_suffix": "server/config.ts",
+          "rank": null,
+          "elapsed_ms": 688.08,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "load",
+            "file": "compiled/@vercel/og/index.node.js"
+          }
+        },
+        {
+          "query": "start server",
+          "query_type": "short_phrase",
+          "expected_symbol": "startServer",
+          "expected_file_suffix": "server/lib/start-server.ts",
+          "rank": null,
+          "elapsed_ms": 696.28,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "start",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "NextRequest",
+          "query_type": "identifier",
+          "expected_symbol": "NextRequest",
+          "expected_file_suffix": "server/web/spec-extension/request.ts",
+          "rank": 1,
+          "elapsed_ms": 446.11,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "NextRequest",
+            "file": "server/web/spec-extension/request.ts"
+          }
+        },
+        {
+          "query": "useSearchParams",
+          "query_type": "identifier",
+          "expected_symbol": "useSearchParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": 1,
+          "elapsed_ms": 449.51,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "useSearchParams",
+            "file": "client/components/navigation.ts"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context_no_semantic",
+      "mrr": 0.22940513644323435,
+      "acc1": 0.20588235294117646,
+      "acc3": 0.23529411764705882,
+      "acc5": 0.23529411764705882,
+      "avg_elapsed_ms": 289.9358823529412,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 1.0,
+          "acc1": 1.0,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 178.75
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.1444729376230924,
+          "acc1": 0.11538461538461539,
+          "acc3": 0.15384615384615385,
+          "acc5": 0.15384615384615385,
+          "avg_elapsed_ms": 313.24
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.34057971014492755,
+          "acc1": 0.3333333333333333,
+          "acc3": 0.3333333333333333,
+          "acc5": 0.3333333333333333,
+          "avg_elapsed_ms": 226.01333333333332
+        }
+      },
+      "rows": [
+        {
+          "query": "get the current request headers in a server component",
+          "query_type": "natural_language",
+          "expected_symbol": "headers",
+          "expected_file_suffix": "server/request/headers.ts",
+          "rank": null,
+          "elapsed_ms": 281.23,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "getAccessFallbackHTTPStatus",
+            "file": "client/components/http-access-fallback/http-access-fallback.ts"
+          }
+        },
+        {
+          "query": "read cookies in a server component",
+          "query_type": "natural_language",
+          "expected_symbol": "cookies",
+          "expected_file_suffix": "server/request/cookies.ts",
+          "rank": null,
+          "elapsed_ms": 328.41,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "read",
+            "file": "compiled/babel/bundle.js"
+          }
+        },
+        {
+          "query": "check if draft mode is enabled",
+          "query_type": "natural_language",
+          "expected_symbol": "draftMode",
+          "expected_file_suffix": "server/request/draft-mode.ts",
+          "rank": 21,
+          "elapsed_ms": 281.86,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "_enabled",
+            "file": "compiled/react-dom-experimental/cjs/react-dom-profiling.profiling.js"
+          }
+        },
+        {
+          "query": "revalidate a cached path on demand",
+          "query_type": "natural_language",
+          "expected_symbol": "revalidatePath",
+          "expected_file_suffix": "server/web/spec-extension/revalidate.ts",
+          "rank": null,
+          "elapsed_ms": 281.48,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "_",
+            "file": "compiled/path-to-regexp/index.js"
+          }
+        },
+        {
+          "query": "invalidate cached data by tag",
+          "query_type": "natural_language",
+          "expected_symbol": "revalidateTag",
+          "expected_file_suffix": "server/web/spec-extension/revalidate.ts",
+          "rank": null,
+          "elapsed_ms": 282.99,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "_invalidate",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "cache the result of a server-side function",
+          "query_type": "natural_language",
+          "expected_symbol": "unstable_cache",
+          "expected_file_suffix": "server/web/spec-extension/unstable-cache.ts",
+          "rank": null,
+          "elapsed_ms": 395.03,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "isIdentifier",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "return a 404 from a server component",
+          "query_type": "natural_language",
+          "expected_symbol": "notFound",
+          "expected_file_suffix": "client/components/not-found.ts",
+          "rank": null,
+          "elapsed_ms": 367.82,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "hasReturn",
+            "file": "compiled/babel/bundle.js"
+          }
+        },
+        {
+          "query": "permanently redirect to a new URL",
+          "query_type": "natural_language",
+          "expected_symbol": "permanentRedirect",
+          "expected_file_suffix": "client/components/redirect.ts",
+          "rank": 24,
+          "elapsed_ms": 299.65,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "new_",
+            "file": "compiled/terser/bundle.min.js"
+          }
+        },
+        {
+          "query": "get the current URL search params in a client component",
+          "query_type": "natural_language",
+          "expected_symbol": "useSearchParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": null,
+          "elapsed_ms": 306.7,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "search",
+            "file": "compiled/@vercel/blob/index.cjs"
+          }
+        },
+        {
+          "query": "read the current pathname in a client component",
+          "query_type": "natural_language",
+          "expected_symbol": "usePathname",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": null,
+          "elapsed_ms": 364.94,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "pathname",
+            "file": "shared/lib/router/router.ts"
+          }
+        },
+        {
+          "query": "access dynamic route params",
+          "query_type": "natural_language",
+          "expected_symbol": "useParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": null,
+          "elapsed_ms": 313.5,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "isDynamicRoute",
+            "file": "shared/lib/router/utils/is-dynamic.ts"
+          }
+        },
+        {
+          "query": "use the router for programmatic navigation",
+          "query_type": "natural_language",
+          "expected_symbol": "useRouter",
+          "expected_file_suffix": "client/compat/router.ts",
+          "rank": null,
+          "elapsed_ms": 364.98,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "for_",
+            "file": "compiled/terser/bundle.min.js"
+          }
+        },
+        {
+          "query": "custom Request class with helpers for Next.js",
+          "query_type": "natural_language",
+          "expected_symbol": "NextRequest",
+          "expected_file_suffix": "server/web/spec-extension/request.ts",
+          "rank": null,
+          "elapsed_ms": 239.08,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "for_",
+            "file": "compiled/terser/bundle.min.js"
+          }
+        },
+        {
+          "query": "Next.js Response helper with cookies and redirects",
+          "query_type": "natural_language",
+          "expected_symbol": "NextResponse",
+          "expected_file_suffix": "server/web/spec-extension/response.ts",
+          "rank": null,
+          "elapsed_ms": 237.73,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "Response",
+            "file": "compiled/@vercel/blob/index.cjs"
+          }
+        },
+        {
+          "query": "load Next.js user config from disk",
+          "query_type": "natural_language",
+          "expected_symbol": "loadConfig",
+          "expected_file_suffix": "server/config.ts",
+          "rank": null,
+          "elapsed_ms": 326.23,
+          "candidate_count": 21,
+          "top_candidate": {
+            "name": "isUser",
+            "file": "compiled/babel/bundle.js"
+          }
+        },
+        {
+          "query": "gather trace output files for the build",
+          "query_type": "natural_language",
+          "expected_symbol": "collectBuildTraces",
+          "expected_file_suffix": "build/collect-build-traces.ts",
+          "rank": null,
+          "elapsed_ms": 235.43,
+          "candidate_count": 19,
+          "top_candidate": {
+            "name": "for_",
+            "file": "compiled/terser/bundle.min.js"
+          }
+        },
+        {
+          "query": "start the Next.js HTTP server",
+          "query_type": "natural_language",
+          "expected_symbol": "startServer",
+          "expected_file_suffix": "server/lib/start-server.ts",
+          "rank": null,
+          "elapsed_ms": 347.54,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "Start",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "check if a route contains dynamic segments",
+          "query_type": "natural_language",
+          "expected_symbol": "isDynamicRoute",
+          "expected_file_suffix": "shared/lib/router/utils/is-dynamic.ts",
+          "rank": 1,
+          "elapsed_ms": 339.46,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "isDynamicRoute",
+            "file": "shared/lib/router/utils/is-dynamic.ts"
+          }
+        },
+        {
+          "query": "build a regex that matches a route pattern",
+          "query_type": "natural_language",
+          "expected_symbol": "getRouteRegex",
+          "expected_file_suffix": "shared/lib/router/utils/route-regex.ts",
+          "rank": 1,
+          "elapsed_ms": 361.85,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "getRouteRegex",
+            "file": "shared/lib/router/utils/route-regex.ts"
+          }
+        },
+        {
+          "query": "get a matcher function for a route",
+          "query_type": "natural_language",
+          "expected_symbol": "getRouteMatcher",
+          "expected_file_suffix": "shared/lib/router/utils/route-matcher.ts",
+          "rank": null,
+          "elapsed_ms": 329.68,
+          "candidate_count": 21,
+          "top_candidate": {
+            "name": "for_",
+            "file": "compiled/terser/bundle.min.js"
+          }
+        },
+        {
+          "query": "add the configured basePath to a URL",
+          "query_type": "natural_language",
+          "expected_symbol": "addBasePath",
+          "expected_file_suffix": "client/add-base-path.ts",
+          "rank": 18,
+          "elapsed_ms": 305.95,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "addConfiguredExperimentalFeature",
+            "file": "server/config.ts"
+          }
+        },
+        {
+          "query": "substitute dynamic segments into the as path",
+          "query_type": "natural_language",
+          "expected_symbol": "interpolateAs",
+          "expected_file_suffix": "shared/lib/router/utils/interpolate-as.ts",
+          "rank": null,
+          "elapsed_ms": 331.39,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "inTopLevel",
+            "file": "compiled/babel/bundle.js"
+          }
+        },
+        {
+          "query": "normalize an app-router path format",
+          "query_type": "natural_language",
+          "expected_symbol": "normalizeAppPath",
+          "expected_file_suffix": "shared/lib/router/utils/app-paths.ts",
+          "rank": 1,
+          "elapsed_ms": 355.53,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "normalizeAppPath",
+            "file": "shared/lib/router/utils/app-paths.ts"
+          }
+        },
+        {
+          "query": "check if a URL is a local in-app URL",
+          "query_type": "natural_language",
+          "expected_symbol": "isLocalURL",
+          "expected_file_suffix": "shared/lib/router/utils/is-local-url.ts",
+          "rank": 17,
+          "elapsed_ms": 320.71,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "locale",
+            "file": "shared/lib/router/router.ts"
+          }
+        },
+        {
+          "query": "format a URL object back to a string",
+          "query_type": "natural_language",
+          "expected_symbol": "formatUrl",
+          "expected_file_suffix": "shared/lib/router/utils/format-url.ts",
+          "rank": 19,
+          "elapsed_ms": 300.69,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "Url",
+            "file": "shared/lib/router/router.ts"
+          }
+        },
+        {
+          "query": "check if a path already has the base path prefix",
+          "query_type": "natural_language",
+          "expected_symbol": "hasBasePath",
+          "expected_file_suffix": "client/has-base-path.ts",
+          "rank": 2,
+          "elapsed_ms": 244.38,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "pathHasPrefix",
+            "file": "shared/lib/router/utils/path-has-prefix.ts"
+          }
+        },
+        {
+          "query": "revalidate path",
+          "query_type": "short_phrase",
+          "expected_symbol": "revalidatePath",
+          "expected_file_suffix": "server/web/spec-extension/revalidate.ts",
+          "rank": null,
+          "elapsed_ms": 196.16,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "_",
+            "file": "compiled/path-to-regexp/index.js"
+          }
+        },
+        {
+          "query": "next request",
+          "query_type": "short_phrase",
+          "expected_symbol": "NextRequest",
+          "expected_file_suffix": "server/web/spec-extension/request.ts",
+          "rank": null,
+          "elapsed_ms": 199.28,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "NextRequestAdapter",
+            "file": "server/web/spec-extension/adapters/next-request.ts"
+          }
+        },
+        {
+          "query": "use search params",
+          "query_type": "short_phrase",
+          "expected_symbol": "useSearchParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": 23,
+          "elapsed_ms": 277.78,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "makeErroringSearchParamsForUseCache",
+            "file": "server/request/search-params.ts"
+          }
+        },
+        {
+          "query": "get route regex",
+          "query_type": "short_phrase",
+          "expected_symbol": "getRouteRegex",
+          "expected_file_suffix": "shared/lib/router/utils/route-regex.ts",
+          "rank": 1,
+          "elapsed_ms": 288.58,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "getRouteRegex",
+            "file": "shared/lib/router/utils/route-regex.ts"
+          }
+        },
+        {
+          "query": "load config",
+          "query_type": "short_phrase",
+          "expected_symbol": "loadConfig",
+          "expected_file_suffix": "server/config.ts",
+          "rank": null,
+          "elapsed_ms": 197.33,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "load",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "start server",
+          "query_type": "short_phrase",
+          "expected_symbol": "startServer",
+          "expected_file_suffix": "server/lib/start-server.ts",
+          "rank": 1,
+          "elapsed_ms": 196.95,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "startServer",
+            "file": "server/lib/start-server.ts"
+          }
+        },
+        {
+          "query": "NextRequest",
+          "query_type": "identifier",
+          "expected_symbol": "NextRequest",
+          "expected_file_suffix": "server/web/spec-extension/request.ts",
+          "rank": 1,
+          "elapsed_ms": 179.2,
+          "candidate_count": 17,
+          "top_candidate": {
+            "name": "NextRequest",
+            "file": "server/web/spec-extension/request.ts"
+          }
+        },
+        {
+          "query": "useSearchParams",
+          "query_type": "identifier",
+          "expected_symbol": "useSearchParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": 1,
+          "elapsed_ms": 178.3,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "useSearchParams",
+            "file": "client/components/navigation.ts"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context",
+      "mrr": 0.19785660675753555,
+      "acc1": 0.14705882352941177,
+      "acc3": 0.20588235294117646,
+      "acc5": 0.23529411764705882,
+      "avg_elapsed_ms": 401.23117647058825,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 1.0,
+          "acc1": 1.0,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 179.585
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.11770992165729008,
+          "acc1": 0.07692307692307693,
+          "acc3": 0.11538461538461539,
+          "acc5": 0.15384615384615385,
+          "avg_elapsed_ms": 430.92461538461544
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.2777777777777778,
+          "acc1": 0.16666666666666666,
+          "acc3": 0.3333333333333333,
+          "acc5": 0.3333333333333333,
+          "avg_elapsed_ms": 346.44166666666666
+        }
+      },
+      "rows": [
+        {
+          "query": "get the current request headers in a server component",
+          "query_type": "natural_language",
+          "expected_symbol": "headers",
+          "expected_file_suffix": "server/request/headers.ts",
+          "rank": null,
+          "elapsed_ms": 401.49,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "headers",
+            "file": "compiled/@vercel/blob/index.cjs"
+          }
+        },
+        {
+          "query": "read cookies in a server component",
+          "query_type": "natural_language",
+          "expected_symbol": "cookies",
+          "expected_file_suffix": "server/request/cookies.ts",
+          "rank": null,
+          "elapsed_ms": 443.92,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "cookies",
+            "file": "compiled/@vercel/blob/index.cjs"
+          }
+        },
+        {
+          "query": "check if draft mode is enabled",
+          "query_type": "natural_language",
+          "expected_symbol": "draftMode",
+          "expected_file_suffix": "server/request/draft-mode.ts",
+          "rank": 21,
+          "elapsed_ms": 397.05,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "_enabled",
+            "file": "compiled/react-dom-experimental/cjs/react-dom-profiling.profiling.js"
+          }
+        },
+        {
+          "query": "revalidate a cached path on demand",
+          "query_type": "natural_language",
+          "expected_symbol": "revalidatePath",
+          "expected_file_suffix": "server/web/spec-extension/revalidate.ts",
+          "rank": null,
+          "elapsed_ms": 406.72,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "cachedProperty",
+            "file": "compiled/crypto-browserify/index.js"
+          }
+        },
+        {
+          "query": "invalidate cached data by tag",
+          "query_type": "natural_language",
+          "expected_symbol": "revalidateTag",
+          "expected_file_suffix": "server/web/spec-extension/revalidate.ts",
+          "rank": null,
+          "elapsed_ms": 422.92,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "invalidate",
+            "file": "compiled/babel/bundle.js"
+          }
+        },
+        {
+          "query": "cache the result of a server-side function",
+          "query_type": "natural_language",
+          "expected_symbol": "unstable_cache",
+          "expected_file_suffix": "server/web/spec-extension/unstable-cache.ts",
+          "rank": null,
+          "elapsed_ms": 516.1,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "cachedProperty",
+            "file": "compiled/crypto-browserify/index.js"
+          }
+        },
+        {
+          "query": "return a 404 from a server component",
+          "query_type": "natural_language",
+          "expected_symbol": "notFound",
+          "expected_file_suffix": "client/components/not-found.ts",
+          "rank": 3,
+          "elapsed_ms": 466.97,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "ServerError",
+            "file": "compiled/raw-body/index.js"
+          }
+        },
+        {
+          "query": "permanently redirect to a new URL",
+          "query_type": "natural_language",
+          "expected_symbol": "permanentRedirect",
+          "expected_file_suffix": "client/components/redirect.ts",
+          "rank": 1,
+          "elapsed_ms": 400.65,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "permanentRedirect",
+            "file": "client/components/redirect.ts"
+          }
+        },
+        {
+          "query": "get the current URL search params in a client component",
+          "query_type": "natural_language",
+          "expected_symbol": "useSearchParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": null,
+          "elapsed_ms": 425.02,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "searchParams",
+            "file": "client/components/client-page.tsx"
+          }
+        },
+        {
+          "query": "read the current pathname in a client component",
+          "query_type": "natural_language",
+          "expected_symbol": "usePathname",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": 11,
+          "elapsed_ms": 490.73,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "pathname",
+            "file": "client/dev/on-demand-entries-client.ts"
+          }
+        },
+        {
+          "query": "access dynamic route params",
+          "query_type": "natural_language",
+          "expected_symbol": "useParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": null,
+          "elapsed_ms": 435.96,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "useDynamicRouteParams",
+            "file": "client/components/navigation.ts"
+          }
+        },
+        {
+          "query": "use the router for programmatic navigation",
+          "query_type": "natural_language",
+          "expected_symbol": "useRouter",
+          "expected_file_suffix": "client/compat/router.ts",
+          "rank": null,
+          "elapsed_ms": 483.81,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "Router",
+            "file": "client/components/app-router.tsx"
+          }
+        },
+        {
+          "query": "custom Request class with helpers for Next.js",
+          "query_type": "natural_language",
+          "expected_symbol": "NextRequest",
+          "expected_file_suffix": "server/web/spec-extension/request.ts",
+          "rank": null,
+          "elapsed_ms": 352.95,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "next",
+            "file": "compiled/crypto-browserify/index.js"
+          }
+        },
+        {
+          "query": "Next.js Response helper with cookies and redirects",
+          "query_type": "natural_language",
+          "expected_symbol": "NextResponse",
+          "expected_file_suffix": "server/web/spec-extension/response.ts",
+          "rank": null,
+          "elapsed_ms": 357.62,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "next",
+            "file": "compiled/crypto-browserify/index.js"
+          }
+        },
+        {
+          "query": "load Next.js user config from disk",
+          "query_type": "natural_language",
+          "expected_symbol": "loadConfig",
+          "expected_file_suffix": "server/config.ts",
+          "rank": null,
+          "elapsed_ms": 437.65,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "nextConfig",
+            "file": "cli/next-typegen.ts"
+          }
+        },
+        {
+          "query": "gather trace output files for the build",
+          "query_type": "natural_language",
+          "expected_symbol": "collectBuildTraces",
+          "expected_file_suffix": "build/collect-build-traces.ts",
+          "rank": null,
+          "elapsed_ms": 352.79,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "makeTrace",
+            "file": "compiled/babel-packages/packages-bundle.js"
+          }
+        },
+        {
+          "query": "start the Next.js HTTP server",
+          "query_type": "natural_language",
+          "expected_symbol": "startServer",
+          "expected_file_suffix": "server/lib/start-server.ts",
+          "rank": null,
+          "elapsed_ms": 465.17,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "startServer",
+            "file": "cli/next-dev.ts"
+          }
+        },
+        {
+          "query": "check if a route contains dynamic segments",
+          "query_type": "natural_language",
+          "expected_symbol": "isDynamicRoute",
+          "expected_file_suffix": "shared/lib/router/utils/is-dynamic.ts",
+          "rank": 6,
+          "elapsed_ms": 457.2,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "doesSegmentNeedDynamicRequest",
+            "file": "client/components/router-reducer/ppr-navigations.ts"
+          }
+        },
+        {
+          "query": "build a regex that matches a route pattern",
+          "query_type": "natural_language",
+          "expected_symbol": "getRouteRegex",
+          "expected_file_suffix": "shared/lib/router/utils/route-regex.ts",
+          "rank": 12,
+          "elapsed_ms": 479.75,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "matchKnownRoute",
+            "file": "client/components/segment-cache/optimistic-routes.ts"
+          }
+        },
+        {
+          "query": "get a matcher function for a route",
+          "query_type": "natural_language",
+          "expected_symbol": "getRouteMatcher",
+          "expected_file_suffix": "shared/lib/router/utils/route-matcher.ts",
+          "rank": null,
+          "elapsed_ms": 446.52,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "match",
+            "file": "client/components/segment-cache/optimistic-routes.ts"
+          }
+        },
+        {
+          "query": "add the configured basePath to a URL",
+          "query_type": "natural_language",
+          "expected_symbol": "addBasePath",
+          "expected_file_suffix": "client/add-base-path.ts",
+          "rank": 5,
+          "elapsed_ms": 423.41,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "baseUrl",
+            "file": "compiled/@vercel/blob/index.cjs"
+          }
+        },
+        {
+          "query": "substitute dynamic segments into the as path",
+          "query_type": "natural_language",
+          "expected_symbol": "interpolateAs",
+          "expected_file_suffix": "shared/lib/router/utils/interpolate-as.ts",
+          "rank": null,
+          "elapsed_ms": 452.58,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "segments",
+            "file": "client/components/router-reducer/compute-changed-path.ts"
+          }
+        },
+        {
+          "query": "normalize an app-router path format",
+          "query_type": "natural_language",
+          "expected_symbol": "normalizeAppPath",
+          "expected_file_suffix": "shared/lib/router/utils/app-paths.ts",
+          "rank": 19,
+          "elapsed_ms": 476.53,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "AppRouter",
+            "file": "client/components/app-router.tsx"
+          }
+        },
+        {
+          "query": "check if a URL is a local in-app URL",
+          "query_type": "natural_language",
+          "expected_symbol": "isLocalURL",
+          "expected_file_suffix": "shared/lib/router/utils/is-local-url.ts",
+          "rank": 19,
+          "elapsed_ms": 434.73,
+          "candidate_count": 34,
+          "top_candidate": {
+            "name": "urlIsLocal",
+            "file": "compiled/@vercel/blob/index.cjs"
+          }
+        },
+        {
+          "query": "format a URL object back to a string",
+          "query_type": "natural_language",
+          "expected_symbol": "formatUrl",
+          "expected_file_suffix": "shared/lib/router/utils/format-url.ts",
+          "rank": 30,
+          "elapsed_ms": 416.03,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "formatStringOrUrl",
+            "file": "client/app-dir/link.tsx"
+          }
+        },
+        {
+          "query": "check if a path already has the base path prefix",
+          "query_type": "natural_language",
+          "expected_symbol": "hasBasePath",
+          "expected_file_suffix": "client/has-base-path.ts",
+          "rank": 1,
+          "elapsed_ms": 359.77,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "hasBasePath",
+            "file": "client/has-base-path.ts"
+          }
+        },
+        {
+          "query": "revalidate path",
+          "query_type": "short_phrase",
+          "expected_symbol": "revalidatePath",
+          "expected_file_suffix": "server/web/spec-extension/revalidate.ts",
+          "rank": null,
+          "elapsed_ms": 331.44,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "revalidatingEntry",
+            "file": "client/components/segment-cache/scheduler.ts"
+          }
+        },
+        {
+          "query": "next request",
+          "query_type": "short_phrase",
+          "expected_symbol": "NextRequest",
+          "expected_file_suffix": "server/web/spec-extension/request.ts",
+          "rank": null,
+          "elapsed_ms": 317.78,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "nextCode",
+            "file": "compiled/@vercel/og/index.node.js"
+          }
+        },
+        {
+          "query": "use search params",
+          "query_type": "short_phrase",
+          "expected_symbol": "useSearchParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": 6,
+          "elapsed_ms": 399.98,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "searchParams",
+            "file": "compiled/@vercel/blob/index.cjs"
+          }
+        },
+        {
+          "query": "get route regex",
+          "query_type": "short_phrase",
+          "expected_symbol": "getRouteRegex",
+          "expected_file_suffix": "shared/lib/router/utils/route-regex.ts",
+          "rank": 2,
+          "elapsed_ms": 404.13,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "regex",
+            "file": "compiled/@modelcontextprotocol/sdk/server/mcp.js"
+          }
+        },
+        {
+          "query": "load config",
+          "query_type": "short_phrase",
+          "expected_symbol": "loadConfig",
+          "expected_file_suffix": "server/config.ts",
+          "rank": null,
+          "elapsed_ms": 313.36,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "load",
+            "file": "compiled/@vercel/og/index.node.js"
+          }
+        },
+        {
+          "query": "start server",
+          "query_type": "short_phrase",
+          "expected_symbol": "startServer",
+          "expected_file_suffix": "server/lib/start-server.ts",
+          "rank": 1,
+          "elapsed_ms": 311.96,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "startServer",
+            "file": "server/lib/start-server.ts"
+          }
+        },
+        {
+          "query": "NextRequest",
+          "query_type": "identifier",
+          "expected_symbol": "NextRequest",
+          "expected_file_suffix": "server/web/spec-extension/request.ts",
+          "rank": 1,
+          "elapsed_ms": 177.58,
+          "candidate_count": 17,
+          "top_candidate": {
+            "name": "NextRequest",
+            "file": "server/web/spec-extension/request.ts"
+          }
+        },
+        {
+          "query": "useSearchParams",
+          "query_type": "identifier",
+          "expected_symbol": "useSearchParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": 1,
+          "elapsed_ms": 181.59,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "useSearchParams",
+            "file": "client/components/navigation.ts"
+          }
+        }
+      ]
+    }
+  ],
+  "hybrid_uplift": {
+    "mrr_delta": -0.031548529685698795,
+    "acc1_delta": -0.05882352941176469,
+    "acc3_delta": -0.02941176470588236,
+    "acc5_delta": 0.0
+  },
+  "hybrid_uplift_by_query_type": {
+    "identifier": {
+      "mrr_delta": 0.0,
+      "acc1_delta": 0.0,
+      "acc3_delta": 0.0,
+      "acc5_delta": 0.0
+    },
+    "natural_language": {
+      "mrr_delta": -0.026763015965802328,
+      "acc1_delta": -0.038461538461538464,
+      "acc3_delta": -0.038461538461538464,
+      "acc5_delta": 0.0
+    },
+    "short_phrase": {
+      "mrr_delta": -0.06280193236714976,
+      "acc1_delta": -0.16666666666666666,
+      "acc3_delta": 0.0,
+      "acc5_delta": 0.0
+    }
+  }
+}

--- a/benchmarks/embedding-quality-v1.6-phase3e-next-js-stacked.json
+++ b/benchmarks/embedding-quality-v1.6-phase3e-next-js-stacked.json
@@ -1,0 +1,1487 @@
+{
+  "project": "/tmp/next-js/packages/next/src",
+  "benchmark_project": "/var/folders/z0/0tcbss795xsdp75jmr_t9_kh0000gn/T/codelens-embed-quality-beo89j0d/src",
+  "isolated_copy": true,
+  "binary": "/Users/bagjaeseog/codelens-mcp-plugin/target/release/codelens-mcp",
+  "embedding_model": "MiniLM-L12-CodeSearchNet-INT8",
+  "runtime_model": {
+    "model_dir": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch",
+    "model_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/model.onnx",
+    "config_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/config.json",
+    "sha256": "ef1d1e9cfa72e4929f5b9faea17d8704b23a2530aadebf0d464a4cc7750920b3",
+    "size_bytes": 34000281,
+    "num_hidden_layers": 12,
+    "hidden_size": 384
+  },
+  "dataset_path": "/Users/bagjaeseog/codelens-mcp-plugin/benchmarks/embedding-quality-dataset-next-js.json",
+  "dataset_size": 34,
+  "ranking_cutoff": 10,
+  "metric_labels": {
+    "mrr": "MRR@10",
+    "acc1": "Acc@1",
+    "acc3": "Acc@3",
+    "acc5": "Acc@5"
+  },
+  "methods": [
+    {
+      "method": "semantic_search",
+      "mrr": 0.14640522875816994,
+      "acc1": 0.11764705882352941,
+      "acc3": 0.14705882352941177,
+      "acc5": 0.17647058823529413,
+      "avg_elapsed_ms": 1873.594705882353,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 1.0,
+          "acc1": 1.0,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 435.37
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.10256410256410256,
+          "acc1": 0.07692307692307693,
+          "acc3": 0.11538461538461539,
+          "acc5": 0.11538461538461539,
+          "avg_elapsed_ms": 2163.9615384615386
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.05185185185185185,
+          "acc1": 0.0,
+          "acc3": 0.0,
+          "acc5": 0.16666666666666666,
+          "avg_elapsed_ms": 1094.7466666666667
+        }
+      },
+      "rows": [
+        {
+          "query": "get the current request headers in a server component",
+          "query_type": "natural_language",
+          "expected_symbol": "headers",
+          "expected_file_suffix": "server/request/headers.ts",
+          "rank": null,
+          "elapsed_ms": 2222.52,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "headers",
+            "file": "compiled/@vercel/blob/index.cjs"
+          }
+        },
+        {
+          "query": "read cookies in a server component",
+          "query_type": "natural_language",
+          "expected_symbol": "cookies",
+          "expected_file_suffix": "server/request/cookies.ts",
+          "rank": null,
+          "elapsed_ms": 2281.15,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "read",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "check if draft mode is enabled",
+          "query_type": "natural_language",
+          "expected_symbol": "draftMode",
+          "expected_file_suffix": "server/request/draft-mode.ts",
+          "rank": 6,
+          "elapsed_ms": 1731.15,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "check",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "revalidate a cached path on demand",
+          "query_type": "natural_language",
+          "expected_symbol": "revalidatePath",
+          "expected_file_suffix": "server/web/spec-extension/revalidate.ts",
+          "rank": null,
+          "elapsed_ms": 1759.49,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "read",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "invalidate cached data by tag",
+          "query_type": "natural_language",
+          "expected_symbol": "revalidateTag",
+          "expected_file_suffix": "server/web/spec-extension/revalidate.ts",
+          "rank": null,
+          "elapsed_ms": 1745.7,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "invalidate",
+            "file": "compiled/babel/bundle.js"
+          }
+        },
+        {
+          "query": "cache the result of a server-side function",
+          "query_type": "natural_language",
+          "expected_symbol": "unstable_cache",
+          "expected_file_suffix": "server/web/spec-extension/unstable-cache.ts",
+          "rank": null,
+          "elapsed_ms": 3137.31,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "cachedProperty",
+            "file": "compiled/crypto-browserify/index.js"
+          }
+        },
+        {
+          "query": "return a 404 from a server component",
+          "query_type": "natural_language",
+          "expected_symbol": "notFound",
+          "expected_file_suffix": "client/components/not-found.ts",
+          "rank": null,
+          "elapsed_ms": 2612.62,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "rename",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "permanently redirect to a new URL",
+          "query_type": "natural_language",
+          "expected_symbol": "permanentRedirect",
+          "expected_file_suffix": "client/components/redirect.ts",
+          "rank": 1,
+          "elapsed_ms": 1747.36,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "permanentRedirect",
+            "file": "client/components/redirect.ts"
+          }
+        },
+        {
+          "query": "get the current URL search params in a client component",
+          "query_type": "natural_language",
+          "expected_symbol": "useSearchParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": null,
+          "elapsed_ms": 2071.47,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "searchParams",
+            "file": "client/components/client-page.tsx"
+          }
+        },
+        {
+          "query": "read the current pathname in a client component",
+          "query_type": "natural_language",
+          "expected_symbol": "usePathname",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": null,
+          "elapsed_ms": 2838.12,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "pathname",
+            "file": "client/dev/on-demand-entries-client.ts"
+          }
+        },
+        {
+          "query": "access dynamic route params",
+          "query_type": "natural_language",
+          "expected_symbol": "useParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": null,
+          "elapsed_ms": 2197.82,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "parseDynamicParamFromURLPart",
+            "file": "client/route-params.ts"
+          }
+        },
+        {
+          "query": "use the router for programmatic navigation",
+          "query_type": "natural_language",
+          "expected_symbol": "useRouter",
+          "expected_file_suffix": "client/compat/router.ts",
+          "rank": null,
+          "elapsed_ms": 2779.62,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "Router",
+            "file": "client/components/app-router.tsx"
+          }
+        },
+        {
+          "query": "custom Request class with helpers for Next.js",
+          "query_type": "natural_language",
+          "expected_symbol": "NextRequest",
+          "expected_file_suffix": "server/web/spec-extension/request.ts",
+          "rank": null,
+          "elapsed_ms": 1149.28,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "next",
+            "file": "compiled/crypto-browserify/index.js"
+          }
+        },
+        {
+          "query": "Next.js Response helper with cookies and redirects",
+          "query_type": "natural_language",
+          "expected_symbol": "NextResponse",
+          "expected_file_suffix": "server/web/spec-extension/response.ts",
+          "rank": null,
+          "elapsed_ms": 1144.31,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "next",
+            "file": "compiled/crypto-browserify/index.js"
+          }
+        },
+        {
+          "query": "load Next.js user config from disk",
+          "query_type": "natural_language",
+          "expected_symbol": "loadConfig",
+          "expected_file_suffix": "server/config.ts",
+          "rank": null,
+          "elapsed_ms": 2313.47,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getNextConfig",
+            "file": "cli/next-info.ts"
+          }
+        },
+        {
+          "query": "gather trace output files for the build",
+          "query_type": "natural_language",
+          "expected_symbol": "collectBuildTraces",
+          "expected_file_suffix": "build/collect-build-traces.ts",
+          "rank": null,
+          "elapsed_ms": 1222.88,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "traceMemoryUsage",
+            "file": "lib/memory/trace.ts"
+          }
+        },
+        {
+          "query": "start the Next.js HTTP server",
+          "query_type": "natural_language",
+          "expected_symbol": "startServer",
+          "expected_file_suffix": "server/lib/start-server.ts",
+          "rank": null,
+          "elapsed_ms": 2557.78,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "startServer",
+            "file": "cli/next-dev.ts"
+          }
+        },
+        {
+          "query": "check if a route contains dynamic segments",
+          "query_type": "natural_language",
+          "expected_symbol": "isDynamicRoute",
+          "expected_file_suffix": "shared/lib/router/utils/is-dynamic.ts",
+          "rank": null,
+          "elapsed_ms": 2499.56,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "checkConstraints",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "build a regex that matches a route pattern",
+          "query_type": "natural_language",
+          "expected_symbol": "getRouteRegex",
+          "expected_file_suffix": "shared/lib/router/utils/route-regex.ts",
+          "rank": null,
+          "elapsed_ms": 2828.98,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "buildNamespaceReexport",
+            "file": "compiled/babel-packages/packages-bundle.js"
+          }
+        },
+        {
+          "query": "get a matcher function for a route",
+          "query_type": "natural_language",
+          "expected_symbol": "getRouteMatcher",
+          "expected_file_suffix": "shared/lib/router/utils/route-matcher.ts",
+          "rank": null,
+          "elapsed_ms": 2505.43,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "matchKnownRoute",
+            "file": "client/components/segment-cache/optimistic-routes.ts"
+          }
+        },
+        {
+          "query": "add the configured basePath to a URL",
+          "query_type": "natural_language",
+          "expected_symbol": "addBasePath",
+          "expected_file_suffix": "client/add-base-path.ts",
+          "rank": 1,
+          "elapsed_ms": 2118.19,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "addBasePath",
+            "file": "client/add-base-path.ts"
+          }
+        },
+        {
+          "query": "substitute dynamic segments into the as path",
+          "query_type": "natural_language",
+          "expected_symbol": "interpolateAs",
+          "expected_file_suffix": "shared/lib/router/utils/interpolate-as.ts",
+          "rank": null,
+          "elapsed_ms": 2375.72,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "collectSegmentPaths",
+            "file": "export/index.ts"
+          }
+        },
+        {
+          "query": "normalize an app-router path format",
+          "query_type": "natural_language",
+          "expected_symbol": "normalizeAppPath",
+          "expected_file_suffix": "shared/lib/router/utils/app-paths.ts",
+          "rank": null,
+          "elapsed_ms": 2685.09,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "normalizeParserOptions",
+            "file": "compiled/babel-packages/packages-bundle.js"
+          }
+        },
+        {
+          "query": "check if a URL is a local in-app URL",
+          "query_type": "natural_language",
+          "expected_symbol": "isLocalURL",
+          "expected_file_suffix": "shared/lib/router/utils/is-local-url.ts",
+          "rank": null,
+          "elapsed_ms": 2317.87,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "urlIsLocal",
+            "file": "compiled/@vercel/blob/index.cjs"
+          }
+        },
+        {
+          "query": "format a URL object back to a string",
+          "query_type": "natural_language",
+          "expected_symbol": "formatUrl",
+          "expected_file_suffix": "shared/lib/router/utils/format-url.ts",
+          "rank": null,
+          "elapsed_ms": 2086.37,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "formatStringOrUrl",
+            "file": "client/app-dir/link.tsx"
+          }
+        },
+        {
+          "query": "check if a path already has the base path prefix",
+          "query_type": "natural_language",
+          "expected_symbol": "hasBasePath",
+          "expected_file_suffix": "client/has-base-path.ts",
+          "rank": 2,
+          "elapsed_ms": 1333.74,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "check",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "revalidate path",
+          "query_type": "short_phrase",
+          "expected_symbol": "revalidatePath",
+          "expected_file_suffix": "server/web/spec-extension/revalidate.ts",
+          "rank": 9,
+          "elapsed_ms": 678.61,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "relative",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "next request",
+          "query_type": "short_phrase",
+          "expected_symbol": "NextRequest",
+          "expected_file_suffix": "server/web/spec-extension/request.ts",
+          "rank": null,
+          "elapsed_ms": 690.57,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "nextInfo",
+            "file": "cli/next-info.ts"
+          }
+        },
+        {
+          "query": "use search params",
+          "query_type": "short_phrase",
+          "expected_symbol": "useSearchParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": 5,
+          "elapsed_ms": 1829.61,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "searchParams",
+            "file": "compiled/@vercel/blob/index.cjs"
+          }
+        },
+        {
+          "query": "get route regex",
+          "query_type": "short_phrase",
+          "expected_symbol": "getRouteRegex",
+          "expected_file_suffix": "shared/lib/router/utils/route-regex.ts",
+          "rank": null,
+          "elapsed_ms": 2001.28,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getReturn",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "load config",
+          "query_type": "short_phrase",
+          "expected_symbol": "loadConfig",
+          "expected_file_suffix": "server/config.ts",
+          "rank": null,
+          "elapsed_ms": 696.73,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "load",
+            "file": "compiled/@vercel/og/index.node.js"
+          }
+        },
+        {
+          "query": "start server",
+          "query_type": "short_phrase",
+          "expected_symbol": "startServer",
+          "expected_file_suffix": "server/lib/start-server.ts",
+          "rank": null,
+          "elapsed_ms": 671.68,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "start",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "NextRequest",
+          "query_type": "identifier",
+          "expected_symbol": "NextRequest",
+          "expected_file_suffix": "server/web/spec-extension/request.ts",
+          "rank": 1,
+          "elapsed_ms": 430.11,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "NextRequest",
+            "file": "server/web/spec-extension/request.ts"
+          }
+        },
+        {
+          "query": "useSearchParams",
+          "query_type": "identifier",
+          "expected_symbol": "useSearchParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": 1,
+          "elapsed_ms": 440.63,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "useSearchParams",
+            "file": "client/components/navigation.ts"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context_no_semantic",
+      "mrr": 0.23124140006879945,
+      "acc1": 0.20588235294117646,
+      "acc3": 0.23529411764705882,
+      "acc5": 0.23529411764705882,
+      "avg_elapsed_ms": 282.9676470588235,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 1.0,
+          "acc1": 1.0,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 177.035
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.14694388214125056,
+          "acc1": 0.11538461538461539,
+          "acc3": 0.15384615384615385,
+          "acc5": 0.15384615384615385,
+          "avg_elapsed_ms": 304.8446153846154
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.34027777777777773,
+          "acc1": 0.3333333333333333,
+          "acc3": 0.3333333333333333,
+          "acc5": 0.3333333333333333,
+          "avg_elapsed_ms": 223.47833333333332
+        }
+      },
+      "rows": [
+        {
+          "query": "get the current request headers in a server component",
+          "query_type": "natural_language",
+          "expected_symbol": "headers",
+          "expected_file_suffix": "server/request/headers.ts",
+          "rank": null,
+          "elapsed_ms": 275.34,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "getAccessFallbackHTTPStatus",
+            "file": "client/components/http-access-fallback/http-access-fallback.ts"
+          }
+        },
+        {
+          "query": "read cookies in a server component",
+          "query_type": "natural_language",
+          "expected_symbol": "cookies",
+          "expected_file_suffix": "server/request/cookies.ts",
+          "rank": null,
+          "elapsed_ms": 317.96,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "read",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "check if draft mode is enabled",
+          "query_type": "natural_language",
+          "expected_symbol": "draftMode",
+          "expected_file_suffix": "server/request/draft-mode.ts",
+          "rank": 16,
+          "elapsed_ms": 277.48,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "_enabled",
+            "file": "compiled/react-dom-experimental/cjs/react-dom-profiling.profiling.js"
+          }
+        },
+        {
+          "query": "revalidate a cached path on demand",
+          "query_type": "natural_language",
+          "expected_symbol": "revalidatePath",
+          "expected_file_suffix": "server/web/spec-extension/revalidate.ts",
+          "rank": null,
+          "elapsed_ms": 278.73,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "_",
+            "file": "compiled/path-to-regexp/index.js"
+          }
+        },
+        {
+          "query": "invalidate cached data by tag",
+          "query_type": "natural_language",
+          "expected_symbol": "revalidateTag",
+          "expected_file_suffix": "server/web/spec-extension/revalidate.ts",
+          "rank": null,
+          "elapsed_ms": 277.89,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "_invalidate",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "cache the result of a server-side function",
+          "query_type": "natural_language",
+          "expected_symbol": "unstable_cache",
+          "expected_file_suffix": "server/web/spec-extension/unstable-cache.ts",
+          "rank": null,
+          "elapsed_ms": 385.02,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "isIdentifier",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "return a 404 from a server component",
+          "query_type": "natural_language",
+          "expected_symbol": "notFound",
+          "expected_file_suffix": "client/components/not-found.ts",
+          "rank": null,
+          "elapsed_ms": 335.29,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "hasReturn",
+            "file": "compiled/babel/bundle.js"
+          }
+        },
+        {
+          "query": "permanently redirect to a new URL",
+          "query_type": "natural_language",
+          "expected_symbol": "permanentRedirect",
+          "expected_file_suffix": "client/components/redirect.ts",
+          "rank": 24,
+          "elapsed_ms": 273.85,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "redirect",
+            "file": "compiled/@vercel/blob/index.cjs"
+          }
+        },
+        {
+          "query": "get the current URL search params in a client component",
+          "query_type": "natural_language",
+          "expected_symbol": "useSearchParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": null,
+          "elapsed_ms": 297.77,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "search",
+            "file": "compiled/@vercel/blob/index.cjs"
+          }
+        },
+        {
+          "query": "read the current pathname in a client component",
+          "query_type": "natural_language",
+          "expected_symbol": "usePathname",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": null,
+          "elapsed_ms": 354.24,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "pathname",
+            "file": "shared/lib/router/router.ts"
+          }
+        },
+        {
+          "query": "access dynamic route params",
+          "query_type": "natural_language",
+          "expected_symbol": "useParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": null,
+          "elapsed_ms": 301.43,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "isDynamicRoute",
+            "file": "shared/lib/router/utils/is-dynamic.ts"
+          }
+        },
+        {
+          "query": "use the router for programmatic navigation",
+          "query_type": "natural_language",
+          "expected_symbol": "useRouter",
+          "expected_file_suffix": "client/compat/router.ts",
+          "rank": null,
+          "elapsed_ms": 355.89,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "for_",
+            "file": "compiled/terser/bundle.min.js"
+          }
+        },
+        {
+          "query": "custom Request class with helpers for Next.js",
+          "query_type": "natural_language",
+          "expected_symbol": "NextRequest",
+          "expected_file_suffix": "server/web/spec-extension/request.ts",
+          "rank": null,
+          "elapsed_ms": 229.97,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "for_",
+            "file": "compiled/terser/bundle.min.js"
+          }
+        },
+        {
+          "query": "Next.js Response helper with cookies and redirects",
+          "query_type": "natural_language",
+          "expected_symbol": "NextResponse",
+          "expected_file_suffix": "server/web/spec-extension/response.ts",
+          "rank": null,
+          "elapsed_ms": 232.35,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "Response",
+            "file": "compiled/@vercel/blob/index.cjs"
+          }
+        },
+        {
+          "query": "load Next.js user config from disk",
+          "query_type": "natural_language",
+          "expected_symbol": "loadConfig",
+          "expected_file_suffix": "server/config.ts",
+          "rank": null,
+          "elapsed_ms": 313.14,
+          "candidate_count": 21,
+          "top_candidate": {
+            "name": "isUser",
+            "file": "compiled/babel/bundle.js"
+          }
+        },
+        {
+          "query": "gather trace output files for the build",
+          "query_type": "natural_language",
+          "expected_symbol": "collectBuildTraces",
+          "expected_file_suffix": "build/collect-build-traces.ts",
+          "rank": null,
+          "elapsed_ms": 233.82,
+          "candidate_count": 19,
+          "top_candidate": {
+            "name": "for_",
+            "file": "compiled/terser/bundle.min.js"
+          }
+        },
+        {
+          "query": "start the Next.js HTTP server",
+          "query_type": "natural_language",
+          "expected_symbol": "startServer",
+          "expected_file_suffix": "server/lib/start-server.ts",
+          "rank": null,
+          "elapsed_ms": 337.66,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "start",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "check if a route contains dynamic segments",
+          "query_type": "natural_language",
+          "expected_symbol": "isDynamicRoute",
+          "expected_file_suffix": "shared/lib/router/utils/is-dynamic.ts",
+          "rank": 1,
+          "elapsed_ms": 328.54,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "isDynamicRoute",
+            "file": "shared/lib/router/utils/is-dynamic.ts"
+          }
+        },
+        {
+          "query": "build a regex that matches a route pattern",
+          "query_type": "natural_language",
+          "expected_symbol": "getRouteRegex",
+          "expected_file_suffix": "shared/lib/router/utils/route-regex.ts",
+          "rank": 1,
+          "elapsed_ms": 353.89,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "getRouteRegex",
+            "file": "shared/lib/router/utils/route-regex.ts"
+          }
+        },
+        {
+          "query": "get a matcher function for a route",
+          "query_type": "natural_language",
+          "expected_symbol": "getRouteMatcher",
+          "expected_file_suffix": "shared/lib/router/utils/route-matcher.ts",
+          "rank": null,
+          "elapsed_ms": 331.15,
+          "candidate_count": 21,
+          "top_candidate": {
+            "name": "for_",
+            "file": "compiled/terser/bundle.min.js"
+          }
+        },
+        {
+          "query": "add the configured basePath to a URL",
+          "query_type": "natural_language",
+          "expected_symbol": "addBasePath",
+          "expected_file_suffix": "client/add-base-path.ts",
+          "rank": 19,
+          "elapsed_ms": 297.68,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "addConfiguredExperimentalFeature",
+            "file": "server/config.ts"
+          }
+        },
+        {
+          "query": "substitute dynamic segments into the as path",
+          "query_type": "natural_language",
+          "expected_symbol": "interpolateAs",
+          "expected_file_suffix": "shared/lib/router/utils/interpolate-as.ts",
+          "rank": null,
+          "elapsed_ms": 325.18,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "inTopLevel",
+            "file": "compiled/babel/bundle.js"
+          }
+        },
+        {
+          "query": "normalize an app-router path format",
+          "query_type": "natural_language",
+          "expected_symbol": "normalizeAppPath",
+          "expected_file_suffix": "shared/lib/router/utils/app-paths.ts",
+          "rank": 1,
+          "elapsed_ms": 361.13,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "normalizeAppPath",
+            "file": "shared/lib/router/utils/app-paths.ts"
+          }
+        },
+        {
+          "query": "check if a URL is a local in-app URL",
+          "query_type": "natural_language",
+          "expected_symbol": "isLocalURL",
+          "expected_file_suffix": "shared/lib/router/utils/is-local-url.ts",
+          "rank": 9,
+          "elapsed_ms": 312.07,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "createAsyncLocalStorage",
+            "file": "server/app-render/async-local-storage.ts"
+          }
+        },
+        {
+          "query": "format a URL object back to a string",
+          "query_type": "natural_language",
+          "expected_symbol": "formatUrl",
+          "expected_file_suffix": "shared/lib/router/utils/format-url.ts",
+          "rank": 19,
+          "elapsed_ms": 292.87,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "Url",
+            "file": "shared/lib/router/router.ts"
+          }
+        },
+        {
+          "query": "check if a path already has the base path prefix",
+          "query_type": "natural_language",
+          "expected_symbol": "hasBasePath",
+          "expected_file_suffix": "client/has-base-path.ts",
+          "rank": 2,
+          "elapsed_ms": 245.62,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "pathHasPrefix",
+            "file": "shared/lib/router/utils/path-has-prefix.ts"
+          }
+        },
+        {
+          "query": "revalidate path",
+          "query_type": "short_phrase",
+          "expected_symbol": "revalidatePath",
+          "expected_file_suffix": "server/web/spec-extension/revalidate.ts",
+          "rank": null,
+          "elapsed_ms": 193.19,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "_",
+            "file": "compiled/path-to-regexp/index.js"
+          }
+        },
+        {
+          "query": "next request",
+          "query_type": "short_phrase",
+          "expected_symbol": "NextRequest",
+          "expected_file_suffix": "server/web/spec-extension/request.ts",
+          "rank": null,
+          "elapsed_ms": 194.93,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "NextRequestAdapter",
+            "file": "server/web/spec-extension/adapters/next-request.ts"
+          }
+        },
+        {
+          "query": "use search params",
+          "query_type": "short_phrase",
+          "expected_symbol": "useSearchParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": 24,
+          "elapsed_ms": 275.13,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "makeErroringSearchParamsForUseCache",
+            "file": "server/request/search-params.ts"
+          }
+        },
+        {
+          "query": "get route regex",
+          "query_type": "short_phrase",
+          "expected_symbol": "getRouteRegex",
+          "expected_file_suffix": "shared/lib/router/utils/route-regex.ts",
+          "rank": 1,
+          "elapsed_ms": 279.23,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "getRouteRegex",
+            "file": "shared/lib/router/utils/route-regex.ts"
+          }
+        },
+        {
+          "query": "load config",
+          "query_type": "short_phrase",
+          "expected_symbol": "loadConfig",
+          "expected_file_suffix": "server/config.ts",
+          "rank": null,
+          "elapsed_ms": 200.5,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "load",
+            "file": "compiled/webpack/bundle5.js"
+          }
+        },
+        {
+          "query": "start server",
+          "query_type": "short_phrase",
+          "expected_symbol": "startServer",
+          "expected_file_suffix": "server/lib/start-server.ts",
+          "rank": 1,
+          "elapsed_ms": 197.89,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "startServer",
+            "file": "server/lib/start-server.ts"
+          }
+        },
+        {
+          "query": "NextRequest",
+          "query_type": "identifier",
+          "expected_symbol": "NextRequest",
+          "expected_file_suffix": "server/web/spec-extension/request.ts",
+          "rank": 1,
+          "elapsed_ms": 176.93,
+          "candidate_count": 17,
+          "top_candidate": {
+            "name": "NextRequest",
+            "file": "server/web/spec-extension/request.ts"
+          }
+        },
+        {
+          "query": "useSearchParams",
+          "query_type": "identifier",
+          "expected_symbol": "useSearchParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": 1,
+          "elapsed_ms": 177.14,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "useSearchParams",
+            "file": "client/components/navigation.ts"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context",
+      "mrr": 0.19620761720219923,
+      "acc1": 0.14705882352941177,
+      "acc3": 0.20588235294117646,
+      "acc5": 0.23529411764705882,
+      "avg_elapsed_ms": 410.43264705882353,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 1.0,
+          "acc1": 1.0,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 179.54500000000002
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.11900522722891144,
+          "acc1": 0.07692307692307693,
+          "acc3": 0.11538461538461539,
+          "acc5": 0.15384615384615385,
+          "avg_elapsed_ms": 441.66230769230765
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.26282051282051283,
+          "acc1": 0.16666666666666666,
+          "acc3": 0.3333333333333333,
+          "acc5": 0.3333333333333333,
+          "avg_elapsed_ms": 352.06666666666666
+        }
+      },
+      "rows": [
+        {
+          "query": "get the current request headers in a server component",
+          "query_type": "natural_language",
+          "expected_symbol": "headers",
+          "expected_file_suffix": "server/request/headers.ts",
+          "rank": null,
+          "elapsed_ms": 502.99,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "headers",
+            "file": "compiled/@vercel/blob/index.cjs"
+          }
+        },
+        {
+          "query": "read cookies in a server component",
+          "query_type": "natural_language",
+          "expected_symbol": "cookies",
+          "expected_file_suffix": "server/request/cookies.ts",
+          "rank": null,
+          "elapsed_ms": 432.78,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "cookies",
+            "file": "compiled/@vercel/blob/index.cjs"
+          }
+        },
+        {
+          "query": "check if draft mode is enabled",
+          "query_type": "natural_language",
+          "expected_symbol": "draftMode",
+          "expected_file_suffix": "server/request/draft-mode.ts",
+          "rank": 16,
+          "elapsed_ms": 391.73,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "_enabled",
+            "file": "compiled/react-dom-experimental/cjs/react-dom-profiling.profiling.js"
+          }
+        },
+        {
+          "query": "revalidate a cached path on demand",
+          "query_type": "natural_language",
+          "expected_symbol": "revalidatePath",
+          "expected_file_suffix": "server/web/spec-extension/revalidate.ts",
+          "rank": null,
+          "elapsed_ms": 393.74,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "cachedProperty",
+            "file": "compiled/crypto-browserify/index.js"
+          }
+        },
+        {
+          "query": "invalidate cached data by tag",
+          "query_type": "natural_language",
+          "expected_symbol": "revalidateTag",
+          "expected_file_suffix": "server/web/spec-extension/revalidate.ts",
+          "rank": null,
+          "elapsed_ms": 390.1,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "invalidate",
+            "file": "compiled/babel/bundle.js"
+          }
+        },
+        {
+          "query": "cache the result of a server-side function",
+          "query_type": "natural_language",
+          "expected_symbol": "unstable_cache",
+          "expected_file_suffix": "server/web/spec-extension/unstable-cache.ts",
+          "rank": null,
+          "elapsed_ms": 507.34,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "cachedProperty",
+            "file": "compiled/crypto-browserify/index.js"
+          }
+        },
+        {
+          "query": "return a 404 from a server component",
+          "query_type": "natural_language",
+          "expected_symbol": "notFound",
+          "expected_file_suffix": "client/components/not-found.ts",
+          "rank": 3,
+          "elapsed_ms": 505.86,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "ServerError",
+            "file": "compiled/raw-body/index.js"
+          }
+        },
+        {
+          "query": "permanently redirect to a new URL",
+          "query_type": "natural_language",
+          "expected_symbol": "permanentRedirect",
+          "expected_file_suffix": "client/components/redirect.ts",
+          "rank": 1,
+          "elapsed_ms": 413.25,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "permanentRedirect",
+            "file": "client/components/redirect.ts"
+          }
+        },
+        {
+          "query": "get the current URL search params in a client component",
+          "query_type": "natural_language",
+          "expected_symbol": "useSearchParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": null,
+          "elapsed_ms": 435.86,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "searchParams",
+            "file": "client/components/client-page.tsx"
+          }
+        },
+        {
+          "query": "read the current pathname in a client component",
+          "query_type": "natural_language",
+          "expected_symbol": "usePathname",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": 11,
+          "elapsed_ms": 493.73,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "pathname",
+            "file": "client/dev/on-demand-entries-client.ts"
+          }
+        },
+        {
+          "query": "access dynamic route params",
+          "query_type": "natural_language",
+          "expected_symbol": "useParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": null,
+          "elapsed_ms": 438.91,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "useDynamicRouteParams",
+            "file": "client/components/navigation.ts"
+          }
+        },
+        {
+          "query": "use the router for programmatic navigation",
+          "query_type": "natural_language",
+          "expected_symbol": "useRouter",
+          "expected_file_suffix": "client/compat/router.ts",
+          "rank": null,
+          "elapsed_ms": 490.25,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "Router",
+            "file": "client/components/app-router.tsx"
+          }
+        },
+        {
+          "query": "custom Request class with helpers for Next.js",
+          "query_type": "natural_language",
+          "expected_symbol": "NextRequest",
+          "expected_file_suffix": "server/web/spec-extension/request.ts",
+          "rank": null,
+          "elapsed_ms": 365.97,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "next",
+            "file": "compiled/crypto-browserify/index.js"
+          }
+        },
+        {
+          "query": "Next.js Response helper with cookies and redirects",
+          "query_type": "natural_language",
+          "expected_symbol": "NextResponse",
+          "expected_file_suffix": "server/web/spec-extension/response.ts",
+          "rank": null,
+          "elapsed_ms": 356.38,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "next",
+            "file": "compiled/crypto-browserify/index.js"
+          }
+        },
+        {
+          "query": "load Next.js user config from disk",
+          "query_type": "natural_language",
+          "expected_symbol": "loadConfig",
+          "expected_file_suffix": "server/config.ts",
+          "rank": null,
+          "elapsed_ms": 486.46,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "nextConfig",
+            "file": "cli/next-typegen.ts"
+          }
+        },
+        {
+          "query": "gather trace output files for the build",
+          "query_type": "natural_language",
+          "expected_symbol": "collectBuildTraces",
+          "expected_file_suffix": "build/collect-build-traces.ts",
+          "rank": null,
+          "elapsed_ms": 374.13,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "makeTrace",
+            "file": "compiled/babel-packages/packages-bundle.js"
+          }
+        },
+        {
+          "query": "start the Next.js HTTP server",
+          "query_type": "natural_language",
+          "expected_symbol": "startServer",
+          "expected_file_suffix": "server/lib/start-server.ts",
+          "rank": null,
+          "elapsed_ms": 469.51,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "startServer",
+            "file": "cli/next-dev.ts"
+          }
+        },
+        {
+          "query": "check if a route contains dynamic segments",
+          "query_type": "natural_language",
+          "expected_symbol": "isDynamicRoute",
+          "expected_file_suffix": "shared/lib/router/utils/is-dynamic.ts",
+          "rank": 6,
+          "elapsed_ms": 462.53,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "doesSegmentNeedDynamicRequest",
+            "file": "client/components/router-reducer/ppr-navigations.ts"
+          }
+        },
+        {
+          "query": "build a regex that matches a route pattern",
+          "query_type": "natural_language",
+          "expected_symbol": "getRouteRegex",
+          "expected_file_suffix": "shared/lib/router/utils/route-regex.ts",
+          "rank": 12,
+          "elapsed_ms": 477.11,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "matchKnownRoute",
+            "file": "client/components/segment-cache/optimistic-routes.ts"
+          }
+        },
+        {
+          "query": "get a matcher function for a route",
+          "query_type": "natural_language",
+          "expected_symbol": "getRouteMatcher",
+          "expected_file_suffix": "shared/lib/router/utils/route-matcher.ts",
+          "rank": null,
+          "elapsed_ms": 449.13,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "match",
+            "file": "client/components/segment-cache/optimistic-routes.ts"
+          }
+        },
+        {
+          "query": "add the configured basePath to a URL",
+          "query_type": "natural_language",
+          "expected_symbol": "addBasePath",
+          "expected_file_suffix": "client/add-base-path.ts",
+          "rank": 5,
+          "elapsed_ms": 437.97,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "baseUrl",
+            "file": "compiled/@vercel/blob/index.cjs"
+          }
+        },
+        {
+          "query": "substitute dynamic segments into the as path",
+          "query_type": "natural_language",
+          "expected_symbol": "interpolateAs",
+          "expected_file_suffix": "shared/lib/router/utils/interpolate-as.ts",
+          "rank": null,
+          "elapsed_ms": 459.44,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "segments",
+            "file": "client/components/router-reducer/compute-changed-path.ts"
+          }
+        },
+        {
+          "query": "normalize an app-router path format",
+          "query_type": "natural_language",
+          "expected_symbol": "normalizeAppPath",
+          "expected_file_suffix": "shared/lib/router/utils/app-paths.ts",
+          "rank": 19,
+          "elapsed_ms": 482.45,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "AppRouter",
+            "file": "client/components/app-router.tsx"
+          }
+        },
+        {
+          "query": "check if a URL is a local in-app URL",
+          "query_type": "natural_language",
+          "expected_symbol": "isLocalURL",
+          "expected_file_suffix": "shared/lib/router/utils/is-local-url.ts",
+          "rank": 14,
+          "elapsed_ms": 457.6,
+          "candidate_count": 34,
+          "top_candidate": {
+            "name": "urlIsLocal",
+            "file": "compiled/@vercel/blob/index.cjs"
+          }
+        },
+        {
+          "query": "format a URL object back to a string",
+          "query_type": "natural_language",
+          "expected_symbol": "formatUrl",
+          "expected_file_suffix": "shared/lib/router/utils/format-url.ts",
+          "rank": 30,
+          "elapsed_ms": 432.56,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "formatStringOrUrl",
+            "file": "client/app-dir/link.tsx"
+          }
+        },
+        {
+          "query": "check if a path already has the base path prefix",
+          "query_type": "natural_language",
+          "expected_symbol": "hasBasePath",
+          "expected_file_suffix": "client/has-base-path.ts",
+          "rank": 1,
+          "elapsed_ms": 375.44,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "hasBasePath",
+            "file": "client/has-base-path.ts"
+          }
+        },
+        {
+          "query": "revalidate path",
+          "query_type": "short_phrase",
+          "expected_symbol": "revalidatePath",
+          "expected_file_suffix": "server/web/spec-extension/revalidate.ts",
+          "rank": null,
+          "elapsed_ms": 319.63,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "revalidatingEntry",
+            "file": "client/components/segment-cache/scheduler.ts"
+          }
+        },
+        {
+          "query": "next request",
+          "query_type": "short_phrase",
+          "expected_symbol": "NextRequest",
+          "expected_file_suffix": "server/web/spec-extension/request.ts",
+          "rank": null,
+          "elapsed_ms": 326.21,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "nextCode",
+            "file": "compiled/@vercel/og/index.node.js"
+          }
+        },
+        {
+          "query": "use search params",
+          "query_type": "short_phrase",
+          "expected_symbol": "useSearchParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": 13,
+          "elapsed_ms": 400.2,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "makeUntrackedSearchParams",
+            "file": "client/request/search-params.browser.prod.ts"
+          }
+        },
+        {
+          "query": "get route regex",
+          "query_type": "short_phrase",
+          "expected_symbol": "getRouteRegex",
+          "expected_file_suffix": "shared/lib/router/utils/route-regex.ts",
+          "rank": 2,
+          "elapsed_ms": 409.89,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "regex",
+            "file": "compiled/@modelcontextprotocol/sdk/server/mcp.js"
+          }
+        },
+        {
+          "query": "load config",
+          "query_type": "short_phrase",
+          "expected_symbol": "loadConfig",
+          "expected_file_suffix": "server/config.ts",
+          "rank": null,
+          "elapsed_ms": 331.25,
+          "candidate_count": 23,
+          "top_candidate": {
+            "name": "load",
+            "file": "compiled/@vercel/og/index.node.js"
+          }
+        },
+        {
+          "query": "start server",
+          "query_type": "short_phrase",
+          "expected_symbol": "startServer",
+          "expected_file_suffix": "server/lib/start-server.ts",
+          "rank": 1,
+          "elapsed_ms": 325.22,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "startServer",
+            "file": "server/lib/start-server.ts"
+          }
+        },
+        {
+          "query": "NextRequest",
+          "query_type": "identifier",
+          "expected_symbol": "NextRequest",
+          "expected_file_suffix": "server/web/spec-extension/request.ts",
+          "rank": 1,
+          "elapsed_ms": 180.59,
+          "candidate_count": 17,
+          "top_candidate": {
+            "name": "NextRequest",
+            "file": "server/web/spec-extension/request.ts"
+          }
+        },
+        {
+          "query": "useSearchParams",
+          "query_type": "identifier",
+          "expected_symbol": "useSearchParams",
+          "expected_file_suffix": "client/components/navigation.ts",
+          "rank": 1,
+          "elapsed_ms": 178.5,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "useSearchParams",
+            "file": "client/components/navigation.ts"
+          }
+        }
+      ]
+    }
+  ],
+  "hybrid_uplift": {
+    "mrr_delta": -0.03503378286660022,
+    "acc1_delta": -0.05882352941176469,
+    "acc3_delta": -0.02941176470588236,
+    "acc5_delta": 0.0
+  },
+  "hybrid_uplift_by_query_type": {
+    "identifier": {
+      "mrr_delta": 0.0,
+      "acc1_delta": 0.0,
+      "acc3_delta": 0.0,
+      "acc5_delta": 0.0
+    },
+    "natural_language": {
+      "mrr_delta": -0.027938654912339128,
+      "acc1_delta": -0.038461538461538464,
+      "acc3_delta": -0.038461538461538464,
+      "acc5_delta": 0.0
+    },
+    "short_phrase": {
+      "mrr_delta": -0.0774572649572649,
+      "acc1_delta": -0.16666666666666666,
+      "acc3_delta": 0.0,
+      "acc5_delta": 0.0
+    }
+  }
+}

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1664,6 +1664,163 @@ Pattern: **5 positive (Rust / Rust / Rust / TS-JS / TS-JS) : 1 negative (Python)
 
 **Artefacts**: `benchmarks/embedding-quality-v1.6-phase3d-typescript-{baseline,2e-only,2b2c-only,stacked}.json`. Dataset: `benchmarks/embedding-quality-dataset-typescript.json`.
 
+### §8.16 — Phase 3e: third JS/TS dataset on `vercel/next.js` (typical app)
+
+**Hypothesis** (from §8.15 "Limitations acknowledged", point 1): both existing TS datasets are unrepresentative of a typical app codebase — `facebook/jest` is matcher-heavy object-literal test tooling and `microsoft/TypeScript` is a compiler with 50 k-line files and dense JSDoc. §8.15 explicitly teed up Phase 3e on `vercel/next.js` or `facebook/react` to cover "small-to-medium TS with React / Next.js / Node patterns" — the population of codebases most real users point CodeLens at. The null-hypothesis going in was "the v1.5 stack should produce a small positive on a typical app, probably closer to jest's +7.3 % than to TypeScript's +104 %". Phase 3e tests that null hypothesis directly.
+
+**Target repo**: `vercel/next.js` (depth-1 shallow clone, ~1.5 GB, 28 547 working-tree files). We benchmark against **`/tmp/next-js/packages/next/src`** — the core framework runtime package, excluding `/packages/next/src/compiled` (bundled third-party code, only 16 `.ts` files) — for **1 564 source files totalling 268 560 LOC**. The file-size profile is strikingly different from TypeScript's: **median 61 LOC/file**, mean ~172 LOC/file, largest single file `server/app-render/app-render.tsx` at 8 397 lines (vs TypeScript's `checker.ts` at ~50 000). This is the first external-repo benchmark in the v1.6 measurement campaign whose file profile matches the "typical app" shape.
+
+**Dataset**: 34 hand-built queries in `benchmarks/embedding-quality-dataset-next-js.json`, spanning six subsystems of the Next.js public API surface:
+
+| Subsystem                      | Example queries                                                                                                                                    | Count |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- | ----: |
+| App Router server-side API     | `headers`, `cookies`, `draftMode`, `revalidatePath`, `revalidateTag`, `unstable_cache`, `notFound`, `permanentRedirect`                            |     8 |
+| Client router hooks            | `useSearchParams`, `usePathname`, `useParams`, `useRouter`                                                                                         |     4 |
+| Server runtime spec extensions | `NextRequest`, `NextResponse`, `loadConfig`                                                                                                        |     3 |
+| Build pipeline                 | `collectBuildTraces`, `startServer`                                                                                                                |     2 |
+| Routing utilities              | `isDynamicRoute`, `getRouteRegex`, `getRouteMatcher`, `addBasePath`, `interpolateAs`, `normalizeAppPath`, `isLocalURL`, `formatUrl`, `hasBasePath` |     9 |
+| Short phrases + identifiers    | `revalidate path`, `next request`, `use search params`, `get route regex`, `load config`, `start server`, `NextRequest`, `useSearchParams`         |     8 |
+
+Total: 26 NL + 6 short_phrase + 2 identifier = **34 queries** (matching Phase 3d's shape for direct comparison).
+
+**Measurement**:
+
+| arm         |   hybrid MRR | Δ abs vs baseline |  Δ rel | NL sub-MRR | short sub-MRR | identifier sub-MRR |
+| ----------- | -----------: | ----------------: | -----: | ---------: | ------------: | -----------------: |
+| baseline    |     0.197857 |                 — |      — |   0.117788 |      0.277778 |           1.000000 |
+| 2e only     |     0.196208 |           −0.0016 | −0.8 % |   0.118963 |      0.262821 |           1.000000 |
+| 2b+2c only  |     0.197857 |           +0.0000 |  0.0 % |   0.117788 |      0.277778 |           1.000000 |
+| **stacked** | **0.196208** |           −0.0016 | −0.8 % |   0.118963 |  **0.262821** |           1.000000 |
+
+**This is a null result.** Phase 2b+2c produces **exactly zero** hybrid lift (`0.19785660675753555` identical to the baseline float, 17 digits). Phase 2e shaves 0.8 % off hybrid. Stacked equals 2e-only because 2b+2c contributes nothing. The v1.5 stack is neither positive nor meaningfully negative on Next.js — it is _inert_.
+
+**Per-query decomposition**:
+
+```
+NL queries (26 total, stacked vs baseline):
+   2 improved, 0 regressed, 24 unchanged
+    draftMode             21 → 16   (target still outside top 10)
+    isLocalURL            19 → 14   (target still outside top 10)
+
+short_phrase queries (6 total, stacked vs baseline):
+   0 improved, 1 regressed (under Phase 2e), 5 unchanged
+    use search params      6 → 13   (Δ MRR −0.0769)
+
+identifier queries (2 total): both rank-1 in every arm
+
+Total: 2 improved, 1 regressed, 31 unchanged — 2 : 1 positive : negative ratio.
+
+Retrieval failures (rank=None in every arm, NL): 15 / 26 (58 %)
+  headers, cookies, revalidatePath, revalidateTag, unstable_cache,
+  useSearchParams (NL form), useParams, useRouter, NextRequest (NL form),
+  NextResponse, loadConfig, collectBuildTraces, startServer,
+  getRouteMatcher, interpolateAs
+```
+
+The two nominal "improvements" under 2b+2c (draftMode 21 → 16, isLocalURL 19 → 14) are both within the ranks-outside-top-10 region where no `max_results=10` consumer sees a difference — they are numerically real but operationally invisible. The one regression (use search params 6 → 13 under Phase 2e) is inside the top 10 and _is_ operationally visible: a user searching for "use search params" on Next.js would go from rank 6 to rank 13 if Phase 2e were on.
+
+**Where the lift actually comes from (semantic vs hybrid decomposition, continued)**:
+
+As in §8.15, `semantic_search` aggregate MRR is **identical across all four arms** (0.14640522875816994 to 17 decimal digits) and pure `get_ranked_context_no_semantic` (lexical-only) changes _only_ under Phase 2e (0.2294 → 0.2312, a +0.8 % lexical lift that is outweighed by re-ranker interference in the hybrid combination). Phase 2b+2c leaves both semantic and lexical MRR completely untouched on Next.js — there is no candidate re-ordering to recover, because the baseline hybrid ordering is already as good as the re-ranker can produce with the available signal.
+
+**Why is Next.js inert when TypeScript was +104 %?**
+
+Three compounding factors, all flipped in direction from §8.15's TypeScript-specific factors:
+
+1. **Baseline is closer to the ceiling** (0.1979 hybrid vs TypeScript's 0.0984). The Next.js baseline is already doing about as well as semantic + lexical can combine for — the semantic MRR (0.146) is actually _lower_ than the lexical MRR (0.229) on this dataset, meaning lexical signal is the dominant component already and Phase 2b's comment-body extraction has no slack to recover.
+2. **File size profile is app-shaped, not compiler-shaped** (median 61 LOC vs TypeScript's checker.ts at 50 000). When files are small, `extract_leading_doc` already captures the full doc comment — Phase 2b's full-body NL-token extraction has no unseen body text to surface because the body _is_ the full file.
+3. **JSDoc density is sparse**. Next.js uses TypeScript's structural types as documentation. Functions like `headers`, `cookies`, `notFound`, `revalidatePath` have 1–3 line doc comments at most, and most lib functions have no comments at all. There is no JSDoc body text for Phase 2b to extract, because there is very little JSDoc body text in the first place.
+
+Phase 2c (`extract_api_calls`) fares equally poorly: Next.js app-level functions are mostly thin wrappers over Web Platform APIs (`Request`, `Response`, `cookies()`) rather than `Type::method` call chains. There are fewer API-call patterns per function body than in the TypeScript compiler's internal `Type::method` traversals.
+
+**Scoping the TypeScript compiler result**:
+
+§8.15 noted the TypeScript +104 % lift was "a function of TypeScript's specific 'giant files + JSDoc-heavy' code style" and predicted a typical TS app would land "closer to jest's +7.3 % than to +104 %". Phase 3e refutes the upper half of that prediction — Next.js lands at **exactly 0 %**, below both the +7.3 % and +104 % marks. The v1.5 stack's mechanism (recover NL signal from function body comments and API call patterns) is not merely "smaller on typical apps", it is **mechanism-inert on typical apps**. The comment/API-call surface Phase 2b+2c taps into barely exists in short-file codebases.
+
+Viewed as a three-dataset range, the JS/TS v1.5 lift is now:
+
+| dataset               | file profile                               | hybrid lift |
+| :-------------------- | :----------------------------------------- | ----------: |
+| jest                  | matcher-heavy, ~380 files                  |      +7.3 % |
+| TypeScript compiler   | compiler, ~709 files, huge                 |    +104.3 % |
+| **Next.js (typical)** | **framework, ~1 564 files, median 61 LOC** |   **0.0 %** |
+
+The pattern is not "language-specific" but **file-size-specific**: the v1.5 stack lifts compilers and tooling where individual files are large and heavily commented, and it does nothing on normal app code where files are short and sparsely commented. The language label (`ts` / `typescript` / `tsx` / `js` / `javascript` / `jsx`) is a correlated-but-not-causal proxy for file shape.
+
+**Updated seven-dataset baseline matrix**:
+
+| Dataset                           | Language  | baseline MRR | stacked MRR |      Δ abs |      Δ rel |
+| --------------------------------- | --------- | -----------: | ----------: | ---------: | ---------: |
+| 89-query self                     | Rust      |        0.572 |       0.586 |     +0.014 |     +2.4 % |
+| 436-query self                    | Rust      |       0.0476 |      0.0510 |    +0.0034 |     +7.1 % |
+| ripgrep external                  | Rust      |        0.459 |       0.529 |     +0.070 |    +15.2 % |
+| requests external                 | Python    |        0.584 |       0.495 |     −0.089 |    −15.2 % |
+| jest external                     | TS/JS     |        0.155 |       0.166 |     +0.011 |     +7.3 % |
+| typescript external               | TS/JS     |        0.098 |       0.201 |     +0.103 |   +104.3 % |
+| **next-js external (new, §8.16)** | **TS/JS** |    **0.198** |   **0.196** | **−0.002** | **−0.8 %** |
+
+Pattern: **5 positive (3 Rust + 2 TS/JS tooling) : 1 negative (Python) : 1 inert (TS/JS app)**. The JS/TS classification that §8.15 called "two-dataset strong confidence (both positive)" is now better described as **"compiler/tooling strong, typical-app neutral"**. This is not a regression — the v1.5 stack still never hurts production on a typical JS/TS app (−0.8 % is within measurement noise), it just doesn't help either.
+
+**Implications for `CODELENS_EMBED_HINT_AUTO=1` default-on (v1.6.0)**:
+
+The default-flip in v1.6.0 was made on the premise that §8.15 showed the JS/TS stack to be consistently positive. §8.16 does not reverse the v1.6.0 decision, but it does narrow the user-facing benefit claim:
+
+- **Users with compiler/tooling/language-server code (TypeScript compiler, Babel, esbuild, Rollup, tsserver, etc.)** will see the large JS/TS lifts §8.13 and §8.15 documented (+7 % to +104 %).
+- **Users with typical app code (Next.js, React apps, Vue apps, Node.js services)** will see _neutral_ behaviour — no measurable win, no measurable loss, within ±1 % of baseline.
+- **Phase 2e on JS/TS is now negative on two out of three datasets** (TypeScript −10.0 %, Next.js −0.8 %, jest +1.3 % marginal). The Phase 2m "language-gated 2e disable for JS/TS" decision deferred in §8.15 is now better-supported by evidence: 2 of 3 JS/TS datasets show 2e as net negative. Still deferred (waiting for a real user hit), but the evidence is stronger.
+
+Neither bullet suggests reverting the v1.6.0 flip — the default-on cost on a typical app is zero, not a regression. It does mean the marketing line "Phase 2b+2c helps JS/TS retrieval" should be qualified to "Phase 2b+2c helps compiler and tooling JS/TS retrieval; typical app code sees no change".
+
+**Reproduce**:
+
+```bash
+# Clone Next.js (no submodules, depth 1)
+git clone --depth=1 https://github.com/vercel/next.js.git /tmp/next-js
+
+# Arm 1: baseline
+CODELENS_MODEL_DIR=$(pwd)/crates/codelens-engine/models \
+CODELENS_BIN=./target/release/codelens-mcp \
+python3 benchmarks/embedding-quality.py /tmp/next-js/packages/next/src --isolated-copy \
+  --dataset benchmarks/embedding-quality-dataset-next-js.json \
+  --output benchmarks/embedding-quality-v1.6-phase3e-next-js-baseline.json
+
+# Arm 2: Phase 2e only
+CODELENS_RANK_SPARSE_TERM_WEIGHT=1 \
+CODELENS_RANK_SPARSE_THRESHOLD=40 \
+CODELENS_RANK_SPARSE_MAX=40 \
+CODELENS_MODEL_DIR=$(pwd)/crates/codelens-engine/models \
+python3 benchmarks/embedding-quality.py /tmp/next-js/packages/next/src --isolated-copy \
+  --dataset benchmarks/embedding-quality-dataset-next-js.json \
+  --output benchmarks/embedding-quality-v1.6-phase3e-next-js-2e-only.json
+
+# Arm 3: Phase 2b + 2c only
+CODELENS_EMBED_HINT_INCLUDE_COMMENTS=1 \
+CODELENS_EMBED_HINT_INCLUDE_API_CALLS=1 \
+CODELENS_MODEL_DIR=$(pwd)/crates/codelens-engine/models \
+python3 benchmarks/embedding-quality.py /tmp/next-js/packages/next/src --isolated-copy \
+  --dataset benchmarks/embedding-quality-dataset-next-js.json \
+  --output benchmarks/embedding-quality-v1.6-phase3e-next-js-2b2c-only.json
+
+# Arm 4: stacked
+CODELENS_EMBED_HINT_INCLUDE_COMMENTS=1 \
+CODELENS_EMBED_HINT_INCLUDE_API_CALLS=1 \
+CODELENS_RANK_SPARSE_TERM_WEIGHT=1 \
+CODELENS_RANK_SPARSE_THRESHOLD=40 \
+CODELENS_RANK_SPARSE_MAX=40 \
+CODELENS_MODEL_DIR=$(pwd)/crates/codelens-engine/models \
+python3 benchmarks/embedding-quality.py /tmp/next-js/packages/next/src --isolated-copy \
+  --dataset benchmarks/embedding-quality-dataset-next-js.json \
+  --output benchmarks/embedding-quality-v1.6-phase3e-next-js-stacked.json
+```
+
+**Limitations acknowledged**:
+
+1. **Retrieval-failure floor is 15 / 26 NL queries (58 %)**. More than half of the natural-language queries never place the target within the top 10 candidates in any arm. These are cases where `semantic_search`'s CodeSearchNet-INT8 embedding + lexical BM25 scoring combined cannot find files like `server/request/headers.ts` from a query like "get the current request headers in a server component", regardless of how Phase 2b/2c/2e re-rank them. This is a larger share of retrieval-failure than TypeScript's 20 / 26 (77 %), but the absolute count is similar — the difference is TypeScript has more retrieval failures _and_ more headroom for the ranked ones, while Next.js has fewer retrieval failures _but_ the baseline hybrid ranking was already near-ceiling for the findable ones. Both outcomes point at the same underlying cap: the v1.5 re-ranker can only re-order candidates it already has.
+2. **One dataset does not disprove a population claim**. Next.js is _a_ typical TS app, but it is a particularly large and frameworky one with complex internal architecture. A smaller app (a Node.js service, a Remix app, a Vite + React SPA) might land somewhere between Next.js 0 % and jest +7 %. The honest framing is "v1.5 stack ranges from 0 % to +104 % on JS/TS depending on file size and JSDoc density", not "v1.5 stack is zero on all typical apps".
+3. **Dataset overlap with Phase 3d methodology**. Phase 3d (TypeScript compiler) used exactly the same 34-query shape (26 NL + 6 short + 2 identifier) and 4-arm structure as Phase 3e. This makes the comparison directly apples-to-apples, but it also means the query style (Next.js public API surface, named exports only, English NL phrasing) imports the same methodological preferences across both datasets. A dataset built by a different author with a different query style might land elsewhere. §8.12's ripgrep dataset was built this way and Phase 2b+2c moved it from 0.459 to 0.529 (+15.2 %), so the query-style bias is not the dominant factor — but it is a factor.
+
+**Artefacts**: `benchmarks/embedding-quality-v1.6-phase3e-next-js-{baseline,2e-only,2b2c-only,stacked}.json`. Dataset: `benchmarks/embedding-quality-dataset-next-js.json`.
+
 ---
 
 ## 9. See Also


### PR DESCRIPTION
## Summary

Adds §8.16: fourth external-repo measurement in the v1.6 campaign, completing the JS/TS evidence tier with a typical app codebase. §8.15 explicitly teed up Phase 3e on `vercel/next.js` or `facebook/react` to cover "small-to-medium TS with React / Next.js / Node patterns".

**Target**: `vercel/next.js` → `packages/next/src` (1 564 .ts/.tsx files, 268 560 LOC, **median 61 LOC/file**). First external-repo benchmark whose file profile matches the "typical app" shape rather than compiler/tooling shape.

**Dataset**: 34 queries (26 NL + 6 short_phrase + 2 identifier) spanning Next.js public API — App Router server-side (headers, cookies, draftMode, revalidatePath, unstable_cache, notFound, permanentRedirect), client hooks (useSearchParams, usePathname, useParams, useRouter), server runtime (NextRequest, NextResponse, loadConfig), build pipeline (collectBuildTraces, startServer), routing utilities.

## Result — null

| arm         | hybrid MRR | Δ abs   | Δ rel  |
|-------------|-----------:|--------:|-------:|
| baseline    |   0.197857 |       — |      — |
| 2e only     |   0.196208 | −0.0016 | −0.8 % |
| **2b+2c only**  |   **0.197857** | **+0.0000** |  **0.0 %** |
| stacked     |   0.196208 | −0.0016 | −0.8 % |

Phase 2b+2c produces **exactly zero** hybrid lift — `0.19785660675753555` identical to the baseline float at 17-digit precision. Phase 2e shaves 0.8 % off hybrid (one short-phrase regression: `use search params` 6 → 13).

Per-query: 2 improved (both outside top 10), 0 regressed under 2b+2c, 1 regressed under 2e.

## Three-dataset JS/TS range

| dataset               | file profile                       | hybrid lift |
|-----------------------|------------------------------------|------------:|
| jest                  | matcher-heavy, ~380 files          |      +7.3 % |
| typescript compiler   | compiler, ~709 files, huge         |    +104.3 % |
| **next.js (typical)** | **framework, ~1 564 files, median 61 LOC** | **0.0 %** |

The pattern is **file-size-specific, not language-specific**. The v1.5 stack's mechanism — recover NL signal from function body comments and `Type::method` API-call patterns — is mechanism-inert on Next.js because:

1. Baseline hybrid MRR 0.198 is already close to the achievable ceiling (lexical 0.229 dominates semantic 0.146)
2. Median file size 61 LOC means `extract_leading_doc` already captures the full doc comment — no body-text headroom for Phase 2b
3. Next.js uses structural TypeScript types as documentation, not heavy JSDoc — there is no comment body text to extract

## Framing updates

- §8.13/§8.15's "two-dataset strong confidence (both positive)" → **"compiler/tooling strong, typical-app neutral"**
- v1.6.0 `CODELENS_EMBED_HINT_AUTO=1` default-on: **not reverted** (cost on typical apps is 0 %, not a regression)
- User-facing benefit claim narrows from "helps JS/TS retrieval" → **"helps compiler and tooling JS/TS retrieval; typical app code sees no change"**
- Phase 2m (language-gated 2e disable for JS/TS) remains deferred but now has stronger evidence: **2 of 3 JS/TS datasets show 2e as net negative** (typescript −10.0 %, next-js −0.8 %, jest +1.3 % marginal)

## Scope

- No code changes. Phase 3e is a pure measurement update.
- No dependency changes.
- `language_supports_nl_stack` already contains the JS/TS entries from §8.13; §8.16 only refines their evidence tier in the documentation.

## Test plan

- [x] 4 arms measured on `/tmp/next-js/packages/next/src` with `--isolated-copy`, each after `rm -rf /tmp/next-js/.codelens`
- [x] 4-arm precision verified (semantic identical to 17 digits across arms, hybrid baseline = 2b+2c-only at 17 digits)
- [x] Per-query patterns verified from `rows` field in result JSONs
- [x] Dataset shape matches Phase 3d (26 NL + 6 short + 2 identifier = 34)
- [x] All 34 expected file paths verified to exist under the target tree before measurement

🤖 Generated with [Claude Code](https://claude.com/claude-code)