### PR TITLE
feat(engine): Phase 2m sparse-gate language split + Phase 3f react-core (§8.17)

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -126,6 +126,18 @@ python3 benchmarks/embedding-quality.py . \
   - `microsoft/typescript` 34-query TS/JS dataset (Phase 3d, landed)
   - 4-arm A/B 측정 완료 — 전체 결과와 해석은 `docs/benchmarks.md` §8.15 참조
   - arm별 결과 파일: `benchmarks/embedding-quality-v1.6-phase3d-typescript-{baseline,2e-only,2b2c-only,stacked}.json`
+- `benchmarks/embedding-quality-dataset-next-js.json`
+  - `vercel/next.js` 34-query TS/JS typical-app dataset (Phase 3e, landed)
+  - 4-arm A/B 측정 완료 — 전체 결과와 해석은 `docs/benchmarks.md` §8.16 참조
+  - arm별 결과 파일: `benchmarks/embedding-quality-v1.6-phase3e-next-js-{baseline,2e-only,2b2c-only,stacked}.json`
+- `benchmarks/embedding-quality-dataset-react-core.json`
+  - `facebook/react` production subtree 34-query JS runtime dataset (Phase 3f, landed)
+  - 4-arm A/B 측정 완료 — 전체 결과와 해석은 `docs/benchmarks.md` §8.17 참조
+  - arm별 결과 파일: `benchmarks/embedding-quality-v1.6-phase3f-react-core-{baseline,2e-only,2b2c-only,stacked}.json`
+- `benchmarks/embedding-quality-dataset-django.json`
+  - `django/django` 34-query Python framework dataset (Phase 3g, landed)
+  - 4-arm A/B 측정 완료 — 전체 결과와 해석은 `docs/benchmarks.md` §8.18 참조
+  - arm별 결과 파일: `benchmarks/embedding-quality-v1.6-phase3g-django-{baseline,2e-only,2b2c-only,stacked}.json`
 
 리포트는 전체 평균 외에 질의 유형별 MRR / Acc@k와 hybrid uplift도 같이 보여준다.
 

--- a/benchmarks/embedding-quality-dataset-react-core.json
+++ b/benchmarks/embedding-quality-dataset-react-core.json
@@ -1,0 +1,206 @@
+[
+  {
+    "query": "create a context object with a default value",
+    "expected_symbol": "createContext",
+    "expected_file_suffix": "ReactContext.js",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "pass a ref through a function component",
+    "expected_symbol": "forwardRef",
+    "expected_file_suffix": "ReactForwardRef.js",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "store local state in a function component",
+    "expected_symbol": "useState",
+    "expected_file_suffix": "ReactHooks.js",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "manage state with a reducer in a function component",
+    "expected_symbol": "useReducer",
+    "expected_file_suffix": "ReactHooks.js",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "hold a mutable ref object that persists across renders",
+    "expected_symbol": "useRef",
+    "expected_file_suffix": "ReactHooks.js",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "run a side effect after rendering",
+    "expected_symbol": "useEffect",
+    "expected_file_suffix": "ReactHooks.js",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "run an effect synchronously after DOM mutations",
+    "expected_symbol": "useLayoutEffect",
+    "expected_file_suffix": "ReactHooks.js",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "memoize a callback function between renders",
+    "expected_symbol": "useCallback",
+    "expected_file_suffix": "ReactHooks.js",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "memoize an expensive computed value",
+    "expected_symbol": "useMemo",
+    "expected_file_suffix": "ReactHooks.js",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "customize the instance value exposed by a ref",
+    "expected_symbol": "useImperativeHandle",
+    "expected_file_suffix": "ReactHooks.js",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "label a custom hook in React DevTools",
+    "expected_symbol": "useDebugValue",
+    "expected_file_suffix": "ReactHooks.js",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "mark an update as a transition and get pending state",
+    "expected_symbol": "useTransition",
+    "expected_file_suffix": "ReactHooks.js",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "defer updating a value to avoid blocking rendering",
+    "expected_symbol": "useDeferredValue",
+    "expected_file_suffix": "ReactHooks.js",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "generate a stable unique id for accessibility attributes",
+    "expected_symbol": "useId",
+    "expected_file_suffix": "ReactHooks.js",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "subscribe to an external store with a snapshot getter",
+    "expected_symbol": "useSyncExternalStore",
+    "expected_file_suffix": "ReactHooks.js",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "create an event callback that reads the latest props and state",
+    "expected_symbol": "useEffectEvent",
+    "expected_file_suffix": "ReactHooks.js",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "optimistically update UI state while an async action runs",
+    "expected_symbol": "useOptimistic",
+    "expected_file_suffix": "ReactHooks.js",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "track the result and pending state of a form action",
+    "expected_symbol": "useActionState",
+    "expected_file_suffix": "ReactHooks.js",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "create a ref object for class components or elements",
+    "expected_symbol": "createRef",
+    "expected_file_suffix": "ReactCreateRef.js",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "skip re-rendering a component when props are unchanged",
+    "expected_symbol": "memo",
+    "expected_file_suffix": "ReactMemo.js",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "load a component lazily with dynamic import",
+    "expected_symbol": "lazy",
+    "expected_file_suffix": "ReactLazy.js",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "schedule a state update as non-urgent work",
+    "expected_symbol": "startTransition",
+    "expected_file_suffix": "ReactStartTransition.js",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "flush updates in a React test",
+    "expected_symbol": "act",
+    "expected_file_suffix": "ReactAct.js",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "create a React element without JSX",
+    "expected_symbol": "createElement",
+    "expected_file_suffix": "jsx/ReactJSXElement.js",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "clone an existing React element with new props",
+    "expected_symbol": "cloneElement",
+    "expected_file_suffix": "jsx/ReactJSXElement.js",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "check whether a value is a valid React element",
+    "expected_symbol": "isValidElement",
+    "expected_file_suffix": "jsx/ReactJSXElement.js",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "state hook",
+    "expected_symbol": "useState",
+    "expected_file_suffix": "ReactHooks.js",
+    "query_type": "short_phrase"
+  },
+  {
+    "query": "effect hook",
+    "expected_symbol": "useEffect",
+    "expected_file_suffix": "ReactHooks.js",
+    "query_type": "short_phrase"
+  },
+  {
+    "query": "memoized callback",
+    "expected_symbol": "useCallback",
+    "expected_file_suffix": "ReactHooks.js",
+    "query_type": "short_phrase"
+  },
+  {
+    "query": "deferred value",
+    "expected_symbol": "useDeferredValue",
+    "expected_file_suffix": "ReactHooks.js",
+    "query_type": "short_phrase"
+  },
+  {
+    "query": "lazy component",
+    "expected_symbol": "lazy",
+    "expected_file_suffix": "ReactLazy.js",
+    "query_type": "short_phrase"
+  },
+  {
+    "query": "transition update",
+    "expected_symbol": "startTransition",
+    "expected_file_suffix": "ReactStartTransition.js",
+    "query_type": "short_phrase"
+  },
+  {
+    "query": "useState",
+    "expected_symbol": "useState",
+    "expected_file_suffix": "ReactHooks.js",
+    "query_type": "identifier"
+  },
+  {
+    "query": "createElement",
+    "expected_symbol": "createElement",
+    "expected_file_suffix": "jsx/ReactJSXElement.js",
+    "query_type": "identifier"
+  }
+]

--- a/benchmarks/embedding-quality-v1.6-phase3f-react-core-2b2c-only.json
+++ b/benchmarks/embedding-quality-v1.6-phase3f-react-core-2b2c-only.json
@@ -1,0 +1,1472 @@
+{
+  "project": "/tmp/react-core-bench",
+  "benchmark_project": "/var/folders/z0/0tcbss795xsdp75jmr_t9_kh0000gn/T/codelens-embed-quality-1cbyy9c7/react-core-bench",
+  "isolated_copy": true,
+  "binary": "/Users/bagjaeseog/codelens-mcp-plugin/target/release/codelens-mcp",
+  "embedding_model": "MiniLM-L12-CodeSearchNet-INT8",
+  "runtime_model": {
+    "model_dir": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch",
+    "model_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/model.onnx",
+    "config_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/config.json",
+    "sha256": "ef1d1e9cfa72e4929f5b9faea17d8704b23a2530aadebf0d464a4cc7750920b3",
+    "size_bytes": 34000281,
+    "num_hidden_layers": 12,
+    "hidden_size": 384
+  },
+  "dataset_path": "/Users/bagjaeseog/codelens-mcp-plugin/benchmarks/embedding-quality-dataset-react-core.json",
+  "dataset_size": 34,
+  "ranking_cutoff": 10,
+  "metric_labels": {
+    "mrr": "MRR@10",
+    "acc1": "Acc@1",
+    "acc3": "Acc@3",
+    "acc5": "Acc@5"
+  },
+  "methods": [
+    {
+      "method": "semantic_search",
+      "mrr": 0.12254901960784315,
+      "acc1": 0.11764705882352941,
+      "acc3": 0.11764705882352941,
+      "acc5": 0.11764705882352941,
+      "avg_elapsed_ms": 137.86970588235295,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 0.5,
+          "acc1": 0.5,
+          "acc3": 0.5,
+          "acc5": 0.5,
+          "avg_elapsed_ms": 121.55
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.12179487179487179,
+          "acc1": 0.11538461538461539,
+          "acc3": 0.11538461538461539,
+          "acc5": 0.11538461538461539,
+          "avg_elapsed_ms": 141.42538461538462
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.0,
+          "acc1": 0.0,
+          "acc3": 0.0,
+          "acc5": 0.0,
+          "avg_elapsed_ms": 127.90166666666666
+        }
+      },
+      "rows": [
+        {
+          "query": "create a context object with a default value",
+          "query_type": "natural_language",
+          "expected_symbol": "createContext",
+          "expected_file_suffix": "ReactContext.js",
+          "rank": null,
+          "elapsed_ms": 148.26,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "noopCacheSignal",
+            "file": "ReactCacheClient.js"
+          }
+        },
+        {
+          "query": "pass a ref through a function component",
+          "query_type": "natural_language",
+          "expected_symbol": "forwardRef",
+          "expected_file_suffix": "ReactForwardRef.js",
+          "rank": null,
+          "elapsed_ms": 145.77,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "ref",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "store local state in a function component",
+          "query_type": "natural_language",
+          "expected_symbol": "useState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 128.01,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "defineKeyPropWarningGetter",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "manage state with a reducer in a function component",
+          "query_type": "natural_language",
+          "expected_symbol": "useReducer",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 131.81,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "if",
+            "file": "ReactAct.js"
+          }
+        },
+        {
+          "query": "hold a mutable ref object that persists across renders",
+          "query_type": "natural_language",
+          "expected_symbol": "useRef",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 140.19,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "refObject",
+            "file": "ReactCreateRef.js"
+          }
+        },
+        {
+          "query": "run a side effect after rendering",
+          "query_type": "natural_language",
+          "expected_symbol": "useEffect",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 145.5,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getElementKey",
+            "file": "ReactChildren.js"
+          }
+        },
+        {
+          "query": "run an effect synchronously after DOM mutations",
+          "query_type": "natural_language",
+          "expected_symbol": "useLayoutEffect",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 143.95,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "thenable",
+            "file": "ReactAct.js"
+          }
+        },
+        {
+          "query": "memoize a callback function between renders",
+          "query_type": "natural_language",
+          "expected_symbol": "useCallback",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 128.03,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "jsxProd",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "memoize an expensive computed value",
+          "query_type": "natural_language",
+          "expected_symbol": "useMemo",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 126.85,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getElementKey",
+            "file": "ReactChildren.js"
+          }
+        },
+        {
+          "query": "customize the instance value exposed by a ref",
+          "query_type": "natural_language",
+          "expected_symbol": "useImperativeHandle",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 140.49,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "noopCacheSignal",
+            "file": "ReactCacheClient.js"
+          }
+        },
+        {
+          "query": "label a custom hook in React DevTools",
+          "query_type": "natural_language",
+          "expected_symbol": "useDebugValue",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 139.62,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "noopCacheSignal",
+            "file": "ReactCacheClient.js"
+          }
+        },
+        {
+          "query": "mark an update as a transition and get pending state",
+          "query_type": "natural_language",
+          "expected_symbol": "useTransition",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 137.18,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "PureComponent",
+            "file": "ReactBaseClasses.js"
+          }
+        },
+        {
+          "query": "defer updating a value to avoid blocking rendering",
+          "query_type": "natural_language",
+          "expected_symbol": "useDeferredValue",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 135.62,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "noopCacheSignal",
+            "file": "ReactCacheClient.js"
+          }
+        },
+        {
+          "query": "generate a stable unique id for accessibility attributes",
+          "query_type": "natural_language",
+          "expected_symbol": "useId",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 139.99,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "noopCacheSignal",
+            "file": "ReactCacheClient.js"
+          }
+        },
+        {
+          "query": "subscribe to an external store with a snapshot getter",
+          "query_type": "natural_language",
+          "expected_symbol": "useSyncExternalStore",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 125.19,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "addTransitionType",
+            "file": "ReactTransitionType.js"
+          }
+        },
+        {
+          "query": "create an event callback that reads the latest props and state",
+          "query_type": "natural_language",
+          "expected_symbol": "useEffectEvent",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 137.45,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getElementKey",
+            "file": "ReactChildren.js"
+          }
+        },
+        {
+          "query": "optimistically update UI state while an async action runs",
+          "query_type": "natural_language",
+          "expected_symbol": "useOptimistic",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 135.88,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getElementKey",
+            "file": "ReactChildren.js"
+          }
+        },
+        {
+          "query": "track the result and pending state of a form action",
+          "query_type": "natural_language",
+          "expected_symbol": "useActionState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 128.93,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "noopCacheSignal",
+            "file": "ReactCacheClient.js"
+          }
+        },
+        {
+          "query": "create a ref object for class components or elements",
+          "query_type": "natural_language",
+          "expected_symbol": "createRef",
+          "expected_file_suffix": "ReactCreateRef.js",
+          "rank": 6,
+          "elapsed_ms": 152.86,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "ref",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "skip re-rendering a component when props are unchanged",
+          "query_type": "natural_language",
+          "expected_symbol": "memo",
+          "expected_file_suffix": "ReactMemo.js",
+          "rank": null,
+          "elapsed_ms": 206.68,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "releaseAsyncTransition",
+            "file": "ReactStartTransition.js"
+          }
+        },
+        {
+          "query": "load a component lazily with dynamic import",
+          "query_type": "natural_language",
+          "expected_symbol": "lazy",
+          "expected_file_suffix": "ReactLazy.js",
+          "rank": null,
+          "elapsed_ms": 141.63,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "noopCacheSignal",
+            "file": "ReactCacheClient.js"
+          }
+        },
+        {
+          "query": "schedule a state update as non-urgent work",
+          "query_type": "natural_language",
+          "expected_symbol": "startTransition",
+          "expected_file_suffix": "ReactStartTransition.js",
+          "rank": null,
+          "elapsed_ms": 162.46,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "noopCacheSignal",
+            "file": "ReactCacheClient.js"
+          }
+        },
+        {
+          "query": "flush updates in a React test",
+          "query_type": "natural_language",
+          "expected_symbol": "act",
+          "expected_file_suffix": "ReactAct.js",
+          "rank": null,
+          "elapsed_ms": 134.58,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "noopCacheSignal",
+            "file": "ReactCacheClient.js"
+          }
+        },
+        {
+          "query": "create a React element without JSX",
+          "query_type": "natural_language",
+          "expected_symbol": "createElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 1,
+          "elapsed_ms": 141.12,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "createElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "clone an existing React element with new props",
+          "query_type": "natural_language",
+          "expected_symbol": "cloneElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 1,
+          "elapsed_ms": 136.47,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "cloneElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "check whether a value is a valid React element",
+          "query_type": "natural_language",
+          "expected_symbol": "isValidElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 1,
+          "elapsed_ms": 142.54,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "isValidElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "state hook",
+          "query_type": "short_phrase",
+          "expected_symbol": "useState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 127.17,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "dispatcher",
+            "file": "ReactHooks.js"
+          }
+        },
+        {
+          "query": "effect hook",
+          "query_type": "short_phrase",
+          "expected_symbol": "useEffect",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 124.52,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "dispatcher",
+            "file": "ReactHooks.js"
+          }
+        },
+        {
+          "query": "memoized callback",
+          "query_type": "short_phrase",
+          "expected_symbol": "useCallback",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 127.41,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "if",
+            "file": "ReactForwardRef.js"
+          }
+        },
+        {
+          "query": "deferred value",
+          "query_type": "short_phrase",
+          "expected_symbol": "useDeferredValue",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 127.07,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "fulfilledValue",
+            "file": "ReactChildren.js"
+          }
+        },
+        {
+          "query": "lazy component",
+          "query_type": "short_phrase",
+          "expected_symbol": "lazy",
+          "expected_file_suffix": "ReactLazy.js",
+          "rank": null,
+          "elapsed_ms": 127.51,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "warningKey",
+            "file": "ReactNoopUpdateQueue.js"
+          }
+        },
+        {
+          "query": "transition update",
+          "query_type": "short_phrase",
+          "expected_symbol": "startTransition",
+          "expected_file_suffix": "ReactStartTransition.js",
+          "rank": null,
+          "elapsed_ms": 133.73,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "transition",
+            "file": "ReactTransitionType.js"
+          }
+        },
+        {
+          "query": "useState",
+          "query_type": "identifier",
+          "expected_symbol": "useState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 121.33,
+          "candidate_count": 4,
+          "top_candidate": {
+            "name": "previousStackTraceLimit",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "createElement",
+          "query_type": "identifier",
+          "expected_symbol": "createElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 1,
+          "elapsed_ms": 121.77,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "createElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context_no_semantic",
+      "mrr": 0.08431372549019608,
+      "acc1": 0.058823529411764705,
+      "acc3": 0.08823529411764706,
+      "acc5": 0.11764705882352941,
+      "avg_elapsed_ms": 15.67,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 0.5,
+          "acc1": 0.5,
+          "acc3": 0.5,
+          "acc5": 0.5,
+          "avg_elapsed_ms": 19.259999999999998
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.07179487179487179,
+          "acc1": 0.038461538461538464,
+          "acc3": 0.07692307692307693,
+          "acc5": 0.11538461538461539,
+          "avg_elapsed_ms": 14.623076923076923
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.0,
+          "acc1": 0.0,
+          "acc3": 0.0,
+          "acc5": 0.0,
+          "avg_elapsed_ms": 19.01
+        }
+      },
+      "rows": [
+        {
+          "query": "create a context object with a default value",
+          "query_type": "natural_language",
+          "expected_symbol": "createContext",
+          "expected_file_suffix": "ReactContext.js",
+          "rank": null,
+          "elapsed_ms": 15.48,
+          "candidate_count": 16,
+          "top_candidate": {
+            "name": "elementRefGetterWithDeprecationWarning",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "pass a ref through a function component",
+          "query_type": "natural_language",
+          "expected_symbol": "forwardRef",
+          "expected_file_suffix": "ReactForwardRef.js",
+          "rank": null,
+          "elapsed_ms": 14.69,
+          "candidate_count": 19,
+          "top_candidate": {
+            "name": "hasValidRef",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "store local state in a function component",
+          "query_type": "natural_language",
+          "expected_symbol": "useState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 13.64,
+          "candidate_count": 8,
+          "top_candidate": {
+            "name": "componentName",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "manage state with a reducer in a function component",
+          "query_type": "natural_language",
+          "expected_symbol": "useReducer",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 13.28,
+          "candidate_count": 11,
+          "top_candidate": {
+            "name": "elementRefGetterWithDeprecationWarning",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "hold a mutable ref object that persists across renders",
+          "query_type": "natural_language",
+          "expected_symbol": "useRef",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 14.01,
+          "candidate_count": 16,
+          "top_candidate": {
+            "name": "ref",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "run a side effect after rendering",
+          "query_type": "natural_language",
+          "expected_symbol": "useEffect",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 13.63,
+          "candidate_count": 5,
+          "top_candidate": {
+            "name": "jsxProdSignatureRunningInDevWithStaticChildren",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "run an effect synchronously after DOM mutations",
+          "query_type": "natural_language",
+          "expected_symbol": "useLayoutEffect",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 14.68,
+          "candidate_count": 5,
+          "top_candidate": {
+            "name": "jsxProdSignatureRunningInDevWithStaticChildren",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "memoize a callback function between renders",
+          "query_type": "natural_language",
+          "expected_symbol": "useCallback",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 13.65,
+          "candidate_count": 0,
+          "top_candidate": null
+        },
+        {
+          "query": "memoize an expensive computed value",
+          "query_type": "natural_language",
+          "expected_symbol": "useMemo",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 13.41,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "fulfilledValue",
+            "file": "ReactChildren.js"
+          }
+        },
+        {
+          "query": "customize the instance value exposed by a ref",
+          "query_type": "natural_language",
+          "expected_symbol": "useImperativeHandle",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 16.32,
+          "candidate_count": 15,
+          "top_candidate": {
+            "name": "ref",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "label a custom hook in React DevTools",
+          "query_type": "natural_language",
+          "expected_symbol": "useDebugValue",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 15.77,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "ReactElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "mark an update as a transition and get pending state",
+          "query_type": "natural_language",
+          "expected_symbol": "useTransition",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 14.68,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "releaseAsyncTransition",
+            "file": "ReactStartTransition.js"
+          }
+        },
+        {
+          "query": "defer updating a value to avoid blocking rendering",
+          "query_type": "natural_language",
+          "expected_symbol": "useDeferredValue",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 14.98,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "fulfilledValue",
+            "file": "ReactChildren.js"
+          }
+        },
+        {
+          "query": "generate a stable unique id for accessibility attributes",
+          "query_type": "natural_language",
+          "expected_symbol": "useId",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 14.18,
+          "candidate_count": 4,
+          "top_candidate": {
+            "name": "beforeExample",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "subscribe to an external store with a snapshot getter",
+          "query_type": "natural_language",
+          "expected_symbol": "useSyncExternalStore",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 14.83,
+          "candidate_count": 6,
+          "top_candidate": {
+            "name": "elementRefGetterWithDeprecationWarning",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "create an event callback that reads the latest props and state",
+          "query_type": "natural_language",
+          "expected_symbol": "useEffectEvent",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 13.87,
+          "candidate_count": 15,
+          "top_candidate": {
+            "name": "cloneAndReplaceKey",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "optimistically update UI state while an async action runs",
+          "query_type": "natural_language",
+          "expected_symbol": "useOptimistic",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 13.12,
+          "candidate_count": 11,
+          "top_candidate": {
+            "name": "releaseAsyncTransition",
+            "file": "ReactStartTransition.js"
+          }
+        },
+        {
+          "query": "track the result and pending state of a form action",
+          "query_type": "natural_language",
+          "expected_symbol": "useActionState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 13.54,
+          "candidate_count": 12,
+          "top_candidate": {
+            "name": "trackActualOwner",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "create a ref object for class components or elements",
+          "query_type": "natural_language",
+          "expected_symbol": "createRef",
+          "expected_file_suffix": "ReactCreateRef.js",
+          "rank": 5,
+          "elapsed_ms": 14.16,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "createElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "skip re-rendering a component when props are unchanged",
+          "query_type": "natural_language",
+          "expected_symbol": "memo",
+          "expected_file_suffix": "ReactMemo.js",
+          "rank": null,
+          "elapsed_ms": 15.4,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "jsxProdSignatureRunningInDevWithDynamicChildren",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "load a component lazily with dynamic import",
+          "query_type": "natural_language",
+          "expected_symbol": "lazy",
+          "expected_file_suffix": "ReactLazy.js",
+          "rank": null,
+          "elapsed_ms": 14.8,
+          "candidate_count": 14,
+          "top_candidate": {
+            "name": "jsxProdSignatureRunningInDevWithDynamicChildren",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "schedule a state update as non-urgent work",
+          "query_type": "natural_language",
+          "expected_symbol": "startTransition",
+          "expected_file_suffix": "ReactStartTransition.js",
+          "rank": null,
+          "elapsed_ms": 14.64,
+          "candidate_count": 15,
+          "top_candidate": {
+            "name": "updatedFibersCount",
+            "file": "ReactStartTransition.js"
+          }
+        },
+        {
+          "query": "flush updates in a React test",
+          "query_type": "natural_language",
+          "expected_symbol": "act",
+          "expected_file_suffix": "ReactAct.js",
+          "rank": null,
+          "elapsed_ms": 14.59,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "ReactElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "create a React element without JSX",
+          "query_type": "natural_language",
+          "expected_symbol": "createElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 2,
+          "elapsed_ms": 16.54,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "ReactElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "clone an existing React element with new props",
+          "query_type": "natural_language",
+          "expected_symbol": "cloneElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 6,
+          "elapsed_ms": 14.36,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "cloneAndReplaceKey",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "check whether a value is a valid React element",
+          "query_type": "natural_language",
+          "expected_symbol": "isValidElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 1,
+          "elapsed_ms": 17.95,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "isValidElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "state hook",
+          "query_type": "short_phrase",
+          "expected_symbol": "useState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 12.76,
+          "candidate_count": 3,
+          "top_candidate": {
+            "name": "didWarnStateUpdateForUnmountedComponent",
+            "file": "ReactNoopUpdateQueue.js"
+          }
+        },
+        {
+          "query": "effect hook",
+          "query_type": "short_phrase",
+          "expected_symbol": "useEffect",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 26.7,
+          "candidate_count": 2,
+          "top_candidate": {
+            "name": "dispatcher",
+            "file": "ReactHooks.js"
+          }
+        },
+        {
+          "query": "memoized callback",
+          "query_type": "short_phrase",
+          "expected_symbol": "useCallback",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 12.38,
+          "candidate_count": 0,
+          "top_candidate": null
+        },
+        {
+          "query": "deferred value",
+          "query_type": "short_phrase",
+          "expected_symbol": "useDeferredValue",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 12.46,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "fulfilledValue",
+            "file": "ReactChildren.js"
+          }
+        },
+        {
+          "query": "lazy component",
+          "query_type": "short_phrase",
+          "expected_symbol": "lazy",
+          "expected_file_suffix": "ReactLazy.js",
+          "rank": null,
+          "elapsed_ms": 23.56,
+          "candidate_count": 19,
+          "top_candidate": {
+            "name": "isLazyType",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "transition update",
+          "query_type": "short_phrase",
+          "expected_symbol": "startTransition",
+          "expected_file_suffix": "ReactStartTransition.js",
+          "rank": null,
+          "elapsed_ms": 26.2,
+          "candidate_count": 17,
+          "top_candidate": {
+            "name": "releaseAsyncTransition",
+            "file": "ReactStartTransition.js"
+          }
+        },
+        {
+          "query": "useState",
+          "query_type": "identifier",
+          "expected_symbol": "useState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 14.46,
+          "candidate_count": 0,
+          "top_candidate": null
+        },
+        {
+          "query": "createElement",
+          "query_type": "identifier",
+          "expected_symbol": "createElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 1,
+          "elapsed_ms": 24.06,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "createElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context",
+      "mrr": 0.12254901960784315,
+      "acc1": 0.11764705882352941,
+      "acc3": 0.11764705882352941,
+      "acc5": 0.11764705882352941,
+      "avg_elapsed_ms": 123.27352941176471,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 0.5,
+          "acc1": 0.5,
+          "acc3": 0.5,
+          "acc5": 0.5,
+          "avg_elapsed_ms": 12.445
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.12179487179487179,
+          "acc1": 0.11538461538461539,
+          "acc3": 0.11538461538461539,
+          "acc5": 0.11538461538461539,
+          "avg_elapsed_ms": 132.28884615384615
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.0,
+          "acc1": 0.0,
+          "acc3": 0.0,
+          "acc5": 0.0,
+          "avg_elapsed_ms": 121.14999999999999
+        }
+      },
+      "rows": [
+        {
+          "query": "create a context object with a default value",
+          "query_type": "natural_language",
+          "expected_symbol": "createContext",
+          "expected_file_suffix": "ReactContext.js",
+          "rank": null,
+          "elapsed_ms": 137.7,
+          "candidate_count": 16,
+          "top_candidate": {
+            "name": "defaultProps",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "pass a ref through a function component",
+          "query_type": "natural_language",
+          "expected_symbol": "forwardRef",
+          "expected_file_suffix": "ReactForwardRef.js",
+          "rank": null,
+          "elapsed_ms": 136.12,
+          "candidate_count": 19,
+          "top_candidate": {
+            "name": "ref",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "store local state in a function component",
+          "query_type": "natural_language",
+          "expected_symbol": "useState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 128.59,
+          "candidate_count": 9,
+          "top_candidate": {
+            "name": "didAwaitActCall",
+            "file": "ReactAct.js"
+          }
+        },
+        {
+          "query": "manage state with a reducer in a function component",
+          "query_type": "natural_language",
+          "expected_symbol": "useReducer",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 132.39,
+          "candidate_count": 11,
+          "top_candidate": {
+            "name": "elementRefGetterWithDeprecationWarning",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "hold a mutable ref object that persists across renders",
+          "query_type": "natural_language",
+          "expected_symbol": "useRef",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 131.45,
+          "candidate_count": 16,
+          "top_candidate": {
+            "name": "refObject",
+            "file": "ReactCreateRef.js"
+          }
+        },
+        {
+          "query": "run a side effect after rendering",
+          "query_type": "natural_language",
+          "expected_symbol": "useEffect",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 130.39,
+          "candidate_count": 6,
+          "top_candidate": {
+            "name": "if",
+            "file": "ReactForwardRef.js"
+          }
+        },
+        {
+          "query": "run an effect synchronously after DOM mutations",
+          "query_type": "natural_language",
+          "expected_symbol": "useLayoutEffect",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 131.56,
+          "candidate_count": 5,
+          "top_candidate": {
+            "name": "jsxProdSignatureRunningInDevWithStaticChildren",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "memoize a callback function between renders",
+          "query_type": "natural_language",
+          "expected_symbol": "useCallback",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 128.04,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "if",
+            "file": "ReactForwardRef.js"
+          }
+        },
+        {
+          "query": "memoize an expensive computed value",
+          "query_type": "natural_language",
+          "expected_symbol": "useMemo",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 123.47,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "fulfilledValue",
+            "file": "ReactChildren.js"
+          }
+        },
+        {
+          "query": "customize the instance value exposed by a ref",
+          "query_type": "natural_language",
+          "expected_symbol": "useImperativeHandle",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 126.18,
+          "candidate_count": 15,
+          "top_candidate": {
+            "name": "ref",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "label a custom hook in React DevTools",
+          "query_type": "natural_language",
+          "expected_symbol": "useDebugValue",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 133.26,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "if",
+            "file": "ReactAct.js"
+          }
+        },
+        {
+          "query": "mark an update as a transition and get pending state",
+          "query_type": "natural_language",
+          "expected_symbol": "useTransition",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 133.42,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "transition",
+            "file": "ReactTransitionType.js"
+          }
+        },
+        {
+          "query": "defer updating a value to avoid blocking rendering",
+          "query_type": "natural_language",
+          "expected_symbol": "useDeferredValue",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 132.72,
+          "candidate_count": 3,
+          "top_candidate": {
+            "name": "ReactNoopUpdateQueue",
+            "file": "ReactNoopUpdateQueue.js"
+          }
+        },
+        {
+          "query": "generate a stable unique id for accessibility attributes",
+          "query_type": "natural_language",
+          "expected_symbol": "useId",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 128.62,
+          "candidate_count": 4,
+          "top_candidate": {
+            "name": "beforeExample",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "subscribe to an external store with a snapshot getter",
+          "query_type": "natural_language",
+          "expected_symbol": "useSyncExternalStore",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 125.73,
+          "candidate_count": 6,
+          "top_candidate": {
+            "name": "elementRefGetterWithDeprecationWarning",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "create an event callback that reads the latest props and state",
+          "query_type": "natural_language",
+          "expected_symbol": "useEffectEvent",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 128.62,
+          "candidate_count": 15,
+          "top_candidate": {
+            "name": "thenable",
+            "file": "ReactAct.js"
+          }
+        },
+        {
+          "query": "optimistically update UI state while an async action runs",
+          "query_type": "natural_language",
+          "expected_symbol": "useOptimistic",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 127.85,
+          "candidate_count": 13,
+          "top_candidate": {
+            "name": "didWarnStateUpdateForUnmountedComponent",
+            "file": "ReactNoopUpdateQueue.js"
+          }
+        },
+        {
+          "query": "track the result and pending state of a form action",
+          "query_type": "natural_language",
+          "expected_symbol": "useActionState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 132.19,
+          "candidate_count": 13,
+          "top_candidate": {
+            "name": "trackActualOwner",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "create a ref object for class components or elements",
+          "query_type": "natural_language",
+          "expected_symbol": "createRef",
+          "expected_file_suffix": "ReactCreateRef.js",
+          "rank": 6,
+          "elapsed_ms": 127.73,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "ref",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "skip re-rendering a component when props are unchanged",
+          "query_type": "natural_language",
+          "expected_symbol": "memo",
+          "expected_file_suffix": "ReactMemo.js",
+          "rank": null,
+          "elapsed_ms": 131.36,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "if",
+            "file": "ReactAct.js"
+          }
+        },
+        {
+          "query": "load a component lazily with dynamic import",
+          "query_type": "natural_language",
+          "expected_symbol": "lazy",
+          "expected_file_suffix": "ReactLazy.js",
+          "rank": null,
+          "elapsed_ms": 172.53,
+          "candidate_count": 14,
+          "top_candidate": {
+            "name": "jsxProdSignatureRunningInDevWithDynamicChildren",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "schedule a state update as non-urgent work",
+          "query_type": "natural_language",
+          "expected_symbol": "startTransition",
+          "expected_file_suffix": "ReactStartTransition.js",
+          "rank": null,
+          "elapsed_ms": 156.15,
+          "candidate_count": 15,
+          "top_candidate": {
+            "name": "ReactNoopUpdateQueue",
+            "file": "ReactNoopUpdateQueue.js"
+          }
+        },
+        {
+          "query": "flush updates in a React test",
+          "query_type": "natural_language",
+          "expected_symbol": "act",
+          "expected_file_suffix": "ReactAct.js",
+          "rank": null,
+          "elapsed_ms": 133.97,
+          "candidate_count": 33,
+          "top_candidate": {
+            "name": "ReactNoopUpdateQueue",
+            "file": "ReactNoopUpdateQueue.js"
+          }
+        },
+        {
+          "query": "create a React element without JSX",
+          "query_type": "natural_language",
+          "expected_symbol": "createElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 1,
+          "elapsed_ms": 126.45,
+          "candidate_count": 33,
+          "top_candidate": {
+            "name": "createElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "clone an existing React element with new props",
+          "query_type": "natural_language",
+          "expected_symbol": "cloneElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 1,
+          "elapsed_ms": 118.14,
+          "candidate_count": 33,
+          "top_candidate": {
+            "name": "cloneElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "check whether a value is a valid React element",
+          "query_type": "natural_language",
+          "expected_symbol": "isValidElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 1,
+          "elapsed_ms": 124.88,
+          "candidate_count": 33,
+          "top_candidate": {
+            "name": "isValidElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "state hook",
+          "query_type": "short_phrase",
+          "expected_symbol": "useState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 118.55,
+          "candidate_count": 3,
+          "top_candidate": {
+            "name": "didWarnStateUpdateForUnmountedComponent",
+            "file": "ReactNoopUpdateQueue.js"
+          }
+        },
+        {
+          "query": "effect hook",
+          "query_type": "short_phrase",
+          "expected_symbol": "useEffect",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 119.12,
+          "candidate_count": 2,
+          "top_candidate": {
+            "name": "dispatcher",
+            "file": "ReactHooks.js"
+          }
+        },
+        {
+          "query": "memoized callback",
+          "query_type": "short_phrase",
+          "expected_symbol": "useCallback",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 120.35,
+          "candidate_count": 0,
+          "top_candidate": null
+        },
+        {
+          "query": "deferred value",
+          "query_type": "short_phrase",
+          "expected_symbol": "useDeferredValue",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 117.28,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "fulfilledValue",
+            "file": "ReactChildren.js"
+          }
+        },
+        {
+          "query": "lazy component",
+          "query_type": "short_phrase",
+          "expected_symbol": "lazy",
+          "expected_file_suffix": "ReactLazy.js",
+          "rank": null,
+          "elapsed_ms": 125.84,
+          "candidate_count": 19,
+          "top_candidate": {
+            "name": "isLazyType",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "transition update",
+          "query_type": "short_phrase",
+          "expected_symbol": "startTransition",
+          "expected_file_suffix": "ReactStartTransition.js",
+          "rank": null,
+          "elapsed_ms": 125.76,
+          "candidate_count": 17,
+          "top_candidate": {
+            "name": "transition",
+            "file": "ReactTransitionType.js"
+          }
+        },
+        {
+          "query": "useState",
+          "query_type": "identifier",
+          "expected_symbol": "useState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 12.93,
+          "candidate_count": 0,
+          "top_candidate": null
+        },
+        {
+          "query": "createElement",
+          "query_type": "identifier",
+          "expected_symbol": "createElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 1,
+          "elapsed_ms": 11.96,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "createElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        }
+      ]
+    }
+  ],
+  "hybrid_uplift": {
+    "mrr_delta": 0.03823529411764706,
+    "acc1_delta": 0.058823529411764705,
+    "acc3_delta": 0.029411764705882346,
+    "acc5_delta": 0.0
+  },
+  "hybrid_uplift_by_query_type": {
+    "identifier": {
+      "mrr_delta": 0.0,
+      "acc1_delta": 0.0,
+      "acc3_delta": 0.0,
+      "acc5_delta": 0.0
+    },
+    "natural_language": {
+      "mrr_delta": 0.05,
+      "acc1_delta": 0.07692307692307693,
+      "acc3_delta": 0.038461538461538464,
+      "acc5_delta": 0.0
+    },
+    "short_phrase": {
+      "mrr_delta": 0.0,
+      "acc1_delta": 0.0,
+      "acc3_delta": 0.0,
+      "acc5_delta": 0.0
+    }
+  }
+}

--- a/benchmarks/embedding-quality-v1.6-phase3f-react-core-2e-only.json
+++ b/benchmarks/embedding-quality-v1.6-phase3f-react-core-2e-only.json
@@ -1,0 +1,1472 @@
+{
+  "project": "/tmp/react-core-bench",
+  "benchmark_project": "/var/folders/z0/0tcbss795xsdp75jmr_t9_kh0000gn/T/codelens-embed-quality-xmxzf2rt/react-core-bench",
+  "isolated_copy": true,
+  "binary": "/Users/bagjaeseog/codelens-mcp-plugin/target/release/codelens-mcp",
+  "embedding_model": "MiniLM-L12-CodeSearchNet-INT8",
+  "runtime_model": {
+    "model_dir": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch",
+    "model_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/model.onnx",
+    "config_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/config.json",
+    "sha256": "ef1d1e9cfa72e4929f5b9faea17d8704b23a2530aadebf0d464a4cc7750920b3",
+    "size_bytes": 34000281,
+    "num_hidden_layers": 12,
+    "hidden_size": 384
+  },
+  "dataset_path": "/Users/bagjaeseog/codelens-mcp-plugin/benchmarks/embedding-quality-dataset-react-core.json",
+  "dataset_size": 34,
+  "ranking_cutoff": 10,
+  "metric_labels": {
+    "mrr": "MRR@10",
+    "acc1": "Acc@1",
+    "acc3": "Acc@3",
+    "acc5": "Acc@5"
+  },
+  "methods": [
+    {
+      "method": "semantic_search",
+      "mrr": 0.12254901960784315,
+      "acc1": 0.11764705882352941,
+      "acc3": 0.11764705882352941,
+      "acc5": 0.11764705882352941,
+      "avg_elapsed_ms": 136.31558823529411,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 0.5,
+          "acc1": 0.5,
+          "acc3": 0.5,
+          "acc5": 0.5,
+          "avg_elapsed_ms": 122.16499999999999
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.12179487179487179,
+          "acc1": 0.11538461538461539,
+          "acc3": 0.11538461538461539,
+          "acc5": 0.11538461538461539,
+          "avg_elapsed_ms": 139.9053846153846
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.0,
+          "acc1": 0.0,
+          "acc3": 0.0,
+          "acc5": 0.0,
+          "avg_elapsed_ms": 125.47666666666667
+        }
+      },
+      "rows": [
+        {
+          "query": "create a context object with a default value",
+          "query_type": "natural_language",
+          "expected_symbol": "createContext",
+          "expected_file_suffix": "ReactContext.js",
+          "rank": null,
+          "elapsed_ms": 147.0,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "noopCacheSignal",
+            "file": "ReactCacheClient.js"
+          }
+        },
+        {
+          "query": "pass a ref through a function component",
+          "query_type": "natural_language",
+          "expected_symbol": "forwardRef",
+          "expected_file_suffix": "ReactForwardRef.js",
+          "rank": null,
+          "elapsed_ms": 139.65,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "ref",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "store local state in a function component",
+          "query_type": "natural_language",
+          "expected_symbol": "useState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 137.69,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "defineKeyPropWarningGetter",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "manage state with a reducer in a function component",
+          "query_type": "natural_language",
+          "expected_symbol": "useReducer",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 129.14,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "if",
+            "file": "ReactAct.js"
+          }
+        },
+        {
+          "query": "hold a mutable ref object that persists across renders",
+          "query_type": "natural_language",
+          "expected_symbol": "useRef",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 134.27,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "refObject",
+            "file": "ReactCreateRef.js"
+          }
+        },
+        {
+          "query": "run a side effect after rendering",
+          "query_type": "natural_language",
+          "expected_symbol": "useEffect",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 143.04,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getElementKey",
+            "file": "ReactChildren.js"
+          }
+        },
+        {
+          "query": "run an effect synchronously after DOM mutations",
+          "query_type": "natural_language",
+          "expected_symbol": "useLayoutEffect",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 146.03,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "thenable",
+            "file": "ReactAct.js"
+          }
+        },
+        {
+          "query": "memoize a callback function between renders",
+          "query_type": "natural_language",
+          "expected_symbol": "useCallback",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 151.4,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "jsxProd",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "memoize an expensive computed value",
+          "query_type": "natural_language",
+          "expected_symbol": "useMemo",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 155.99,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getElementKey",
+            "file": "ReactChildren.js"
+          }
+        },
+        {
+          "query": "customize the instance value exposed by a ref",
+          "query_type": "natural_language",
+          "expected_symbol": "useImperativeHandle",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 133.2,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "noopCacheSignal",
+            "file": "ReactCacheClient.js"
+          }
+        },
+        {
+          "query": "label a custom hook in React DevTools",
+          "query_type": "natural_language",
+          "expected_symbol": "useDebugValue",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 143.2,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "noopCacheSignal",
+            "file": "ReactCacheClient.js"
+          }
+        },
+        {
+          "query": "mark an update as a transition and get pending state",
+          "query_type": "natural_language",
+          "expected_symbol": "useTransition",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 156.87,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "PureComponent",
+            "file": "ReactBaseClasses.js"
+          }
+        },
+        {
+          "query": "defer updating a value to avoid blocking rendering",
+          "query_type": "natural_language",
+          "expected_symbol": "useDeferredValue",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 132.38,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "noopCacheSignal",
+            "file": "ReactCacheClient.js"
+          }
+        },
+        {
+          "query": "generate a stable unique id for accessibility attributes",
+          "query_type": "natural_language",
+          "expected_symbol": "useId",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 141.9,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "noopCacheSignal",
+            "file": "ReactCacheClient.js"
+          }
+        },
+        {
+          "query": "subscribe to an external store with a snapshot getter",
+          "query_type": "natural_language",
+          "expected_symbol": "useSyncExternalStore",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 131.55,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "addTransitionType",
+            "file": "ReactTransitionType.js"
+          }
+        },
+        {
+          "query": "create an event callback that reads the latest props and state",
+          "query_type": "natural_language",
+          "expected_symbol": "useEffectEvent",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 137.15,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getElementKey",
+            "file": "ReactChildren.js"
+          }
+        },
+        {
+          "query": "optimistically update UI state while an async action runs",
+          "query_type": "natural_language",
+          "expected_symbol": "useOptimistic",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 129.91,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getElementKey",
+            "file": "ReactChildren.js"
+          }
+        },
+        {
+          "query": "track the result and pending state of a form action",
+          "query_type": "natural_language",
+          "expected_symbol": "useActionState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 132.04,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "noopCacheSignal",
+            "file": "ReactCacheClient.js"
+          }
+        },
+        {
+          "query": "create a ref object for class components or elements",
+          "query_type": "natural_language",
+          "expected_symbol": "createRef",
+          "expected_file_suffix": "ReactCreateRef.js",
+          "rank": 6,
+          "elapsed_ms": 140.6,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "ref",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "skip re-rendering a component when props are unchanged",
+          "query_type": "natural_language",
+          "expected_symbol": "memo",
+          "expected_file_suffix": "ReactMemo.js",
+          "rank": null,
+          "elapsed_ms": 141.63,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "releaseAsyncTransition",
+            "file": "ReactStartTransition.js"
+          }
+        },
+        {
+          "query": "load a component lazily with dynamic import",
+          "query_type": "natural_language",
+          "expected_symbol": "lazy",
+          "expected_file_suffix": "ReactLazy.js",
+          "rank": null,
+          "elapsed_ms": 132.9,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "noopCacheSignal",
+            "file": "ReactCacheClient.js"
+          }
+        },
+        {
+          "query": "schedule a state update as non-urgent work",
+          "query_type": "natural_language",
+          "expected_symbol": "startTransition",
+          "expected_file_suffix": "ReactStartTransition.js",
+          "rank": null,
+          "elapsed_ms": 144.47,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "noopCacheSignal",
+            "file": "ReactCacheClient.js"
+          }
+        },
+        {
+          "query": "flush updates in a React test",
+          "query_type": "natural_language",
+          "expected_symbol": "act",
+          "expected_file_suffix": "ReactAct.js",
+          "rank": null,
+          "elapsed_ms": 134.29,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "noopCacheSignal",
+            "file": "ReactCacheClient.js"
+          }
+        },
+        {
+          "query": "create a React element without JSX",
+          "query_type": "natural_language",
+          "expected_symbol": "createElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 1,
+          "elapsed_ms": 139.88,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "createElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "clone an existing React element with new props",
+          "query_type": "natural_language",
+          "expected_symbol": "cloneElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 1,
+          "elapsed_ms": 137.88,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "cloneElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "check whether a value is a valid React element",
+          "query_type": "natural_language",
+          "expected_symbol": "isValidElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 1,
+          "elapsed_ms": 143.48,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "isValidElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "state hook",
+          "query_type": "short_phrase",
+          "expected_symbol": "useState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 129.31,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "dispatcher",
+            "file": "ReactHooks.js"
+          }
+        },
+        {
+          "query": "effect hook",
+          "query_type": "short_phrase",
+          "expected_symbol": "useEffect",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 122.5,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "dispatcher",
+            "file": "ReactHooks.js"
+          }
+        },
+        {
+          "query": "memoized callback",
+          "query_type": "short_phrase",
+          "expected_symbol": "useCallback",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 125.37,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "if",
+            "file": "ReactForwardRef.js"
+          }
+        },
+        {
+          "query": "deferred value",
+          "query_type": "short_phrase",
+          "expected_symbol": "useDeferredValue",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 123.98,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "fulfilledValue",
+            "file": "ReactChildren.js"
+          }
+        },
+        {
+          "query": "lazy component",
+          "query_type": "short_phrase",
+          "expected_symbol": "lazy",
+          "expected_file_suffix": "ReactLazy.js",
+          "rank": null,
+          "elapsed_ms": 126.27,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "warningKey",
+            "file": "ReactNoopUpdateQueue.js"
+          }
+        },
+        {
+          "query": "transition update",
+          "query_type": "short_phrase",
+          "expected_symbol": "startTransition",
+          "expected_file_suffix": "ReactStartTransition.js",
+          "rank": null,
+          "elapsed_ms": 125.43,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "transition",
+            "file": "ReactTransitionType.js"
+          }
+        },
+        {
+          "query": "useState",
+          "query_type": "identifier",
+          "expected_symbol": "useState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 116.75,
+          "candidate_count": 4,
+          "top_candidate": {
+            "name": "previousStackTraceLimit",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "createElement",
+          "query_type": "identifier",
+          "expected_symbol": "createElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 1,
+          "elapsed_ms": 127.58,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "createElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context_no_semantic",
+      "mrr": 0.08431372549019608,
+      "acc1": 0.058823529411764705,
+      "acc3": 0.08823529411764706,
+      "acc5": 0.11764705882352941,
+      "avg_elapsed_ms": 15.383823529411764,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 0.5,
+          "acc1": 0.5,
+          "acc3": 0.5,
+          "acc5": 0.5,
+          "avg_elapsed_ms": 11.965
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.07179487179487179,
+          "acc1": 0.038461538461538464,
+          "acc3": 0.07692307692307693,
+          "acc5": 0.11538461538461539,
+          "avg_elapsed_ms": 16.01423076923077
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.0,
+          "acc1": 0.0,
+          "acc3": 0.0,
+          "acc5": 0.0,
+          "avg_elapsed_ms": 13.791666666666666
+        }
+      },
+      "rows": [
+        {
+          "query": "create a context object with a default value",
+          "query_type": "natural_language",
+          "expected_symbol": "createContext",
+          "expected_file_suffix": "ReactContext.js",
+          "rank": null,
+          "elapsed_ms": 15.42,
+          "candidate_count": 16,
+          "top_candidate": {
+            "name": "elementRefGetterWithDeprecationWarning",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "pass a ref through a function component",
+          "query_type": "natural_language",
+          "expected_symbol": "forwardRef",
+          "expected_file_suffix": "ReactForwardRef.js",
+          "rank": null,
+          "elapsed_ms": 15.07,
+          "candidate_count": 19,
+          "top_candidate": {
+            "name": "hasValidRef",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "store local state in a function component",
+          "query_type": "natural_language",
+          "expected_symbol": "useState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 18.1,
+          "candidate_count": 8,
+          "top_candidate": {
+            "name": "componentName",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "manage state with a reducer in a function component",
+          "query_type": "natural_language",
+          "expected_symbol": "useReducer",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 14.45,
+          "candidate_count": 11,
+          "top_candidate": {
+            "name": "elementRefGetterWithDeprecationWarning",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "hold a mutable ref object that persists across renders",
+          "query_type": "natural_language",
+          "expected_symbol": "useRef",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 15.81,
+          "candidate_count": 16,
+          "top_candidate": {
+            "name": "ref",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "run a side effect after rendering",
+          "query_type": "natural_language",
+          "expected_symbol": "useEffect",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 16.02,
+          "candidate_count": 5,
+          "top_candidate": {
+            "name": "jsxProdSignatureRunningInDevWithStaticChildren",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "run an effect synchronously after DOM mutations",
+          "query_type": "natural_language",
+          "expected_symbol": "useLayoutEffect",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 17.96,
+          "candidate_count": 5,
+          "top_candidate": {
+            "name": "jsxProdSignatureRunningInDevWithStaticChildren",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "memoize a callback function between renders",
+          "query_type": "natural_language",
+          "expected_symbol": "useCallback",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 14.99,
+          "candidate_count": 0,
+          "top_candidate": null
+        },
+        {
+          "query": "memoize an expensive computed value",
+          "query_type": "natural_language",
+          "expected_symbol": "useMemo",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 14.18,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "fulfilledValue",
+            "file": "ReactChildren.js"
+          }
+        },
+        {
+          "query": "customize the instance value exposed by a ref",
+          "query_type": "natural_language",
+          "expected_symbol": "useImperativeHandle",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 20.63,
+          "candidate_count": 15,
+          "top_candidate": {
+            "name": "ref",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "label a custom hook in React DevTools",
+          "query_type": "natural_language",
+          "expected_symbol": "useDebugValue",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 17.19,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "ReactElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "mark an update as a transition and get pending state",
+          "query_type": "natural_language",
+          "expected_symbol": "useTransition",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 14.89,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "releaseAsyncTransition",
+            "file": "ReactStartTransition.js"
+          }
+        },
+        {
+          "query": "defer updating a value to avoid blocking rendering",
+          "query_type": "natural_language",
+          "expected_symbol": "useDeferredValue",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 16.47,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "fulfilledValue",
+            "file": "ReactChildren.js"
+          }
+        },
+        {
+          "query": "generate a stable unique id for accessibility attributes",
+          "query_type": "natural_language",
+          "expected_symbol": "useId",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 15.17,
+          "candidate_count": 4,
+          "top_candidate": {
+            "name": "beforeExample",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "subscribe to an external store with a snapshot getter",
+          "query_type": "natural_language",
+          "expected_symbol": "useSyncExternalStore",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 15.64,
+          "candidate_count": 6,
+          "top_candidate": {
+            "name": "elementRefGetterWithDeprecationWarning",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "create an event callback that reads the latest props and state",
+          "query_type": "natural_language",
+          "expected_symbol": "useEffectEvent",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 15.09,
+          "candidate_count": 15,
+          "top_candidate": {
+            "name": "cloneAndReplaceKey",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "optimistically update UI state while an async action runs",
+          "query_type": "natural_language",
+          "expected_symbol": "useOptimistic",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 15.58,
+          "candidate_count": 11,
+          "top_candidate": {
+            "name": "releaseAsyncTransition",
+            "file": "ReactStartTransition.js"
+          }
+        },
+        {
+          "query": "track the result and pending state of a form action",
+          "query_type": "natural_language",
+          "expected_symbol": "useActionState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 14.04,
+          "candidate_count": 12,
+          "top_candidate": {
+            "name": "trackActualOwner",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "create a ref object for class components or elements",
+          "query_type": "natural_language",
+          "expected_symbol": "createRef",
+          "expected_file_suffix": "ReactCreateRef.js",
+          "rank": 5,
+          "elapsed_ms": 14.43,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "createElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "skip re-rendering a component when props are unchanged",
+          "query_type": "natural_language",
+          "expected_symbol": "memo",
+          "expected_file_suffix": "ReactMemo.js",
+          "rank": null,
+          "elapsed_ms": 17.09,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "jsxProdSignatureRunningInDevWithDynamicChildren",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "load a component lazily with dynamic import",
+          "query_type": "natural_language",
+          "expected_symbol": "lazy",
+          "expected_file_suffix": "ReactLazy.js",
+          "rank": null,
+          "elapsed_ms": 14.35,
+          "candidate_count": 14,
+          "top_candidate": {
+            "name": "jsxProdSignatureRunningInDevWithDynamicChildren",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "schedule a state update as non-urgent work",
+          "query_type": "natural_language",
+          "expected_symbol": "startTransition",
+          "expected_file_suffix": "ReactStartTransition.js",
+          "rank": null,
+          "elapsed_ms": 16.01,
+          "candidate_count": 15,
+          "top_candidate": {
+            "name": "updatedFibersCount",
+            "file": "ReactStartTransition.js"
+          }
+        },
+        {
+          "query": "flush updates in a React test",
+          "query_type": "natural_language",
+          "expected_symbol": "act",
+          "expected_file_suffix": "ReactAct.js",
+          "rank": null,
+          "elapsed_ms": 17.96,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "ReactElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "create a React element without JSX",
+          "query_type": "natural_language",
+          "expected_symbol": "createElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 2,
+          "elapsed_ms": 15.94,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "ReactElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "clone an existing React element with new props",
+          "query_type": "natural_language",
+          "expected_symbol": "cloneElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 6,
+          "elapsed_ms": 15.34,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "cloneAndReplaceKey",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "check whether a value is a valid React element",
+          "query_type": "natural_language",
+          "expected_symbol": "isValidElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 1,
+          "elapsed_ms": 18.55,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "isValidElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "state hook",
+          "query_type": "short_phrase",
+          "expected_symbol": "useState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 15.88,
+          "candidate_count": 3,
+          "top_candidate": {
+            "name": "didWarnStateUpdateForUnmountedComponent",
+            "file": "ReactNoopUpdateQueue.js"
+          }
+        },
+        {
+          "query": "effect hook",
+          "query_type": "short_phrase",
+          "expected_symbol": "useEffect",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 13.29,
+          "candidate_count": 2,
+          "top_candidate": {
+            "name": "dispatcher",
+            "file": "ReactHooks.js"
+          }
+        },
+        {
+          "query": "memoized callback",
+          "query_type": "short_phrase",
+          "expected_symbol": "useCallback",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 11.76,
+          "candidate_count": 0,
+          "top_candidate": null
+        },
+        {
+          "query": "deferred value",
+          "query_type": "short_phrase",
+          "expected_symbol": "useDeferredValue",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 11.79,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "fulfilledValue",
+            "file": "ReactChildren.js"
+          }
+        },
+        {
+          "query": "lazy component",
+          "query_type": "short_phrase",
+          "expected_symbol": "lazy",
+          "expected_file_suffix": "ReactLazy.js",
+          "rank": null,
+          "elapsed_ms": 15.94,
+          "candidate_count": 19,
+          "top_candidate": {
+            "name": "isLazyType",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "transition update",
+          "query_type": "short_phrase",
+          "expected_symbol": "startTransition",
+          "expected_file_suffix": "ReactStartTransition.js",
+          "rank": null,
+          "elapsed_ms": 14.09,
+          "candidate_count": 17,
+          "top_candidate": {
+            "name": "releaseAsyncTransition",
+            "file": "ReactStartTransition.js"
+          }
+        },
+        {
+          "query": "useState",
+          "query_type": "identifier",
+          "expected_symbol": "useState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 12.47,
+          "candidate_count": 0,
+          "top_candidate": null
+        },
+        {
+          "query": "createElement",
+          "query_type": "identifier",
+          "expected_symbol": "createElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 1,
+          "elapsed_ms": 11.46,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "createElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context",
+      "mrr": 0.12254901960784315,
+      "acc1": 0.11764705882352941,
+      "acc3": 0.11764705882352941,
+      "acc5": 0.11764705882352941,
+      "avg_elapsed_ms": 123.72441176470589,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 0.5,
+          "acc1": 0.5,
+          "acc3": 0.5,
+          "acc5": 0.5,
+          "avg_elapsed_ms": 12.4
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.12179487179487179,
+          "acc1": 0.11538461538461539,
+          "acc3": 0.11538461538461539,
+          "acc5": 0.11538461538461539,
+          "avg_elapsed_ms": 131.24807692307692
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.0,
+          "acc1": 0.0,
+          "acc3": 0.0,
+          "acc5": 0.0,
+          "avg_elapsed_ms": 128.23
+        }
+      },
+      "rows": [
+        {
+          "query": "create a context object with a default value",
+          "query_type": "natural_language",
+          "expected_symbol": "createContext",
+          "expected_file_suffix": "ReactContext.js",
+          "rank": null,
+          "elapsed_ms": 128.01,
+          "candidate_count": 16,
+          "top_candidate": {
+            "name": "defaultProps",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "pass a ref through a function component",
+          "query_type": "natural_language",
+          "expected_symbol": "forwardRef",
+          "expected_file_suffix": "ReactForwardRef.js",
+          "rank": null,
+          "elapsed_ms": 129.28,
+          "candidate_count": 19,
+          "top_candidate": {
+            "name": "ref",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "store local state in a function component",
+          "query_type": "natural_language",
+          "expected_symbol": "useState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 127.81,
+          "candidate_count": 9,
+          "top_candidate": {
+            "name": "didAwaitActCall",
+            "file": "ReactAct.js"
+          }
+        },
+        {
+          "query": "manage state with a reducer in a function component",
+          "query_type": "natural_language",
+          "expected_symbol": "useReducer",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 123.24,
+          "candidate_count": 11,
+          "top_candidate": {
+            "name": "elementRefGetterWithDeprecationWarning",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "hold a mutable ref object that persists across renders",
+          "query_type": "natural_language",
+          "expected_symbol": "useRef",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 124.04,
+          "candidate_count": 16,
+          "top_candidate": {
+            "name": "refObject",
+            "file": "ReactCreateRef.js"
+          }
+        },
+        {
+          "query": "run a side effect after rendering",
+          "query_type": "natural_language",
+          "expected_symbol": "useEffect",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 127.75,
+          "candidate_count": 6,
+          "top_candidate": {
+            "name": "if",
+            "file": "ReactForwardRef.js"
+          }
+        },
+        {
+          "query": "run an effect synchronously after DOM mutations",
+          "query_type": "natural_language",
+          "expected_symbol": "useLayoutEffect",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 129.98,
+          "candidate_count": 5,
+          "top_candidate": {
+            "name": "jsxProdSignatureRunningInDevWithStaticChildren",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "memoize a callback function between renders",
+          "query_type": "natural_language",
+          "expected_symbol": "useCallback",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 127.06,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "if",
+            "file": "ReactForwardRef.js"
+          }
+        },
+        {
+          "query": "memoize an expensive computed value",
+          "query_type": "natural_language",
+          "expected_symbol": "useMemo",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 129.29,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "fulfilledValue",
+            "file": "ReactChildren.js"
+          }
+        },
+        {
+          "query": "customize the instance value exposed by a ref",
+          "query_type": "natural_language",
+          "expected_symbol": "useImperativeHandle",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 132.76,
+          "candidate_count": 15,
+          "top_candidate": {
+            "name": "ref",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "label a custom hook in React DevTools",
+          "query_type": "natural_language",
+          "expected_symbol": "useDebugValue",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 129.23,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "if",
+            "file": "ReactAct.js"
+          }
+        },
+        {
+          "query": "mark an update as a transition and get pending state",
+          "query_type": "natural_language",
+          "expected_symbol": "useTransition",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 130.98,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "transition",
+            "file": "ReactTransitionType.js"
+          }
+        },
+        {
+          "query": "defer updating a value to avoid blocking rendering",
+          "query_type": "natural_language",
+          "expected_symbol": "useDeferredValue",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 129.86,
+          "candidate_count": 3,
+          "top_candidate": {
+            "name": "ReactNoopUpdateQueue",
+            "file": "ReactNoopUpdateQueue.js"
+          }
+        },
+        {
+          "query": "generate a stable unique id for accessibility attributes",
+          "query_type": "natural_language",
+          "expected_symbol": "useId",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 133.67,
+          "candidate_count": 4,
+          "top_candidate": {
+            "name": "beforeExample",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "subscribe to an external store with a snapshot getter",
+          "query_type": "natural_language",
+          "expected_symbol": "useSyncExternalStore",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 124.52,
+          "candidate_count": 6,
+          "top_candidate": {
+            "name": "elementRefGetterWithDeprecationWarning",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "create an event callback that reads the latest props and state",
+          "query_type": "natural_language",
+          "expected_symbol": "useEffectEvent",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 134.28,
+          "candidate_count": 15,
+          "top_candidate": {
+            "name": "thenable",
+            "file": "ReactAct.js"
+          }
+        },
+        {
+          "query": "optimistically update UI state while an async action runs",
+          "query_type": "natural_language",
+          "expected_symbol": "useOptimistic",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 142.3,
+          "candidate_count": 13,
+          "top_candidate": {
+            "name": "didWarnStateUpdateForUnmountedComponent",
+            "file": "ReactNoopUpdateQueue.js"
+          }
+        },
+        {
+          "query": "track the result and pending state of a form action",
+          "query_type": "natural_language",
+          "expected_symbol": "useActionState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 130.7,
+          "candidate_count": 13,
+          "top_candidate": {
+            "name": "trackActualOwner",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "create a ref object for class components or elements",
+          "query_type": "natural_language",
+          "expected_symbol": "createRef",
+          "expected_file_suffix": "ReactCreateRef.js",
+          "rank": 6,
+          "elapsed_ms": 139.31,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "ref",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "skip re-rendering a component when props are unchanged",
+          "query_type": "natural_language",
+          "expected_symbol": "memo",
+          "expected_file_suffix": "ReactMemo.js",
+          "rank": null,
+          "elapsed_ms": 136.27,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "if",
+            "file": "ReactAct.js"
+          }
+        },
+        {
+          "query": "load a component lazily with dynamic import",
+          "query_type": "natural_language",
+          "expected_symbol": "lazy",
+          "expected_file_suffix": "ReactLazy.js",
+          "rank": null,
+          "elapsed_ms": 134.9,
+          "candidate_count": 14,
+          "top_candidate": {
+            "name": "jsxProdSignatureRunningInDevWithDynamicChildren",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "schedule a state update as non-urgent work",
+          "query_type": "natural_language",
+          "expected_symbol": "startTransition",
+          "expected_file_suffix": "ReactStartTransition.js",
+          "rank": null,
+          "elapsed_ms": 128.42,
+          "candidate_count": 15,
+          "top_candidate": {
+            "name": "ReactNoopUpdateQueue",
+            "file": "ReactNoopUpdateQueue.js"
+          }
+        },
+        {
+          "query": "flush updates in a React test",
+          "query_type": "natural_language",
+          "expected_symbol": "act",
+          "expected_file_suffix": "ReactAct.js",
+          "rank": null,
+          "elapsed_ms": 135.19,
+          "candidate_count": 33,
+          "top_candidate": {
+            "name": "ReactNoopUpdateQueue",
+            "file": "ReactNoopUpdateQueue.js"
+          }
+        },
+        {
+          "query": "create a React element without JSX",
+          "query_type": "natural_language",
+          "expected_symbol": "createElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 1,
+          "elapsed_ms": 137.15,
+          "candidate_count": 33,
+          "top_candidate": {
+            "name": "createElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "clone an existing React element with new props",
+          "query_type": "natural_language",
+          "expected_symbol": "cloneElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 1,
+          "elapsed_ms": 133.76,
+          "candidate_count": 33,
+          "top_candidate": {
+            "name": "cloneElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "check whether a value is a valid React element",
+          "query_type": "natural_language",
+          "expected_symbol": "isValidElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 1,
+          "elapsed_ms": 132.69,
+          "candidate_count": 33,
+          "top_candidate": {
+            "name": "isValidElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "state hook",
+          "query_type": "short_phrase",
+          "expected_symbol": "useState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 127.54,
+          "candidate_count": 3,
+          "top_candidate": {
+            "name": "didWarnStateUpdateForUnmountedComponent",
+            "file": "ReactNoopUpdateQueue.js"
+          }
+        },
+        {
+          "query": "effect hook",
+          "query_type": "short_phrase",
+          "expected_symbol": "useEffect",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 135.4,
+          "candidate_count": 2,
+          "top_candidate": {
+            "name": "dispatcher",
+            "file": "ReactHooks.js"
+          }
+        },
+        {
+          "query": "memoized callback",
+          "query_type": "short_phrase",
+          "expected_symbol": "useCallback",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 124.78,
+          "candidate_count": 0,
+          "top_candidate": null
+        },
+        {
+          "query": "deferred value",
+          "query_type": "short_phrase",
+          "expected_symbol": "useDeferredValue",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 131.16,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "fulfilledValue",
+            "file": "ReactChildren.js"
+          }
+        },
+        {
+          "query": "lazy component",
+          "query_type": "short_phrase",
+          "expected_symbol": "lazy",
+          "expected_file_suffix": "ReactLazy.js",
+          "rank": null,
+          "elapsed_ms": 125.34,
+          "candidate_count": 19,
+          "top_candidate": {
+            "name": "isLazyType",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "transition update",
+          "query_type": "short_phrase",
+          "expected_symbol": "startTransition",
+          "expected_file_suffix": "ReactStartTransition.js",
+          "rank": null,
+          "elapsed_ms": 125.16,
+          "candidate_count": 17,
+          "top_candidate": {
+            "name": "transition",
+            "file": "ReactTransitionType.js"
+          }
+        },
+        {
+          "query": "useState",
+          "query_type": "identifier",
+          "expected_symbol": "useState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 12.88,
+          "candidate_count": 0,
+          "top_candidate": null
+        },
+        {
+          "query": "createElement",
+          "query_type": "identifier",
+          "expected_symbol": "createElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 1,
+          "elapsed_ms": 11.92,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "createElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        }
+      ]
+    }
+  ],
+  "hybrid_uplift": {
+    "mrr_delta": 0.03823529411764706,
+    "acc1_delta": 0.058823529411764705,
+    "acc3_delta": 0.029411764705882346,
+    "acc5_delta": 0.0
+  },
+  "hybrid_uplift_by_query_type": {
+    "identifier": {
+      "mrr_delta": 0.0,
+      "acc1_delta": 0.0,
+      "acc3_delta": 0.0,
+      "acc5_delta": 0.0
+    },
+    "natural_language": {
+      "mrr_delta": 0.05,
+      "acc1_delta": 0.07692307692307693,
+      "acc3_delta": 0.038461538461538464,
+      "acc5_delta": 0.0
+    },
+    "short_phrase": {
+      "mrr_delta": 0.0,
+      "acc1_delta": 0.0,
+      "acc3_delta": 0.0,
+      "acc5_delta": 0.0
+    }
+  }
+}

--- a/benchmarks/embedding-quality-v1.6-phase3f-react-core-baseline.json
+++ b/benchmarks/embedding-quality-v1.6-phase3f-react-core-baseline.json
@@ -1,0 +1,1472 @@
+{
+  "project": "/tmp/react-core-bench",
+  "benchmark_project": "/var/folders/z0/0tcbss795xsdp75jmr_t9_kh0000gn/T/codelens-embed-quality-3z34z_xq/react-core-bench",
+  "isolated_copy": true,
+  "binary": "/Users/bagjaeseog/codelens-mcp-plugin/target/release/codelens-mcp",
+  "embedding_model": "MiniLM-L12-CodeSearchNet-INT8",
+  "runtime_model": {
+    "model_dir": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch",
+    "model_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/model.onnx",
+    "config_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/config.json",
+    "sha256": "ef1d1e9cfa72e4929f5b9faea17d8704b23a2530aadebf0d464a4cc7750920b3",
+    "size_bytes": 34000281,
+    "num_hidden_layers": 12,
+    "hidden_size": 384
+  },
+  "dataset_path": "/Users/bagjaeseog/codelens-mcp-plugin/benchmarks/embedding-quality-dataset-react-core.json",
+  "dataset_size": 34,
+  "ranking_cutoff": 10,
+  "metric_labels": {
+    "mrr": "MRR@10",
+    "acc1": "Acc@1",
+    "acc3": "Acc@3",
+    "acc5": "Acc@5"
+  },
+  "methods": [
+    {
+      "method": "semantic_search",
+      "mrr": 0.12254901960784315,
+      "acc1": 0.11764705882352941,
+      "acc3": 0.11764705882352941,
+      "acc5": 0.11764705882352941,
+      "avg_elapsed_ms": 128.44323529411764,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 0.5,
+          "acc1": 0.5,
+          "acc3": 0.5,
+          "acc5": 0.5,
+          "avg_elapsed_ms": 118.08500000000001
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.12179487179487179,
+          "acc1": 0.11538461538461539,
+          "acc3": 0.11538461538461539,
+          "acc5": 0.11538461538461539,
+          "avg_elapsed_ms": 130.84576923076924
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.0,
+          "acc1": 0.0,
+          "acc3": 0.0,
+          "acc5": 0.0,
+          "avg_elapsed_ms": 121.485
+        }
+      },
+      "rows": [
+        {
+          "query": "create a context object with a default value",
+          "query_type": "natural_language",
+          "expected_symbol": "createContext",
+          "expected_file_suffix": "ReactContext.js",
+          "rank": null,
+          "elapsed_ms": 137.58,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "noopCacheSignal",
+            "file": "ReactCacheClient.js"
+          }
+        },
+        {
+          "query": "pass a ref through a function component",
+          "query_type": "natural_language",
+          "expected_symbol": "forwardRef",
+          "expected_file_suffix": "ReactForwardRef.js",
+          "rank": null,
+          "elapsed_ms": 133.44,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "ref",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "store local state in a function component",
+          "query_type": "natural_language",
+          "expected_symbol": "useState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 122.83,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "defineKeyPropWarningGetter",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "manage state with a reducer in a function component",
+          "query_type": "natural_language",
+          "expected_symbol": "useReducer",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 120.3,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "if",
+            "file": "ReactAct.js"
+          }
+        },
+        {
+          "query": "hold a mutable ref object that persists across renders",
+          "query_type": "natural_language",
+          "expected_symbol": "useRef",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 127.18,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "refObject",
+            "file": "ReactCreateRef.js"
+          }
+        },
+        {
+          "query": "run a side effect after rendering",
+          "query_type": "natural_language",
+          "expected_symbol": "useEffect",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 131.42,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getElementKey",
+            "file": "ReactChildren.js"
+          }
+        },
+        {
+          "query": "run an effect synchronously after DOM mutations",
+          "query_type": "natural_language",
+          "expected_symbol": "useLayoutEffect",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 139.09,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "thenable",
+            "file": "ReactAct.js"
+          }
+        },
+        {
+          "query": "memoize a callback function between renders",
+          "query_type": "natural_language",
+          "expected_symbol": "useCallback",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 128.82,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "jsxProd",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "memoize an expensive computed value",
+          "query_type": "natural_language",
+          "expected_symbol": "useMemo",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 125.38,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getElementKey",
+            "file": "ReactChildren.js"
+          }
+        },
+        {
+          "query": "customize the instance value exposed by a ref",
+          "query_type": "natural_language",
+          "expected_symbol": "useImperativeHandle",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 135.66,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "noopCacheSignal",
+            "file": "ReactCacheClient.js"
+          }
+        },
+        {
+          "query": "label a custom hook in React DevTools",
+          "query_type": "natural_language",
+          "expected_symbol": "useDebugValue",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 130.86,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "noopCacheSignal",
+            "file": "ReactCacheClient.js"
+          }
+        },
+        {
+          "query": "mark an update as a transition and get pending state",
+          "query_type": "natural_language",
+          "expected_symbol": "useTransition",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 128.15,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "PureComponent",
+            "file": "ReactBaseClasses.js"
+          }
+        },
+        {
+          "query": "defer updating a value to avoid blocking rendering",
+          "query_type": "natural_language",
+          "expected_symbol": "useDeferredValue",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 123.38,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "noopCacheSignal",
+            "file": "ReactCacheClient.js"
+          }
+        },
+        {
+          "query": "generate a stable unique id for accessibility attributes",
+          "query_type": "natural_language",
+          "expected_symbol": "useId",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 137.3,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "noopCacheSignal",
+            "file": "ReactCacheClient.js"
+          }
+        },
+        {
+          "query": "subscribe to an external store with a snapshot getter",
+          "query_type": "natural_language",
+          "expected_symbol": "useSyncExternalStore",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 169.41,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "addTransitionType",
+            "file": "ReactTransitionType.js"
+          }
+        },
+        {
+          "query": "create an event callback that reads the latest props and state",
+          "query_type": "natural_language",
+          "expected_symbol": "useEffectEvent",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 126.23,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getElementKey",
+            "file": "ReactChildren.js"
+          }
+        },
+        {
+          "query": "optimistically update UI state while an async action runs",
+          "query_type": "natural_language",
+          "expected_symbol": "useOptimistic",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 127.36,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getElementKey",
+            "file": "ReactChildren.js"
+          }
+        },
+        {
+          "query": "track the result and pending state of a form action",
+          "query_type": "natural_language",
+          "expected_symbol": "useActionState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 121.21,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "noopCacheSignal",
+            "file": "ReactCacheClient.js"
+          }
+        },
+        {
+          "query": "create a ref object for class components or elements",
+          "query_type": "natural_language",
+          "expected_symbol": "createRef",
+          "expected_file_suffix": "ReactCreateRef.js",
+          "rank": 6,
+          "elapsed_ms": 122.93,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "ref",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "skip re-rendering a component when props are unchanged",
+          "query_type": "natural_language",
+          "expected_symbol": "memo",
+          "expected_file_suffix": "ReactMemo.js",
+          "rank": null,
+          "elapsed_ms": 126.68,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "releaseAsyncTransition",
+            "file": "ReactStartTransition.js"
+          }
+        },
+        {
+          "query": "load a component lazily with dynamic import",
+          "query_type": "natural_language",
+          "expected_symbol": "lazy",
+          "expected_file_suffix": "ReactLazy.js",
+          "rank": null,
+          "elapsed_ms": 121.68,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "noopCacheSignal",
+            "file": "ReactCacheClient.js"
+          }
+        },
+        {
+          "query": "schedule a state update as non-urgent work",
+          "query_type": "natural_language",
+          "expected_symbol": "startTransition",
+          "expected_file_suffix": "ReactStartTransition.js",
+          "rank": null,
+          "elapsed_ms": 131.64,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "noopCacheSignal",
+            "file": "ReactCacheClient.js"
+          }
+        },
+        {
+          "query": "flush updates in a React test",
+          "query_type": "natural_language",
+          "expected_symbol": "act",
+          "expected_file_suffix": "ReactAct.js",
+          "rank": null,
+          "elapsed_ms": 132.3,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "noopCacheSignal",
+            "file": "ReactCacheClient.js"
+          }
+        },
+        {
+          "query": "create a React element without JSX",
+          "query_type": "natural_language",
+          "expected_symbol": "createElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 1,
+          "elapsed_ms": 133.1,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "createElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "clone an existing React element with new props",
+          "query_type": "natural_language",
+          "expected_symbol": "cloneElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 1,
+          "elapsed_ms": 127.48,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "cloneElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "check whether a value is a valid React element",
+          "query_type": "natural_language",
+          "expected_symbol": "isValidElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 1,
+          "elapsed_ms": 140.58,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "isValidElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "state hook",
+          "query_type": "short_phrase",
+          "expected_symbol": "useState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 117.11,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "dispatcher",
+            "file": "ReactHooks.js"
+          }
+        },
+        {
+          "query": "effect hook",
+          "query_type": "short_phrase",
+          "expected_symbol": "useEffect",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 122.64,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "dispatcher",
+            "file": "ReactHooks.js"
+          }
+        },
+        {
+          "query": "memoized callback",
+          "query_type": "short_phrase",
+          "expected_symbol": "useCallback",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 122.04,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "if",
+            "file": "ReactForwardRef.js"
+          }
+        },
+        {
+          "query": "deferred value",
+          "query_type": "short_phrase",
+          "expected_symbol": "useDeferredValue",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 123.38,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "fulfilledValue",
+            "file": "ReactChildren.js"
+          }
+        },
+        {
+          "query": "lazy component",
+          "query_type": "short_phrase",
+          "expected_symbol": "lazy",
+          "expected_file_suffix": "ReactLazy.js",
+          "rank": null,
+          "elapsed_ms": 122.22,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "warningKey",
+            "file": "ReactNoopUpdateQueue.js"
+          }
+        },
+        {
+          "query": "transition update",
+          "query_type": "short_phrase",
+          "expected_symbol": "startTransition",
+          "expected_file_suffix": "ReactStartTransition.js",
+          "rank": null,
+          "elapsed_ms": 121.52,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "transition",
+            "file": "ReactTransitionType.js"
+          }
+        },
+        {
+          "query": "useState",
+          "query_type": "identifier",
+          "expected_symbol": "useState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 117.8,
+          "candidate_count": 4,
+          "top_candidate": {
+            "name": "previousStackTraceLimit",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "createElement",
+          "query_type": "identifier",
+          "expected_symbol": "createElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 1,
+          "elapsed_ms": 118.37,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "createElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context_no_semantic",
+      "mrr": 0.08431372549019608,
+      "acc1": 0.058823529411764705,
+      "acc3": 0.08823529411764706,
+      "acc5": 0.11764705882352941,
+      "avg_elapsed_ms": 14.831176470588234,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 0.5,
+          "acc1": 0.5,
+          "acc3": 0.5,
+          "acc5": 0.5,
+          "avg_elapsed_ms": 12.2
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.07179487179487179,
+          "acc1": 0.038461538461538464,
+          "acc3": 0.07692307692307693,
+          "acc5": 0.11538461538461539,
+          "avg_elapsed_ms": 15.269615384615385
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.0,
+          "acc1": 0.0,
+          "acc3": 0.0,
+          "acc5": 0.0,
+          "avg_elapsed_ms": 13.808333333333332
+        }
+      },
+      "rows": [
+        {
+          "query": "create a context object with a default value",
+          "query_type": "natural_language",
+          "expected_symbol": "createContext",
+          "expected_file_suffix": "ReactContext.js",
+          "rank": null,
+          "elapsed_ms": 17.01,
+          "candidate_count": 16,
+          "top_candidate": {
+            "name": "elementRefGetterWithDeprecationWarning",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "pass a ref through a function component",
+          "query_type": "natural_language",
+          "expected_symbol": "forwardRef",
+          "expected_file_suffix": "ReactForwardRef.js",
+          "rank": null,
+          "elapsed_ms": 17.46,
+          "candidate_count": 19,
+          "top_candidate": {
+            "name": "hasValidRef",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "store local state in a function component",
+          "query_type": "natural_language",
+          "expected_symbol": "useState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 15.35,
+          "candidate_count": 8,
+          "top_candidate": {
+            "name": "componentName",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "manage state with a reducer in a function component",
+          "query_type": "natural_language",
+          "expected_symbol": "useReducer",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 14.63,
+          "candidate_count": 11,
+          "top_candidate": {
+            "name": "elementRefGetterWithDeprecationWarning",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "hold a mutable ref object that persists across renders",
+          "query_type": "natural_language",
+          "expected_symbol": "useRef",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 17.77,
+          "candidate_count": 16,
+          "top_candidate": {
+            "name": "ref",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "run a side effect after rendering",
+          "query_type": "natural_language",
+          "expected_symbol": "useEffect",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 14.48,
+          "candidate_count": 5,
+          "top_candidate": {
+            "name": "jsxProdSignatureRunningInDevWithStaticChildren",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "run an effect synchronously after DOM mutations",
+          "query_type": "natural_language",
+          "expected_symbol": "useLayoutEffect",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 16.74,
+          "candidate_count": 5,
+          "top_candidate": {
+            "name": "jsxProdSignatureRunningInDevWithStaticChildren",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "memoize a callback function between renders",
+          "query_type": "natural_language",
+          "expected_symbol": "useCallback",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 14.37,
+          "candidate_count": 0,
+          "top_candidate": null
+        },
+        {
+          "query": "memoize an expensive computed value",
+          "query_type": "natural_language",
+          "expected_symbol": "useMemo",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 12.67,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "fulfilledValue",
+            "file": "ReactChildren.js"
+          }
+        },
+        {
+          "query": "customize the instance value exposed by a ref",
+          "query_type": "natural_language",
+          "expected_symbol": "useImperativeHandle",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 15.34,
+          "candidate_count": 15,
+          "top_candidate": {
+            "name": "ref",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "label a custom hook in React DevTools",
+          "query_type": "natural_language",
+          "expected_symbol": "useDebugValue",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 15.46,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "ReactElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "mark an update as a transition and get pending state",
+          "query_type": "natural_language",
+          "expected_symbol": "useTransition",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 14.31,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "releaseAsyncTransition",
+            "file": "ReactStartTransition.js"
+          }
+        },
+        {
+          "query": "defer updating a value to avoid blocking rendering",
+          "query_type": "natural_language",
+          "expected_symbol": "useDeferredValue",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 14.1,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "fulfilledValue",
+            "file": "ReactChildren.js"
+          }
+        },
+        {
+          "query": "generate a stable unique id for accessibility attributes",
+          "query_type": "natural_language",
+          "expected_symbol": "useId",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 15.36,
+          "candidate_count": 4,
+          "top_candidate": {
+            "name": "beforeExample",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "subscribe to an external store with a snapshot getter",
+          "query_type": "natural_language",
+          "expected_symbol": "useSyncExternalStore",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 14.87,
+          "candidate_count": 6,
+          "top_candidate": {
+            "name": "elementRefGetterWithDeprecationWarning",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "create an event callback that reads the latest props and state",
+          "query_type": "natural_language",
+          "expected_symbol": "useEffectEvent",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 13.16,
+          "candidate_count": 15,
+          "top_candidate": {
+            "name": "cloneAndReplaceKey",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "optimistically update UI state while an async action runs",
+          "query_type": "natural_language",
+          "expected_symbol": "useOptimistic",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 13.78,
+          "candidate_count": 11,
+          "top_candidate": {
+            "name": "releaseAsyncTransition",
+            "file": "ReactStartTransition.js"
+          }
+        },
+        {
+          "query": "track the result and pending state of a form action",
+          "query_type": "natural_language",
+          "expected_symbol": "useActionState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 13.12,
+          "candidate_count": 12,
+          "top_candidate": {
+            "name": "trackActualOwner",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "create a ref object for class components or elements",
+          "query_type": "natural_language",
+          "expected_symbol": "createRef",
+          "expected_file_suffix": "ReactCreateRef.js",
+          "rank": 5,
+          "elapsed_ms": 15.31,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "createElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "skip re-rendering a component when props are unchanged",
+          "query_type": "natural_language",
+          "expected_symbol": "memo",
+          "expected_file_suffix": "ReactMemo.js",
+          "rank": null,
+          "elapsed_ms": 15.18,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "jsxProdSignatureRunningInDevWithDynamicChildren",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "load a component lazily with dynamic import",
+          "query_type": "natural_language",
+          "expected_symbol": "lazy",
+          "expected_file_suffix": "ReactLazy.js",
+          "rank": null,
+          "elapsed_ms": 14.57,
+          "candidate_count": 14,
+          "top_candidate": {
+            "name": "jsxProdSignatureRunningInDevWithDynamicChildren",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "schedule a state update as non-urgent work",
+          "query_type": "natural_language",
+          "expected_symbol": "startTransition",
+          "expected_file_suffix": "ReactStartTransition.js",
+          "rank": null,
+          "elapsed_ms": 14.61,
+          "candidate_count": 15,
+          "top_candidate": {
+            "name": "updatedFibersCount",
+            "file": "ReactStartTransition.js"
+          }
+        },
+        {
+          "query": "flush updates in a React test",
+          "query_type": "natural_language",
+          "expected_symbol": "act",
+          "expected_file_suffix": "ReactAct.js",
+          "rank": null,
+          "elapsed_ms": 17.59,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "ReactElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "create a React element without JSX",
+          "query_type": "natural_language",
+          "expected_symbol": "createElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 2,
+          "elapsed_ms": 17.59,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "ReactElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "clone an existing React element with new props",
+          "query_type": "natural_language",
+          "expected_symbol": "cloneElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 6,
+          "elapsed_ms": 15.51,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "cloneAndReplaceKey",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "check whether a value is a valid React element",
+          "query_type": "natural_language",
+          "expected_symbol": "isValidElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 1,
+          "elapsed_ms": 16.67,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "isValidElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "state hook",
+          "query_type": "short_phrase",
+          "expected_symbol": "useState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 15.62,
+          "candidate_count": 3,
+          "top_candidate": {
+            "name": "didWarnStateUpdateForUnmountedComponent",
+            "file": "ReactNoopUpdateQueue.js"
+          }
+        },
+        {
+          "query": "effect hook",
+          "query_type": "short_phrase",
+          "expected_symbol": "useEffect",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 13.0,
+          "candidate_count": 2,
+          "top_candidate": {
+            "name": "dispatcher",
+            "file": "ReactHooks.js"
+          }
+        },
+        {
+          "query": "memoized callback",
+          "query_type": "short_phrase",
+          "expected_symbol": "useCallback",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 13.42,
+          "candidate_count": 0,
+          "top_candidate": null
+        },
+        {
+          "query": "deferred value",
+          "query_type": "short_phrase",
+          "expected_symbol": "useDeferredValue",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 12.25,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "fulfilledValue",
+            "file": "ReactChildren.js"
+          }
+        },
+        {
+          "query": "lazy component",
+          "query_type": "short_phrase",
+          "expected_symbol": "lazy",
+          "expected_file_suffix": "ReactLazy.js",
+          "rank": null,
+          "elapsed_ms": 15.59,
+          "candidate_count": 19,
+          "top_candidate": {
+            "name": "isLazyType",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "transition update",
+          "query_type": "short_phrase",
+          "expected_symbol": "startTransition",
+          "expected_file_suffix": "ReactStartTransition.js",
+          "rank": null,
+          "elapsed_ms": 12.97,
+          "candidate_count": 17,
+          "top_candidate": {
+            "name": "releaseAsyncTransition",
+            "file": "ReactStartTransition.js"
+          }
+        },
+        {
+          "query": "useState",
+          "query_type": "identifier",
+          "expected_symbol": "useState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 13.14,
+          "candidate_count": 0,
+          "top_candidate": null
+        },
+        {
+          "query": "createElement",
+          "query_type": "identifier",
+          "expected_symbol": "createElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 1,
+          "elapsed_ms": 11.26,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "createElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context",
+      "mrr": 0.12254901960784315,
+      "acc1": 0.11764705882352941,
+      "acc3": 0.11764705882352941,
+      "acc5": 0.11764705882352941,
+      "avg_elapsed_ms": 116.30735294117646,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 0.5,
+          "acc1": 0.5,
+          "acc3": 0.5,
+          "acc5": 0.5,
+          "avg_elapsed_ms": 18.23
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.12179487179487179,
+          "acc1": 0.11538461538461539,
+          "acc3": 0.11538461538461539,
+          "acc5": 0.11538461538461539,
+          "avg_elapsed_ms": 122.94192307692308
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.0,
+          "acc1": 0.0,
+          "acc3": 0.0,
+          "acc5": 0.0,
+          "avg_elapsed_ms": 120.25
+        }
+      },
+      "rows": [
+        {
+          "query": "create a context object with a default value",
+          "query_type": "natural_language",
+          "expected_symbol": "createContext",
+          "expected_file_suffix": "ReactContext.js",
+          "rank": null,
+          "elapsed_ms": 129.35,
+          "candidate_count": 16,
+          "top_candidate": {
+            "name": "defaultProps",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "pass a ref through a function component",
+          "query_type": "natural_language",
+          "expected_symbol": "forwardRef",
+          "expected_file_suffix": "ReactForwardRef.js",
+          "rank": null,
+          "elapsed_ms": 125.05,
+          "candidate_count": 19,
+          "top_candidate": {
+            "name": "ref",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "store local state in a function component",
+          "query_type": "natural_language",
+          "expected_symbol": "useState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 125.23,
+          "candidate_count": 9,
+          "top_candidate": {
+            "name": "didAwaitActCall",
+            "file": "ReactAct.js"
+          }
+        },
+        {
+          "query": "manage state with a reducer in a function component",
+          "query_type": "natural_language",
+          "expected_symbol": "useReducer",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 121.59,
+          "candidate_count": 11,
+          "top_candidate": {
+            "name": "elementRefGetterWithDeprecationWarning",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "hold a mutable ref object that persists across renders",
+          "query_type": "natural_language",
+          "expected_symbol": "useRef",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 122.03,
+          "candidate_count": 16,
+          "top_candidate": {
+            "name": "refObject",
+            "file": "ReactCreateRef.js"
+          }
+        },
+        {
+          "query": "run a side effect after rendering",
+          "query_type": "natural_language",
+          "expected_symbol": "useEffect",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 122.1,
+          "candidate_count": 6,
+          "top_candidate": {
+            "name": "if",
+            "file": "ReactForwardRef.js"
+          }
+        },
+        {
+          "query": "run an effect synchronously after DOM mutations",
+          "query_type": "natural_language",
+          "expected_symbol": "useLayoutEffect",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 120.45,
+          "candidate_count": 5,
+          "top_candidate": {
+            "name": "jsxProdSignatureRunningInDevWithStaticChildren",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "memoize a callback function between renders",
+          "query_type": "natural_language",
+          "expected_symbol": "useCallback",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 121.08,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "if",
+            "file": "ReactForwardRef.js"
+          }
+        },
+        {
+          "query": "memoize an expensive computed value",
+          "query_type": "natural_language",
+          "expected_symbol": "useMemo",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 119.5,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "fulfilledValue",
+            "file": "ReactChildren.js"
+          }
+        },
+        {
+          "query": "customize the instance value exposed by a ref",
+          "query_type": "natural_language",
+          "expected_symbol": "useImperativeHandle",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 124.33,
+          "candidate_count": 15,
+          "top_candidate": {
+            "name": "ref",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "label a custom hook in React DevTools",
+          "query_type": "natural_language",
+          "expected_symbol": "useDebugValue",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 121.28,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "if",
+            "file": "ReactAct.js"
+          }
+        },
+        {
+          "query": "mark an update as a transition and get pending state",
+          "query_type": "natural_language",
+          "expected_symbol": "useTransition",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 121.01,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "transition",
+            "file": "ReactTransitionType.js"
+          }
+        },
+        {
+          "query": "defer updating a value to avoid blocking rendering",
+          "query_type": "natural_language",
+          "expected_symbol": "useDeferredValue",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 121.87,
+          "candidate_count": 3,
+          "top_candidate": {
+            "name": "ReactNoopUpdateQueue",
+            "file": "ReactNoopUpdateQueue.js"
+          }
+        },
+        {
+          "query": "generate a stable unique id for accessibility attributes",
+          "query_type": "natural_language",
+          "expected_symbol": "useId",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 121.68,
+          "candidate_count": 4,
+          "top_candidate": {
+            "name": "beforeExample",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "subscribe to an external store with a snapshot getter",
+          "query_type": "natural_language",
+          "expected_symbol": "useSyncExternalStore",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 122.43,
+          "candidate_count": 6,
+          "top_candidate": {
+            "name": "elementRefGetterWithDeprecationWarning",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "create an event callback that reads the latest props and state",
+          "query_type": "natural_language",
+          "expected_symbol": "useEffectEvent",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 122.78,
+          "candidate_count": 15,
+          "top_candidate": {
+            "name": "thenable",
+            "file": "ReactAct.js"
+          }
+        },
+        {
+          "query": "optimistically update UI state while an async action runs",
+          "query_type": "natural_language",
+          "expected_symbol": "useOptimistic",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 120.66,
+          "candidate_count": 13,
+          "top_candidate": {
+            "name": "didWarnStateUpdateForUnmountedComponent",
+            "file": "ReactNoopUpdateQueue.js"
+          }
+        },
+        {
+          "query": "track the result and pending state of a form action",
+          "query_type": "natural_language",
+          "expected_symbol": "useActionState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 121.14,
+          "candidate_count": 13,
+          "top_candidate": {
+            "name": "trackActualOwner",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "create a ref object for class components or elements",
+          "query_type": "natural_language",
+          "expected_symbol": "createRef",
+          "expected_file_suffix": "ReactCreateRef.js",
+          "rank": 6,
+          "elapsed_ms": 124.25,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "ref",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "skip re-rendering a component when props are unchanged",
+          "query_type": "natural_language",
+          "expected_symbol": "memo",
+          "expected_file_suffix": "ReactMemo.js",
+          "rank": null,
+          "elapsed_ms": 125.73,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "if",
+            "file": "ReactAct.js"
+          }
+        },
+        {
+          "query": "load a component lazily with dynamic import",
+          "query_type": "natural_language",
+          "expected_symbol": "lazy",
+          "expected_file_suffix": "ReactLazy.js",
+          "rank": null,
+          "elapsed_ms": 120.88,
+          "candidate_count": 14,
+          "top_candidate": {
+            "name": "jsxProdSignatureRunningInDevWithDynamicChildren",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "schedule a state update as non-urgent work",
+          "query_type": "natural_language",
+          "expected_symbol": "startTransition",
+          "expected_file_suffix": "ReactStartTransition.js",
+          "rank": null,
+          "elapsed_ms": 121.43,
+          "candidate_count": 15,
+          "top_candidate": {
+            "name": "ReactNoopUpdateQueue",
+            "file": "ReactNoopUpdateQueue.js"
+          }
+        },
+        {
+          "query": "flush updates in a React test",
+          "query_type": "natural_language",
+          "expected_symbol": "act",
+          "expected_file_suffix": "ReactAct.js",
+          "rank": null,
+          "elapsed_ms": 124.85,
+          "candidate_count": 33,
+          "top_candidate": {
+            "name": "ReactNoopUpdateQueue",
+            "file": "ReactNoopUpdateQueue.js"
+          }
+        },
+        {
+          "query": "create a React element without JSX",
+          "query_type": "natural_language",
+          "expected_symbol": "createElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 1,
+          "elapsed_ms": 126.25,
+          "candidate_count": 33,
+          "top_candidate": {
+            "name": "createElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "clone an existing React element with new props",
+          "query_type": "natural_language",
+          "expected_symbol": "cloneElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 1,
+          "elapsed_ms": 126.24,
+          "candidate_count": 33,
+          "top_candidate": {
+            "name": "cloneElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "check whether a value is a valid React element",
+          "query_type": "natural_language",
+          "expected_symbol": "isValidElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 1,
+          "elapsed_ms": 123.3,
+          "candidate_count": 33,
+          "top_candidate": {
+            "name": "isValidElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "state hook",
+          "query_type": "short_phrase",
+          "expected_symbol": "useState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 121.16,
+          "candidate_count": 3,
+          "top_candidate": {
+            "name": "didWarnStateUpdateForUnmountedComponent",
+            "file": "ReactNoopUpdateQueue.js"
+          }
+        },
+        {
+          "query": "effect hook",
+          "query_type": "short_phrase",
+          "expected_symbol": "useEffect",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 119.56,
+          "candidate_count": 2,
+          "top_candidate": {
+            "name": "dispatcher",
+            "file": "ReactHooks.js"
+          }
+        },
+        {
+          "query": "memoized callback",
+          "query_type": "short_phrase",
+          "expected_symbol": "useCallback",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 120.39,
+          "candidate_count": 0,
+          "top_candidate": null
+        },
+        {
+          "query": "deferred value",
+          "query_type": "short_phrase",
+          "expected_symbol": "useDeferredValue",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 120.65,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "fulfilledValue",
+            "file": "ReactChildren.js"
+          }
+        },
+        {
+          "query": "lazy component",
+          "query_type": "short_phrase",
+          "expected_symbol": "lazy",
+          "expected_file_suffix": "ReactLazy.js",
+          "rank": null,
+          "elapsed_ms": 122.48,
+          "candidate_count": 19,
+          "top_candidate": {
+            "name": "isLazyType",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "transition update",
+          "query_type": "short_phrase",
+          "expected_symbol": "startTransition",
+          "expected_file_suffix": "ReactStartTransition.js",
+          "rank": null,
+          "elapsed_ms": 117.26,
+          "candidate_count": 17,
+          "top_candidate": {
+            "name": "transition",
+            "file": "ReactTransitionType.js"
+          }
+        },
+        {
+          "query": "useState",
+          "query_type": "identifier",
+          "expected_symbol": "useState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 12.01,
+          "candidate_count": 0,
+          "top_candidate": null
+        },
+        {
+          "query": "createElement",
+          "query_type": "identifier",
+          "expected_symbol": "createElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 1,
+          "elapsed_ms": 24.45,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "createElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        }
+      ]
+    }
+  ],
+  "hybrid_uplift": {
+    "mrr_delta": 0.03823529411764706,
+    "acc1_delta": 0.058823529411764705,
+    "acc3_delta": 0.029411764705882346,
+    "acc5_delta": 0.0
+  },
+  "hybrid_uplift_by_query_type": {
+    "identifier": {
+      "mrr_delta": 0.0,
+      "acc1_delta": 0.0,
+      "acc3_delta": 0.0,
+      "acc5_delta": 0.0
+    },
+    "natural_language": {
+      "mrr_delta": 0.05,
+      "acc1_delta": 0.07692307692307693,
+      "acc3_delta": 0.038461538461538464,
+      "acc5_delta": 0.0
+    },
+    "short_phrase": {
+      "mrr_delta": 0.0,
+      "acc1_delta": 0.0,
+      "acc3_delta": 0.0,
+      "acc5_delta": 0.0
+    }
+  }
+}

--- a/benchmarks/embedding-quality-v1.6-phase3f-react-core-stacked.json
+++ b/benchmarks/embedding-quality-v1.6-phase3f-react-core-stacked.json
@@ -1,0 +1,1472 @@
+{
+  "project": "/tmp/react-core-bench",
+  "benchmark_project": "/var/folders/z0/0tcbss795xsdp75jmr_t9_kh0000gn/T/codelens-embed-quality-bnydllb0/react-core-bench",
+  "isolated_copy": true,
+  "binary": "/Users/bagjaeseog/codelens-mcp-plugin/target/release/codelens-mcp",
+  "embedding_model": "MiniLM-L12-CodeSearchNet-INT8",
+  "runtime_model": {
+    "model_dir": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch",
+    "model_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/model.onnx",
+    "config_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/config.json",
+    "sha256": "ef1d1e9cfa72e4929f5b9faea17d8704b23a2530aadebf0d464a4cc7750920b3",
+    "size_bytes": 34000281,
+    "num_hidden_layers": 12,
+    "hidden_size": 384
+  },
+  "dataset_path": "/Users/bagjaeseog/codelens-mcp-plugin/benchmarks/embedding-quality-dataset-react-core.json",
+  "dataset_size": 34,
+  "ranking_cutoff": 10,
+  "metric_labels": {
+    "mrr": "MRR@10",
+    "acc1": "Acc@1",
+    "acc3": "Acc@3",
+    "acc5": "Acc@5"
+  },
+  "methods": [
+    {
+      "method": "semantic_search",
+      "mrr": 0.12254901960784315,
+      "acc1": 0.11764705882352941,
+      "acc3": 0.11764705882352941,
+      "acc5": 0.11764705882352941,
+      "avg_elapsed_ms": 186.02205882352942,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 0.5,
+          "acc1": 0.5,
+          "acc3": 0.5,
+          "acc5": 0.5,
+          "avg_elapsed_ms": 123.08500000000001
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.12179487179487179,
+          "acc1": 0.11538461538461539,
+          "acc3": 0.11538461538461539,
+          "acc5": 0.11538461538461539,
+          "avg_elapsed_ms": 204.26230769230767
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.0,
+          "acc1": 0.0,
+          "acc3": 0.0,
+          "acc5": 0.0,
+          "avg_elapsed_ms": 127.96
+        }
+      },
+      "rows": [
+        {
+          "query": "create a context object with a default value",
+          "query_type": "natural_language",
+          "expected_symbol": "createContext",
+          "expected_file_suffix": "ReactContext.js",
+          "rank": null,
+          "elapsed_ms": 131.95,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "noopCacheSignal",
+            "file": "ReactCacheClient.js"
+          }
+        },
+        {
+          "query": "pass a ref through a function component",
+          "query_type": "natural_language",
+          "expected_symbol": "forwardRef",
+          "expected_file_suffix": "ReactForwardRef.js",
+          "rank": null,
+          "elapsed_ms": 136.05,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "ref",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "store local state in a function component",
+          "query_type": "natural_language",
+          "expected_symbol": "useState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 129.6,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "defineKeyPropWarningGetter",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "manage state with a reducer in a function component",
+          "query_type": "natural_language",
+          "expected_symbol": "useReducer",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 124.55,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "if",
+            "file": "ReactAct.js"
+          }
+        },
+        {
+          "query": "hold a mutable ref object that persists across renders",
+          "query_type": "natural_language",
+          "expected_symbol": "useRef",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 122.21,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "refObject",
+            "file": "ReactCreateRef.js"
+          }
+        },
+        {
+          "query": "run a side effect after rendering",
+          "query_type": "natural_language",
+          "expected_symbol": "useEffect",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 126.87,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getElementKey",
+            "file": "ReactChildren.js"
+          }
+        },
+        {
+          "query": "run an effect synchronously after DOM mutations",
+          "query_type": "natural_language",
+          "expected_symbol": "useLayoutEffect",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 128.97,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "thenable",
+            "file": "ReactAct.js"
+          }
+        },
+        {
+          "query": "memoize a callback function between renders",
+          "query_type": "natural_language",
+          "expected_symbol": "useCallback",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 117.43,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "jsxProd",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "memoize an expensive computed value",
+          "query_type": "natural_language",
+          "expected_symbol": "useMemo",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 117.09,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getElementKey",
+            "file": "ReactChildren.js"
+          }
+        },
+        {
+          "query": "customize the instance value exposed by a ref",
+          "query_type": "natural_language",
+          "expected_symbol": "useImperativeHandle",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 133.42,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "noopCacheSignal",
+            "file": "ReactCacheClient.js"
+          }
+        },
+        {
+          "query": "label a custom hook in React DevTools",
+          "query_type": "natural_language",
+          "expected_symbol": "useDebugValue",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 127.6,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "noopCacheSignal",
+            "file": "ReactCacheClient.js"
+          }
+        },
+        {
+          "query": "mark an update as a transition and get pending state",
+          "query_type": "natural_language",
+          "expected_symbol": "useTransition",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 118.06,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "PureComponent",
+            "file": "ReactBaseClasses.js"
+          }
+        },
+        {
+          "query": "defer updating a value to avoid blocking rendering",
+          "query_type": "natural_language",
+          "expected_symbol": "useDeferredValue",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 114.34,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "noopCacheSignal",
+            "file": "ReactCacheClient.js"
+          }
+        },
+        {
+          "query": "generate a stable unique id for accessibility attributes",
+          "query_type": "natural_language",
+          "expected_symbol": "useId",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 127.41,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "noopCacheSignal",
+            "file": "ReactCacheClient.js"
+          }
+        },
+        {
+          "query": "subscribe to an external store with a snapshot getter",
+          "query_type": "natural_language",
+          "expected_symbol": "useSyncExternalStore",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 113.28,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "addTransitionType",
+            "file": "ReactTransitionType.js"
+          }
+        },
+        {
+          "query": "create an event callback that reads the latest props and state",
+          "query_type": "natural_language",
+          "expected_symbol": "useEffectEvent",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 122.92,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getElementKey",
+            "file": "ReactChildren.js"
+          }
+        },
+        {
+          "query": "optimistically update UI state while an async action runs",
+          "query_type": "natural_language",
+          "expected_symbol": "useOptimistic",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 123.59,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "getElementKey",
+            "file": "ReactChildren.js"
+          }
+        },
+        {
+          "query": "track the result and pending state of a form action",
+          "query_type": "natural_language",
+          "expected_symbol": "useActionState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 276.07,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "noopCacheSignal",
+            "file": "ReactCacheClient.js"
+          }
+        },
+        {
+          "query": "create a ref object for class components or elements",
+          "query_type": "natural_language",
+          "expected_symbol": "createRef",
+          "expected_file_suffix": "ReactCreateRef.js",
+          "rank": 6,
+          "elapsed_ms": 1565.55,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "ref",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "skip re-rendering a component when props are unchanged",
+          "query_type": "natural_language",
+          "expected_symbol": "memo",
+          "expected_file_suffix": "ReactMemo.js",
+          "rank": null,
+          "elapsed_ms": 495.72,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "releaseAsyncTransition",
+            "file": "ReactStartTransition.js"
+          }
+        },
+        {
+          "query": "load a component lazily with dynamic import",
+          "query_type": "natural_language",
+          "expected_symbol": "lazy",
+          "expected_file_suffix": "ReactLazy.js",
+          "rank": null,
+          "elapsed_ms": 128.16,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "noopCacheSignal",
+            "file": "ReactCacheClient.js"
+          }
+        },
+        {
+          "query": "schedule a state update as non-urgent work",
+          "query_type": "natural_language",
+          "expected_symbol": "startTransition",
+          "expected_file_suffix": "ReactStartTransition.js",
+          "rank": null,
+          "elapsed_ms": 144.17,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "noopCacheSignal",
+            "file": "ReactCacheClient.js"
+          }
+        },
+        {
+          "query": "flush updates in a React test",
+          "query_type": "natural_language",
+          "expected_symbol": "act",
+          "expected_file_suffix": "ReactAct.js",
+          "rank": null,
+          "elapsed_ms": 138.21,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "noopCacheSignal",
+            "file": "ReactCacheClient.js"
+          }
+        },
+        {
+          "query": "create a React element without JSX",
+          "query_type": "natural_language",
+          "expected_symbol": "createElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 1,
+          "elapsed_ms": 139.55,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "createElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "clone an existing React element with new props",
+          "query_type": "natural_language",
+          "expected_symbol": "cloneElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 1,
+          "elapsed_ms": 160.57,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "cloneElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "check whether a value is a valid React element",
+          "query_type": "natural_language",
+          "expected_symbol": "isValidElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 1,
+          "elapsed_ms": 147.48,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "isValidElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "state hook",
+          "query_type": "short_phrase",
+          "expected_symbol": "useState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 128.69,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "dispatcher",
+            "file": "ReactHooks.js"
+          }
+        },
+        {
+          "query": "effect hook",
+          "query_type": "short_phrase",
+          "expected_symbol": "useEffect",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 133.82,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "dispatcher",
+            "file": "ReactHooks.js"
+          }
+        },
+        {
+          "query": "memoized callback",
+          "query_type": "short_phrase",
+          "expected_symbol": "useCallback",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 132.28,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "if",
+            "file": "ReactForwardRef.js"
+          }
+        },
+        {
+          "query": "deferred value",
+          "query_type": "short_phrase",
+          "expected_symbol": "useDeferredValue",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 123.32,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "fulfilledValue",
+            "file": "ReactChildren.js"
+          }
+        },
+        {
+          "query": "lazy component",
+          "query_type": "short_phrase",
+          "expected_symbol": "lazy",
+          "expected_file_suffix": "ReactLazy.js",
+          "rank": null,
+          "elapsed_ms": 125.03,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "warningKey",
+            "file": "ReactNoopUpdateQueue.js"
+          }
+        },
+        {
+          "query": "transition update",
+          "query_type": "short_phrase",
+          "expected_symbol": "startTransition",
+          "expected_file_suffix": "ReactStartTransition.js",
+          "rank": null,
+          "elapsed_ms": 124.62,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "transition",
+            "file": "ReactTransitionType.js"
+          }
+        },
+        {
+          "query": "useState",
+          "query_type": "identifier",
+          "expected_symbol": "useState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 119.13,
+          "candidate_count": 4,
+          "top_candidate": {
+            "name": "previousStackTraceLimit",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "createElement",
+          "query_type": "identifier",
+          "expected_symbol": "createElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 1,
+          "elapsed_ms": 127.04,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "createElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context_no_semantic",
+      "mrr": 0.08431372549019608,
+      "acc1": 0.058823529411764705,
+      "acc3": 0.08823529411764706,
+      "acc5": 0.11764705882352941,
+      "avg_elapsed_ms": 16.40058823529412,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 0.5,
+          "acc1": 0.5,
+          "acc3": 0.5,
+          "acc5": 0.5,
+          "avg_elapsed_ms": 11.48
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.07179487179487179,
+          "acc1": 0.038461538461538464,
+          "acc3": 0.07692307692307693,
+          "acc5": 0.11538461538461539,
+          "avg_elapsed_ms": 16.63423076923077
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.0,
+          "acc1": 0.0,
+          "acc3": 0.0,
+          "acc5": 0.0,
+          "avg_elapsed_ms": 17.028333333333332
+        }
+      },
+      "rows": [
+        {
+          "query": "create a context object with a default value",
+          "query_type": "natural_language",
+          "expected_symbol": "createContext",
+          "expected_file_suffix": "ReactContext.js",
+          "rank": null,
+          "elapsed_ms": 17.13,
+          "candidate_count": 16,
+          "top_candidate": {
+            "name": "elementRefGetterWithDeprecationWarning",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "pass a ref through a function component",
+          "query_type": "natural_language",
+          "expected_symbol": "forwardRef",
+          "expected_file_suffix": "ReactForwardRef.js",
+          "rank": null,
+          "elapsed_ms": 16.53,
+          "candidate_count": 19,
+          "top_candidate": {
+            "name": "hasValidRef",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "store local state in a function component",
+          "query_type": "natural_language",
+          "expected_symbol": "useState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 16.42,
+          "candidate_count": 8,
+          "top_candidate": {
+            "name": "componentName",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "manage state with a reducer in a function component",
+          "query_type": "natural_language",
+          "expected_symbol": "useReducer",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 15.2,
+          "candidate_count": 11,
+          "top_candidate": {
+            "name": "elementRefGetterWithDeprecationWarning",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "hold a mutable ref object that persists across renders",
+          "query_type": "natural_language",
+          "expected_symbol": "useRef",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 15.8,
+          "candidate_count": 16,
+          "top_candidate": {
+            "name": "ref",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "run a side effect after rendering",
+          "query_type": "natural_language",
+          "expected_symbol": "useEffect",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 14.15,
+          "candidate_count": 5,
+          "top_candidate": {
+            "name": "jsxProdSignatureRunningInDevWithStaticChildren",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "run an effect synchronously after DOM mutations",
+          "query_type": "natural_language",
+          "expected_symbol": "useLayoutEffect",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 15.19,
+          "candidate_count": 5,
+          "top_candidate": {
+            "name": "jsxProdSignatureRunningInDevWithStaticChildren",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "memoize a callback function between renders",
+          "query_type": "natural_language",
+          "expected_symbol": "useCallback",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 14.71,
+          "candidate_count": 0,
+          "top_candidate": null
+        },
+        {
+          "query": "memoize an expensive computed value",
+          "query_type": "natural_language",
+          "expected_symbol": "useMemo",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 14.57,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "fulfilledValue",
+            "file": "ReactChildren.js"
+          }
+        },
+        {
+          "query": "customize the instance value exposed by a ref",
+          "query_type": "natural_language",
+          "expected_symbol": "useImperativeHandle",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 16.39,
+          "candidate_count": 15,
+          "top_candidate": {
+            "name": "ref",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "label a custom hook in React DevTools",
+          "query_type": "natural_language",
+          "expected_symbol": "useDebugValue",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 19.37,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "ReactElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "mark an update as a transition and get pending state",
+          "query_type": "natural_language",
+          "expected_symbol": "useTransition",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 15.28,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "releaseAsyncTransition",
+            "file": "ReactStartTransition.js"
+          }
+        },
+        {
+          "query": "defer updating a value to avoid blocking rendering",
+          "query_type": "natural_language",
+          "expected_symbol": "useDeferredValue",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 16.56,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "fulfilledValue",
+            "file": "ReactChildren.js"
+          }
+        },
+        {
+          "query": "generate a stable unique id for accessibility attributes",
+          "query_type": "natural_language",
+          "expected_symbol": "useId",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 16.13,
+          "candidate_count": 4,
+          "top_candidate": {
+            "name": "beforeExample",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "subscribe to an external store with a snapshot getter",
+          "query_type": "natural_language",
+          "expected_symbol": "useSyncExternalStore",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 15.6,
+          "candidate_count": 6,
+          "top_candidate": {
+            "name": "elementRefGetterWithDeprecationWarning",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "create an event callback that reads the latest props and state",
+          "query_type": "natural_language",
+          "expected_symbol": "useEffectEvent",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 15.21,
+          "candidate_count": 15,
+          "top_candidate": {
+            "name": "cloneAndReplaceKey",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "optimistically update UI state while an async action runs",
+          "query_type": "natural_language",
+          "expected_symbol": "useOptimistic",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 12.68,
+          "candidate_count": 11,
+          "top_candidate": {
+            "name": "releaseAsyncTransition",
+            "file": "ReactStartTransition.js"
+          }
+        },
+        {
+          "query": "track the result and pending state of a form action",
+          "query_type": "natural_language",
+          "expected_symbol": "useActionState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 14.4,
+          "candidate_count": 12,
+          "top_candidate": {
+            "name": "trackActualOwner",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "create a ref object for class components or elements",
+          "query_type": "natural_language",
+          "expected_symbol": "createRef",
+          "expected_file_suffix": "ReactCreateRef.js",
+          "rank": 5,
+          "elapsed_ms": 27.35,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "createElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "skip re-rendering a component when props are unchanged",
+          "query_type": "natural_language",
+          "expected_symbol": "memo",
+          "expected_file_suffix": "ReactMemo.js",
+          "rank": null,
+          "elapsed_ms": 15.13,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "jsxProdSignatureRunningInDevWithDynamicChildren",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "load a component lazily with dynamic import",
+          "query_type": "natural_language",
+          "expected_symbol": "lazy",
+          "expected_file_suffix": "ReactLazy.js",
+          "rank": null,
+          "elapsed_ms": 14.85,
+          "candidate_count": 14,
+          "top_candidate": {
+            "name": "jsxProdSignatureRunningInDevWithDynamicChildren",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "schedule a state update as non-urgent work",
+          "query_type": "natural_language",
+          "expected_symbol": "startTransition",
+          "expected_file_suffix": "ReactStartTransition.js",
+          "rank": null,
+          "elapsed_ms": 15.95,
+          "candidate_count": 15,
+          "top_candidate": {
+            "name": "updatedFibersCount",
+            "file": "ReactStartTransition.js"
+          }
+        },
+        {
+          "query": "flush updates in a React test",
+          "query_type": "natural_language",
+          "expected_symbol": "act",
+          "expected_file_suffix": "ReactAct.js",
+          "rank": null,
+          "elapsed_ms": 15.33,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "ReactElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "create a React element without JSX",
+          "query_type": "natural_language",
+          "expected_symbol": "createElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 2,
+          "elapsed_ms": 28.97,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "ReactElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "clone an existing React element with new props",
+          "query_type": "natural_language",
+          "expected_symbol": "cloneElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 6,
+          "elapsed_ms": 16.35,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "cloneAndReplaceKey",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "check whether a value is a valid React element",
+          "query_type": "natural_language",
+          "expected_symbol": "isValidElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 1,
+          "elapsed_ms": 17.24,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "isValidElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "state hook",
+          "query_type": "short_phrase",
+          "expected_symbol": "useState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 26.37,
+          "candidate_count": 3,
+          "top_candidate": {
+            "name": "didWarnStateUpdateForUnmountedComponent",
+            "file": "ReactNoopUpdateQueue.js"
+          }
+        },
+        {
+          "query": "effect hook",
+          "query_type": "short_phrase",
+          "expected_symbol": "useEffect",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 13.46,
+          "candidate_count": 2,
+          "top_candidate": {
+            "name": "dispatcher",
+            "file": "ReactHooks.js"
+          }
+        },
+        {
+          "query": "memoized callback",
+          "query_type": "short_phrase",
+          "expected_symbol": "useCallback",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 11.53,
+          "candidate_count": 0,
+          "top_candidate": null
+        },
+        {
+          "query": "deferred value",
+          "query_type": "short_phrase",
+          "expected_symbol": "useDeferredValue",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 12.05,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "fulfilledValue",
+            "file": "ReactChildren.js"
+          }
+        },
+        {
+          "query": "lazy component",
+          "query_type": "short_phrase",
+          "expected_symbol": "lazy",
+          "expected_file_suffix": "ReactLazy.js",
+          "rank": null,
+          "elapsed_ms": 25.6,
+          "candidate_count": 19,
+          "top_candidate": {
+            "name": "isLazyType",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "transition update",
+          "query_type": "short_phrase",
+          "expected_symbol": "startTransition",
+          "expected_file_suffix": "ReactStartTransition.js",
+          "rank": null,
+          "elapsed_ms": 13.16,
+          "candidate_count": 17,
+          "top_candidate": {
+            "name": "releaseAsyncTransition",
+            "file": "ReactStartTransition.js"
+          }
+        },
+        {
+          "query": "useState",
+          "query_type": "identifier",
+          "expected_symbol": "useState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 11.71,
+          "candidate_count": 0,
+          "top_candidate": null
+        },
+        {
+          "query": "createElement",
+          "query_type": "identifier",
+          "expected_symbol": "createElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 1,
+          "elapsed_ms": 11.25,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "createElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context",
+      "mrr": 0.12254901960784315,
+      "acc1": 0.11764705882352941,
+      "acc3": 0.11764705882352941,
+      "acc5": 0.11764705882352941,
+      "avg_elapsed_ms": 119.9085294117647,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 0.5,
+          "acc1": 0.5,
+          "acc3": 0.5,
+          "acc5": 0.5,
+          "avg_elapsed_ms": 13.375
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.12179487179487179,
+          "acc1": 0.11538461538461539,
+          "acc3": 0.11538461538461539,
+          "acc5": 0.11538461538461539,
+          "avg_elapsed_ms": 127.32461538461538
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.0,
+          "acc1": 0.0,
+          "acc3": 0.0,
+          "acc5": 0.0,
+          "avg_elapsed_ms": 123.28333333333332
+        }
+      },
+      "rows": [
+        {
+          "query": "create a context object with a default value",
+          "query_type": "natural_language",
+          "expected_symbol": "createContext",
+          "expected_file_suffix": "ReactContext.js",
+          "rank": null,
+          "elapsed_ms": 119.0,
+          "candidate_count": 16,
+          "top_candidate": {
+            "name": "defaultProps",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "pass a ref through a function component",
+          "query_type": "natural_language",
+          "expected_symbol": "forwardRef",
+          "expected_file_suffix": "ReactForwardRef.js",
+          "rank": null,
+          "elapsed_ms": 121.99,
+          "candidate_count": 19,
+          "top_candidate": {
+            "name": "ref",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "store local state in a function component",
+          "query_type": "natural_language",
+          "expected_symbol": "useState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 123.52,
+          "candidate_count": 9,
+          "top_candidate": {
+            "name": "didAwaitActCall",
+            "file": "ReactAct.js"
+          }
+        },
+        {
+          "query": "manage state with a reducer in a function component",
+          "query_type": "natural_language",
+          "expected_symbol": "useReducer",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 123.31,
+          "candidate_count": 11,
+          "top_candidate": {
+            "name": "elementRefGetterWithDeprecationWarning",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "hold a mutable ref object that persists across renders",
+          "query_type": "natural_language",
+          "expected_symbol": "useRef",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 130.9,
+          "candidate_count": 16,
+          "top_candidate": {
+            "name": "refObject",
+            "file": "ReactCreateRef.js"
+          }
+        },
+        {
+          "query": "run a side effect after rendering",
+          "query_type": "natural_language",
+          "expected_symbol": "useEffect",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 130.55,
+          "candidate_count": 6,
+          "top_candidate": {
+            "name": "if",
+            "file": "ReactForwardRef.js"
+          }
+        },
+        {
+          "query": "run an effect synchronously after DOM mutations",
+          "query_type": "natural_language",
+          "expected_symbol": "useLayoutEffect",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 130.62,
+          "candidate_count": 5,
+          "top_candidate": {
+            "name": "jsxProdSignatureRunningInDevWithStaticChildren",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "memoize a callback function between renders",
+          "query_type": "natural_language",
+          "expected_symbol": "useCallback",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 133.3,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "if",
+            "file": "ReactForwardRef.js"
+          }
+        },
+        {
+          "query": "memoize an expensive computed value",
+          "query_type": "natural_language",
+          "expected_symbol": "useMemo",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 133.06,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "fulfilledValue",
+            "file": "ReactChildren.js"
+          }
+        },
+        {
+          "query": "customize the instance value exposed by a ref",
+          "query_type": "natural_language",
+          "expected_symbol": "useImperativeHandle",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 130.69,
+          "candidate_count": 15,
+          "top_candidate": {
+            "name": "ref",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "label a custom hook in React DevTools",
+          "query_type": "natural_language",
+          "expected_symbol": "useDebugValue",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 130.21,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "if",
+            "file": "ReactAct.js"
+          }
+        },
+        {
+          "query": "mark an update as a transition and get pending state",
+          "query_type": "natural_language",
+          "expected_symbol": "useTransition",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 124.21,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "transition",
+            "file": "ReactTransitionType.js"
+          }
+        },
+        {
+          "query": "defer updating a value to avoid blocking rendering",
+          "query_type": "natural_language",
+          "expected_symbol": "useDeferredValue",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 125.48,
+          "candidate_count": 3,
+          "top_candidate": {
+            "name": "ReactNoopUpdateQueue",
+            "file": "ReactNoopUpdateQueue.js"
+          }
+        },
+        {
+          "query": "generate a stable unique id for accessibility attributes",
+          "query_type": "natural_language",
+          "expected_symbol": "useId",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 126.78,
+          "candidate_count": 4,
+          "top_candidate": {
+            "name": "beforeExample",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "subscribe to an external store with a snapshot getter",
+          "query_type": "natural_language",
+          "expected_symbol": "useSyncExternalStore",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 127.88,
+          "candidate_count": 6,
+          "top_candidate": {
+            "name": "elementRefGetterWithDeprecationWarning",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "create an event callback that reads the latest props and state",
+          "query_type": "natural_language",
+          "expected_symbol": "useEffectEvent",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 125.79,
+          "candidate_count": 15,
+          "top_candidate": {
+            "name": "thenable",
+            "file": "ReactAct.js"
+          }
+        },
+        {
+          "query": "optimistically update UI state while an async action runs",
+          "query_type": "natural_language",
+          "expected_symbol": "useOptimistic",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 121.07,
+          "candidate_count": 13,
+          "top_candidate": {
+            "name": "didWarnStateUpdateForUnmountedComponent",
+            "file": "ReactNoopUpdateQueue.js"
+          }
+        },
+        {
+          "query": "track the result and pending state of a form action",
+          "query_type": "natural_language",
+          "expected_symbol": "useActionState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 119.87,
+          "candidate_count": 13,
+          "top_candidate": {
+            "name": "trackActualOwner",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "create a ref object for class components or elements",
+          "query_type": "natural_language",
+          "expected_symbol": "createRef",
+          "expected_file_suffix": "ReactCreateRef.js",
+          "rank": 6,
+          "elapsed_ms": 128.58,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "ref",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "skip re-rendering a component when props are unchanged",
+          "query_type": "natural_language",
+          "expected_symbol": "memo",
+          "expected_file_suffix": "ReactMemo.js",
+          "rank": null,
+          "elapsed_ms": 129.59,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "if",
+            "file": "ReactAct.js"
+          }
+        },
+        {
+          "query": "load a component lazily with dynamic import",
+          "query_type": "natural_language",
+          "expected_symbol": "lazy",
+          "expected_file_suffix": "ReactLazy.js",
+          "rank": null,
+          "elapsed_ms": 128.58,
+          "candidate_count": 14,
+          "top_candidate": {
+            "name": "jsxProdSignatureRunningInDevWithDynamicChildren",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "schedule a state update as non-urgent work",
+          "query_type": "natural_language",
+          "expected_symbol": "startTransition",
+          "expected_file_suffix": "ReactStartTransition.js",
+          "rank": null,
+          "elapsed_ms": 129.09,
+          "candidate_count": 15,
+          "top_candidate": {
+            "name": "ReactNoopUpdateQueue",
+            "file": "ReactNoopUpdateQueue.js"
+          }
+        },
+        {
+          "query": "flush updates in a React test",
+          "query_type": "natural_language",
+          "expected_symbol": "act",
+          "expected_file_suffix": "ReactAct.js",
+          "rank": null,
+          "elapsed_ms": 125.59,
+          "candidate_count": 33,
+          "top_candidate": {
+            "name": "ReactNoopUpdateQueue",
+            "file": "ReactNoopUpdateQueue.js"
+          }
+        },
+        {
+          "query": "create a React element without JSX",
+          "query_type": "natural_language",
+          "expected_symbol": "createElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 1,
+          "elapsed_ms": 128.85,
+          "candidate_count": 33,
+          "top_candidate": {
+            "name": "createElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "clone an existing React element with new props",
+          "query_type": "natural_language",
+          "expected_symbol": "cloneElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 1,
+          "elapsed_ms": 127.93,
+          "candidate_count": 33,
+          "top_candidate": {
+            "name": "cloneElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "check whether a value is a valid React element",
+          "query_type": "natural_language",
+          "expected_symbol": "isValidElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 1,
+          "elapsed_ms": 134.0,
+          "candidate_count": 33,
+          "top_candidate": {
+            "name": "isValidElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "state hook",
+          "query_type": "short_phrase",
+          "expected_symbol": "useState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 127.24,
+          "candidate_count": 3,
+          "top_candidate": {
+            "name": "didWarnStateUpdateForUnmountedComponent",
+            "file": "ReactNoopUpdateQueue.js"
+          }
+        },
+        {
+          "query": "effect hook",
+          "query_type": "short_phrase",
+          "expected_symbol": "useEffect",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 126.72,
+          "candidate_count": 2,
+          "top_candidate": {
+            "name": "dispatcher",
+            "file": "ReactHooks.js"
+          }
+        },
+        {
+          "query": "memoized callback",
+          "query_type": "short_phrase",
+          "expected_symbol": "useCallback",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 121.08,
+          "candidate_count": 0,
+          "top_candidate": null
+        },
+        {
+          "query": "deferred value",
+          "query_type": "short_phrase",
+          "expected_symbol": "useDeferredValue",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 118.71,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "fulfilledValue",
+            "file": "ReactChildren.js"
+          }
+        },
+        {
+          "query": "lazy component",
+          "query_type": "short_phrase",
+          "expected_symbol": "lazy",
+          "expected_file_suffix": "ReactLazy.js",
+          "rank": null,
+          "elapsed_ms": 119.85,
+          "candidate_count": 19,
+          "top_candidate": {
+            "name": "isLazyType",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        },
+        {
+          "query": "transition update",
+          "query_type": "short_phrase",
+          "expected_symbol": "startTransition",
+          "expected_file_suffix": "ReactStartTransition.js",
+          "rank": null,
+          "elapsed_ms": 126.1,
+          "candidate_count": 17,
+          "top_candidate": {
+            "name": "transition",
+            "file": "ReactTransitionType.js"
+          }
+        },
+        {
+          "query": "useState",
+          "query_type": "identifier",
+          "expected_symbol": "useState",
+          "expected_file_suffix": "ReactHooks.js",
+          "rank": null,
+          "elapsed_ms": 13.33,
+          "candidate_count": 0,
+          "top_candidate": null
+        },
+        {
+          "query": "createElement",
+          "query_type": "identifier",
+          "expected_symbol": "createElement",
+          "expected_file_suffix": "jsx/ReactJSXElement.js",
+          "rank": 1,
+          "elapsed_ms": 13.42,
+          "candidate_count": 1,
+          "top_candidate": {
+            "name": "createElement",
+            "file": "jsx/ReactJSXElement.js"
+          }
+        }
+      ]
+    }
+  ],
+  "hybrid_uplift": {
+    "mrr_delta": 0.03823529411764706,
+    "acc1_delta": 0.058823529411764705,
+    "acc3_delta": 0.029411764705882346,
+    "acc5_delta": 0.0
+  },
+  "hybrid_uplift_by_query_type": {
+    "identifier": {
+      "mrr_delta": 0.0,
+      "acc1_delta": 0.0,
+      "acc3_delta": 0.0,
+      "acc5_delta": 0.0
+    },
+    "natural_language": {
+      "mrr_delta": 0.05,
+      "acc1_delta": 0.07692307692307693,
+      "acc3_delta": 0.038461538461538464,
+      "acc5_delta": 0.0
+    },
+    "short_phrase": {
+      "mrr_delta": 0.0,
+      "acc1_delta": 0.0,
+      "acc3_delta": 0.0,
+      "acc5_delta": 0.0
+    }
+  }
+}

--- a/crates/codelens-engine/src/embedding/mod.rs
+++ b/crates/codelens-engine/src/embedding/mod.rs
@@ -29,7 +29,9 @@ pub(super) mod ffi {
                     *mut *mut i8,
                     *const rusqlite::ffi::sqlite3_api_routines,
                 ) -> i32,
-            >(sqlite_vec::sqlite3_vec_init as *const ())))
+            >(
+                sqlite_vec::sqlite3_vec_init as *const ()
+            )))
         };
         if rc != rusqlite::ffi::SQLITE_OK {
             anyhow::bail!("failed to register sqlite-vec extension (SQLite error code: {rc})");
@@ -1867,8 +1869,12 @@ fn nl_tokens_enabled() -> bool {
 ///
 /// 1. Rust / C / C++ / Go / Java / Kotlin / Scala / C# projects hit
 ///    the §8.7 stacked arm (+2.4 % to +15.2 % hybrid MRR).
-/// 2. TypeScript / JavaScript projects hit the §8.13 stacked arm
-///    (+7.3 % hybrid MRR on `facebook/jest`).
+/// 2. TypeScript / JavaScript projects validated the Phase 2b/2c
+///    embedding hints on `facebook/jest` and later `microsoft/typescript`.
+///    Subsequent app/runtime follow-ups (`vercel/next.js`,
+///    `facebook/react` production subtree) motivated splitting Phase 2e
+///    out of the JS/TS auto path, but not removing JS/TS from the
+///    embedding-hint default.
 /// 3. Python projects hit the §8.8 baseline (no change) — the
 ///    §8.11 language gate + §8.12 MCP auto-set means Python is
 ///    auto-detected and the stack stays OFF without user action.
@@ -1891,8 +1897,8 @@ fn nl_tokens_enabled() -> bool {
 /// a lock-in.
 ///
 /// **Opt-out**: set `CODELENS_EMBED_HINT_AUTO=0` to restore v1.5.x
-/// behaviour (no auto-detection, all three Phase 2 gates default
-/// off unless their individual env vars are set).
+/// behaviour (no auto-detection, all Phase 2 gates default off unless
+/// their individual env vars are set).
 pub(super) fn auto_hint_mode_enabled() -> bool {
     parse_bool_env("CODELENS_EMBED_HINT_AUTO").unwrap_or(true)
 }
@@ -1913,13 +1919,21 @@ pub(super) fn auto_hint_lang() -> Option<String> {
         .map(|raw| raw.trim().to_ascii_lowercase())
 }
 
-/// Return true when `lang` is a language where the v1.5 opt-in stack
-/// has been measured to net-positive (§8.2, §8.4, §8.6, §8.7, §8.13)
-/// or where the language's static typing + snake_case naming +
-/// comment-first culture makes the Phase 2b mechanism behave the same
-/// way it does on Rust. The list is intentionally conservative —
-/// additions require an actual external-repo A/B following the §8.7
-/// methodology, not a language-similarity argument alone.
+/// Return true when `lang` is a language where the v1.5 embedding-hint
+/// stack (Phase 2b comments + Phase 2c API-call extraction) has been
+/// measured to net-positive (§8.2, §8.4, §8.6, §8.7, §8.13, §8.15) or
+/// where the language's static typing + snake_case naming + comment-first
+/// culture makes the mechanism behave the same way it does on Rust.
+///
+/// This gate is intentionally separate from the Phase 2e sparse
+/// re-ranker. As of the §8.15 / §8.16 / §8.17 follow-up arc, JS/TS stays
+/// enabled here because tooling/compiler repos are positive and short-file
+/// runtime repos are inert, but JS/TS is disabled in the **sparse**
+/// auto-gate because Phase 2e is negative-or-null on that family.
+///
+/// The list is intentionally conservative — additions require an actual
+/// external-repo A/B following the §8.7 methodology, not a
+/// language-similarity argument alone.
 ///
 /// **Supported** (measured or by static-typing analogy):
 /// - `rs`, `rust` (§8.2, §8.4, §8.6, §8.7: +2.4 %, +7.1 %, +15.2 %)
@@ -1966,11 +1980,47 @@ pub(super) fn language_supports_nl_stack(lang: &str) -> bool {
     )
 }
 
+/// Return true when `lang` is a language where the Phase 2e sparse
+/// coverage re-ranker should be auto-enabled when the user has not set
+/// `CODELENS_RANK_SPARSE_TERM_WEIGHT` explicitly.
+///
+/// This is deliberately narrower than `language_supports_nl_stack`.
+/// Phase 2e remains positive on Rust-style codebases, but the JS/TS
+/// measurement arc now says:
+///
+/// - `facebook/jest`: marginal positive
+/// - `microsoft/typescript`: negative
+/// - `vercel/next.js`: slight negative
+/// - `facebook/react` production subtree: exact no-op
+///
+/// So the conservative Phase 2m policy is:
+/// - keep Phase 2b/2c auto-eligible on JS/TS
+/// - disable **auto** Phase 2e on JS/TS
+/// - preserve explicit env override for users who want to force it on
+pub(super) fn language_supports_sparse_weighting(lang: &str) -> bool {
+    matches!(
+        lang.trim().to_ascii_lowercase().as_str(),
+        "rs" | "rust"
+            | "cpp"
+            | "cc"
+            | "cxx"
+            | "c++"
+            | "c"
+            | "go"
+            | "golang"
+            | "java"
+            | "kt"
+            | "kotlin"
+            | "scala"
+            | "cs"
+            | "csharp"
+    )
+}
+
 /// Combined decision: Phase 2j auto mode is enabled AND the detected
-/// language supports the stack. This is the `else` branch that
-/// `nl_tokens_enabled`, `api_calls_enabled`, and
-/// `sparse_weighting_enabled` (via its re-export) fall through to
-/// when no explicit env var is set.
+/// language supports the Phase 2b/2c embedding-hint stack. This is the
+/// `else` branch that `nl_tokens_enabled` and `api_calls_enabled` fall
+/// through to when no explicit env var is set.
 pub(super) fn auto_hint_should_enable() -> bool {
     if !auto_hint_mode_enabled() {
         return false;
@@ -1978,6 +2028,22 @@ pub(super) fn auto_hint_should_enable() -> bool {
     match auto_hint_lang() {
         Some(lang) => language_supports_nl_stack(&lang),
         None => false, // auto mode on but no language tag → conservative OFF
+    }
+}
+
+/// Combined decision: Phase 2j auto mode is enabled AND the detected
+/// language supports auto-enabling the Phase 2e sparse re-ranker.
+///
+/// This intentionally differs from `auto_hint_should_enable()` after the
+/// §8.15 / §8.16 / §8.17 JS/TS follow-up arc: embedding hints stay
+/// auto-on for JS/TS, but sparse weighting does not.
+pub(super) fn auto_sparse_should_enable() -> bool {
+    if !auto_hint_mode_enabled() {
+        return false;
+    }
+    match auto_hint_lang() {
+        Some(lang) => language_supports_sparse_weighting(&lang),
+        None => false,
     }
 }
 
@@ -2119,10 +2185,7 @@ pub(super) fn contains_format_specifier(s: &str) -> bool {
     while i + 1 < len {
         if bytes[i] == b'%' {
             let next = bytes[i + 1];
-            if matches!(
-                next,
-                b's' | b'd' | b'r' | b'f' | b'x' | b'o' | b'i' | b'u'
-            ) {
+            if matches!(next, b's' | b'd' | b'r' | b'f' | b'x' | b'o' | b'i' | b'u') {
                 return true;
             }
         }
@@ -2238,11 +2301,7 @@ fn extract_nl_tokens(source: &str, start: usize, end: usize) -> Option<String> {
 /// so unit tests can run deterministically without touching env vars
 /// (which would race with the other tests that set
 /// `CODELENS_EMBED_HINT_INCLUDE_COMMENTS`).
-pub(super) fn extract_nl_tokens_inner(
-    source: &str,
-    start: usize,
-    end: usize,
-) -> Option<String> {
+pub(super) fn extract_nl_tokens_inner(source: &str, start: usize, end: usize) -> Option<String> {
     if start >= source.len() || end > source.len() || start >= end {
         return None;
     }
@@ -2346,10 +2405,7 @@ fn api_calls_enabled() -> bool {
 /// than PascalCase detection but deliberate — the goal is high-precision
 /// Type filtering, not lexical accuracy.
 pub(super) fn is_static_method_ident(ident: &str) -> bool {
-    ident
-        .chars()
-        .next()
-        .is_some_and(|c| c.is_ascii_uppercase())
+    ident.chars().next().is_some_and(|c| c.is_ascii_uppercase())
 }
 
 /// Collect `Type::method` call sites from a function body.
@@ -2383,11 +2439,7 @@ fn extract_api_calls(source: &str, start: usize, end: usize) -> Option<String> {
 ///
 /// Duplicate `Type::method` pairs collapse into a single entry to avoid
 /// biasing the embedding toward repeated calls in hot loops.
-pub(super) fn extract_api_calls_inner(
-    source: &str,
-    start: usize,
-    end: usize,
-) -> Option<String> {
+pub(super) fn extract_api_calls_inner(source: &str, start: usize, end: usize) -> Option<String> {
     if start >= source.len() || end > source.len() || start >= end {
         return None;
     }
@@ -3093,6 +3145,28 @@ fn skip_things() {
     }
 
     #[test]
+    fn language_supports_sparse_weighting_classifies_correctly() {
+        assert!(super::language_supports_sparse_weighting("rs"));
+        assert!(super::language_supports_sparse_weighting("rust"));
+        assert!(super::language_supports_sparse_weighting("cpp"));
+        assert!(super::language_supports_sparse_weighting("go"));
+        assert!(super::language_supports_sparse_weighting("java"));
+        assert!(super::language_supports_sparse_weighting("kotlin"));
+        assert!(super::language_supports_sparse_weighting("csharp"));
+
+        assert!(!super::language_supports_sparse_weighting("ts"));
+        assert!(!super::language_supports_sparse_weighting("typescript"));
+        assert!(!super::language_supports_sparse_weighting("tsx"));
+        assert!(!super::language_supports_sparse_weighting("js"));
+        assert!(!super::language_supports_sparse_weighting("javascript"));
+        assert!(!super::language_supports_sparse_weighting("jsx"));
+        assert!(!super::language_supports_sparse_weighting("py"));
+        assert!(!super::language_supports_sparse_weighting("python"));
+        assert!(!super::language_supports_sparse_weighting("klingon"));
+        assert!(!super::language_supports_sparse_weighting(""));
+    }
+
+    #[test]
     fn auto_hint_should_enable_requires_both_gate_and_supported_lang() {
         let _env_guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let prev_auto = std::env::var("CODELENS_EMBED_HINT_AUTO").ok();
@@ -3120,6 +3194,15 @@ fn skip_things() {
             "gate-on + lang=rust must enable"
         );
 
+        unsafe {
+            std::env::set_var("CODELENS_EMBED_HINT_AUTO", "1");
+            std::env::set_var("CODELENS_EMBED_HINT_AUTO_LANG", "typescript");
+        }
+        assert!(
+            super::auto_hint_should_enable(),
+            "gate-on + lang=typescript must keep Phase 2b/2c enabled"
+        );
+
         // Case 3: gate on, unsupported language → disable
         unsafe {
             std::env::set_var("CODELENS_EMBED_HINT_AUTO", "1");
@@ -3141,6 +3224,69 @@ fn skip_things() {
         );
 
         // Restore
+        unsafe {
+            match prev_auto {
+                Some(v) => std::env::set_var("CODELENS_EMBED_HINT_AUTO", v),
+                None => std::env::remove_var("CODELENS_EMBED_HINT_AUTO"),
+            }
+            match prev_lang {
+                Some(v) => std::env::set_var("CODELENS_EMBED_HINT_AUTO_LANG", v),
+                None => std::env::remove_var("CODELENS_EMBED_HINT_AUTO_LANG"),
+            }
+        }
+    }
+
+    #[test]
+    fn auto_sparse_should_enable_requires_both_gate_and_sparse_supported_lang() {
+        let _env_guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prev_auto = std::env::var("CODELENS_EMBED_HINT_AUTO").ok();
+        let prev_lang = std::env::var("CODELENS_EMBED_HINT_AUTO_LANG").ok();
+
+        unsafe {
+            std::env::set_var("CODELENS_EMBED_HINT_AUTO", "0");
+            std::env::set_var("CODELENS_EMBED_HINT_AUTO_LANG", "rust");
+        }
+        assert!(
+            !super::auto_sparse_should_enable(),
+            "gate-off (explicit =0) must disable sparse auto gate"
+        );
+
+        unsafe {
+            std::env::set_var("CODELENS_EMBED_HINT_AUTO", "1");
+            std::env::set_var("CODELENS_EMBED_HINT_AUTO_LANG", "rust");
+        }
+        assert!(
+            super::auto_sparse_should_enable(),
+            "gate-on + lang=rust must enable sparse auto gate"
+        );
+
+        unsafe {
+            std::env::set_var("CODELENS_EMBED_HINT_AUTO", "1");
+            std::env::set_var("CODELENS_EMBED_HINT_AUTO_LANG", "typescript");
+        }
+        assert!(
+            !super::auto_sparse_should_enable(),
+            "gate-on + lang=typescript must keep sparse auto gate disabled"
+        );
+
+        unsafe {
+            std::env::set_var("CODELENS_EMBED_HINT_AUTO", "1");
+            std::env::set_var("CODELENS_EMBED_HINT_AUTO_LANG", "python");
+        }
+        assert!(
+            !super::auto_sparse_should_enable(),
+            "gate-on + lang=python must keep sparse auto gate disabled"
+        );
+
+        unsafe {
+            std::env::set_var("CODELENS_EMBED_HINT_AUTO", "1");
+            std::env::remove_var("CODELENS_EMBED_HINT_AUTO_LANG");
+        }
+        assert!(
+            !super::auto_sparse_should_enable(),
+            "gate-on + no lang tag must keep sparse auto gate disabled"
+        );
+
         unsafe {
             match prev_auto {
                 Some(v) => std::env::set_var("CODELENS_EMBED_HINT_AUTO", v),
@@ -3243,28 +3389,52 @@ fn skip_things() {
         assert!(super::looks_like_meta_annotation("TODO: fix later"));
         assert!(super::looks_like_meta_annotation("todo handle edge case"));
         assert!(super::looks_like_meta_annotation("FIXME this is broken"));
-        assert!(super::looks_like_meta_annotation("HACK: workaround for bug"));
+        assert!(super::looks_like_meta_annotation(
+            "HACK: workaround for bug"
+        ));
         assert!(super::looks_like_meta_annotation("XXX not implemented yet"));
-        assert!(super::looks_like_meta_annotation("BUG in the upstream crate"));
+        assert!(super::looks_like_meta_annotation(
+            "BUG in the upstream crate"
+        ));
         assert!(super::looks_like_meta_annotation("REVIEW before merging"));
-        assert!(super::looks_like_meta_annotation("REFACTOR this block later"));
+        assert!(super::looks_like_meta_annotation(
+            "REFACTOR this block later"
+        ));
         assert!(super::looks_like_meta_annotation("TEMP: remove before v2"));
-        assert!(super::looks_like_meta_annotation("DEPRECATED use new_api instead"));
+        assert!(super::looks_like_meta_annotation(
+            "DEPRECATED use new_api instead"
+        ));
         // Leading whitespace inside the comment body is handled.
-        assert!(super::looks_like_meta_annotation("   TODO: with leading ws"));
+        assert!(super::looks_like_meta_annotation(
+            "   TODO: with leading ws"
+        ));
     }
 
     #[test]
     fn looks_like_meta_annotation_preserves_behaviour_prefixes() {
         // Explicitly-excluded prefixes — kept as behaviour signal.
-        assert!(!super::looks_like_meta_annotation("NOTE: this branch handles empty input"));
-        assert!(!super::looks_like_meta_annotation("WARN: overflow is possible"));
-        assert!(!super::looks_like_meta_annotation("SAFETY: caller must hold the lock"));
-        assert!(!super::looks_like_meta_annotation("PANIC: unreachable by construction"));
+        assert!(!super::looks_like_meta_annotation(
+            "NOTE: this branch handles empty input"
+        ));
+        assert!(!super::looks_like_meta_annotation(
+            "WARN: overflow is possible"
+        ));
+        assert!(!super::looks_like_meta_annotation(
+            "SAFETY: caller must hold the lock"
+        ));
+        assert!(!super::looks_like_meta_annotation(
+            "PANIC: unreachable by construction"
+        ));
         // Behaviour-descriptive prose must pass through.
-        assert!(!super::looks_like_meta_annotation("parse json body from request"));
-        assert!(!super::looks_like_meta_annotation("walk directory respecting gitignore"));
-        assert!(!super::looks_like_meta_annotation("compute cosine similarity between vectors"));
+        assert!(!super::looks_like_meta_annotation(
+            "parse json body from request"
+        ));
+        assert!(!super::looks_like_meta_annotation(
+            "walk directory respecting gitignore"
+        ));
+        assert!(!super::looks_like_meta_annotation(
+            "compute cosine similarity between vectors"
+        ));
         // Empty / edge inputs
         assert!(!super::looks_like_meta_annotation(""));
         assert!(!super::looks_like_meta_annotation("   "));
@@ -3304,14 +3474,8 @@ fn handle_request() {
         );
         // TODO / FIXME must NOT appear anywhere in the hint (they were
         // rejected before join, so they cannot be there even partially).
-        assert!(
-            !hint.contains("TODO"),
-            "TODO annotation leaked: {hint}"
-        );
-        assert!(
-            !hint.contains("FIXME"),
-            "FIXME annotation leaked: {hint}"
-        );
+        assert!(!hint.contains("TODO"), "TODO annotation leaked: {hint}");
+        assert!(!hint.contains("FIXME"), "FIXME annotation leaked: {hint}");
     }
 
     #[test]
@@ -3386,7 +3550,9 @@ fn handle() {
         assert!(super::contains_format_specifier("value: {x:.2f}"));
         assert!(super::contains_format_specifier("{}"));
         // Plain prose with no format specifier
-        assert!(!super::contains_format_specifier("skip comments and string literals"));
+        assert!(!super::contains_format_specifier(
+            "skip comments and string literals"
+        ));
         assert!(!super::contains_format_specifier("failed to open database"));
         // JSON-like brace content should not count as a format specifier
         // (multi-word content inside braces)
@@ -3396,17 +3562,35 @@ fn handle() {
     #[test]
     fn looks_like_error_or_log_prefix_rejects_common_patterns() {
         assert!(super::looks_like_error_or_log_prefix("Invalid URL format"));
-        assert!(super::looks_like_error_or_log_prefix("Cannot decode response"));
+        assert!(super::looks_like_error_or_log_prefix(
+            "Cannot decode response"
+        ));
         assert!(super::looks_like_error_or_log_prefix("could not open file"));
-        assert!(super::looks_like_error_or_log_prefix("Failed to send request"));
-        assert!(super::looks_like_error_or_log_prefix("Expected int, got str"));
-        assert!(super::looks_like_error_or_log_prefix("sending request to server"));
-        assert!(super::looks_like_error_or_log_prefix("received response headers"));
-        assert!(super::looks_like_error_or_log_prefix("starting worker pool"));
+        assert!(super::looks_like_error_or_log_prefix(
+            "Failed to send request"
+        ));
+        assert!(super::looks_like_error_or_log_prefix(
+            "Expected int, got str"
+        ));
+        assert!(super::looks_like_error_or_log_prefix(
+            "sending request to server"
+        ));
+        assert!(super::looks_like_error_or_log_prefix(
+            "received response headers"
+        ));
+        assert!(super::looks_like_error_or_log_prefix(
+            "starting worker pool"
+        ));
         // Real behaviour strings must pass
-        assert!(!super::looks_like_error_or_log_prefix("parse json body from request"));
-        assert!(!super::looks_like_error_or_log_prefix("compute cosine similarity between vectors"));
-        assert!(!super::looks_like_error_or_log_prefix("walk directory tree respecting gitignore"));
+        assert!(!super::looks_like_error_or_log_prefix(
+            "parse json body from request"
+        ));
+        assert!(!super::looks_like_error_or_log_prefix(
+            "compute cosine similarity between vectors"
+        ));
+        assert!(!super::looks_like_error_or_log_prefix(
+            "walk directory tree respecting gitignore"
+        ));
     }
 
     #[test]
@@ -3499,7 +3683,9 @@ fn do_work() {
         // a literal is rejected iff it is a format specifier OR an error/log
         // prefix (the production filter uses exactly this disjunction).
         assert!(super::should_reject_literal_strict("Invalid URL %s"));
-        assert!(super::should_reject_literal_strict("sending request to server"));
+        assert!(super::should_reject_literal_strict(
+            "sending request to server"
+        ));
         assert!(super::should_reject_literal_strict("value: {x:.2f}"));
         // Real behaviour strings pass through.
         assert!(!super::should_reject_literal_strict(
@@ -3579,18 +3765,12 @@ fn read_config() {
         // If any API hint is produced, it must not contain the snake_case
         // module prefixes; otherwise `None` is acceptable too.
         if let Some(hint) = hint {
-            assert!(
-                !hint.contains("std::fs"),
-                "lowercase module leaked: {hint}"
-            );
+            assert!(!hint.contains("std::fs"), "lowercase module leaked: {hint}");
             assert!(
                 !hint.contains("fs::read_to_string"),
                 "module-prefixed free function leaked: {hint}"
             );
-            assert!(
-                !hint.contains("crate::util"),
-                "crate path leaked: {hint}"
-            );
+            assert!(!hint.contains("crate::util"), "crate path leaked: {hint}");
         }
     }
 

--- a/crates/codelens-engine/src/symbols/scoring.rs
+++ b/crates/codelens-engine/src/symbols/scoring.rs
@@ -224,15 +224,17 @@ pub(crate) fn score_symbol_with_lower(
 /// ranking path.
 ///
 /// v1.5 Phase 2j: when no explicit env var is set, fall through to
-/// `crate::embedding::auto_hint_should_enable()` for language-gated
-/// defaults (same fallback as `nl_tokens_enabled` and
-/// `api_calls_enabled`). Explicit env always wins.
+/// `crate::embedding::auto_sparse_should_enable()` for language-gated
+/// defaults. This intentionally diverges from `nl_tokens_enabled` and
+/// `api_calls_enabled`: Phase 2m keeps JS/TS auto-enabled for Phase 2b/2c
+/// but auto-disables sparse weighting there because recent JS/TS
+/// measurements were negative-or-inert. Explicit env always wins.
 pub fn sparse_weighting_enabled() -> bool {
     if let Ok(raw) = std::env::var("CODELENS_RANK_SPARSE_TERM_WEIGHT") {
         let lowered = raw.trim().to_ascii_lowercase();
         return matches!(lowered.as_str(), "1" | "true" | "yes" | "on");
     }
-    crate::embedding::auto_hint_should_enable()
+    crate::embedding::auto_sparse_should_enable()
 }
 
 /// Maximum sparse coverage bonus added to the blended score when a query
@@ -431,6 +433,9 @@ pub(crate) fn sparse_coverage_bonus(query_lower: &str, symbol: &SymbolInfo) -> f
 mod tests {
     use super::super::types::{SymbolInfo, SymbolKind};
     use super::*;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     fn mk_symbol(name: &str, signature: &str) -> SymbolInfo {
         SymbolInfo {
@@ -451,17 +456,94 @@ mod tests {
 
     #[test]
     fn sparse_weighting_gated_off_by_default() {
-        let previous = std::env::var("CODELENS_RANK_SPARSE_TERM_WEIGHT").ok();
+        let _env_guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let previous_explicit = std::env::var("CODELENS_RANK_SPARSE_TERM_WEIGHT").ok();
+        let previous_auto = std::env::var("CODELENS_EMBED_HINT_AUTO").ok();
+        let previous_lang = std::env::var("CODELENS_EMBED_HINT_AUTO_LANG").ok();
         unsafe {
             std::env::remove_var("CODELENS_RANK_SPARSE_TERM_WEIGHT");
+            std::env::remove_var("CODELENS_EMBED_HINT_AUTO");
+            std::env::remove_var("CODELENS_EMBED_HINT_AUTO_LANG");
         }
         let enabled = sparse_weighting_enabled();
         unsafe {
-            if let Some(value) = previous {
-                std::env::set_var("CODELENS_RANK_SPARSE_TERM_WEIGHT", value);
+            match previous_explicit {
+                Some(value) => std::env::set_var("CODELENS_RANK_SPARSE_TERM_WEIGHT", value),
+                None => std::env::remove_var("CODELENS_RANK_SPARSE_TERM_WEIGHT"),
+            }
+            match previous_auto {
+                Some(value) => std::env::set_var("CODELENS_EMBED_HINT_AUTO", value),
+                None => std::env::remove_var("CODELENS_EMBED_HINT_AUTO"),
+            }
+            match previous_lang {
+                Some(value) => std::env::set_var("CODELENS_EMBED_HINT_AUTO_LANG", value),
+                None => std::env::remove_var("CODELENS_EMBED_HINT_AUTO_LANG"),
             }
         }
         assert!(!enabled, "sparse weighting gate leaked");
+    }
+
+    #[test]
+    fn sparse_weighting_auto_gate_disables_for_js_ts_but_explicit_env_still_wins() {
+        let _env_guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let previous_explicit = std::env::var("CODELENS_RANK_SPARSE_TERM_WEIGHT").ok();
+        let previous_auto = std::env::var("CODELENS_EMBED_HINT_AUTO").ok();
+        let previous_lang = std::env::var("CODELENS_EMBED_HINT_AUTO_LANG").ok();
+
+        unsafe {
+            std::env::remove_var("CODELENS_RANK_SPARSE_TERM_WEIGHT");
+            std::env::set_var("CODELENS_EMBED_HINT_AUTO", "1");
+            std::env::set_var("CODELENS_EMBED_HINT_AUTO_LANG", "rust");
+        }
+        assert!(
+            sparse_weighting_enabled(),
+            "auto+rust should enable sparse weighting"
+        );
+
+        unsafe {
+            std::env::remove_var("CODELENS_RANK_SPARSE_TERM_WEIGHT");
+            std::env::set_var("CODELENS_EMBED_HINT_AUTO", "1");
+            std::env::set_var("CODELENS_EMBED_HINT_AUTO_LANG", "typescript");
+        }
+        assert!(
+            !sparse_weighting_enabled(),
+            "auto+typescript should disable sparse weighting after Phase 2m split"
+        );
+
+        unsafe {
+            std::env::set_var("CODELENS_RANK_SPARSE_TERM_WEIGHT", "1");
+            std::env::set_var("CODELENS_EMBED_HINT_AUTO", "1");
+            std::env::set_var("CODELENS_EMBED_HINT_AUTO_LANG", "typescript");
+        }
+        assert!(
+            sparse_weighting_enabled(),
+            "explicit sparse=1 must still win over JS/TS auto-off"
+        );
+
+        unsafe {
+            std::env::set_var("CODELENS_RANK_SPARSE_TERM_WEIGHT", "0");
+            std::env::set_var("CODELENS_EMBED_HINT_AUTO", "1");
+            std::env::set_var("CODELENS_EMBED_HINT_AUTO_LANG", "rust");
+        }
+        assert!(
+            !sparse_weighting_enabled(),
+            "explicit sparse=0 must still win over rust auto-on"
+        );
+
+        unsafe {
+            match previous_explicit {
+                Some(value) => std::env::set_var("CODELENS_RANK_SPARSE_TERM_WEIGHT", value),
+                None => std::env::remove_var("CODELENS_RANK_SPARSE_TERM_WEIGHT"),
+            }
+            match previous_auto {
+                Some(value) => std::env::set_var("CODELENS_EMBED_HINT_AUTO", value),
+                None => std::env::remove_var("CODELENS_EMBED_HINT_AUTO"),
+            }
+            match previous_lang {
+                Some(value) => std::env::set_var("CODELENS_EMBED_HINT_AUTO_LANG", value),
+                None => std::env::remove_var("CODELENS_EMBED_HINT_AUTO_LANG"),
+            }
+        }
     }
 
     #[test]

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1457,7 +1457,7 @@ With §8.13 shipping, the `CODELENS_EMBED_HINT_AUTO=1` default is the right beha
 
 Measurement artefacts: `benchmarks/embedding-quality-v1.5-phase3c-jest-{baseline,2e-only,2b2c-only,stacked}.json`. Dataset: `benchmarks/embedding-quality-dataset-jest.json`.
 
-**Phase 3d follow-up scaffolding**: the larger TypeScript follow-up assets now live in-repo as `benchmarks/embedding-quality-dataset-typescript.json` (34 hand-built queries, split 26 natural_language / 6 short_phrase / 2 identifier against `microsoft/typescript`) plus the baseline-only snapshot `benchmarks/embedding-quality-v1.6-phase3d-typescript-baseline.json`. This does **not** mean Phase 3d is complete; it means the input dataset and baseline artefact are now versioned so the future full four-arm A/B can be reproduced instead of rebuilt from scratch.
+**Phase 3d follow-up scaffolding**: the larger TypeScript follow-up assets that were staged here later landed fully in §8.15 as `benchmarks/embedding-quality-dataset-typescript.json` plus `benchmarks/embedding-quality-v1.6-phase3d-typescript-{baseline,2e-only,2b2c-only,stacked}.json`. The next open follow-up after that was the typical-app Phase 3e measurement, which later landed in §8.16 on `vercel/next.js`.
 
 ---
 
@@ -1514,7 +1514,7 @@ python3 benchmarks/embedding-quality.py /tmp/requests-ext --isolated-copy \
 **Limitations**:
 
 1. **Process-scoped env var**. `auto_set_embed_hint_lang` exports `CODELENS_EMBED_HINT_AUTO_LANG` for the rest of the process. Switching projects mid-session via the `activate_project` MCP tool re-runs the helper, but because `user_forced_lang` short-circuits when the env var is already set, **switching from a Rust project to a Python project mid-session still sees the Rust language tag**. This was an acknowledged follow-up limitation from §8.12 and is unchanged by the flip. Restart the server to pick up a language change.
-2. **No Phase 3d evidence yet**. JS/TS classification rests on a single external-repo measurement (§8.13 `facebook/jest`). A Phase 3d follow-up on `microsoft/typescript` or `microsoft/vscode` is still open and would firm up the evidence for users with very large TS monorepos.
+2. **Only one JS/TS dataset at the time of the flip decision**. This limitation was later resolved, then reframed: §8.15 added a positive compiler-style TypeScript measurement on `microsoft/typescript`, while §8.16 added a neutral-to-slightly-negative typical-app-style measurement on `vercel/next.js`. Read the family-wide confidence in this section as the launch-time rationale for v1.6.0, not the latest blanket recommendation.
 3. **Test race exposed, not eliminated for all future env-var tests**. New tests that mutate `CODELENS_EMBED_HINT_*` env vars must remember to take `ENV_LOCK` or they will see race conditions against the existing eleven tests. A clippy lint or helper macro would be a nicer long-term fix.
 
 **Artefacts**: `benchmarks/embedding-quality-v1.6-flip-{ripgrep,requests}-default-on.json`. Both files are bit-identical to their `§8.12 phase2j-*-mcpauto.json` counterparts — readers can verify with `diff` if they want to confirm the parity claim independently.
@@ -1653,12 +1653,12 @@ Pattern: **5 positive (Rust / Rust / Rust / TS-JS / TS-JS) : 1 negative (Python)
 \*\*Implications for v1.6.x`:
 
 - The JS/TS branch of `CODELENS_EMBED_HINT_AUTO=1` default-on behaviour is now empirically on even firmer ground. Users with large TS projects (compilers, language servers, editor extensions) are likely to see the largest quality gains from flipping `AUTO=1` on.
-- **Phase 2e remains the weakest of the three knobs**. §8.12 measured Phase 2e as positive on ripgrep, Phase 3c measured it as +1.3 % marginal on jest, and §8.15 measures it as **−10.0 %** on TypeScript (the first explicitly negative measurement on the sparse re-ranker alone). The stack's lift comes almost entirely from Phase 2b + 2c on JS/TS. A future Phase 2m could consider dropping Phase 2e from the auto-on set for JS/TS while keeping it on for Rust — but that's a two-axis gate complication deferred until a user actually hits the problem.
+- **Phase 2e remains the weakest of the three knobs**. §8.12 measured Phase 2e as positive on ripgrep, Phase 3c measured it as +1.3 % marginal on jest, and §8.15 measures it as **−10.0 %** on TypeScript (the first explicitly negative measurement on the sparse re-ranker alone). The stack's lift comes almost entirely from Phase 2b + 2c on JS/TS. This later became the core motivation for the narrow Phase 2m policy split: keep JS/TS auto-enabled for Phase 2b/2c, but remove JS/TS from the **auto** Phase 2e sparse gate.
 - **No code changes required by this phase**. Phase 3d is a pure measurement update. `language_supports_nl_stack` already contains the JS/TS entries from §8.13; §8.15 only upgrades their evidence tier in the documentation.
 
 **Limitations acknowledged**:
 
-1. **Still only two TS datasets**. Jest is matcher-heavy object-literal code; TypeScript is a large compiler with heavy JSDoc. Both are positive, but both are unrepresentative of a typical app codebase (small-to-medium TS with React / Next.js / Node patterns). A Phase 3e on a typical app repo (e.g. `vercel/next.js` or `facebook/react` internals) would cover the remaining population.
+1. **Still only two TS datasets**. Jest is matcher-heavy object-literal code; TypeScript is a large compiler with heavy JSDoc. Both are positive, but both are unrepresentative of a typical app codebase (small-to-medium TS with React / Next.js / Node patterns). This gap was later filled by §8.16 on `vercel/next.js`.
 2. **20 / 26 NL queries remain `None` in both arms**. These are retrieval failures, not ranking failures — the candidate pool never includes the target. The v1.5 stack does not address retrieval failures; that's an embedding-model issue, not a ranking one, and belongs to Phase 2d (model swap).
 3. **TypeScript `src/` is not the full repo**. Benchmarking against `/src` (709 files) excludes the `/tests` fixture tree (50 k+ files). A user who actually points CodeLens at the full TypeScript checkout will get `/tests` in their embedding index, which will shift the NL results toward test fixtures. This is a user-facing reality, but benchmarking the production codebase in isolation is the scientifically cleaner choice.
 
@@ -1668,7 +1668,7 @@ Pattern: **5 positive (Rust / Rust / Rust / TS-JS / TS-JS) : 1 negative (Python)
 
 **Hypothesis** (from §8.15 "Limitations acknowledged", point 1): both existing TS datasets are unrepresentative of a typical app codebase — `facebook/jest` is matcher-heavy object-literal test tooling and `microsoft/TypeScript` is a compiler with 50 k-line files and dense JSDoc. §8.15 explicitly teed up Phase 3e on `vercel/next.js` or `facebook/react` to cover "small-to-medium TS with React / Next.js / Node patterns" — the population of codebases most real users point CodeLens at. The null-hypothesis going in was "the v1.5 stack should produce a small positive on a typical app, probably closer to jest's +7.3 % than to TypeScript's +104 %". Phase 3e tests that null hypothesis directly.
 
-**Target repo**: `vercel/next.js` (depth-1 shallow clone, ~1.5 GB, 28 547 working-tree files). We benchmark against **`/tmp/next-js/packages/next/src`** — the core framework runtime package, excluding `/packages/next/src/compiled` (bundled third-party code, only 16 `.ts` files) — for **1 564 source files totalling 268 560 LOC**. The file-size profile is strikingly different from TypeScript's: **median 61 LOC/file**, mean ~172 LOC/file, largest single file `server/app-render/app-render.tsx` at 8 397 lines (vs TypeScript's `checker.ts` at ~50 000). This is the first external-repo benchmark in the v1.6 measurement campaign whose file profile matches the "typical app" shape.
+**Target repo**: `vercel/next.js` (depth-1 shallow clone, ~1.5 GB, 28 547 working-tree files). We benchmark against **`/tmp/next-js/packages/next/src`** — the core framework runtime package. That subtree contains **1 580 `.ts` / `.tsx` files** in total, of which only **16** live under `/compiled`, and **268 560 LOC** overall. The file-size profile is strikingly different from TypeScript's: **median 61 LOC/file**, mean ~172 LOC/file, largest single file `server/app-render/app-render.tsx` at 8 397 lines (vs TypeScript's `checker.ts` at ~50 000). This is the first external-repo benchmark in the v1.6 measurement campaign whose file profile matches the "typical app" shape.
 
 **Dataset**: 34 hand-built queries in `benchmarks/embedding-quality-dataset-next-js.json`, spanning six subsystems of the Next.js public API surface:
 
@@ -1767,7 +1767,7 @@ The default-flip in v1.6.0 was made on the premise that §8.15 showed the JS/TS 
 
 - **Users with compiler/tooling/language-server code (TypeScript compiler, Babel, esbuild, Rollup, tsserver, etc.)** will see the large JS/TS lifts §8.13 and §8.15 documented (+7 % to +104 %).
 - **Users with typical app code (Next.js, React apps, Vue apps, Node.js services)** will see _neutral_ behaviour — no measurable win, no measurable loss, within ±1 % of baseline.
-- **Phase 2e on JS/TS is now negative on two out of three datasets** (TypeScript −10.0 %, Next.js −0.8 %, jest +1.3 % marginal). The Phase 2m "language-gated 2e disable for JS/TS" decision deferred in §8.15 is now better-supported by evidence: 2 of 3 JS/TS datasets show 2e as net negative. Still deferred (waiting for a real user hit), but the evidence is stronger.
+- **Phase 2e on JS/TS is now negative on two out of three datasets** (TypeScript −10.0 %, Next.js −0.8 %, jest +1.3 % marginal). This later landed as the narrow Phase 2m policy split: JS/TS stays auto-enabled for Phase 2b/2c, but the **auto** sparse gate no longer enables Phase 2e on JS/TS. Explicit `CODELENS_RANK_SPARSE_TERM_WEIGHT=1` still overrides the auto policy.
 
 Neither bullet suggests reverting the v1.6.0 flip — the default-on cost on a typical app is zero, not a regression. It does mean the marketing line "Phase 2b+2c helps JS/TS retrieval" should be qualified to "Phase 2b+2c helps compiler and tooling JS/TS retrieval; typical app code sees no change".
 
@@ -1816,10 +1816,289 @@ python3 benchmarks/embedding-quality.py /tmp/next-js/packages/next/src --isolate
 **Limitations acknowledged**:
 
 1. **Retrieval-failure floor is 15 / 26 NL queries (58 %)**. More than half of the natural-language queries never place the target within the top 10 candidates in any arm. These are cases where `semantic_search`'s CodeSearchNet-INT8 embedding + lexical BM25 scoring combined cannot find files like `server/request/headers.ts` from a query like "get the current request headers in a server component", regardless of how Phase 2b/2c/2e re-rank them. This is a larger share of retrieval-failure than TypeScript's 20 / 26 (77 %), but the absolute count is similar — the difference is TypeScript has more retrieval failures _and_ more headroom for the ranked ones, while Next.js has fewer retrieval failures _but_ the baseline hybrid ranking was already near-ceiling for the findable ones. Both outcomes point at the same underlying cap: the v1.5 re-ranker can only re-order candidates it already has.
-2. **One dataset does not disprove a population claim**. Next.js is _a_ typical TS app, but it is a particularly large and frameworky one with complex internal architecture. A smaller app (a Node.js service, a Remix app, a Vite + React SPA) might land somewhere between Next.js 0 % and jest +7 %. The honest framing is "v1.5 stack ranges from 0 % to +104 % on JS/TS depending on file size and JSDoc density", not "v1.5 stack is zero on all typical apps".
+2. **One dataset does not disprove a population claim**. Next.js is _a_ typical TS app, but it is a particularly large and frameworky one with complex internal architecture. This concern was later partially addressed by §8.17 on the `facebook/react` production subtree, which also measured as inert. That shifts the honest framing toward "short-file JS/TS runtime code has measured 0 % lift twice so far", but it still does not prove all typical apps are zero.
 3. **Dataset overlap with Phase 3d methodology**. Phase 3d (TypeScript compiler) used exactly the same 34-query shape (26 NL + 6 short + 2 identifier) and 4-arm structure as Phase 3e. This makes the comparison directly apples-to-apples, but it also means the query style (Next.js public API surface, named exports only, English NL phrasing) imports the same methodological preferences across both datasets. A dataset built by a different author with a different query style might land elsewhere. §8.12's ripgrep dataset was built this way and Phase 2b+2c moved it from 0.459 to 0.529 (+15.2 %), so the query-style bias is not the dominant factor — but it is a factor.
 
 **Artefacts**: `benchmarks/embedding-quality-v1.6-phase3e-next-js-{baseline,2e-only,2b2c-only,stacked}.json`. Dataset: `benchmarks/embedding-quality-dataset-next-js.json`.
+
+---
+
+### §8.17 — Phase 3f: short-file React runtime subtree on `facebook/react`
+
+**Hypothesis** (from §8.16 "Limitations acknowledged", point 2): `vercel/next.js` measured as a null result, but Next.js is still a large framework repo with server/runtime complexity and long-tail build internals. A much smaller, shorter-file JS runtime surface could still show the mild positive that §8.16 failed to see. Phase 3f tests that by moving from a large Next.js subtree to the production `react` core package itself.
+
+**Target repo**: `facebook/react` (depth-1 shallow clone), but not the full package tree. We benchmark a production-only copy of **`packages/react/src`** materialized as **`/tmp/react-core-bench`** with `__tests__/` excluded. That leaves **30 source files** and **4,035 LOC**. This is an order of magnitude smaller than the Next.js subtree and two orders smaller than the TypeScript compiler slice. If the v1.5 stack needs big files or comment-heavy bodies to work, this is the kind of corpus where it should disappear.
+
+**Dataset**: 34 hand-built queries in `benchmarks/embedding-quality-dataset-react-core.json`, again keeping the §8.15 / §8.16 shape for apples-to-apples comparison: **26 `natural_language` + 6 `short_phrase` + 2 `identifier`**. The symbols cover the public React surface that ordinary users search for:
+
+| Area                  | Example queries                                                                 | Count |
+| --------------------- | ------------------------------------------------------------------------------- | ----: |
+| Core hooks            | `useState`, `useEffect`, `useMemo`, `useTransition`, `useDeferredValue`, ...   |    16 |
+| Element / ref API     | `createRef`, `createElement`, `cloneElement`, `isValidElement`, `forwardRef`   |     5 |
+| Context / memo / lazy | `createContext`, `memo`, `lazy`                                                 |     3 |
+| Transitions / testing | `startTransition`, `act`                                                        |     2 |
+| Short phrases + ids   | `state hook`, `lazy component`, `useState`, `createElement`                     |     8 |
+
+**Measurement**:
+
+| arm         |   hybrid MRR | Δ abs vs baseline | Δ rel | semantic MRR | lexical-only MRR |
+| ----------- | -----------: | ----------------: | ----: | -----------: | ---------------: |
+| baseline    |     0.122549 |                 — |     — |     0.122549 |         0.084314 |
+| 2e only     |     0.122549 |          0.000000 | +0.0 % |     0.122549 |         0.084314 |
+| 2b+2c only  |     0.122549 |          0.000000 | +0.0 % |     0.122549 |         0.084314 |
+| **stacked** | **0.122549** |      **0.000000** | **+0.0 %** | **0.122549** |     **0.084314** |
+
+This is a **stronger null result than Next.js**. In Phase 3e, the aggregate moved by a small amount under `2e`. In Phase 3f, **every arm is row-for-row identical to baseline across all three methods** (`semantic_search`, `get_ranked_context_no_semantic`, and `get_ranked_context`). There are **zero per-query rank changes** and **zero top-candidate changes** between baseline and any candidate arm.
+
+**Per-query decomposition**:
+
+```
+baseline vs any candidate arm:
+  0 improved, 0 regressed, 34 unchanged
+
+top-10 hits in every arm: 5 / 34
+  createRef      rank 6
+  createElement  rank 1 (NL)
+  cloneElement   rank 1
+  isValidElement rank 1
+  createElement  rank 1 (identifier)
+
+top-10 misses in every arm: 29 / 34
+  by query type:
+    natural_language: 22 / 26 misses
+    short_phrase:      6 / 6 misses
+    identifier:        1 / 2 misses
+```
+
+This is almost a pure retrieval-floor dataset. The stack has nothing to work with because the candidate pool barely contains the target in the first place.
+
+**Where the signal disappears**:
+
+- `semantic_search` and `get_ranked_context` are not just equal in aggregate; on this dataset they are **rank-identical row-by-row**. Hybrid effectively collapses to semantic.
+- `get_ranked_context_no_semantic` is weaker than semantic/hybrid, but the three knobs still do not change it at all. The sparse term weighting and the comment/API-call extraction simply never move the lexical candidate set.
+- The only hybrid-vs-lexical differences in baseline are three already-findable queries:
+  - `createRef` `5 → 6`
+  - `createElement` `2 → 1`
+  - `cloneElement` `6 → 1`
+  Everything else is either a miss in both paths or the same rank in both.
+
+So the React core result says something narrower but stronger than §8.16: **on short-file JS runtime code, the v1.5 stack is not mildly weaker or mildly stronger; it is functionally inert.**
+
+**Updated eight-dataset baseline matrix**:
+
+| Dataset                              | Language / archetype     | baseline MRR | stacked MRR |      Δ abs |      Δ rel |
+| ------------------------------------ | ------------------------ | -----------: | ----------: | ---------: | ---------: |
+| 89-query self                        | Rust / self              |        0.572 |       0.586 |     +0.014 |     +2.4 % |
+| 436-query self                       | Rust / self              |       0.0476 |      0.0510 |    +0.0034 |     +7.1 % |
+| ripgrep external                     | Rust / tooling           |        0.459 |       0.529 |     +0.070 |    +15.2 % |
+| requests external                    | Python / app library     |        0.584 |       0.495 |     −0.089 |    −15.2 % |
+| jest external                        | TS/JS / tooling          |        0.155 |       0.166 |     +0.011 |     +7.3 % |
+| typescript external                  | TS/JS / compiler         |        0.098 |       0.201 |     +0.103 |   +104.3 % |
+| next-js external                     | TS/JS / typical app      |        0.198 |       0.196 |     −0.002 |     −0.8 % |
+| **react-core external (new, §8.17)** | **TS/JS / short runtime** |    **0.123** |   **0.123** | **+0.000** | **+0.0 %** |
+
+Pattern: **5 positive / 1 negative / 2 inert**. The positive JS/TS evidence is now clearly concentrated in **tooling/compiler-style** code, while the two shortest-file runtime/app-style datasets measured so far are inert.
+
+**Implications**:
+
+- The family-level statement should now be: **JS/TS is bifurcated by code shape**. Tooling/compiler repos benefit; short-file runtime/app repos do not.
+- §8.16's "typical app might still land between 0 % and +7 %" is no longer the default expectation. After React core, the better prior is **"short-file JS runtime code likely lands at 0 %"** until contradicted by a real product app.
+- Combined with §8.16, this is enough to justify a **narrow** code-path change: keep the shipped Phase 2b/2c default-on behaviour, but split Phase 2e out of the JS/TS auto path. It still does **not** justify a broader rollback of the v1.6 default-on behaviour, because the app/runtime measurements are inert rather than systematically harmful.
+
+**Reproduce**:
+
+```bash
+git clone --depth=1 https://github.com/facebook/react.git /tmp/react
+rm -rf /tmp/react-core-bench
+rsync -a --delete --exclude '__tests__/' /tmp/react/packages/react/src/ /tmp/react-core-bench/
+
+# Arm 1: baseline
+CODELENS_MODEL_DIR=$(pwd)/crates/codelens-engine/models \
+CODELENS_BIN=./target/release/codelens-mcp \
+python3 benchmarks/embedding-quality.py /tmp/react-core-bench --isolated-copy \
+  --dataset benchmarks/embedding-quality-dataset-react-core.json \
+  --output benchmarks/embedding-quality-v1.6-phase3f-react-core-baseline.json
+
+# Arm 2: Phase 2e only
+CODELENS_RANK_SPARSE_TERM_WEIGHT=1 \
+CODELENS_RANK_SPARSE_THRESHOLD=40 \
+CODELENS_RANK_SPARSE_MAX=40 \
+CODELENS_MODEL_DIR=$(pwd)/crates/codelens-engine/models \
+CODELENS_BIN=./target/release/codelens-mcp \
+python3 benchmarks/embedding-quality.py /tmp/react-core-bench --isolated-copy \
+  --dataset benchmarks/embedding-quality-dataset-react-core.json \
+  --output benchmarks/embedding-quality-v1.6-phase3f-react-core-2e-only.json
+
+# Arm 3: Phase 2b + 2c only
+CODELENS_EMBED_HINT_INCLUDE_COMMENTS=1 \
+CODELENS_EMBED_HINT_INCLUDE_API_CALLS=1 \
+CODELENS_MODEL_DIR=$(pwd)/crates/codelens-engine/models \
+CODELENS_BIN=./target/release/codelens-mcp \
+python3 benchmarks/embedding-quality.py /tmp/react-core-bench --isolated-copy \
+  --dataset benchmarks/embedding-quality-dataset-react-core.json \
+  --output benchmarks/embedding-quality-v1.6-phase3f-react-core-2b2c-only.json
+
+# Arm 4: stacked
+CODELENS_EMBED_HINT_INCLUDE_COMMENTS=1 \
+CODELENS_EMBED_HINT_INCLUDE_API_CALLS=1 \
+CODELENS_RANK_SPARSE_TERM_WEIGHT=1 \
+CODELENS_RANK_SPARSE_THRESHOLD=40 \
+CODELENS_RANK_SPARSE_MAX=40 \
+CODELENS_MODEL_DIR=$(pwd)/crates/codelens-engine/models \
+CODELENS_BIN=./target/release/codelens-mcp \
+python3 benchmarks/embedding-quality.py /tmp/react-core-bench --isolated-copy \
+  --dataset benchmarks/embedding-quality-dataset-react-core.json \
+  --output benchmarks/embedding-quality-v1.6-phase3f-react-core-stacked.json
+```
+
+**Limitations acknowledged**:
+
+1. **This is a curated production subtree, not the full React repo.** We explicitly excluded `__tests__/`, because the point of the measurement is runtime code shape, not test helper pollution. That makes it a cleaner scientific slice but a less literal "user points CodeLens at the whole repo" simulation.
+2. **React core is runtime/library code, not a product app.** It reinforces the short-file inertness story, but it still is not the same thing as a large React application with domain-specific components.
+3. **Recall is extremely low.** If only 5 / 34 queries hit the top 10 in every arm, there is almost no space left for a ranking-only intervention to prove itself. This dataset is primarily evidence about the limits of the current embedding/candidate pool.
+
+**Artefacts**: `benchmarks/embedding-quality-v1.6-phase3f-react-core-{baseline,2e-only,2b2c-only,stacked}.json`. Dataset: `benchmarks/embedding-quality-dataset-react-core.json`.
+
+---
+
+### §8.18 — Phase 3g: semantic-dominant Python framework validation on `django/django`
+
+**Hypothesis**: `requests` in §8.14 was clearly negative for Python, but it was still a single **app-library** dataset. That left an obvious escape hatch: maybe Python only looked bad because `requests` is a flat HTTP client with weak lexical anchors and small semantic neighborhoods. Phase 3g tests the other major Python regime: a large framework repo with stronger symbol families (`Model`, `QuerySet`, `HttpRequest`, `login_required`, `ListView`) and a much richer natural-language vocabulary. If Python's regression were dataset-specific, `django/django` is where the stack should recover.
+
+**Target repo**: `django/django` shallow-cloned under `/tmp/django-src/django`. The measured subtree contains **902 `.py` files**, **162,768 LOC** total, and a **61.5 LOC median file size**. That makes it a useful contrast against both the tiny `requests` library and the much larger compiler-oriented TypeScript slice: Django has broad framework vocabulary, but its average file is still short enough that re-rank-only gains can vanish if the candidate pool is already semantic-heavy.
+
+**Dataset**: 34 hand-built queries in `benchmarks/embedding-quality-dataset-django.json`, keeping the now-standard external-repo shape for direct comparison: **26 `natural_language` + 6 `short_phrase` + 2 `identifier`**. Coverage spans four framework surfaces:
+
+| Area                 | Example targets                                                   | Count |
+| -------------------- | ----------------------------------------------------------------- | ----: |
+| ORM / model layer    | `QuerySet`, `Manager`, `Model`, `ForeignKey`                      |    10 |
+| HTTP / shortcuts     | `HttpRequest`, `HttpResponse`, `JsonResponse`, `redirect`, `render` |     8 |
+| URL + auth           | `reverse`, `resolve`, `login`, `logout`, `authenticate`, `login_required` |     8 |
+| Views / forms / misc | `View`, `ListView`, `DetailView`, `Form`, `ModelForm`, `csrf_exempt` |     8 |
+
+**Measurement**:
+
+| arm         |   hybrid MRR | Δ abs vs baseline | Δ rel | semantic MRR | lexical-only MRR |
+| ----------- | -----------: | ----------------: | ----: | -----------: | ---------------: |
+| baseline    |     0.293677 |                 — |     — |     0.285084 |         0.133927 |
+| 2e only     |     0.293677 |          0.000000 | +0.0 % |     0.285084 |         0.135398 |
+| 2b+2c only  |     0.285940 |         -0.007737 | -2.6 % |     0.286765 |         0.133927 |
+| **stacked** | **0.288448** |      **-0.005229** | **-1.8 %** | **0.286765** |     **0.135398** |
+
+Django is a **third regime**, distinct from both Next.js and TypeScript:
+
+- **Semantic-dominant baseline**: `semantic_search` starts at **0.285**, far above lexical-only **0.134**. The baseline hybrid score (**0.294**) is already mostly semantic, so sparse lexical rescue has little room to matter.
+- **`2e` is a true no-op on hybrid**: lexical-only nudges up slightly (`0.1339 → 0.1354`), but the hybrid aggregate does not move at all. The sparse pass touches some BM25 ordering, but those changes never beat the semantic ranking that already dominates Django's candidate pool.
+- **`2b+2c` slightly improves pure semantic, yet still hurts hybrid**: `semantic_search` rises from **0.2851 → 0.2868**, but `get_ranked_context` falls from **0.2937 → 0.2859**. The extra comment / API-call text helps a few natural-language misses, but it perturbs already-retrievable framework queries enough to lose net quality.
+
+**Per-query decomposition**:
+
+```
+baseline vs 2e-only:
+  0 improved, 0 regressed, 34 unchanged
+
+baseline vs 2b+2c only:
+  4 improved, 5 regressed, 25 unchanged
+
+baseline vs stacked:
+  4 improved, 6 regressed, 24 unchanged
+```
+
+Representative stacked changes:
+
+- Improvements:
+  - `Model`: `None → 5`
+  - `login_required`: `None → 10`
+  - `get_object_or_404`: `5 → 3`
+  - `logout`: `3 → 2`
+- Regressions:
+  - `check_password`: `2 → 6`
+  - `redirect`: `7 → 17`
+  - `HttpRequest`: `12 → None`
+  - `HttpResponse` (`short_phrase`): `2 → 4`
+  - `ForeignKey`: `6 → 7`
+
+The query-type split explains the sign:
+
+| query type          | baseline hybrid MRR | stacked hybrid MRR |      Δ |
+| ------------------- | ------------------: | -----------------: | -----: |
+| natural_language    |            0.172501 |           0.175278 | +0.0028 |
+| short_phrase        |            0.750000 |           0.708333 | -0.0417 |
+| identifier          |            0.500000 |           0.500000 | +0.0000 |
+
+So Django is not "uniformly worse"; it is more specific than that. The stack rescues a handful of natural-language framework lookups, but the gain is too small to offset short-phrase regressions on queries that Django's baseline already handled reasonably well.
+
+**Updated nine-dataset baseline matrix**:
+
+| Dataset                           | Language / archetype      | baseline MRR | stacked MRR |      Δ abs |      Δ rel |
+| --------------------------------- | ------------------------- | -----------: | ----------: | ---------: | ---------: |
+| 89-query self                     | Rust / self               |        0.572 |       0.586 |     +0.014 |     +2.4 % |
+| 436-query self                    | Rust / self               |       0.0476 |      0.0510 |    +0.0034 |     +7.1 % |
+| ripgrep external                  | Rust / tooling            |        0.459 |       0.529 |     +0.070 |    +15.2 % |
+| requests external                 | Python / app library      |        0.584 |       0.495 |     -0.089 |    -15.2 % |
+| **django external (new, §8.18)**  | **Python / framework**    |    **0.294** |   **0.288** | **-0.005** | **-1.8 %** |
+| jest external                     | TS/JS / tooling           |        0.155 |       0.166 |     +0.011 |     +7.3 % |
+| typescript external               | TS/JS / compiler          |        0.098 |       0.201 |     +0.103 |   +104.3 % |
+| next-js external                  | TS/JS / typical app       |        0.198 |       0.196 |     -0.002 |     -0.8 % |
+| react-core external               | TS/JS / short runtime     |        0.123 |       0.123 |     +0.000 |     +0.0 % |
+
+Pattern is now **5 positive / 2 negative / 2 inert**.
+
+- **Rust** remains consistently positive.
+- **TS/JS** remains bifurcated by code shape: tooling/compiler positive, runtime/app mostly inert.
+- **Python is now negative in two distinct regimes**: one app library (`requests`) and one semantic-heavy framework (`django`). That is materially stronger evidence than the old single-dataset Python story.
+
+**Policy interpretation**:
+
+- This does **not** justify widening the already-landed Phase 2m split. Phase 2m was the narrow JS/TS fix: keep JS/TS auto-enabled for Phase 2b/2c, but remove JS/TS from the **auto** Phase 2e sparse gate.
+- It **does** validate the existing choice to keep Python outside the auto-on family entirely. The code path already does this: `auto_hint_should_enable()` excludes Python from the NL stack, and `auto_sparse_should_enable()` excludes Python from auto sparse weighting as well.
+- In other words, Django is not a trigger for a new rollback. It is a second external proof that the current Python-off default is the correct side of the tradeoff.
+
+**Reproduce**:
+
+```bash
+git clone --depth=1 https://github.com/django/django.git /tmp/django-src
+
+# Arm 1: baseline
+CODELENS_MODEL_DIR=$(pwd)/crates/codelens-engine/models \
+CODELENS_BIN=./target/release/codelens-mcp \
+python3 benchmarks/embedding-quality.py /tmp/django-src/django --isolated-copy \
+  --dataset benchmarks/embedding-quality-dataset-django.json \
+  --output benchmarks/embedding-quality-v1.6-phase3g-django-baseline.json
+
+# Arm 2: Phase 2e only
+CODELENS_RANK_SPARSE_TERM_WEIGHT=1 \
+CODELENS_RANK_SPARSE_THRESHOLD=40 \
+CODELENS_RANK_SPARSE_MAX=40 \
+CODELENS_MODEL_DIR=$(pwd)/crates/codelens-engine/models \
+CODELENS_BIN=./target/release/codelens-mcp \
+python3 benchmarks/embedding-quality.py /tmp/django-src/django --isolated-copy \
+  --dataset benchmarks/embedding-quality-dataset-django.json \
+  --output benchmarks/embedding-quality-v1.6-phase3g-django-2e-only.json
+
+# Arm 3: Phase 2b + 2c only
+CODELENS_EMBED_HINT_INCLUDE_COMMENTS=1 \
+CODELENS_EMBED_HINT_INCLUDE_API_CALLS=1 \
+CODELENS_MODEL_DIR=$(pwd)/crates/codelens-engine/models \
+CODELENS_BIN=./target/release/codelens-mcp \
+python3 benchmarks/embedding-quality.py /tmp/django-src/django --isolated-copy \
+  --dataset benchmarks/embedding-quality-dataset-django.json \
+  --output benchmarks/embedding-quality-v1.6-phase3g-django-2b2c-only.json
+
+# Arm 4: stacked
+CODELENS_EMBED_HINT_INCLUDE_COMMENTS=1 \
+CODELENS_EMBED_HINT_INCLUDE_API_CALLS=1 \
+CODELENS_RANK_SPARSE_TERM_WEIGHT=1 \
+CODELENS_RANK_SPARSE_THRESHOLD=40 \
+CODELENS_RANK_SPARSE_MAX=40 \
+CODELENS_MODEL_DIR=$(pwd)/crates/codelens-engine/models \
+CODELENS_BIN=./target/release/codelens-mcp \
+python3 benchmarks/embedding-quality.py /tmp/django-src/django --isolated-copy \
+  --dataset benchmarks/embedding-quality-dataset-django.json \
+  --output benchmarks/embedding-quality-v1.6-phase3g-django-stacked.json
+```
+
+**Artefacts**: `benchmarks/embedding-quality-v1.6-phase3g-django-{baseline,2e-only,2b2c-only,stacked}.json`. Dataset: `benchmarks/embedding-quality-dataset-django.json`.
 
 ---
 


### PR DESCRIPTION
## Summary

Two coupled changes driven by the §8.12 → §8.13 → §8.15 → §8.16 → §8.17 JS/TS sparse-weighting evidence arc. No API/schema changes, minimal code footprint (2 engine files), full test green on 260 engine + 155 mcp tests.

### 1. Phase 3f measurement on \`facebook/react\` production subtree (§8.17)

- **Target**: rsync of \`packages/react/src\` minus \`__tests__/\` → 30 source files, 4 035 LOC. Order of magnitude smaller than Next.js, two orders smaller than the TypeScript compiler slice.
- **Dataset**: 34 queries (26 NL + 6 short_phrase + 2 identifier) — React hooks, element/ref API, context/memo/lazy.
- **Result — stronger null than §8.16 Next.js**:

  | arm        | hybrid MRR | Δ abs    | Δ rel   |
  |------------|-----------:|---------:|--------:|
  | baseline   |   0.122549 |        — |       — |
  | 2e only    |   0.122549 |  +0.0000 |  +0.0 % |
  | 2b+2c only |   0.122549 |  +0.0000 |  +0.0 % |
  | stacked    |   0.122549 |  +0.0000 |  +0.0 % |

  Every arm is **row-for-row identical to baseline** across \`semantic_search\`, \`get_ranked_context_no_semantic\`, and \`get_ranked_context\`. 0 improved, 0 regressed, 34 unchanged. 5 / 34 in the top 10; 29 / 34 miss. This is a **pure retrieval-floor dataset** — the v1.5 stack has nothing to work with because the baseline candidate pool barely contains the target.

### 2. Phase 2m — split sparse-weighting auto gate from embedding-hint auto gate

**Evidence base**:

| dataset                          | Phase 2e-only |
|----------------------------------|--------------:|
| §8.12 ripgrep                    |        +0.8 % |
| §8.13 jest                       |        +1.3 % (marginal) |
| §8.15 typescript                 |       −10.0 % |
| §8.16 next-js                    |        −0.8 % |
| §8.17 react-core                 |         0.0 % |

**2 of 3 JS/TS datasets are explicitly negative for 2e; 1 is inert. All Rust tooling is positive.** Phase 2m lands the split that §8.15 / §8.16 had deferred.

**Code change** (2 files, minimal):

- \`crates/codelens-engine/src/embedding/mod.rs\`:
  - New fn \`language_supports_sparse_weighting(lang)\` — \`rust\` / \`c\` / \`c++\` / \`go\` / \`java\` / \`kotlin\` / \`scala\` / \`c#\` only. Excludes \`js\`/\`ts\`/\`python\` and everything else.
  - New fn \`auto_sparse_should_enable()\` — combines §8.11 auto gate with the narrower sparse-supported-lang classifier.
  - Tests: \`language_supports_sparse_weighting_classifies_correctly\`, \`auto_sparse_should_enable_requires_both_gate_and_sparse_supported_lang\`.

- \`crates/codelens-engine/src/symbols/scoring.rs\`:
  - \`sparse_weighting_enabled()\` falls through to \`auto_sparse_should_enable()\` instead of \`auto_hint_should_enable()\`. Single-line behavioural change.
  - New test \`sparse_weighting_auto_gate_disables_for_js_ts_but_explicit_env_still_wins\` covers 4 cases: auto+rust on, auto+ts off, explicit=1 wins over auto-off, explicit=0 wins over auto-on.
  - Pre-existing \`sparse_weighting_gated_off_by_default\` test reworked to serialize via \`ENV_LOCK\` mutex (mirrors \`embedding/mod.rs\` pattern).

**Backwards compatibility**:
- Phase 2b/2c auto-on behaviour on JS/TS is **unchanged** — \`language_supports_nl_stack\` still includes \`ts\`/\`typescript\`/\`tsx\`/\`js\`/\`javascript\`/\`jsx\`.
- Only the sparse re-ranker auto path is narrowed.
- Explicit \`CODELENS_RANK_SPARSE_TERM_WEIGHT\` env override still wins over auto gating (verified by test).

### 3. Documentation cross-refs

- New §8.17 section in \`docs/benchmarks.md\` (full methodology, result table, per-query decomposition, interpretation, reproduce script, limitations, artefacts).
- §8.13 / §8.14 / §8.15 / §8.16 updated with forward cross-refs to §8.15 / §8.16 / §8.17 landing states.
- \`benchmarks/README.md\` indexes the next-js (§8.16) and react-core (§8.17) datasets alongside the typescript (§8.15) entry.

## Test plan

- [x] \`cargo check -p codelens-engine\` — green
- [x] \`cargo test -p codelens-engine\` — **260 passed, 0 failed** (incl. 3 new Phase 2m tests)
- [x] \`cargo test -p codelens-mcp\` — **155 passed, 0 failed**
- [x] 4 arms measured on \`/tmp/react-core-bench\` with \`--isolated-copy\`, each after index reset
- [x] Per-query identity verified across arms — 0 improved / 0 regressed / 34 unchanged in every arm

🤖 Generated with [Claude Code](https://claude.com/claude-code)