### PR TITLE
chore(bench): land Phase 3g django dataset + 4-arm artifacts

### DIFF
--- a/benchmarks/embedding-quality-dataset-django.json
+++ b/benchmarks/embedding-quality-dataset-django.json
@@ -1,0 +1,206 @@
+[
+  {
+    "query": "query rows from a database model",
+    "expected_symbol": "QuerySet",
+    "expected_file_suffix": "db/models/query.py",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "default manager that provides access to objects",
+    "expected_symbol": "Manager",
+    "expected_file_suffix": "db/models/manager.py",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "base class for all database models",
+    "expected_symbol": "Model",
+    "expected_file_suffix": "db/models/base.py",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "declare a foreign-key relationship to another model",
+    "expected_symbol": "ForeignKey",
+    "expected_file_suffix": "db/models/fields/related.py",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "HTTP response with body headers and status",
+    "expected_symbol": "HttpResponse",
+    "expected_file_suffix": "http/response.py",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "return a JSON encoded response to the client",
+    "expected_symbol": "JsonResponse",
+    "expected_file_suffix": "http/response.py",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "object representing an incoming HTTP request",
+    "expected_symbol": "HttpRequest",
+    "expected_file_suffix": "http/request.py",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "render a template with a context into a response",
+    "expected_symbol": "render",
+    "expected_file_suffix": "shortcuts.py",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "get a model instance or raise 404",
+    "expected_symbol": "get_object_or_404",
+    "expected_file_suffix": "shortcuts.py",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "issue an HTTP redirect to a URL or view",
+    "expected_symbol": "redirect",
+    "expected_file_suffix": "shortcuts.py",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "match a URL path against the URL configuration",
+    "expected_symbol": "resolve",
+    "expected_file_suffix": "urls/base.py",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "look up a URL path from its view name",
+    "expected_symbol": "reverse",
+    "expected_file_suffix": "urls/base.py",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "mount a sub-URL configuration into the URL tree",
+    "expected_symbol": "include",
+    "expected_file_suffix": "urls/conf.py",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "log a user in for the current session",
+    "expected_symbol": "login",
+    "expected_file_suffix": "contrib/auth/__init__.py",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "log a user out and clear the session",
+    "expected_symbol": "logout",
+    "expected_file_suffix": "contrib/auth/__init__.py",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "verify a username and password against backends",
+    "expected_symbol": "authenticate",
+    "expected_file_suffix": "contrib/auth/__init__.py",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "require a logged in user to access a view",
+    "expected_symbol": "login_required",
+    "expected_file_suffix": "contrib/auth/decorators.py",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "check that a plain password matches a stored hash",
+    "expected_symbol": "check_password",
+    "expected_file_suffix": "contrib/auth/hashers.py",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "hash a password for storage in the database",
+    "expected_symbol": "make_password",
+    "expected_file_suffix": "contrib/auth/hashers.py",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "generic base class for all class-based views",
+    "expected_symbol": "View",
+    "expected_file_suffix": "views/generic/base.py",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "display a paginated list of model instances",
+    "expected_symbol": "ListView",
+    "expected_file_suffix": "views/generic/list.py",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "display a single object retrieved from a model",
+    "expected_symbol": "DetailView",
+    "expected_file_suffix": "views/generic/detail.py",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "render a template without any extra view logic",
+    "expected_symbol": "TemplateView",
+    "expected_file_suffix": "views/generic/base.py",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "exempt a view from CSRF protection",
+    "expected_symbol": "csrf_exempt",
+    "expected_file_suffix": "views/decorators/csrf.py",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "declarative form with field validation",
+    "expected_symbol": "Form",
+    "expected_file_suffix": "forms/forms.py",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "form that is bound to a model for create and update",
+    "expected_symbol": "ModelForm",
+    "expected_file_suffix": "forms/models.py",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "get object or 404",
+    "expected_symbol": "get_object_or_404",
+    "expected_file_suffix": "shortcuts.py",
+    "query_type": "short_phrase"
+  },
+  {
+    "query": "login required",
+    "expected_symbol": "login_required",
+    "expected_file_suffix": "contrib/auth/decorators.py",
+    "query_type": "short_phrase"
+  },
+  {
+    "query": "http response",
+    "expected_symbol": "HttpResponse",
+    "expected_file_suffix": "http/response.py",
+    "query_type": "short_phrase"
+  },
+  {
+    "query": "query set",
+    "expected_symbol": "QuerySet",
+    "expected_file_suffix": "db/models/query.py",
+    "query_type": "short_phrase"
+  },
+  {
+    "query": "reverse url",
+    "expected_symbol": "reverse",
+    "expected_file_suffix": "urls/base.py",
+    "query_type": "short_phrase"
+  },
+  {
+    "query": "make password",
+    "expected_symbol": "make_password",
+    "expected_file_suffix": "contrib/auth/hashers.py",
+    "query_type": "short_phrase"
+  },
+  {
+    "query": "QuerySet",
+    "expected_symbol": "QuerySet",
+    "expected_file_suffix": "db/models/query.py",
+    "query_type": "identifier"
+  },
+  {
+    "query": "HttpResponse",
+    "expected_symbol": "HttpResponse",
+    "expected_file_suffix": "http/response.py",
+    "query_type": "identifier"
+  }
+]

--- a/benchmarks/embedding-quality-v1.6-phase3g-django-2b2c-only.json
+++ b/benchmarks/embedding-quality-v1.6-phase3g-django-2b2c-only.json
@@ -1,0 +1,1487 @@
+{
+  "project": "/tmp/django-src/django",
+  "benchmark_project": "/var/folders/z0/0tcbss795xsdp75jmr_t9_kh0000gn/T/codelens-embed-quality-490l3f38/django",
+  "isolated_copy": true,
+  "binary": "/Users/bagjaeseog/codelens-mcp-plugin/target/release/codelens-mcp",
+  "embedding_model": "MiniLM-L12-CodeSearchNet-INT8",
+  "runtime_model": {
+    "model_dir": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch",
+    "model_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/model.onnx",
+    "config_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/config.json",
+    "sha256": "ef1d1e9cfa72e4929f5b9faea17d8704b23a2530aadebf0d464a4cc7750920b3",
+    "size_bytes": 34000281,
+    "num_hidden_layers": 12,
+    "hidden_size": 384
+  },
+  "dataset_path": "/Users/bagjaeseog/codelens-mcp-plugin/benchmarks/embedding-quality-dataset-django.json",
+  "dataset_size": 34,
+  "ranking_cutoff": 10,
+  "metric_labels": {
+    "mrr": "MRR@10",
+    "acc1": "Acc@1",
+    "acc3": "Acc@3",
+    "acc5": "Acc@5"
+  },
+  "methods": [
+    {
+      "method": "semantic_search",
+      "mrr": 0.2867647058823529,
+      "acc1": 0.23529411764705882,
+      "acc3": 0.3235294117647059,
+      "acc5": 0.35294117647058826,
+      "avg_elapsed_ms": 1246.7208823529413,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 1.0,
+          "acc1": 1.0,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 322.96500000000003
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.14423076923076922,
+          "acc1": 0.07692307692307693,
+          "acc3": 0.19230769230769232,
+          "acc5": 0.23076923076923078,
+          "avg_elapsed_ms": 1471.4546153846154
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.6666666666666666,
+          "acc1": 0.6666666666666666,
+          "acc3": 0.6666666666666666,
+          "acc5": 0.6666666666666666,
+          "avg_elapsed_ms": 580.7933333333334
+        }
+      },
+      "rows": [
+        {
+          "query": "query rows from a database model",
+          "query_type": "natural_language",
+          "expected_symbol": "QuerySet",
+          "expected_file_suffix": "db/models/query.py",
+          "rank": null,
+          "elapsed_ms": 1943.48,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "query",
+            "file": "db/models/query.py"
+          }
+        },
+        {
+          "query": "default manager that provides access to objects",
+          "query_type": "natural_language",
+          "expected_symbol": "Manager",
+          "expected_file_suffix": "db/models/manager.py",
+          "rank": null,
+          "elapsed_ms": 1716.15,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "_default_manager",
+            "file": "db/models/base.py"
+          }
+        },
+        {
+          "query": "base class for all database models",
+          "query_type": "natural_language",
+          "expected_symbol": "Model",
+          "expected_file_suffix": "db/models/base.py",
+          "rank": null,
+          "elapsed_ms": 1760.25,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "ModelBase",
+            "file": "db/models/base.py"
+          }
+        },
+        {
+          "query": "declare a foreign-key relationship to another model",
+          "query_type": "natural_language",
+          "expected_symbol": "ForeignKey",
+          "expected_file_suffix": "db/models/fields/related.py",
+          "rank": null,
+          "elapsed_ms": 1939.25,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "_foreign_key_constraints",
+            "file": "db/backends/oracle/operations.py"
+          }
+        },
+        {
+          "query": "HTTP response with body headers and status",
+          "query_type": "natural_language",
+          "expected_symbol": "HttpResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": null,
+          "elapsed_ms": 1312.16,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "body",
+            "file": "http/request.py"
+          }
+        },
+        {
+          "query": "return a JSON encoded response to the client",
+          "query_type": "natural_language",
+          "expected_symbol": "JsonResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": null,
+          "elapsed_ms": 2075.85,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "_encode_json",
+            "file": "test/client.py"
+          }
+        },
+        {
+          "query": "object representing an incoming HTTP request",
+          "query_type": "natural_language",
+          "expected_symbol": "HttpRequest",
+          "expected_file_suffix": "http/request.py",
+          "rank": null,
+          "elapsed_ms": 1870.99,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "_get_edited_object_pks",
+            "file": "contrib/admin/options.py"
+          }
+        },
+        {
+          "query": "render a template with a context into a response",
+          "query_type": "natural_language",
+          "expected_symbol": "render",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": null,
+          "elapsed_ms": 1755.18,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "context",
+            "file": "template/response.py"
+          }
+        },
+        {
+          "query": "get a model instance or raise 404",
+          "query_type": "natural_language",
+          "expected_symbol": "get_object_or_404",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": 1,
+          "elapsed_ms": 1499.17,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "get_object_or_404",
+            "file": "shortcuts.py"
+          }
+        },
+        {
+          "query": "issue an HTTP redirect to a URL or view",
+          "query_type": "natural_language",
+          "expected_symbol": "redirect",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": 4,
+          "elapsed_ms": 1967.76,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "redirect_to_str",
+            "file": "http/response.py"
+          }
+        },
+        {
+          "query": "match a URL path against the URL configuration",
+          "query_type": "natural_language",
+          "expected_symbol": "resolve",
+          "expected_file_suffix": "urls/base.py",
+          "rank": null,
+          "elapsed_ms": 902.67,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "match_url",
+            "file": "contrib/admin/templatetags/admin_urls.py"
+          }
+        },
+        {
+          "query": "look up a URL path from its view name",
+          "query_type": "natural_language",
+          "expected_symbol": "reverse",
+          "expected_file_suffix": "urls/base.py",
+          "rank": null,
+          "elapsed_ms": 925.56,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "view",
+            "file": "views/generic/base.py"
+          }
+        },
+        {
+          "query": "mount a sub-URL configuration into the URL tree",
+          "query_type": "natural_language",
+          "expected_symbol": "include",
+          "expected_file_suffix": "urls/conf.py",
+          "rank": null,
+          "elapsed_ms": 971.07,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "urls",
+            "file": "contrib/admin/sites.py"
+          }
+        },
+        {
+          "query": "log a user in for the current session",
+          "query_type": "natural_language",
+          "expected_symbol": "login",
+          "expected_file_suffix": "contrib/auth/__init__.py",
+          "rank": 2,
+          "elapsed_ms": 1771.15,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "login",
+            "file": "contrib/admin/sites.py"
+          }
+        },
+        {
+          "query": "log a user out and clear the session",
+          "query_type": "natural_language",
+          "expected_symbol": "logout",
+          "expected_file_suffix": "contrib/auth/__init__.py",
+          "rank": 2,
+          "elapsed_ms": 872.13,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "logout",
+            "file": "contrib/admin/sites.py"
+          }
+        },
+        {
+          "query": "verify a username and password against backends",
+          "query_type": "natural_language",
+          "expected_symbol": "authenticate",
+          "expected_file_suffix": "contrib/auth/__init__.py",
+          "rank": null,
+          "elapsed_ms": 1699.68,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "verify",
+            "file": "contrib/auth/hashers.py"
+          }
+        },
+        {
+          "query": "require a logged in user to access a view",
+          "query_type": "natural_language",
+          "expected_symbol": "login_required",
+          "expected_file_suffix": "contrib/auth/decorators.py",
+          "rank": null,
+          "elapsed_ms": 1503.92,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "view",
+            "file": "views/generic/base.py"
+          }
+        },
+        {
+          "query": "check that a plain password matches a stored hash",
+          "query_type": "natural_language",
+          "expected_symbol": "check_password",
+          "expected_file_suffix": "contrib/auth/hashers.py",
+          "rank": null,
+          "elapsed_ms": 910.53,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "check",
+            "file": "contrib/admin/options.py"
+          }
+        },
+        {
+          "query": "hash a password for storage in the database",
+          "query_type": "natural_language",
+          "expected_symbol": "make_password",
+          "expected_file_suffix": "contrib/auth/hashers.py",
+          "rank": null,
+          "elapsed_ms": 1729.21,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "__hash__",
+            "file": "db/models/manager.py"
+          }
+        },
+        {
+          "query": "generic base class for all class-based views",
+          "query_type": "natural_language",
+          "expected_symbol": "View",
+          "expected_file_suffix": "views/generic/base.py",
+          "rank": 2,
+          "elapsed_ms": 999.66,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "BaseDetailView",
+            "file": "views/generic/detail.py"
+          }
+        },
+        {
+          "query": "display a paginated list of model instances",
+          "query_type": "natural_language",
+          "expected_symbol": "ListView",
+          "expected_file_suffix": "views/generic/list.py",
+          "rank": null,
+          "elapsed_ms": 1518.93,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "display",
+            "file": "template/defaulttags.py"
+          }
+        },
+        {
+          "query": "display a single object retrieved from a model",
+          "query_type": "natural_language",
+          "expected_symbol": "DetailView",
+          "expected_file_suffix": "views/generic/detail.py",
+          "rank": null,
+          "elapsed_ms": 1794.41,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "display",
+            "file": "template/defaulttags.py"
+          }
+        },
+        {
+          "query": "render a template without any extra view logic",
+          "query_type": "natural_language",
+          "expected_symbol": "TemplateView",
+          "expected_file_suffix": "views/generic/base.py",
+          "rank": null,
+          "elapsed_ms": 895.17,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "render",
+            "file": "template/backends/dummy.py"
+          }
+        },
+        {
+          "query": "exempt a view from CSRF protection",
+          "query_type": "natural_language",
+          "expected_symbol": "csrf_exempt",
+          "expected_file_suffix": "views/decorators/csrf.py",
+          "rank": 1,
+          "elapsed_ms": 1484.21,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "csrf_exempt",
+            "file": "views/decorators/csrf.py"
+          }
+        },
+        {
+          "query": "declarative form with field validation",
+          "query_type": "natural_language",
+          "expected_symbol": "Form",
+          "expected_file_suffix": "forms/forms.py",
+          "rank": null,
+          "elapsed_ms": 1475.34,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "form_valid",
+            "file": "views/generic/edit.py"
+          }
+        },
+        {
+          "query": "form that is bound to a model for create and update",
+          "query_type": "natural_language",
+          "expected_symbol": "ModelForm",
+          "expected_file_suffix": "forms/models.py",
+          "rank": null,
+          "elapsed_ms": 963.94,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "_update",
+            "file": "db/models/query.py"
+          }
+        },
+        {
+          "query": "get object or 404",
+          "query_type": "short_phrase",
+          "expected_symbol": "get_object_or_404",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": 1,
+          "elapsed_ms": 1049.15,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "get_object_or_404",
+            "file": "shortcuts.py"
+          }
+        },
+        {
+          "query": "login required",
+          "query_type": "short_phrase",
+          "expected_symbol": "login_required",
+          "expected_file_suffix": "contrib/auth/decorators.py",
+          "rank": 1,
+          "elapsed_ms": 483.39,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "login_required",
+            "file": "contrib/auth/decorators.py"
+          }
+        },
+        {
+          "query": "http response",
+          "query_type": "short_phrase",
+          "expected_symbol": "HttpResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": null,
+          "elapsed_ms": 486.45,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "response",
+            "file": "views/generic/base.py"
+          }
+        },
+        {
+          "query": "query set",
+          "query_type": "short_phrase",
+          "expected_symbol": "QuerySet",
+          "expected_file_suffix": "db/models/query.py",
+          "rank": null,
+          "elapsed_ms": 486.74,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "queryset",
+            "file": "db/models/query.py"
+          }
+        },
+        {
+          "query": "reverse url",
+          "query_type": "short_phrase",
+          "expected_symbol": "reverse",
+          "expected_file_suffix": "urls/base.py",
+          "rank": 1,
+          "elapsed_ms": 483.8,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "reverse",
+            "file": "urls/base.py"
+          }
+        },
+        {
+          "query": "make password",
+          "query_type": "short_phrase",
+          "expected_symbol": "make_password",
+          "expected_file_suffix": "contrib/auth/hashers.py",
+          "rank": 1,
+          "elapsed_ms": 495.23,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "make_password",
+            "file": "contrib/auth/hashers.py"
+          }
+        },
+        {
+          "query": "QuerySet",
+          "query_type": "identifier",
+          "expected_symbol": "QuerySet",
+          "expected_file_suffix": "db/models/query.py",
+          "rank": 1,
+          "elapsed_ms": 327.79,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "QuerySet",
+            "file": "db/models/query.py"
+          }
+        },
+        {
+          "query": "HttpResponse",
+          "query_type": "identifier",
+          "expected_symbol": "HttpResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": 1,
+          "elapsed_ms": 318.14,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "HttpResponse",
+            "file": "http/response.py"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context_no_semantic",
+      "mrr": 0.1339273640490679,
+      "acc1": 0.08823529411764706,
+      "acc3": 0.11764705882352941,
+      "acc5": 0.20588235294117646,
+      "avg_elapsed_ms": 160.4979411764706,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 0.5,
+          "acc1": 0.5,
+          "acc3": 0.5,
+          "acc5": 0.5,
+          "avg_elapsed_ms": 124.895
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.04244347606416572,
+          "acc1": 0.0,
+          "acc3": 0.038461538461538464,
+          "acc5": 0.07692307692307693,
+          "avg_elapsed_ms": 168.06192307692305
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.4083333333333334,
+          "acc1": 0.3333333333333333,
+          "acc3": 0.3333333333333333,
+          "acc5": 0.6666666666666666,
+          "avg_elapsed_ms": 139.58833333333334
+        }
+      },
+      "rows": [
+        {
+          "query": "query rows from a database model",
+          "query_type": "natural_language",
+          "expected_symbol": "QuerySet",
+          "expected_file_suffix": "db/models/query.py",
+          "rank": null,
+          "elapsed_ms": 177.72,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "del_query",
+            "file": "db/models/query.py"
+          }
+        },
+        {
+          "query": "default manager that provides access to objects",
+          "query_type": "natural_language",
+          "expected_symbol": "Manager",
+          "expected_file_suffix": "db/models/manager.py",
+          "rank": 7,
+          "elapsed_ms": 182.37,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "ManagerDescriptor",
+            "file": "db/models/manager.py"
+          }
+        },
+        {
+          "query": "base class for all database models",
+          "query_type": "natural_language",
+          "expected_symbol": "Model",
+          "expected_file_suffix": "db/models/base.py",
+          "rank": null,
+          "elapsed_ms": 175.63,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "database",
+            "file": "core/checks/registry.py"
+          }
+        },
+        {
+          "query": "declare a foreign-key relationship to another model",
+          "query_type": "natural_language",
+          "expected_symbol": "ForeignKey",
+          "expected_file_suffix": "db/models/fields/related.py",
+          "rank": 3,
+          "elapsed_ms": 181.99,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "foreign_key",
+            "file": "db/backends/sqlite3/base.py"
+          }
+        },
+        {
+          "query": "HTTP response with body headers and status",
+          "query_type": "natural_language",
+          "expected_symbol": "HttpResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": null,
+          "elapsed_ms": 164.05,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "http_date",
+            "file": "utils/http.py"
+          }
+        },
+        {
+          "query": "return a JSON encoded response to the client",
+          "query_type": "natural_language",
+          "expected_symbol": "JsonResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": null,
+          "elapsed_ms": 183.61,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "client",
+            "file": "core/cache/backends/redis.py"
+          }
+        },
+        {
+          "query": "object representing an incoming HTTP request",
+          "query_type": "natural_language",
+          "expected_symbol": "HttpRequest",
+          "expected_file_suffix": "http/request.py",
+          "rank": null,
+          "elapsed_ms": 183.03,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "parse_http_date",
+            "file": "utils/http.py"
+          }
+        },
+        {
+          "query": "render a template with a context into a response",
+          "query_type": "natural_language",
+          "expected_symbol": "render",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": null,
+          "elapsed_ms": 175.18,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "Template",
+            "file": "template/base.py"
+          }
+        },
+        {
+          "query": "get a model instance or raise 404",
+          "query_type": "natural_language",
+          "expected_symbol": "get_object_or_404",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": 6,
+          "elapsed_ms": 166.87,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "get_for_model",
+            "file": "contrib/contenttypes/models.py"
+          }
+        },
+        {
+          "query": "issue an HTTP redirect to a URL or view",
+          "query_type": "natural_language",
+          "expected_symbol": "redirect",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": 12,
+          "elapsed_ms": 177.66,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "redirect_to",
+            "file": "contrib/auth/views.py"
+          }
+        },
+        {
+          "query": "match a URL path against the URL configuration",
+          "query_type": "natural_language",
+          "expected_symbol": "resolve",
+          "expected_file_suffix": "urls/base.py",
+          "rank": null,
+          "elapsed_ms": 148.29,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "match_url",
+            "file": "contrib/admin/templatetags/admin_urls.py"
+          }
+        },
+        {
+          "query": "look up a URL path from its view name",
+          "query_type": "natural_language",
+          "expected_symbol": "reverse",
+          "expected_file_suffix": "urls/base.py",
+          "rank": null,
+          "elapsed_ms": 148.3,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "from_",
+            "file": "db/models/fields/related.py"
+          }
+        },
+        {
+          "query": "mount a sub-URL configuration into the URL tree",
+          "query_type": "natural_language",
+          "expected_symbol": "include",
+          "expected_file_suffix": "urls/conf.py",
+          "rank": null,
+          "elapsed_ms": 165.11,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "use_returning_into",
+            "file": "db/backends/oracle/base.py"
+          }
+        },
+        {
+          "query": "log a user in for the current session",
+          "query_type": "natural_language",
+          "expected_symbol": "login",
+          "expected_file_suffix": "contrib/auth/__init__.py",
+          "rank": null,
+          "elapsed_ms": 176.17,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "_session",
+            "file": "contrib/sessions/backends/base.py"
+          }
+        },
+        {
+          "query": "log a user out and clear the session",
+          "query_type": "natural_language",
+          "expected_symbol": "logout",
+          "expected_file_suffix": "contrib/auth/__init__.py",
+          "rank": null,
+          "elapsed_ms": 148.27,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "_session",
+            "file": "contrib/sessions/backends/base.py"
+          }
+        },
+        {
+          "query": "verify a username and password against backends",
+          "query_type": "natural_language",
+          "expected_symbol": "authenticate",
+          "expected_file_suffix": "contrib/auth/__init__.py",
+          "rank": null,
+          "elapsed_ms": 172.47,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "task_backends",
+            "file": "tasks/__init__.py"
+          }
+        },
+        {
+          "query": "require a logged in user to access a view",
+          "query_type": "natural_language",
+          "expected_symbol": "login_required",
+          "expected_file_suffix": "contrib/auth/decorators.py",
+          "rank": null,
+          "elapsed_ms": 170.51,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "user_logged_in",
+            "file": "contrib/auth/signals.py"
+          }
+        },
+        {
+          "query": "check that a plain password matches a stored hash",
+          "query_type": "natural_language",
+          "expected_symbol": "check_password",
+          "expected_file_suffix": "contrib/auth/hashers.py",
+          "rank": null,
+          "elapsed_ms": 153.97,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "cmatches",
+            "file": "utils/translation/template.py"
+          }
+        },
+        {
+          "query": "hash a password for storage in the database",
+          "query_type": "natural_language",
+          "expected_symbol": "make_password",
+          "expected_file_suffix": "contrib/auth/hashers.py",
+          "rank": null,
+          "elapsed_ms": 177.04,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "hash_",
+            "file": "contrib/auth/hashers.py"
+          }
+        },
+        {
+          "query": "generic base class for all class-based views",
+          "query_type": "natural_language",
+          "expected_symbol": "View",
+          "expected_file_suffix": "views/generic/base.py",
+          "rank": null,
+          "elapsed_ms": 159.02,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "GenericForeignKey",
+            "file": "contrib/contenttypes/fields.py"
+          }
+        },
+        {
+          "query": "display a paginated list of model instances",
+          "query_type": "natural_language",
+          "expected_symbol": "ListView",
+          "expected_file_suffix": "views/generic/list.py",
+          "rank": null,
+          "elapsed_ms": 170.73,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "list_",
+            "file": "http/request.py"
+          }
+        },
+        {
+          "query": "display a single object retrieved from a model",
+          "query_type": "natural_language",
+          "expected_symbol": "DetailView",
+          "expected_file_suffix": "views/generic/detail.py",
+          "rank": null,
+          "elapsed_ms": 172.12,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "from_",
+            "file": "db/models/fields/related.py"
+          }
+        },
+        {
+          "query": "render a template without any extra view logic",
+          "query_type": "natural_language",
+          "expected_symbol": "TemplateView",
+          "expected_file_suffix": "views/generic/base.py",
+          "rank": null,
+          "elapsed_ms": 148.23,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "set_many",
+            "file": "core/cache/backends/redis.py"
+          }
+        },
+        {
+          "query": "exempt a view from CSRF protection",
+          "query_type": "natural_language",
+          "expected_symbol": "csrf_exempt",
+          "expected_file_suffix": "views/decorators/csrf.py",
+          "rank": 5,
+          "elapsed_ms": 168.36,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "from_",
+            "file": "db/models/fields/related.py"
+          }
+        },
+        {
+          "query": "declarative form with field validation",
+          "query_type": "natural_language",
+          "expected_symbol": "Form",
+          "expected_file_suffix": "forms/forms.py",
+          "rank": 7,
+          "elapsed_ms": 167.37,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "Field",
+            "file": "db/models/fields/__init__.py"
+          }
+        },
+        {
+          "query": "form that is bound to a model for create and update",
+          "query_type": "natural_language",
+          "expected_symbol": "ModelForm",
+          "expected_file_suffix": "forms/models.py",
+          "rank": 29,
+          "elapsed_ms": 155.54,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "_update",
+            "file": "db/models/query.py"
+          }
+        },
+        {
+          "query": "get object or 404",
+          "query_type": "short_phrase",
+          "expected_symbol": "get_object_or_404",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": 1,
+          "elapsed_ms": 155.23,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "get_object_or_404",
+            "file": "shortcuts.py"
+          }
+        },
+        {
+          "query": "login required",
+          "query_type": "short_phrase",
+          "expected_symbol": "login_required",
+          "expected_file_suffix": "contrib/auth/decorators.py",
+          "rank": 1,
+          "elapsed_ms": 143.73,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "login_required",
+            "file": "contrib/auth/decorators.py"
+          }
+        },
+        {
+          "query": "http response",
+          "query_type": "short_phrase",
+          "expected_symbol": "HttpResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": 4,
+          "elapsed_ms": 142.78,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "HttpResponseNotFound",
+            "file": "http/response.py"
+          }
+        },
+        {
+          "query": "query set",
+          "query_type": "short_phrase",
+          "expected_symbol": "QuerySet",
+          "expected_file_suffix": "db/models/query.py",
+          "rank": null,
+          "elapsed_ms": 131.68,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "set",
+            "file": "core/cache/backends/redis.py"
+          }
+        },
+        {
+          "query": "reverse url",
+          "query_type": "short_phrase",
+          "expected_symbol": "reverse",
+          "expected_file_suffix": "urls/base.py",
+          "rank": 5,
+          "elapsed_ms": 131.5,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "reverse",
+            "file": "urls/resolvers.py"
+          }
+        },
+        {
+          "query": "make password",
+          "query_type": "short_phrase",
+          "expected_symbol": "make_password",
+          "expected_file_suffix": "contrib/auth/hashers.py",
+          "rank": null,
+          "elapsed_ms": 132.61,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "make_aware",
+            "file": "utils/timezone.py"
+          }
+        },
+        {
+          "query": "QuerySet",
+          "query_type": "identifier",
+          "expected_symbol": "QuerySet",
+          "expected_file_suffix": "db/models/query.py",
+          "rank": null,
+          "elapsed_ms": 125.85,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "queryset",
+            "file": "contrib/contenttypes/fields.py"
+          }
+        },
+        {
+          "query": "HttpResponse",
+          "query_type": "identifier",
+          "expected_symbol": "HttpResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": 1,
+          "elapsed_ms": 123.94,
+          "candidate_count": 13,
+          "top_candidate": {
+            "name": "HttpResponse",
+            "file": "http/response.py"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context",
+      "mrr": 0.2859398483100905,
+      "acc1": 0.23529411764705882,
+      "acc3": 0.29411764705882354,
+      "acc5": 0.3235294117647059,
+      "avg_elapsed_ms": 262.0811764705882,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 0.5,
+          "acc1": 0.5,
+          "acc3": 0.5,
+          "acc5": 0.5,
+          "avg_elapsed_ms": 130.655
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.17199826317473377,
+          "acc1": 0.11538461538461539,
+          "acc3": 0.19230769230769232,
+          "acc5": 0.19230769230769232,
+          "avg_elapsed_ms": 275.24384615384616
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.7083333333333334,
+          "acc1": 0.6666666666666666,
+          "acc3": 0.6666666666666666,
+          "acc5": 0.8333333333333334,
+          "avg_elapsed_ms": 248.85166666666666
+        }
+      },
+      "rows": [
+        {
+          "query": "query rows from a database model",
+          "query_type": "natural_language",
+          "expected_symbol": "QuerySet",
+          "expected_file_suffix": "db/models/query.py",
+          "rank": null,
+          "elapsed_ms": 301.14,
+          "candidate_count": 36,
+          "top_candidate": {
+            "name": "fetch_returned_rows",
+            "file": "db/backends/base/operations.py"
+          }
+        },
+        {
+          "query": "default manager that provides access to objects",
+          "query_type": "natural_language",
+          "expected_symbol": "Manager",
+          "expected_file_suffix": "db/models/manager.py",
+          "rank": 18,
+          "elapsed_ms": 283.46,
+          "candidate_count": 34,
+          "top_candidate": {
+            "name": "_default_manager",
+            "file": "db/models/base.py"
+          }
+        },
+        {
+          "query": "base class for all database models",
+          "query_type": "natural_language",
+          "expected_symbol": "Model",
+          "expected_file_suffix": "db/models/base.py",
+          "rank": 11,
+          "elapsed_ms": 279.45,
+          "candidate_count": 34,
+          "top_candidate": {
+            "name": "ModelBase",
+            "file": "db/models/base.py"
+          }
+        },
+        {
+          "query": "declare a foreign-key relationship to another model",
+          "query_type": "natural_language",
+          "expected_symbol": "ForeignKey",
+          "expected_file_suffix": "db/models/fields/related.py",
+          "rank": 6,
+          "elapsed_ms": 284.52,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "fk",
+            "file": "forms/models.py"
+          }
+        },
+        {
+          "query": "HTTP response with body headers and status",
+          "query_type": "natural_language",
+          "expected_symbol": "HttpResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": null,
+          "elapsed_ms": 264.51,
+          "candidate_count": 36,
+          "top_candidate": {
+            "name": "body",
+            "file": "http/request.py"
+          }
+        },
+        {
+          "query": "return a JSON encoded response to the client",
+          "query_type": "natural_language",
+          "expected_symbol": "JsonResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": null,
+          "elapsed_ms": 295.09,
+          "candidate_count": 35,
+          "top_candidate": {
+            "name": "_encode_json",
+            "file": "test/client.py"
+          }
+        },
+        {
+          "query": "object representing an incoming HTTP request",
+          "query_type": "natural_language",
+          "expected_symbol": "HttpRequest",
+          "expected_file_suffix": "http/request.py",
+          "rank": null,
+          "elapsed_ms": 287.77,
+          "candidate_count": 34,
+          "top_candidate": {
+            "name": "encoding",
+            "file": "http/request.py"
+          }
+        },
+        {
+          "query": "render a template with a context into a response",
+          "query_type": "natural_language",
+          "expected_symbol": "render",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": null,
+          "elapsed_ms": 285.44,
+          "candidate_count": 35,
+          "top_candidate": {
+            "name": "context",
+            "file": "template/response.py"
+          }
+        },
+        {
+          "query": "get a model instance or raise 404",
+          "query_type": "natural_language",
+          "expected_symbol": "get_object_or_404",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": 3,
+          "elapsed_ms": 273.04,
+          "candidate_count": 33,
+          "top_candidate": {
+            "name": "get_model",
+            "file": "apps/registry.py"
+          }
+        },
+        {
+          "query": "issue an HTTP redirect to a URL or view",
+          "query_type": "natural_language",
+          "expected_symbol": "redirect",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": 17,
+          "elapsed_ms": 288.28,
+          "candidate_count": 34,
+          "top_candidate": {
+            "name": "get_redirect_url",
+            "file": "contrib/auth/views.py"
+          }
+        },
+        {
+          "query": "match a URL path against the URL configuration",
+          "query_type": "natural_language",
+          "expected_symbol": "resolve",
+          "expected_file_suffix": "urls/base.py",
+          "rank": null,
+          "elapsed_ms": 256.97,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "match",
+            "file": "urls/resolvers.py"
+          }
+        },
+        {
+          "query": "look up a URL path from its view name",
+          "query_type": "natural_language",
+          "expected_symbol": "reverse",
+          "expected_file_suffix": "urls/base.py",
+          "rank": null,
+          "elapsed_ms": 255.07,
+          "candidate_count": 34,
+          "top_candidate": {
+            "name": "view_path",
+            "file": "urls/resolvers.py"
+          }
+        },
+        {
+          "query": "mount a sub-URL configuration into the URL tree",
+          "query_type": "natural_language",
+          "expected_symbol": "include",
+          "expected_file_suffix": "urls/conf.py",
+          "rank": null,
+          "elapsed_ms": 259.46,
+          "candidate_count": 35,
+          "top_candidate": {
+            "name": "check_url_config",
+            "file": "core/checks/urls.py"
+          }
+        },
+        {
+          "query": "log a user in for the current session",
+          "query_type": "natural_language",
+          "expected_symbol": "login",
+          "expected_file_suffix": "contrib/auth/__init__.py",
+          "rank": 1,
+          "elapsed_ms": 281.59,
+          "candidate_count": 34,
+          "top_candidate": {
+            "name": "login",
+            "file": "contrib/auth/__init__.py"
+          }
+        },
+        {
+          "query": "log a user out and clear the session",
+          "query_type": "natural_language",
+          "expected_symbol": "logout",
+          "expected_file_suffix": "contrib/auth/__init__.py",
+          "rank": 2,
+          "elapsed_ms": 265.46,
+          "candidate_count": 36,
+          "top_candidate": {
+            "name": "logout",
+            "file": "contrib/admin/sites.py"
+          }
+        },
+        {
+          "query": "verify a username and password against backends",
+          "query_type": "natural_language",
+          "expected_symbol": "authenticate",
+          "expected_file_suffix": "contrib/auth/__init__.py",
+          "rank": null,
+          "elapsed_ms": 282.89,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "verify",
+            "file": "contrib/auth/hashers.py"
+          }
+        },
+        {
+          "query": "require a logged in user to access a view",
+          "query_type": "natural_language",
+          "expected_symbol": "login_required",
+          "expected_file_suffix": "contrib/auth/decorators.py",
+          "rank": 10,
+          "elapsed_ms": 275.11,
+          "candidate_count": 34,
+          "top_candidate": {
+            "name": "view",
+            "file": "views/generic/base.py"
+          }
+        },
+        {
+          "query": "check that a plain password matches a stored hash",
+          "query_type": "natural_language",
+          "expected_symbol": "check_password",
+          "expected_file_suffix": "contrib/auth/hashers.py",
+          "rank": 6,
+          "elapsed_ms": 254.95,
+          "candidate_count": 36,
+          "top_candidate": {
+            "name": "render_password_as_hash",
+            "file": "contrib/auth/templatetags/auth.py"
+          }
+        },
+        {
+          "query": "hash a password for storage in the database",
+          "query_type": "natural_language",
+          "expected_symbol": "make_password",
+          "expected_file_suffix": "contrib/auth/hashers.py",
+          "rank": null,
+          "elapsed_ms": 280.06,
+          "candidate_count": 36,
+          "top_candidate": {
+            "name": "__hash__",
+            "file": "db/models/manager.py"
+          }
+        },
+        {
+          "query": "generic base class for all class-based views",
+          "query_type": "natural_language",
+          "expected_symbol": "View",
+          "expected_file_suffix": "views/generic/base.py",
+          "rank": 1,
+          "elapsed_ms": 258.79,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "View",
+            "file": "views/generic/base.py"
+          }
+        },
+        {
+          "query": "display a paginated list of model instances",
+          "query_type": "natural_language",
+          "expected_symbol": "ListView",
+          "expected_file_suffix": "views/generic/list.py",
+          "rank": null,
+          "elapsed_ms": 273.67,
+          "candidate_count": 37,
+          "top_candidate": {
+            "name": "model",
+            "file": "contrib/postgres/fields/array.py"
+          }
+        },
+        {
+          "query": "display a single object retrieved from a model",
+          "query_type": "natural_language",
+          "expected_symbol": "DetailView",
+          "expected_file_suffix": "views/generic/detail.py",
+          "rank": null,
+          "elapsed_ms": 282.53,
+          "candidate_count": 36,
+          "top_candidate": {
+            "name": "model",
+            "file": "views/generic/detail.py"
+          }
+        },
+        {
+          "query": "render a template without any extra view logic",
+          "query_type": "natural_language",
+          "expected_symbol": "TemplateView",
+          "expected_file_suffix": "views/generic/base.py",
+          "rank": null,
+          "elapsed_ms": 258.78,
+          "candidate_count": 37,
+          "top_candidate": {
+            "name": "render",
+            "file": "template/backends/dummy.py"
+          }
+        },
+        {
+          "query": "exempt a view from CSRF protection",
+          "query_type": "natural_language",
+          "expected_symbol": "csrf_exempt",
+          "expected_file_suffix": "views/decorators/csrf.py",
+          "rank": 1,
+          "elapsed_ms": 286.37,
+          "candidate_count": 33,
+          "top_candidate": {
+            "name": "csrf_exempt",
+            "file": "views/decorators/csrf.py"
+          }
+        },
+        {
+          "query": "declarative form with field validation",
+          "query_type": "natural_language",
+          "expected_symbol": "Form",
+          "expected_file_suffix": "forms/forms.py",
+          "rank": null,
+          "elapsed_ms": 280.24,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "form_valid",
+            "file": "views/generic/edit.py"
+          }
+        },
+        {
+          "query": "form that is bound to a model for create and update",
+          "query_type": "natural_language",
+          "expected_symbol": "ModelForm",
+          "expected_file_suffix": "forms/models.py",
+          "rank": null,
+          "elapsed_ms": 261.7,
+          "candidate_count": 37,
+          "top_candidate": {
+            "name": "_do_update",
+            "file": "db/models/base.py"
+          }
+        },
+        {
+          "query": "get object or 404",
+          "query_type": "short_phrase",
+          "expected_symbol": "get_object_or_404",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": 1,
+          "elapsed_ms": 255.76,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "get_object_or_404",
+            "file": "shortcuts.py"
+          }
+        },
+        {
+          "query": "login required",
+          "query_type": "short_phrase",
+          "expected_symbol": "login_required",
+          "expected_file_suffix": "contrib/auth/decorators.py",
+          "rank": 1,
+          "elapsed_ms": 254.05,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "login_required",
+            "file": "contrib/auth/decorators.py"
+          }
+        },
+        {
+          "query": "http response",
+          "query_type": "short_phrase",
+          "expected_symbol": "HttpResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": 4,
+          "elapsed_ms": 246.39,
+          "candidate_count": 33,
+          "top_candidate": {
+            "name": "response",
+            "file": "views/generic/base.py"
+          }
+        },
+        {
+          "query": "query set",
+          "query_type": "short_phrase",
+          "expected_symbol": "QuerySet",
+          "expected_file_suffix": "db/models/query.py",
+          "rank": null,
+          "elapsed_ms": 246.53,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "queryset",
+            "file": "db/models/query.py"
+          }
+        },
+        {
+          "query": "reverse url",
+          "query_type": "short_phrase",
+          "expected_symbol": "reverse",
+          "expected_file_suffix": "urls/base.py",
+          "rank": 1,
+          "elapsed_ms": 245.73,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "reverse",
+            "file": "urls/base.py"
+          }
+        },
+        {
+          "query": "make password",
+          "query_type": "short_phrase",
+          "expected_symbol": "make_password",
+          "expected_file_suffix": "contrib/auth/hashers.py",
+          "rank": 1,
+          "elapsed_ms": 244.65,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "make_password",
+            "file": "contrib/auth/hashers.py"
+          }
+        },
+        {
+          "query": "QuerySet",
+          "query_type": "identifier",
+          "expected_symbol": "QuerySet",
+          "expected_file_suffix": "db/models/query.py",
+          "rank": null,
+          "elapsed_ms": 131.16,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "queryset",
+            "file": "contrib/contenttypes/fields.py"
+          }
+        },
+        {
+          "query": "HttpResponse",
+          "query_type": "identifier",
+          "expected_symbol": "HttpResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": 1,
+          "elapsed_ms": 130.15,
+          "candidate_count": 13,
+          "top_candidate": {
+            "name": "HttpResponse",
+            "file": "http/response.py"
+          }
+        }
+      ]
+    }
+  ],
+  "hybrid_uplift": {
+    "mrr_delta": 0.1520124842610226,
+    "acc1_delta": 0.14705882352941174,
+    "acc3_delta": 0.17647058823529413,
+    "acc5_delta": 0.11764705882352944
+  },
+  "hybrid_uplift_by_query_type": {
+    "identifier": {
+      "mrr_delta": 0.0,
+      "acc1_delta": 0.0,
+      "acc3_delta": 0.0,
+      "acc5_delta": 0.0
+    },
+    "natural_language": {
+      "mrr_delta": 0.12955478711056806,
+      "acc1_delta": 0.11538461538461539,
+      "acc3_delta": 0.15384615384615385,
+      "acc5_delta": 0.11538461538461539
+    },
+    "short_phrase": {
+      "mrr_delta": 0.3,
+      "acc1_delta": 0.3333333333333333,
+      "acc3_delta": 0.3333333333333333,
+      "acc5_delta": 0.16666666666666674
+    }
+  }
+}

--- a/benchmarks/embedding-quality-v1.6-phase3g-django-2e-only.json
+++ b/benchmarks/embedding-quality-v1.6-phase3g-django-2e-only.json
@@ -1,0 +1,1487 @@
+{
+  "project": "/tmp/django-src/django",
+  "benchmark_project": "/var/folders/z0/0tcbss795xsdp75jmr_t9_kh0000gn/T/codelens-embed-quality-l0wij6bi/django",
+  "isolated_copy": true,
+  "binary": "/Users/bagjaeseog/codelens-mcp-plugin/target/release/codelens-mcp",
+  "embedding_model": "MiniLM-L12-CodeSearchNet-INT8",
+  "runtime_model": {
+    "model_dir": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch",
+    "model_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/model.onnx",
+    "config_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/config.json",
+    "sha256": "ef1d1e9cfa72e4929f5b9faea17d8704b23a2530aadebf0d464a4cc7750920b3",
+    "size_bytes": 34000281,
+    "num_hidden_layers": 12,
+    "hidden_size": 384
+  },
+  "dataset_path": "/Users/bagjaeseog/codelens-mcp-plugin/benchmarks/embedding-quality-dataset-django.json",
+  "dataset_size": 34,
+  "ranking_cutoff": 10,
+  "metric_labels": {
+    "mrr": "MRR@10",
+    "acc1": "Acc@1",
+    "acc3": "Acc@3",
+    "acc5": "Acc@5"
+  },
+  "methods": [
+    {
+      "method": "semantic_search",
+      "mrr": 0.28508403361344536,
+      "acc1": 0.2647058823529412,
+      "acc3": 0.2647058823529412,
+      "acc5": 0.3235294117647059,
+      "avg_elapsed_ms": 1361.7685294117646,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 1.0,
+          "acc1": 1.0,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 347.66499999999996
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.10357142857142858,
+          "acc1": 0.07692307692307693,
+          "acc3": 0.07692307692307693,
+          "acc5": 0.15384615384615385,
+          "avg_elapsed_ms": 1606.04
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.8333333333333334,
+          "acc1": 0.8333333333333334,
+          "acc3": 0.8333333333333334,
+          "acc5": 0.8333333333333334,
+          "avg_elapsed_ms": 641.2933333333334
+        }
+      },
+      "rows": [
+        {
+          "query": "query rows from a database model",
+          "query_type": "natural_language",
+          "expected_symbol": "QuerySet",
+          "expected_file_suffix": "db/models/query.py",
+          "rank": null,
+          "elapsed_ms": 2102.25,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "query",
+            "file": "db/models/query.py"
+          }
+        },
+        {
+          "query": "default manager that provides access to objects",
+          "query_type": "natural_language",
+          "expected_symbol": "Manager",
+          "expected_file_suffix": "db/models/manager.py",
+          "rank": null,
+          "elapsed_ms": 1850.92,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "_default_manager",
+            "file": "db/models/base.py"
+          }
+        },
+        {
+          "query": "base class for all database models",
+          "query_type": "natural_language",
+          "expected_symbol": "Model",
+          "expected_file_suffix": "db/models/base.py",
+          "rank": null,
+          "elapsed_ms": 1784.19,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "ModelBase",
+            "file": "db/models/base.py"
+          }
+        },
+        {
+          "query": "declare a foreign-key relationship to another model",
+          "query_type": "natural_language",
+          "expected_symbol": "ForeignKey",
+          "expected_file_suffix": "db/models/fields/related.py",
+          "rank": null,
+          "elapsed_ms": 2051.25,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "_get_foreign_key",
+            "file": "forms/models.py"
+          }
+        },
+        {
+          "query": "HTTP response with body headers and status",
+          "query_type": "natural_language",
+          "expected_symbol": "HttpResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": null,
+          "elapsed_ms": 1395.27,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "body",
+            "file": "http/request.py"
+          }
+        },
+        {
+          "query": "return a JSON encoded response to the client",
+          "query_type": "natural_language",
+          "expected_symbol": "JsonResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": null,
+          "elapsed_ms": 2268.69,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "_encode_json",
+            "file": "test/client.py"
+          }
+        },
+        {
+          "query": "object representing an incoming HTTP request",
+          "query_type": "natural_language",
+          "expected_symbol": "HttpRequest",
+          "expected_file_suffix": "http/request.py",
+          "rank": 10,
+          "elapsed_ms": 2082.52,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "__init__",
+            "file": "http/response.py"
+          }
+        },
+        {
+          "query": "render a template with a context into a response",
+          "query_type": "natural_language",
+          "expected_symbol": "render",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": null,
+          "elapsed_ms": 1809.08,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "context",
+            "file": "template/response.py"
+          }
+        },
+        {
+          "query": "get a model instance or raise 404",
+          "query_type": "natural_language",
+          "expected_symbol": "get_object_or_404",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": null,
+          "elapsed_ms": 1567.58,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "get_model",
+            "file": "apps/config.py"
+          }
+        },
+        {
+          "query": "issue an HTTP redirect to a URL or view",
+          "query_type": "natural_language",
+          "expected_symbol": "redirect",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": 5,
+          "elapsed_ms": 1917.2,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "redirect_to_str",
+            "file": "http/response.py"
+          }
+        },
+        {
+          "query": "match a URL path against the URL configuration",
+          "query_type": "natural_language",
+          "expected_symbol": "resolve",
+          "expected_file_suffix": "urls/base.py",
+          "rank": null,
+          "elapsed_ms": 1124.95,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "match_url",
+            "file": "contrib/admin/templatetags/admin_urls.py"
+          }
+        },
+        {
+          "query": "look up a URL path from its view name",
+          "query_type": "natural_language",
+          "expected_symbol": "reverse",
+          "expected_file_suffix": "urls/base.py",
+          "rank": null,
+          "elapsed_ms": 1778.68,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "view",
+            "file": "views/generic/base.py"
+          }
+        },
+        {
+          "query": "mount a sub-URL configuration into the URL tree",
+          "query_type": "natural_language",
+          "expected_symbol": "include",
+          "expected_file_suffix": "urls/conf.py",
+          "rank": null,
+          "elapsed_ms": 1047.96,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "urls",
+            "file": "contrib/admin/sites.py"
+          }
+        },
+        {
+          "query": "log a user in for the current session",
+          "query_type": "natural_language",
+          "expected_symbol": "login",
+          "expected_file_suffix": "contrib/auth/__init__.py",
+          "rank": 7,
+          "elapsed_ms": 1849.82,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "login",
+            "file": "contrib/admin/sites.py"
+          }
+        },
+        {
+          "query": "log a user out and clear the session",
+          "query_type": "natural_language",
+          "expected_symbol": "logout",
+          "expected_file_suffix": "contrib/auth/__init__.py",
+          "rank": 4,
+          "elapsed_ms": 990.0,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "logout",
+            "file": "test/client.py"
+          }
+        },
+        {
+          "query": "verify a username and password against backends",
+          "query_type": "natural_language",
+          "expected_symbol": "authenticate",
+          "expected_file_suffix": "contrib/auth/__init__.py",
+          "rank": null,
+          "elapsed_ms": 1860.21,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "verify",
+            "file": "contrib/auth/hashers.py"
+          }
+        },
+        {
+          "query": "require a logged in user to access a view",
+          "query_type": "natural_language",
+          "expected_symbol": "login_required",
+          "expected_file_suffix": "contrib/auth/decorators.py",
+          "rank": null,
+          "elapsed_ms": 1672.53,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "view",
+            "file": "views/generic/base.py"
+          }
+        },
+        {
+          "query": "check that a plain password matches a stored hash",
+          "query_type": "natural_language",
+          "expected_symbol": "check_password",
+          "expected_file_suffix": "contrib/auth/hashers.py",
+          "rank": null,
+          "elapsed_ms": 989.67,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "check",
+            "file": "contrib/admin/options.py"
+          }
+        },
+        {
+          "query": "hash a password for storage in the database",
+          "query_type": "natural_language",
+          "expected_symbol": "make_password",
+          "expected_file_suffix": "contrib/auth/hashers.py",
+          "rank": null,
+          "elapsed_ms": 1874.86,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "__hash__",
+            "file": "db/models/manager.py"
+          }
+        },
+        {
+          "query": "generic base class for all class-based views",
+          "query_type": "natural_language",
+          "expected_symbol": "View",
+          "expected_file_suffix": "views/generic/base.py",
+          "rank": 1,
+          "elapsed_ms": 1042.8,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "View",
+            "file": "views/generic/base.py"
+          }
+        },
+        {
+          "query": "display a paginated list of model instances",
+          "query_type": "natural_language",
+          "expected_symbol": "ListView",
+          "expected_file_suffix": "views/generic/list.py",
+          "rank": null,
+          "elapsed_ms": 1584.59,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "display",
+            "file": "template/defaulttags.py"
+          }
+        },
+        {
+          "query": "display a single object retrieved from a model",
+          "query_type": "natural_language",
+          "expected_symbol": "DetailView",
+          "expected_file_suffix": "views/generic/detail.py",
+          "rank": null,
+          "elapsed_ms": 1860.59,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "display",
+            "file": "template/defaulttags.py"
+          }
+        },
+        {
+          "query": "render a template without any extra view logic",
+          "query_type": "natural_language",
+          "expected_symbol": "TemplateView",
+          "expected_file_suffix": "views/generic/base.py",
+          "rank": null,
+          "elapsed_ms": 952.71,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "render",
+            "file": "template/backends/dummy.py"
+          }
+        },
+        {
+          "query": "exempt a view from CSRF protection",
+          "query_type": "natural_language",
+          "expected_symbol": "csrf_exempt",
+          "expected_file_suffix": "views/decorators/csrf.py",
+          "rank": 1,
+          "elapsed_ms": 1593.8,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "csrf_exempt",
+            "file": "views/decorators/csrf.py"
+          }
+        },
+        {
+          "query": "declarative form with field validation",
+          "query_type": "natural_language",
+          "expected_symbol": "Form",
+          "expected_file_suffix": "forms/forms.py",
+          "rank": null,
+          "elapsed_ms": 1648.5,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "form_valid",
+            "file": "views/generic/edit.py"
+          }
+        },
+        {
+          "query": "form that is bound to a model for create and update",
+          "query_type": "natural_language",
+          "expected_symbol": "ModelForm",
+          "expected_file_suffix": "forms/models.py",
+          "rank": null,
+          "elapsed_ms": 1056.42,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "form",
+            "file": "forms/models.py"
+          }
+        },
+        {
+          "query": "get object or 404",
+          "query_type": "short_phrase",
+          "expected_symbol": "get_object_or_404",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": 1,
+          "elapsed_ms": 1136.54,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "get_object_or_404",
+            "file": "shortcuts.py"
+          }
+        },
+        {
+          "query": "login required",
+          "query_type": "short_phrase",
+          "expected_symbol": "login_required",
+          "expected_file_suffix": "contrib/auth/decorators.py",
+          "rank": 1,
+          "elapsed_ms": 524.88,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "login_required",
+            "file": "contrib/auth/decorators.py"
+          }
+        },
+        {
+          "query": "http response",
+          "query_type": "short_phrase",
+          "expected_symbol": "HttpResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": 1,
+          "elapsed_ms": 543.41,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "HttpResponse",
+            "file": "http/response.py"
+          }
+        },
+        {
+          "query": "query set",
+          "query_type": "short_phrase",
+          "expected_symbol": "QuerySet",
+          "expected_file_suffix": "db/models/query.py",
+          "rank": null,
+          "elapsed_ms": 534.04,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "queryset",
+            "file": "db/models/query.py"
+          }
+        },
+        {
+          "query": "reverse url",
+          "query_type": "short_phrase",
+          "expected_symbol": "reverse",
+          "expected_file_suffix": "urls/base.py",
+          "rank": 1,
+          "elapsed_ms": 578.2,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "reverse",
+            "file": "urls/base.py"
+          }
+        },
+        {
+          "query": "make password",
+          "query_type": "short_phrase",
+          "expected_symbol": "make_password",
+          "expected_file_suffix": "contrib/auth/hashers.py",
+          "rank": 1,
+          "elapsed_ms": 530.69,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "make_password",
+            "file": "contrib/auth/hashers.py"
+          }
+        },
+        {
+          "query": "QuerySet",
+          "query_type": "identifier",
+          "expected_symbol": "QuerySet",
+          "expected_file_suffix": "db/models/query.py",
+          "rank": 1,
+          "elapsed_ms": 358.58,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "QuerySet",
+            "file": "db/models/query.py"
+          }
+        },
+        {
+          "query": "HttpResponse",
+          "query_type": "identifier",
+          "expected_symbol": "HttpResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": 1,
+          "elapsed_ms": 336.75,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "HttpResponse",
+            "file": "http/response.py"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context_no_semantic",
+      "mrr": 0.13539795228436202,
+      "acc1": 0.08823529411764706,
+      "acc3": 0.11764705882352941,
+      "acc5": 0.20588235294117646,
+      "avg_elapsed_ms": 170.7635294117647,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 0.5,
+          "acc1": 0.5,
+          "acc3": 0.5,
+          "acc5": 0.5,
+          "avg_elapsed_ms": 139.84500000000003
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.04436655298724264,
+          "acc1": 0.0,
+          "acc3": 0.038461538461538464,
+          "acc5": 0.07692307692307693,
+          "avg_elapsed_ms": 177.86653846153845
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.4083333333333334,
+          "acc1": 0.3333333333333333,
+          "acc3": 0.3333333333333333,
+          "acc5": 0.6666666666666666,
+          "avg_elapsed_ms": 150.29
+        }
+      },
+      "rows": [
+        {
+          "query": "query rows from a database model",
+          "query_type": "natural_language",
+          "expected_symbol": "QuerySet",
+          "expected_file_suffix": "db/models/query.py",
+          "rank": null,
+          "elapsed_ms": 192.61,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "del_query",
+            "file": "db/models/query.py"
+          }
+        },
+        {
+          "query": "default manager that provides access to objects",
+          "query_type": "natural_language",
+          "expected_symbol": "Manager",
+          "expected_file_suffix": "db/models/manager.py",
+          "rank": 7,
+          "elapsed_ms": 191.0,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "ManagerDescriptor",
+            "file": "db/models/manager.py"
+          }
+        },
+        {
+          "query": "base class for all database models",
+          "query_type": "natural_language",
+          "expected_symbol": "Model",
+          "expected_file_suffix": "db/models/base.py",
+          "rank": null,
+          "elapsed_ms": 189.19,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "prepare_database_save",
+            "file": "db/models/base.py"
+          }
+        },
+        {
+          "query": "declare a foreign-key relationship to another model",
+          "query_type": "natural_language",
+          "expected_symbol": "ForeignKey",
+          "expected_file_suffix": "db/models/fields/related.py",
+          "rank": 4,
+          "elapsed_ms": 190.52,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "foreign_key",
+            "file": "db/backends/sqlite3/base.py"
+          }
+        },
+        {
+          "query": "HTTP response with body headers and status",
+          "query_type": "natural_language",
+          "expected_symbol": "HttpResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": null,
+          "elapsed_ms": 171.72,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "serialize_headers",
+            "file": "http/response.py"
+          }
+        },
+        {
+          "query": "return a JSON encoded response to the client",
+          "query_type": "natural_language",
+          "expected_symbol": "JsonResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": null,
+          "elapsed_ms": 196.29,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "client",
+            "file": "core/cache/backends/redis.py"
+          }
+        },
+        {
+          "query": "object representing an incoming HTTP request",
+          "query_type": "natural_language",
+          "expected_symbol": "HttpRequest",
+          "expected_file_suffix": "http/request.py",
+          "rank": null,
+          "elapsed_ms": 196.34,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "parse_http_date",
+            "file": "utils/http.py"
+          }
+        },
+        {
+          "query": "render a template with a context into a response",
+          "query_type": "natural_language",
+          "expected_symbol": "render",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": null,
+          "elapsed_ms": 187.63,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "RenderContext",
+            "file": "template/context.py"
+          }
+        },
+        {
+          "query": "get a model instance or raise 404",
+          "query_type": "natural_language",
+          "expected_symbol": "get_object_or_404",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": 6,
+          "elapsed_ms": 173.6,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "get_for_model",
+            "file": "contrib/contenttypes/models.py"
+          }
+        },
+        {
+          "query": "issue an HTTP redirect to a URL or view",
+          "query_type": "natural_language",
+          "expected_symbol": "redirect",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": 12,
+          "elapsed_ms": 196.66,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "redirect_to",
+            "file": "contrib/auth/views.py"
+          }
+        },
+        {
+          "query": "match a URL path against the URL configuration",
+          "query_type": "natural_language",
+          "expected_symbol": "resolve",
+          "expected_file_suffix": "urls/base.py",
+          "rank": null,
+          "elapsed_ms": 159.65,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "match_url",
+            "file": "contrib/admin/templatetags/admin_urls.py"
+          }
+        },
+        {
+          "query": "look up a URL path from its view name",
+          "query_type": "natural_language",
+          "expected_symbol": "reverse",
+          "expected_file_suffix": "urls/base.py",
+          "rank": null,
+          "elapsed_ms": 159.56,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "from_",
+            "file": "db/models/fields/related.py"
+          }
+        },
+        {
+          "query": "mount a sub-URL configuration into the URL tree",
+          "query_type": "natural_language",
+          "expected_symbol": "include",
+          "expected_file_suffix": "urls/conf.py",
+          "rank": null,
+          "elapsed_ms": 162.87,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "use_returning_into",
+            "file": "db/backends/oracle/base.py"
+          }
+        },
+        {
+          "query": "log a user in for the current session",
+          "query_type": "natural_language",
+          "expected_symbol": "login",
+          "expected_file_suffix": "contrib/auth/__init__.py",
+          "rank": null,
+          "elapsed_ms": 189.54,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "_session",
+            "file": "contrib/sessions/backends/base.py"
+          }
+        },
+        {
+          "query": "log a user out and clear the session",
+          "query_type": "natural_language",
+          "expected_symbol": "logout",
+          "expected_file_suffix": "contrib/auth/__init__.py",
+          "rank": null,
+          "elapsed_ms": 162.55,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "_session",
+            "file": "contrib/sessions/backends/base.py"
+          }
+        },
+        {
+          "query": "verify a username and password against backends",
+          "query_type": "natural_language",
+          "expected_symbol": "authenticate",
+          "expected_file_suffix": "contrib/auth/__init__.py",
+          "rank": null,
+          "elapsed_ms": 186.29,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "task_backends",
+            "file": "tasks/__init__.py"
+          }
+        },
+        {
+          "query": "require a logged in user to access a view",
+          "query_type": "natural_language",
+          "expected_symbol": "login_required",
+          "expected_file_suffix": "contrib/auth/decorators.py",
+          "rank": null,
+          "elapsed_ms": 175.04,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "user_logged_in",
+            "file": "contrib/auth/signals.py"
+          }
+        },
+        {
+          "query": "check that a plain password matches a stored hash",
+          "query_type": "natural_language",
+          "expected_symbol": "check_password",
+          "expected_file_suffix": "contrib/auth/hashers.py",
+          "rank": null,
+          "elapsed_ms": 157.93,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "cmatches",
+            "file": "utils/translation/template.py"
+          }
+        },
+        {
+          "query": "hash a password for storage in the database",
+          "query_type": "natural_language",
+          "expected_symbol": "make_password",
+          "expected_file_suffix": "contrib/auth/hashers.py",
+          "rank": null,
+          "elapsed_ms": 183.19,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "hash_",
+            "file": "contrib/auth/hashers.py"
+          }
+        },
+        {
+          "query": "generic base class for all class-based views",
+          "query_type": "natural_language",
+          "expected_symbol": "View",
+          "expected_file_suffix": "views/generic/base.py",
+          "rank": null,
+          "elapsed_ms": 160.15,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "BaseDeleteView",
+            "file": "views/generic/edit.py"
+          }
+        },
+        {
+          "query": "display a paginated list of model instances",
+          "query_type": "natural_language",
+          "expected_symbol": "ListView",
+          "expected_file_suffix": "views/generic/list.py",
+          "rank": null,
+          "elapsed_ms": 177.58,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "list_",
+            "file": "http/request.py"
+          }
+        },
+        {
+          "query": "display a single object retrieved from a model",
+          "query_type": "natural_language",
+          "expected_symbol": "DetailView",
+          "expected_file_suffix": "views/generic/detail.py",
+          "rank": null,
+          "elapsed_ms": 188.38,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "from_",
+            "file": "db/models/fields/related.py"
+          }
+        },
+        {
+          "query": "render a template without any extra view logic",
+          "query_type": "natural_language",
+          "expected_symbol": "TemplateView",
+          "expected_file_suffix": "views/generic/base.py",
+          "rank": null,
+          "elapsed_ms": 157.09,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "set_many",
+            "file": "core/cache/backends/redis.py"
+          }
+        },
+        {
+          "query": "exempt a view from CSRF protection",
+          "query_type": "natural_language",
+          "expected_symbol": "csrf_exempt",
+          "expected_file_suffix": "views/decorators/csrf.py",
+          "rank": 3,
+          "elapsed_ms": 179.57,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "from_",
+            "file": "db/models/fields/related.py"
+          }
+        },
+        {
+          "query": "declarative form with field validation",
+          "query_type": "natural_language",
+          "expected_symbol": "Form",
+          "expected_file_suffix": "forms/forms.py",
+          "rank": 7,
+          "elapsed_ms": 177.33,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "Field",
+            "file": "db/models/fields/__init__.py"
+          }
+        },
+        {
+          "query": "form that is bound to a model for create and update",
+          "query_type": "natural_language",
+          "expected_symbol": "ModelForm",
+          "expected_file_suffix": "forms/models.py",
+          "rank": 29,
+          "elapsed_ms": 162.25,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "_update",
+            "file": "db/models/query.py"
+          }
+        },
+        {
+          "query": "get object or 404",
+          "query_type": "short_phrase",
+          "expected_symbol": "get_object_or_404",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": 1,
+          "elapsed_ms": 164.09,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "get_object_or_404",
+            "file": "shortcuts.py"
+          }
+        },
+        {
+          "query": "login required",
+          "query_type": "short_phrase",
+          "expected_symbol": "login_required",
+          "expected_file_suffix": "contrib/auth/decorators.py",
+          "rank": 1,
+          "elapsed_ms": 146.91,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "login_required",
+            "file": "contrib/auth/decorators.py"
+          }
+        },
+        {
+          "query": "http response",
+          "query_type": "short_phrase",
+          "expected_symbol": "HttpResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": 4,
+          "elapsed_ms": 148.09,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "HttpResponseNotFound",
+            "file": "http/response.py"
+          }
+        },
+        {
+          "query": "query set",
+          "query_type": "short_phrase",
+          "expected_symbol": "QuerySet",
+          "expected_file_suffix": "db/models/query.py",
+          "rank": null,
+          "elapsed_ms": 147.58,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "set",
+            "file": "core/cache/backends/redis.py"
+          }
+        },
+        {
+          "query": "reverse url",
+          "query_type": "short_phrase",
+          "expected_symbol": "reverse",
+          "expected_file_suffix": "urls/base.py",
+          "rank": 5,
+          "elapsed_ms": 148.71,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "url",
+            "file": "contrib/admin/options.py"
+          }
+        },
+        {
+          "query": "make password",
+          "query_type": "short_phrase",
+          "expected_symbol": "make_password",
+          "expected_file_suffix": "contrib/auth/hashers.py",
+          "rank": null,
+          "elapsed_ms": 146.36,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "make_aware",
+            "file": "utils/timezone.py"
+          }
+        },
+        {
+          "query": "QuerySet",
+          "query_type": "identifier",
+          "expected_symbol": "QuerySet",
+          "expected_file_suffix": "db/models/query.py",
+          "rank": null,
+          "elapsed_ms": 140.36,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "queryset",
+            "file": "contrib/contenttypes/fields.py"
+          }
+        },
+        {
+          "query": "HttpResponse",
+          "query_type": "identifier",
+          "expected_symbol": "HttpResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": 1,
+          "elapsed_ms": 139.33,
+          "candidate_count": 13,
+          "top_candidate": {
+            "name": "HttpResponse",
+            "file": "http/response.py"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context",
+      "mrr": 0.29367688251771296,
+      "acc1": 0.23529411764705882,
+      "acc3": 0.3235294117647059,
+      "acc5": 0.35294117647058826,
+      "avg_elapsed_ms": 283.9182352941176,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 0.5,
+          "acc1": 0.5,
+          "acc3": 0.5,
+          "acc5": 0.5,
+          "avg_elapsed_ms": 128.215
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.17250053867700926,
+          "acc1": 0.11538461538461539,
+          "acc3": 0.19230769230769232,
+          "acc5": 0.23076923076923078,
+          "avg_elapsed_ms": 303.5873076923077
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.75,
+          "acc1": 0.6666666666666666,
+          "acc3": 0.8333333333333334,
+          "acc5": 0.8333333333333334,
+          "avg_elapsed_ms": 250.58666666666667
+        }
+      },
+      "rows": [
+        {
+          "query": "query rows from a database model",
+          "query_type": "natural_language",
+          "expected_symbol": "QuerySet",
+          "expected_file_suffix": "db/models/query.py",
+          "rank": null,
+          "elapsed_ms": 310.09,
+          "candidate_count": 36,
+          "top_candidate": {
+            "name": "fetch_returned_rows",
+            "file": "db/backends/base/operations.py"
+          }
+        },
+        {
+          "query": "default manager that provides access to objects",
+          "query_type": "natural_language",
+          "expected_symbol": "Manager",
+          "expected_file_suffix": "db/models/manager.py",
+          "rank": 17,
+          "elapsed_ms": 312.46,
+          "candidate_count": 34,
+          "top_candidate": {
+            "name": "_default_manager",
+            "file": "db/models/base.py"
+          }
+        },
+        {
+          "query": "base class for all database models",
+          "query_type": "natural_language",
+          "expected_symbol": "Model",
+          "expected_file_suffix": "db/models/base.py",
+          "rank": null,
+          "elapsed_ms": 301.03,
+          "candidate_count": 35,
+          "top_candidate": {
+            "name": "ModelBase",
+            "file": "db/models/base.py"
+          }
+        },
+        {
+          "query": "declare a foreign-key relationship to another model",
+          "query_type": "natural_language",
+          "expected_symbol": "ForeignKey",
+          "expected_file_suffix": "db/models/fields/related.py",
+          "rank": 6,
+          "elapsed_ms": 315.36,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "fk",
+            "file": "forms/models.py"
+          }
+        },
+        {
+          "query": "HTTP response with body headers and status",
+          "query_type": "natural_language",
+          "expected_symbol": "HttpResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": null,
+          "elapsed_ms": 296.53,
+          "candidate_count": 35,
+          "top_candidate": {
+            "name": "body",
+            "file": "http/request.py"
+          }
+        },
+        {
+          "query": "return a JSON encoded response to the client",
+          "query_type": "natural_language",
+          "expected_symbol": "JsonResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": null,
+          "elapsed_ms": 313.82,
+          "candidate_count": 37,
+          "top_candidate": {
+            "name": "_encode_json",
+            "file": "test/client.py"
+          }
+        },
+        {
+          "query": "object representing an incoming HTTP request",
+          "query_type": "natural_language",
+          "expected_symbol": "HttpRequest",
+          "expected_file_suffix": "http/request.py",
+          "rank": 12,
+          "elapsed_ms": 319.31,
+          "candidate_count": 34,
+          "top_candidate": {
+            "name": "body",
+            "file": "http/request.py"
+          }
+        },
+        {
+          "query": "render a template with a context into a response",
+          "query_type": "natural_language",
+          "expected_symbol": "render",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": null,
+          "elapsed_ms": 298.34,
+          "candidate_count": 37,
+          "top_candidate": {
+            "name": "context",
+            "file": "template/response.py"
+          }
+        },
+        {
+          "query": "get a model instance or raise 404",
+          "query_type": "natural_language",
+          "expected_symbol": "get_object_or_404",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": 5,
+          "elapsed_ms": 308.35,
+          "candidate_count": 34,
+          "top_candidate": {
+            "name": "get_model",
+            "file": "apps/config.py"
+          }
+        },
+        {
+          "query": "issue an HTTP redirect to a URL or view",
+          "query_type": "natural_language",
+          "expected_symbol": "redirect",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": 7,
+          "elapsed_ms": 353.79,
+          "candidate_count": 34,
+          "top_candidate": {
+            "name": "get_redirect_url",
+            "file": "contrib/auth/views.py"
+          }
+        },
+        {
+          "query": "match a URL path against the URL configuration",
+          "query_type": "natural_language",
+          "expected_symbol": "resolve",
+          "expected_file_suffix": "urls/base.py",
+          "rank": null,
+          "elapsed_ms": 279.24,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "match",
+            "file": "urls/resolvers.py"
+          }
+        },
+        {
+          "query": "look up a URL path from its view name",
+          "query_type": "natural_language",
+          "expected_symbol": "reverse",
+          "expected_file_suffix": "urls/base.py",
+          "rank": null,
+          "elapsed_ms": 271.14,
+          "candidate_count": 35,
+          "top_candidate": {
+            "name": "view_path",
+            "file": "urls/resolvers.py"
+          }
+        },
+        {
+          "query": "mount a sub-URL configuration into the URL tree",
+          "query_type": "natural_language",
+          "expected_symbol": "include",
+          "expected_file_suffix": "urls/conf.py",
+          "rank": null,
+          "elapsed_ms": 279.98,
+          "candidate_count": 35,
+          "top_candidate": {
+            "name": "check_url_config",
+            "file": "core/checks/urls.py"
+          }
+        },
+        {
+          "query": "log a user in for the current session",
+          "query_type": "natural_language",
+          "expected_symbol": "login",
+          "expected_file_suffix": "contrib/auth/__init__.py",
+          "rank": 1,
+          "elapsed_ms": 303.11,
+          "candidate_count": 34,
+          "top_candidate": {
+            "name": "login",
+            "file": "contrib/auth/__init__.py"
+          }
+        },
+        {
+          "query": "log a user out and clear the session",
+          "query_type": "natural_language",
+          "expected_symbol": "logout",
+          "expected_file_suffix": "contrib/auth/__init__.py",
+          "rank": 3,
+          "elapsed_ms": 277.21,
+          "candidate_count": 36,
+          "top_candidate": {
+            "name": "logout",
+            "file": "test/client.py"
+          }
+        },
+        {
+          "query": "verify a username and password against backends",
+          "query_type": "natural_language",
+          "expected_symbol": "authenticate",
+          "expected_file_suffix": "contrib/auth/__init__.py",
+          "rank": null,
+          "elapsed_ms": 317.63,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "verify",
+            "file": "contrib/auth/hashers.py"
+          }
+        },
+        {
+          "query": "require a logged in user to access a view",
+          "query_type": "natural_language",
+          "expected_symbol": "login_required",
+          "expected_file_suffix": "contrib/auth/decorators.py",
+          "rank": null,
+          "elapsed_ms": 300.98,
+          "candidate_count": 35,
+          "top_candidate": {
+            "name": "view",
+            "file": "views/generic/base.py"
+          }
+        },
+        {
+          "query": "check that a plain password matches a stored hash",
+          "query_type": "natural_language",
+          "expected_symbol": "check_password",
+          "expected_file_suffix": "contrib/auth/hashers.py",
+          "rank": 2,
+          "elapsed_ms": 278.83,
+          "candidate_count": 36,
+          "top_candidate": {
+            "name": "render_password_as_hash",
+            "file": "contrib/auth/templatetags/auth.py"
+          }
+        },
+        {
+          "query": "hash a password for storage in the database",
+          "query_type": "natural_language",
+          "expected_symbol": "make_password",
+          "expected_file_suffix": "contrib/auth/hashers.py",
+          "rank": null,
+          "elapsed_ms": 312.28,
+          "candidate_count": 36,
+          "top_candidate": {
+            "name": "__hash__",
+            "file": "db/models/manager.py"
+          }
+        },
+        {
+          "query": "generic base class for all class-based views",
+          "query_type": "natural_language",
+          "expected_symbol": "View",
+          "expected_file_suffix": "views/generic/base.py",
+          "rank": 1,
+          "elapsed_ms": 291.61,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "View",
+            "file": "views/generic/base.py"
+          }
+        },
+        {
+          "query": "display a paginated list of model instances",
+          "query_type": "natural_language",
+          "expected_symbol": "ListView",
+          "expected_file_suffix": "views/generic/list.py",
+          "rank": null,
+          "elapsed_ms": 307.72,
+          "candidate_count": 37,
+          "top_candidate": {
+            "name": "model",
+            "file": "contrib/postgres/fields/array.py"
+          }
+        },
+        {
+          "query": "display a single object retrieved from a model",
+          "query_type": "natural_language",
+          "expected_symbol": "DetailView",
+          "expected_file_suffix": "views/generic/detail.py",
+          "rank": null,
+          "elapsed_ms": 311.36,
+          "candidate_count": 36,
+          "top_candidate": {
+            "name": "get_object",
+            "file": "views/generic/detail.py"
+          }
+        },
+        {
+          "query": "render a template without any extra view logic",
+          "query_type": "natural_language",
+          "expected_symbol": "TemplateView",
+          "expected_file_suffix": "views/generic/base.py",
+          "rank": null,
+          "elapsed_ms": 281.56,
+          "candidate_count": 37,
+          "top_candidate": {
+            "name": "render",
+            "file": "template/backends/dummy.py"
+          }
+        },
+        {
+          "query": "exempt a view from CSRF protection",
+          "query_type": "natural_language",
+          "expected_symbol": "csrf_exempt",
+          "expected_file_suffix": "views/decorators/csrf.py",
+          "rank": 1,
+          "elapsed_ms": 363.13,
+          "candidate_count": 33,
+          "top_candidate": {
+            "name": "csrf_exempt",
+            "file": "views/decorators/csrf.py"
+          }
+        },
+        {
+          "query": "declarative form with field validation",
+          "query_type": "natural_language",
+          "expected_symbol": "Form",
+          "expected_file_suffix": "forms/forms.py",
+          "rank": null,
+          "elapsed_ms": 305.44,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "form_valid",
+            "file": "views/generic/edit.py"
+          }
+        },
+        {
+          "query": "form that is bound to a model for create and update",
+          "query_type": "natural_language",
+          "expected_symbol": "ModelForm",
+          "expected_file_suffix": "forms/models.py",
+          "rank": null,
+          "elapsed_ms": 282.97,
+          "candidate_count": 38,
+          "top_candidate": {
+            "name": "_do_update",
+            "file": "db/models/base.py"
+          }
+        },
+        {
+          "query": "get object or 404",
+          "query_type": "short_phrase",
+          "expected_symbol": "get_object_or_404",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": 1,
+          "elapsed_ms": 264.39,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "get_object_or_404",
+            "file": "shortcuts.py"
+          }
+        },
+        {
+          "query": "login required",
+          "query_type": "short_phrase",
+          "expected_symbol": "login_required",
+          "expected_file_suffix": "contrib/auth/decorators.py",
+          "rank": 1,
+          "elapsed_ms": 250.44,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "login_required",
+            "file": "contrib/auth/decorators.py"
+          }
+        },
+        {
+          "query": "http response",
+          "query_type": "short_phrase",
+          "expected_symbol": "HttpResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": 2,
+          "elapsed_ms": 249.04,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "response",
+            "file": "views/generic/base.py"
+          }
+        },
+        {
+          "query": "query set",
+          "query_type": "short_phrase",
+          "expected_symbol": "QuerySet",
+          "expected_file_suffix": "db/models/query.py",
+          "rank": null,
+          "elapsed_ms": 246.79,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "queryset",
+            "file": "db/models/query.py"
+          }
+        },
+        {
+          "query": "reverse url",
+          "query_type": "short_phrase",
+          "expected_symbol": "reverse",
+          "expected_file_suffix": "urls/base.py",
+          "rank": 1,
+          "elapsed_ms": 246.5,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "reverse",
+            "file": "urls/base.py"
+          }
+        },
+        {
+          "query": "make password",
+          "query_type": "short_phrase",
+          "expected_symbol": "make_password",
+          "expected_file_suffix": "contrib/auth/hashers.py",
+          "rank": 1,
+          "elapsed_ms": 246.36,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "make_password",
+            "file": "contrib/auth/hashers.py"
+          }
+        },
+        {
+          "query": "QuerySet",
+          "query_type": "identifier",
+          "expected_symbol": "QuerySet",
+          "expected_file_suffix": "db/models/query.py",
+          "rank": null,
+          "elapsed_ms": 126.72,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "queryset",
+            "file": "contrib/contenttypes/fields.py"
+          }
+        },
+        {
+          "query": "HttpResponse",
+          "query_type": "identifier",
+          "expected_symbol": "HttpResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": 1,
+          "elapsed_ms": 129.71,
+          "candidate_count": 13,
+          "top_candidate": {
+            "name": "HttpResponse",
+            "file": "http/response.py"
+          }
+        }
+      ]
+    }
+  ],
+  "hybrid_uplift": {
+    "mrr_delta": 0.15827893023335093,
+    "acc1_delta": 0.14705882352941174,
+    "acc3_delta": 0.2058823529411765,
+    "acc5_delta": 0.1470588235294118
+  },
+  "hybrid_uplift_by_query_type": {
+    "identifier": {
+      "mrr_delta": 0.0,
+      "acc1_delta": 0.0,
+      "acc3_delta": 0.0,
+      "acc5_delta": 0.0
+    },
+    "natural_language": {
+      "mrr_delta": 0.12813398568976664,
+      "acc1_delta": 0.11538461538461539,
+      "acc3_delta": 0.15384615384615385,
+      "acc5_delta": 0.15384615384615385
+    },
+    "short_phrase": {
+      "mrr_delta": 0.3416666666666666,
+      "acc1_delta": 0.3333333333333333,
+      "acc3_delta": 0.5,
+      "acc5_delta": 0.16666666666666674
+    }
+  }
+}

--- a/benchmarks/embedding-quality-v1.6-phase3g-django-baseline.json
+++ b/benchmarks/embedding-quality-v1.6-phase3g-django-baseline.json
@@ -1,0 +1,1487 @@
+{
+  "project": "/tmp/django-src/django",
+  "benchmark_project": "/var/folders/z0/0tcbss795xsdp75jmr_t9_kh0000gn/T/codelens-embed-quality-hy04sosg/django",
+  "isolated_copy": true,
+  "binary": "/Users/bagjaeseog/codelens-mcp-plugin/target/release/codelens-mcp",
+  "embedding_model": "MiniLM-L12-CodeSearchNet-INT8",
+  "runtime_model": {
+    "model_dir": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch",
+    "model_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/model.onnx",
+    "config_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/config.json",
+    "sha256": "ef1d1e9cfa72e4929f5b9faea17d8704b23a2530aadebf0d464a4cc7750920b3",
+    "size_bytes": 34000281,
+    "num_hidden_layers": 12,
+    "hidden_size": 384
+  },
+  "dataset_path": "/Users/bagjaeseog/codelens-mcp-plugin/benchmarks/embedding-quality-dataset-django.json",
+  "dataset_size": 34,
+  "ranking_cutoff": 10,
+  "metric_labels": {
+    "mrr": "MRR@10",
+    "acc1": "Acc@1",
+    "acc3": "Acc@3",
+    "acc5": "Acc@5"
+  },
+  "methods": [
+    {
+      "method": "semantic_search",
+      "mrr": 0.28508403361344536,
+      "acc1": 0.2647058823529412,
+      "acc3": 0.2647058823529412,
+      "acc5": 0.3235294117647059,
+      "avg_elapsed_ms": 1249.9423529411765,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 1.0,
+          "acc1": 1.0,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 318.21500000000003
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.10357142857142858,
+          "acc1": 0.07692307692307693,
+          "acc3": 0.07692307692307693,
+          "acc5": 0.15384615384615385,
+          "avg_elapsed_ms": 1478.069230769231
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.8333333333333334,
+          "acc1": 0.8333333333333334,
+          "acc3": 0.8333333333333334,
+          "acc5": 0.8333333333333334,
+          "avg_elapsed_ms": 571.9683333333334
+        }
+      },
+      "rows": [
+        {
+          "query": "query rows from a database model",
+          "query_type": "natural_language",
+          "expected_symbol": "QuerySet",
+          "expected_file_suffix": "db/models/query.py",
+          "rank": null,
+          "elapsed_ms": 1969.63,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "query",
+            "file": "db/models/query.py"
+          }
+        },
+        {
+          "query": "default manager that provides access to objects",
+          "query_type": "natural_language",
+          "expected_symbol": "Manager",
+          "expected_file_suffix": "db/models/manager.py",
+          "rank": null,
+          "elapsed_ms": 1701.67,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "_default_manager",
+            "file": "db/models/base.py"
+          }
+        },
+        {
+          "query": "base class for all database models",
+          "query_type": "natural_language",
+          "expected_symbol": "Model",
+          "expected_file_suffix": "db/models/base.py",
+          "rank": null,
+          "elapsed_ms": 1730.55,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "ModelBase",
+            "file": "db/models/base.py"
+          }
+        },
+        {
+          "query": "declare a foreign-key relationship to another model",
+          "query_type": "natural_language",
+          "expected_symbol": "ForeignKey",
+          "expected_file_suffix": "db/models/fields/related.py",
+          "rank": null,
+          "elapsed_ms": 1896.55,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "_get_foreign_key",
+            "file": "forms/models.py"
+          }
+        },
+        {
+          "query": "HTTP response with body headers and status",
+          "query_type": "natural_language",
+          "expected_symbol": "HttpResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": null,
+          "elapsed_ms": 1293.5,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "body",
+            "file": "http/request.py"
+          }
+        },
+        {
+          "query": "return a JSON encoded response to the client",
+          "query_type": "natural_language",
+          "expected_symbol": "JsonResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": null,
+          "elapsed_ms": 2126.05,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "_encode_json",
+            "file": "test/client.py"
+          }
+        },
+        {
+          "query": "object representing an incoming HTTP request",
+          "query_type": "natural_language",
+          "expected_symbol": "HttpRequest",
+          "expected_file_suffix": "http/request.py",
+          "rank": 10,
+          "elapsed_ms": 1961.23,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "__init__",
+            "file": "http/response.py"
+          }
+        },
+        {
+          "query": "render a template with a context into a response",
+          "query_type": "natural_language",
+          "expected_symbol": "render",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": null,
+          "elapsed_ms": 1735.41,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "context",
+            "file": "template/response.py"
+          }
+        },
+        {
+          "query": "get a model instance or raise 404",
+          "query_type": "natural_language",
+          "expected_symbol": "get_object_or_404",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": null,
+          "elapsed_ms": 1476.27,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "get_model",
+            "file": "apps/config.py"
+          }
+        },
+        {
+          "query": "issue an HTTP redirect to a URL or view",
+          "query_type": "natural_language",
+          "expected_symbol": "redirect",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": 5,
+          "elapsed_ms": 1921.41,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "redirect_to_str",
+            "file": "http/response.py"
+          }
+        },
+        {
+          "query": "match a URL path against the URL configuration",
+          "query_type": "natural_language",
+          "expected_symbol": "resolve",
+          "expected_file_suffix": "urls/base.py",
+          "rank": null,
+          "elapsed_ms": 889.14,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "match_url",
+            "file": "contrib/admin/templatetags/admin_urls.py"
+          }
+        },
+        {
+          "query": "look up a URL path from its view name",
+          "query_type": "natural_language",
+          "expected_symbol": "reverse",
+          "expected_file_suffix": "urls/base.py",
+          "rank": null,
+          "elapsed_ms": 890.77,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "view",
+            "file": "views/generic/base.py"
+          }
+        },
+        {
+          "query": "mount a sub-URL configuration into the URL tree",
+          "query_type": "natural_language",
+          "expected_symbol": "include",
+          "expected_file_suffix": "urls/conf.py",
+          "rank": null,
+          "elapsed_ms": 967.53,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "urls",
+            "file": "contrib/admin/sites.py"
+          }
+        },
+        {
+          "query": "log a user in for the current session",
+          "query_type": "natural_language",
+          "expected_symbol": "login",
+          "expected_file_suffix": "contrib/auth/__init__.py",
+          "rank": 7,
+          "elapsed_ms": 1767.64,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "login",
+            "file": "contrib/admin/sites.py"
+          }
+        },
+        {
+          "query": "log a user out and clear the session",
+          "query_type": "natural_language",
+          "expected_symbol": "logout",
+          "expected_file_suffix": "contrib/auth/__init__.py",
+          "rank": 4,
+          "elapsed_ms": 899.48,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "logout",
+            "file": "test/client.py"
+          }
+        },
+        {
+          "query": "verify a username and password against backends",
+          "query_type": "natural_language",
+          "expected_symbol": "authenticate",
+          "expected_file_suffix": "contrib/auth/__init__.py",
+          "rank": null,
+          "elapsed_ms": 1789.77,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "verify",
+            "file": "contrib/auth/hashers.py"
+          }
+        },
+        {
+          "query": "require a logged in user to access a view",
+          "query_type": "natural_language",
+          "expected_symbol": "login_required",
+          "expected_file_suffix": "contrib/auth/decorators.py",
+          "rank": null,
+          "elapsed_ms": 1549.21,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "view",
+            "file": "views/generic/base.py"
+          }
+        },
+        {
+          "query": "check that a plain password matches a stored hash",
+          "query_type": "natural_language",
+          "expected_symbol": "check_password",
+          "expected_file_suffix": "contrib/auth/hashers.py",
+          "rank": null,
+          "elapsed_ms": 895.67,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "check",
+            "file": "contrib/admin/options.py"
+          }
+        },
+        {
+          "query": "hash a password for storage in the database",
+          "query_type": "natural_language",
+          "expected_symbol": "make_password",
+          "expected_file_suffix": "contrib/auth/hashers.py",
+          "rank": null,
+          "elapsed_ms": 1729.25,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "__hash__",
+            "file": "db/models/manager.py"
+          }
+        },
+        {
+          "query": "generic base class for all class-based views",
+          "query_type": "natural_language",
+          "expected_symbol": "View",
+          "expected_file_suffix": "views/generic/base.py",
+          "rank": 1,
+          "elapsed_ms": 959.27,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "View",
+            "file": "views/generic/base.py"
+          }
+        },
+        {
+          "query": "display a paginated list of model instances",
+          "query_type": "natural_language",
+          "expected_symbol": "ListView",
+          "expected_file_suffix": "views/generic/list.py",
+          "rank": null,
+          "elapsed_ms": 1494.19,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "display",
+            "file": "template/defaulttags.py"
+          }
+        },
+        {
+          "query": "display a single object retrieved from a model",
+          "query_type": "natural_language",
+          "expected_symbol": "DetailView",
+          "expected_file_suffix": "views/generic/detail.py",
+          "rank": null,
+          "elapsed_ms": 1772.27,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "display",
+            "file": "template/defaulttags.py"
+          }
+        },
+        {
+          "query": "render a template without any extra view logic",
+          "query_type": "natural_language",
+          "expected_symbol": "TemplateView",
+          "expected_file_suffix": "views/generic/base.py",
+          "rank": null,
+          "elapsed_ms": 926.08,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "render",
+            "file": "template/backends/dummy.py"
+          }
+        },
+        {
+          "query": "exempt a view from CSRF protection",
+          "query_type": "natural_language",
+          "expected_symbol": "csrf_exempt",
+          "expected_file_suffix": "views/decorators/csrf.py",
+          "rank": 1,
+          "elapsed_ms": 1542.31,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "csrf_exempt",
+            "file": "views/decorators/csrf.py"
+          }
+        },
+        {
+          "query": "declarative form with field validation",
+          "query_type": "natural_language",
+          "expected_symbol": "Form",
+          "expected_file_suffix": "forms/forms.py",
+          "rank": null,
+          "elapsed_ms": 1549.59,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "form_valid",
+            "file": "views/generic/edit.py"
+          }
+        },
+        {
+          "query": "form that is bound to a model for create and update",
+          "query_type": "natural_language",
+          "expected_symbol": "ModelForm",
+          "expected_file_suffix": "forms/models.py",
+          "rank": null,
+          "elapsed_ms": 995.36,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "form",
+            "file": "forms/models.py"
+          }
+        },
+        {
+          "query": "get object or 404",
+          "query_type": "short_phrase",
+          "expected_symbol": "get_object_or_404",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": 1,
+          "elapsed_ms": 1009.43,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "get_object_or_404",
+            "file": "shortcuts.py"
+          }
+        },
+        {
+          "query": "login required",
+          "query_type": "short_phrase",
+          "expected_symbol": "login_required",
+          "expected_file_suffix": "contrib/auth/decorators.py",
+          "rank": 1,
+          "elapsed_ms": 478.27,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "login_required",
+            "file": "contrib/auth/decorators.py"
+          }
+        },
+        {
+          "query": "http response",
+          "query_type": "short_phrase",
+          "expected_symbol": "HttpResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": 1,
+          "elapsed_ms": 488.09,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "HttpResponse",
+            "file": "http/response.py"
+          }
+        },
+        {
+          "query": "query set",
+          "query_type": "short_phrase",
+          "expected_symbol": "QuerySet",
+          "expected_file_suffix": "db/models/query.py",
+          "rank": null,
+          "elapsed_ms": 489.02,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "queryset",
+            "file": "db/models/query.py"
+          }
+        },
+        {
+          "query": "reverse url",
+          "query_type": "short_phrase",
+          "expected_symbol": "reverse",
+          "expected_file_suffix": "urls/base.py",
+          "rank": 1,
+          "elapsed_ms": 479.39,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "reverse",
+            "file": "urls/base.py"
+          }
+        },
+        {
+          "query": "make password",
+          "query_type": "short_phrase",
+          "expected_symbol": "make_password",
+          "expected_file_suffix": "contrib/auth/hashers.py",
+          "rank": 1,
+          "elapsed_ms": 487.61,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "make_password",
+            "file": "contrib/auth/hashers.py"
+          }
+        },
+        {
+          "query": "QuerySet",
+          "query_type": "identifier",
+          "expected_symbol": "QuerySet",
+          "expected_file_suffix": "db/models/query.py",
+          "rank": 1,
+          "elapsed_ms": 315.94,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "QuerySet",
+            "file": "db/models/query.py"
+          }
+        },
+        {
+          "query": "HttpResponse",
+          "query_type": "identifier",
+          "expected_symbol": "HttpResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": 1,
+          "elapsed_ms": 320.49,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "HttpResponse",
+            "file": "http/response.py"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context_no_semantic",
+      "mrr": 0.1339273640490679,
+      "acc1": 0.08823529411764706,
+      "acc3": 0.11764705882352941,
+      "acc5": 0.20588235294117646,
+      "avg_elapsed_ms": 160.22470588235296,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 0.5,
+          "acc1": 0.5,
+          "acc3": 0.5,
+          "acc5": 0.5,
+          "avg_elapsed_ms": 130.59
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.04244347606416572,
+          "acc1": 0.0,
+          "acc3": 0.038461538461538464,
+          "acc5": 0.07692307692307693,
+          "avg_elapsed_ms": 166.46615384615384
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.4083333333333334,
+          "acc1": 0.3333333333333333,
+          "acc3": 0.3333333333333333,
+          "acc5": 0.6666666666666666,
+          "avg_elapsed_ms": 143.05666666666667
+        }
+      },
+      "rows": [
+        {
+          "query": "query rows from a database model",
+          "query_type": "natural_language",
+          "expected_symbol": "QuerySet",
+          "expected_file_suffix": "db/models/query.py",
+          "rank": null,
+          "elapsed_ms": 181.46,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "del_query",
+            "file": "db/models/query.py"
+          }
+        },
+        {
+          "query": "default manager that provides access to objects",
+          "query_type": "natural_language",
+          "expected_symbol": "Manager",
+          "expected_file_suffix": "db/models/manager.py",
+          "rank": 7,
+          "elapsed_ms": 174.9,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "ManagerDescriptor",
+            "file": "db/models/manager.py"
+          }
+        },
+        {
+          "query": "base class for all database models",
+          "query_type": "natural_language",
+          "expected_symbol": "Model",
+          "expected_file_suffix": "db/models/base.py",
+          "rank": null,
+          "elapsed_ms": 176.21,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "database",
+            "file": "core/checks/registry.py"
+          }
+        },
+        {
+          "query": "declare a foreign-key relationship to another model",
+          "query_type": "natural_language",
+          "expected_symbol": "ForeignKey",
+          "expected_file_suffix": "db/models/fields/related.py",
+          "rank": 3,
+          "elapsed_ms": 178.1,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "foreign_key",
+            "file": "db/backends/sqlite3/base.py"
+          }
+        },
+        {
+          "query": "HTTP response with body headers and status",
+          "query_type": "natural_language",
+          "expected_symbol": "HttpResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": null,
+          "elapsed_ms": 159.83,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "http_date",
+            "file": "utils/http.py"
+          }
+        },
+        {
+          "query": "return a JSON encoded response to the client",
+          "query_type": "natural_language",
+          "expected_symbol": "JsonResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": null,
+          "elapsed_ms": 181.51,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "client",
+            "file": "core/cache/backends/redis.py"
+          }
+        },
+        {
+          "query": "object representing an incoming HTTP request",
+          "query_type": "natural_language",
+          "expected_symbol": "HttpRequest",
+          "expected_file_suffix": "http/request.py",
+          "rank": null,
+          "elapsed_ms": 178.72,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "parse_http_date",
+            "file": "utils/http.py"
+          }
+        },
+        {
+          "query": "render a template with a context into a response",
+          "query_type": "natural_language",
+          "expected_symbol": "render",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": null,
+          "elapsed_ms": 172.03,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "Template",
+            "file": "template/base.py"
+          }
+        },
+        {
+          "query": "get a model instance or raise 404",
+          "query_type": "natural_language",
+          "expected_symbol": "get_object_or_404",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": 6,
+          "elapsed_ms": 164.55,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "get_for_model",
+            "file": "contrib/contenttypes/models.py"
+          }
+        },
+        {
+          "query": "issue an HTTP redirect to a URL or view",
+          "query_type": "natural_language",
+          "expected_symbol": "redirect",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": 12,
+          "elapsed_ms": 177.71,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "redirect_to",
+            "file": "contrib/auth/views.py"
+          }
+        },
+        {
+          "query": "match a URL path against the URL configuration",
+          "query_type": "natural_language",
+          "expected_symbol": "resolve",
+          "expected_file_suffix": "urls/base.py",
+          "rank": null,
+          "elapsed_ms": 145.59,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "match_url",
+            "file": "contrib/admin/templatetags/admin_urls.py"
+          }
+        },
+        {
+          "query": "look up a URL path from its view name",
+          "query_type": "natural_language",
+          "expected_symbol": "reverse",
+          "expected_file_suffix": "urls/base.py",
+          "rank": null,
+          "elapsed_ms": 145.68,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "from_",
+            "file": "db/models/fields/related.py"
+          }
+        },
+        {
+          "query": "mount a sub-URL configuration into the URL tree",
+          "query_type": "natural_language",
+          "expected_symbol": "include",
+          "expected_file_suffix": "urls/conf.py",
+          "rank": null,
+          "elapsed_ms": 147.9,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "use_returning_into",
+            "file": "db/backends/oracle/base.py"
+          }
+        },
+        {
+          "query": "log a user in for the current session",
+          "query_type": "natural_language",
+          "expected_symbol": "login",
+          "expected_file_suffix": "contrib/auth/__init__.py",
+          "rank": null,
+          "elapsed_ms": 170.4,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "_session",
+            "file": "contrib/sessions/backends/base.py"
+          }
+        },
+        {
+          "query": "log a user out and clear the session",
+          "query_type": "natural_language",
+          "expected_symbol": "logout",
+          "expected_file_suffix": "contrib/auth/__init__.py",
+          "rank": null,
+          "elapsed_ms": 146.3,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "_session",
+            "file": "contrib/sessions/backends/base.py"
+          }
+        },
+        {
+          "query": "verify a username and password against backends",
+          "query_type": "natural_language",
+          "expected_symbol": "authenticate",
+          "expected_file_suffix": "contrib/auth/__init__.py",
+          "rank": null,
+          "elapsed_ms": 172.49,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "task_backends",
+            "file": "tasks/__init__.py"
+          }
+        },
+        {
+          "query": "require a logged in user to access a view",
+          "query_type": "natural_language",
+          "expected_symbol": "login_required",
+          "expected_file_suffix": "contrib/auth/decorators.py",
+          "rank": null,
+          "elapsed_ms": 163.01,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "user_logged_in",
+            "file": "contrib/auth/signals.py"
+          }
+        },
+        {
+          "query": "check that a plain password matches a stored hash",
+          "query_type": "natural_language",
+          "expected_symbol": "check_password",
+          "expected_file_suffix": "contrib/auth/hashers.py",
+          "rank": null,
+          "elapsed_ms": 157.27,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "cmatches",
+            "file": "utils/translation/template.py"
+          }
+        },
+        {
+          "query": "hash a password for storage in the database",
+          "query_type": "natural_language",
+          "expected_symbol": "make_password",
+          "expected_file_suffix": "contrib/auth/hashers.py",
+          "rank": null,
+          "elapsed_ms": 172.69,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "hash_",
+            "file": "contrib/auth/hashers.py"
+          }
+        },
+        {
+          "query": "generic base class for all class-based views",
+          "query_type": "natural_language",
+          "expected_symbol": "View",
+          "expected_file_suffix": "views/generic/base.py",
+          "rank": null,
+          "elapsed_ms": 150.25,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "GenericForeignKey",
+            "file": "contrib/contenttypes/fields.py"
+          }
+        },
+        {
+          "query": "display a paginated list of model instances",
+          "query_type": "natural_language",
+          "expected_symbol": "ListView",
+          "expected_file_suffix": "views/generic/list.py",
+          "rank": null,
+          "elapsed_ms": 190.01,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "list_",
+            "file": "http/request.py"
+          }
+        },
+        {
+          "query": "display a single object retrieved from a model",
+          "query_type": "natural_language",
+          "expected_symbol": "DetailView",
+          "expected_file_suffix": "views/generic/detail.py",
+          "rank": null,
+          "elapsed_ms": 176.18,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "from_",
+            "file": "db/models/fields/related.py"
+          }
+        },
+        {
+          "query": "render a template without any extra view logic",
+          "query_type": "natural_language",
+          "expected_symbol": "TemplateView",
+          "expected_file_suffix": "views/generic/base.py",
+          "rank": null,
+          "elapsed_ms": 153.54,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "set_many",
+            "file": "core/cache/backends/redis.py"
+          }
+        },
+        {
+          "query": "exempt a view from CSRF protection",
+          "query_type": "natural_language",
+          "expected_symbol": "csrf_exempt",
+          "expected_file_suffix": "views/decorators/csrf.py",
+          "rank": 5,
+          "elapsed_ms": 171.72,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "from_",
+            "file": "db/models/fields/related.py"
+          }
+        },
+        {
+          "query": "declarative form with field validation",
+          "query_type": "natural_language",
+          "expected_symbol": "Form",
+          "expected_file_suffix": "forms/forms.py",
+          "rank": 7,
+          "elapsed_ms": 167.96,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "Field",
+            "file": "db/models/fields/__init__.py"
+          }
+        },
+        {
+          "query": "form that is bound to a model for create and update",
+          "query_type": "natural_language",
+          "expected_symbol": "ModelForm",
+          "expected_file_suffix": "forms/models.py",
+          "rank": 29,
+          "elapsed_ms": 152.11,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "_update",
+            "file": "db/models/query.py"
+          }
+        },
+        {
+          "query": "get object or 404",
+          "query_type": "short_phrase",
+          "expected_symbol": "get_object_or_404",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": 1,
+          "elapsed_ms": 157.15,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "get_object_or_404",
+            "file": "shortcuts.py"
+          }
+        },
+        {
+          "query": "login required",
+          "query_type": "short_phrase",
+          "expected_symbol": "login_required",
+          "expected_file_suffix": "contrib/auth/decorators.py",
+          "rank": 1,
+          "elapsed_ms": 134.17,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "login_required",
+            "file": "contrib/auth/decorators.py"
+          }
+        },
+        {
+          "query": "http response",
+          "query_type": "short_phrase",
+          "expected_symbol": "HttpResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": 4,
+          "elapsed_ms": 137.71,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "HttpResponseNotFound",
+            "file": "http/response.py"
+          }
+        },
+        {
+          "query": "query set",
+          "query_type": "short_phrase",
+          "expected_symbol": "QuerySet",
+          "expected_file_suffix": "db/models/query.py",
+          "rank": null,
+          "elapsed_ms": 144.1,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "set",
+            "file": "core/cache/backends/redis.py"
+          }
+        },
+        {
+          "query": "reverse url",
+          "query_type": "short_phrase",
+          "expected_symbol": "reverse",
+          "expected_file_suffix": "urls/base.py",
+          "rank": 5,
+          "elapsed_ms": 143.21,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "reverse",
+            "file": "urls/resolvers.py"
+          }
+        },
+        {
+          "query": "make password",
+          "query_type": "short_phrase",
+          "expected_symbol": "make_password",
+          "expected_file_suffix": "contrib/auth/hashers.py",
+          "rank": null,
+          "elapsed_ms": 142.0,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "make_aware",
+            "file": "utils/timezone.py"
+          }
+        },
+        {
+          "query": "QuerySet",
+          "query_type": "identifier",
+          "expected_symbol": "QuerySet",
+          "expected_file_suffix": "db/models/query.py",
+          "rank": null,
+          "elapsed_ms": 132.37,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "queryset",
+            "file": "contrib/contenttypes/fields.py"
+          }
+        },
+        {
+          "query": "HttpResponse",
+          "query_type": "identifier",
+          "expected_symbol": "HttpResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": 1,
+          "elapsed_ms": 128.81,
+          "candidate_count": 13,
+          "top_candidate": {
+            "name": "HttpResponse",
+            "file": "http/response.py"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context",
+      "mrr": 0.29367688251771296,
+      "acc1": 0.23529411764705882,
+      "acc3": 0.3235294117647059,
+      "acc5": 0.35294117647058826,
+      "avg_elapsed_ms": 288.2832352941177,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 0.5,
+          "acc1": 0.5,
+          "acc3": 0.5,
+          "acc5": 0.5,
+          "avg_elapsed_ms": 136.66
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.17250053867700926,
+          "acc1": 0.11538461538461539,
+          "acc3": 0.19230769230769232,
+          "acc5": 0.23076923076923078,
+          "avg_elapsed_ms": 296.7069230769231
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.75,
+          "acc1": 0.6666666666666666,
+          "acc3": 0.8333333333333334,
+          "acc5": 0.8333333333333334,
+          "avg_elapsed_ms": 302.32166666666666
+        }
+      },
+      "rows": [
+        {
+          "query": "query rows from a database model",
+          "query_type": "natural_language",
+          "expected_symbol": "QuerySet",
+          "expected_file_suffix": "db/models/query.py",
+          "rank": null,
+          "elapsed_ms": 295.52,
+          "candidate_count": 36,
+          "top_candidate": {
+            "name": "fetch_returned_rows",
+            "file": "db/backends/base/operations.py"
+          }
+        },
+        {
+          "query": "default manager that provides access to objects",
+          "query_type": "natural_language",
+          "expected_symbol": "Manager",
+          "expected_file_suffix": "db/models/manager.py",
+          "rank": 17,
+          "elapsed_ms": 302.47,
+          "candidate_count": 34,
+          "top_candidate": {
+            "name": "_default_manager",
+            "file": "db/models/base.py"
+          }
+        },
+        {
+          "query": "base class for all database models",
+          "query_type": "natural_language",
+          "expected_symbol": "Model",
+          "expected_file_suffix": "db/models/base.py",
+          "rank": null,
+          "elapsed_ms": 287.15,
+          "candidate_count": 35,
+          "top_candidate": {
+            "name": "ModelBase",
+            "file": "db/models/base.py"
+          }
+        },
+        {
+          "query": "declare a foreign-key relationship to another model",
+          "query_type": "natural_language",
+          "expected_symbol": "ForeignKey",
+          "expected_file_suffix": "db/models/fields/related.py",
+          "rank": 6,
+          "elapsed_ms": 298.55,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "fk",
+            "file": "forms/models.py"
+          }
+        },
+        {
+          "query": "HTTP response with body headers and status",
+          "query_type": "natural_language",
+          "expected_symbol": "HttpResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": null,
+          "elapsed_ms": 280.95,
+          "candidate_count": 35,
+          "top_candidate": {
+            "name": "body",
+            "file": "http/request.py"
+          }
+        },
+        {
+          "query": "return a JSON encoded response to the client",
+          "query_type": "natural_language",
+          "expected_symbol": "JsonResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": null,
+          "elapsed_ms": 303.34,
+          "candidate_count": 37,
+          "top_candidate": {
+            "name": "_encode_json",
+            "file": "test/client.py"
+          }
+        },
+        {
+          "query": "object representing an incoming HTTP request",
+          "query_type": "natural_language",
+          "expected_symbol": "HttpRequest",
+          "expected_file_suffix": "http/request.py",
+          "rank": 12,
+          "elapsed_ms": 296.56,
+          "candidate_count": 34,
+          "top_candidate": {
+            "name": "body",
+            "file": "http/request.py"
+          }
+        },
+        {
+          "query": "render a template with a context into a response",
+          "query_type": "natural_language",
+          "expected_symbol": "render",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": null,
+          "elapsed_ms": 286.83,
+          "candidate_count": 37,
+          "top_candidate": {
+            "name": "context",
+            "file": "template/response.py"
+          }
+        },
+        {
+          "query": "get a model instance or raise 404",
+          "query_type": "natural_language",
+          "expected_symbol": "get_object_or_404",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": 5,
+          "elapsed_ms": 282.86,
+          "candidate_count": 34,
+          "top_candidate": {
+            "name": "get_model",
+            "file": "apps/config.py"
+          }
+        },
+        {
+          "query": "issue an HTTP redirect to a URL or view",
+          "query_type": "natural_language",
+          "expected_symbol": "redirect",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": 7,
+          "elapsed_ms": 290.27,
+          "candidate_count": 34,
+          "top_candidate": {
+            "name": "get_redirect_url",
+            "file": "contrib/auth/views.py"
+          }
+        },
+        {
+          "query": "match a URL path against the URL configuration",
+          "query_type": "natural_language",
+          "expected_symbol": "resolve",
+          "expected_file_suffix": "urls/base.py",
+          "rank": null,
+          "elapsed_ms": 262.58,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "match",
+            "file": "urls/resolvers.py"
+          }
+        },
+        {
+          "query": "look up a URL path from its view name",
+          "query_type": "natural_language",
+          "expected_symbol": "reverse",
+          "expected_file_suffix": "urls/base.py",
+          "rank": null,
+          "elapsed_ms": 254.02,
+          "candidate_count": 35,
+          "top_candidate": {
+            "name": "view_path",
+            "file": "urls/resolvers.py"
+          }
+        },
+        {
+          "query": "mount a sub-URL configuration into the URL tree",
+          "query_type": "natural_language",
+          "expected_symbol": "include",
+          "expected_file_suffix": "urls/conf.py",
+          "rank": null,
+          "elapsed_ms": 258.41,
+          "candidate_count": 35,
+          "top_candidate": {
+            "name": "check_url_config",
+            "file": "core/checks/urls.py"
+          }
+        },
+        {
+          "query": "log a user in for the current session",
+          "query_type": "natural_language",
+          "expected_symbol": "login",
+          "expected_file_suffix": "contrib/auth/__init__.py",
+          "rank": 1,
+          "elapsed_ms": 279.8,
+          "candidate_count": 34,
+          "top_candidate": {
+            "name": "login",
+            "file": "contrib/auth/__init__.py"
+          }
+        },
+        {
+          "query": "log a user out and clear the session",
+          "query_type": "natural_language",
+          "expected_symbol": "logout",
+          "expected_file_suffix": "contrib/auth/__init__.py",
+          "rank": 3,
+          "elapsed_ms": 254.4,
+          "candidate_count": 36,
+          "top_candidate": {
+            "name": "logout",
+            "file": "test/client.py"
+          }
+        },
+        {
+          "query": "verify a username and password against backends",
+          "query_type": "natural_language",
+          "expected_symbol": "authenticate",
+          "expected_file_suffix": "contrib/auth/__init__.py",
+          "rank": null,
+          "elapsed_ms": 281.91,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "verify",
+            "file": "contrib/auth/hashers.py"
+          }
+        },
+        {
+          "query": "require a logged in user to access a view",
+          "query_type": "natural_language",
+          "expected_symbol": "login_required",
+          "expected_file_suffix": "contrib/auth/decorators.py",
+          "rank": null,
+          "elapsed_ms": 272.92,
+          "candidate_count": 35,
+          "top_candidate": {
+            "name": "view",
+            "file": "views/generic/base.py"
+          }
+        },
+        {
+          "query": "check that a plain password matches a stored hash",
+          "query_type": "natural_language",
+          "expected_symbol": "check_password",
+          "expected_file_suffix": "contrib/auth/hashers.py",
+          "rank": 2,
+          "elapsed_ms": 257.85,
+          "candidate_count": 36,
+          "top_candidate": {
+            "name": "render_password_as_hash",
+            "file": "contrib/auth/templatetags/auth.py"
+          }
+        },
+        {
+          "query": "hash a password for storage in the database",
+          "query_type": "natural_language",
+          "expected_symbol": "make_password",
+          "expected_file_suffix": "contrib/auth/hashers.py",
+          "rank": null,
+          "elapsed_ms": 285.97,
+          "candidate_count": 36,
+          "top_candidate": {
+            "name": "__hash__",
+            "file": "db/models/manager.py"
+          }
+        },
+        {
+          "query": "generic base class for all class-based views",
+          "query_type": "natural_language",
+          "expected_symbol": "View",
+          "expected_file_suffix": "views/generic/base.py",
+          "rank": 1,
+          "elapsed_ms": 262.19,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "View",
+            "file": "views/generic/base.py"
+          }
+        },
+        {
+          "query": "display a paginated list of model instances",
+          "query_type": "natural_language",
+          "expected_symbol": "ListView",
+          "expected_file_suffix": "views/generic/list.py",
+          "rank": null,
+          "elapsed_ms": 283.94,
+          "candidate_count": 37,
+          "top_candidate": {
+            "name": "model",
+            "file": "contrib/postgres/fields/array.py"
+          }
+        },
+        {
+          "query": "display a single object retrieved from a model",
+          "query_type": "natural_language",
+          "expected_symbol": "DetailView",
+          "expected_file_suffix": "views/generic/detail.py",
+          "rank": null,
+          "elapsed_ms": 301.25,
+          "candidate_count": 36,
+          "top_candidate": {
+            "name": "get_object",
+            "file": "views/generic/detail.py"
+          }
+        },
+        {
+          "query": "render a template without any extra view logic",
+          "query_type": "natural_language",
+          "expected_symbol": "TemplateView",
+          "expected_file_suffix": "views/generic/base.py",
+          "rank": null,
+          "elapsed_ms": 263.48,
+          "candidate_count": 37,
+          "top_candidate": {
+            "name": "render",
+            "file": "template/backends/dummy.py"
+          }
+        },
+        {
+          "query": "exempt a view from CSRF protection",
+          "query_type": "natural_language",
+          "expected_symbol": "csrf_exempt",
+          "expected_file_suffix": "views/decorators/csrf.py",
+          "rank": 1,
+          "elapsed_ms": 284.12,
+          "candidate_count": 33,
+          "top_candidate": {
+            "name": "csrf_exempt",
+            "file": "views/decorators/csrf.py"
+          }
+        },
+        {
+          "query": "declarative form with field validation",
+          "query_type": "natural_language",
+          "expected_symbol": "Form",
+          "expected_file_suffix": "forms/forms.py",
+          "rank": null,
+          "elapsed_ms": 283.67,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "form_valid",
+            "file": "views/generic/edit.py"
+          }
+        },
+        {
+          "query": "form that is bound to a model for create and update",
+          "query_type": "natural_language",
+          "expected_symbol": "ModelForm",
+          "expected_file_suffix": "forms/models.py",
+          "rank": null,
+          "elapsed_ms": 703.37,
+          "candidate_count": 38,
+          "top_candidate": {
+            "name": "_do_update",
+            "file": "db/models/base.py"
+          }
+        },
+        {
+          "query": "get object or 404",
+          "query_type": "short_phrase",
+          "expected_symbol": "get_object_or_404",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": 1,
+          "elapsed_ms": 280.02,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "get_object_or_404",
+            "file": "shortcuts.py"
+          }
+        },
+        {
+          "query": "login required",
+          "query_type": "short_phrase",
+          "expected_symbol": "login_required",
+          "expected_file_suffix": "contrib/auth/decorators.py",
+          "rank": 1,
+          "elapsed_ms": 500.72,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "login_required",
+            "file": "contrib/auth/decorators.py"
+          }
+        },
+        {
+          "query": "http response",
+          "query_type": "short_phrase",
+          "expected_symbol": "HttpResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": 2,
+          "elapsed_ms": 261.36,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "response",
+            "file": "views/generic/base.py"
+          }
+        },
+        {
+          "query": "query set",
+          "query_type": "short_phrase",
+          "expected_symbol": "QuerySet",
+          "expected_file_suffix": "db/models/query.py",
+          "rank": null,
+          "elapsed_ms": 256.97,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "queryset",
+            "file": "db/models/query.py"
+          }
+        },
+        {
+          "query": "reverse url",
+          "query_type": "short_phrase",
+          "expected_symbol": "reverse",
+          "expected_file_suffix": "urls/base.py",
+          "rank": 1,
+          "elapsed_ms": 253.64,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "reverse",
+            "file": "urls/base.py"
+          }
+        },
+        {
+          "query": "make password",
+          "query_type": "short_phrase",
+          "expected_symbol": "make_password",
+          "expected_file_suffix": "contrib/auth/hashers.py",
+          "rank": 1,
+          "elapsed_ms": 261.22,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "make_password",
+            "file": "contrib/auth/hashers.py"
+          }
+        },
+        {
+          "query": "QuerySet",
+          "query_type": "identifier",
+          "expected_symbol": "QuerySet",
+          "expected_file_suffix": "db/models/query.py",
+          "rank": null,
+          "elapsed_ms": 140.06,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "queryset",
+            "file": "contrib/contenttypes/fields.py"
+          }
+        },
+        {
+          "query": "HttpResponse",
+          "query_type": "identifier",
+          "expected_symbol": "HttpResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": 1,
+          "elapsed_ms": 133.26,
+          "candidate_count": 13,
+          "top_candidate": {
+            "name": "HttpResponse",
+            "file": "http/response.py"
+          }
+        }
+      ]
+    }
+  ],
+  "hybrid_uplift": {
+    "mrr_delta": 0.15974951846864505,
+    "acc1_delta": 0.14705882352941174,
+    "acc3_delta": 0.2058823529411765,
+    "acc5_delta": 0.1470588235294118
+  },
+  "hybrid_uplift_by_query_type": {
+    "identifier": {
+      "mrr_delta": 0.0,
+      "acc1_delta": 0.0,
+      "acc3_delta": 0.0,
+      "acc5_delta": 0.0
+    },
+    "natural_language": {
+      "mrr_delta": 0.13005706261284355,
+      "acc1_delta": 0.11538461538461539,
+      "acc3_delta": 0.15384615384615385,
+      "acc5_delta": 0.15384615384615385
+    },
+    "short_phrase": {
+      "mrr_delta": 0.3416666666666666,
+      "acc1_delta": 0.3333333333333333,
+      "acc3_delta": 0.5,
+      "acc5_delta": 0.16666666666666674
+    }
+  }
+}

--- a/benchmarks/embedding-quality-v1.6-phase3g-django-stacked.json
+++ b/benchmarks/embedding-quality-v1.6-phase3g-django-stacked.json
@@ -1,0 +1,1487 @@
+{
+  "project": "/tmp/django-src/django",
+  "benchmark_project": "/var/folders/z0/0tcbss795xsdp75jmr_t9_kh0000gn/T/codelens-embed-quality-22s3utaz/django",
+  "isolated_copy": true,
+  "binary": "/Users/bagjaeseog/codelens-mcp-plugin/target/release/codelens-mcp",
+  "embedding_model": "MiniLM-L12-CodeSearchNet-INT8",
+  "runtime_model": {
+    "model_dir": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch",
+    "model_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/model.onnx",
+    "config_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/config.json",
+    "sha256": "ef1d1e9cfa72e4929f5b9faea17d8704b23a2530aadebf0d464a4cc7750920b3",
+    "size_bytes": 34000281,
+    "num_hidden_layers": 12,
+    "hidden_size": 384
+  },
+  "dataset_path": "/Users/bagjaeseog/codelens-mcp-plugin/benchmarks/embedding-quality-dataset-django.json",
+  "dataset_size": 34,
+  "ranking_cutoff": 10,
+  "metric_labels": {
+    "mrr": "MRR@10",
+    "acc1": "Acc@1",
+    "acc3": "Acc@3",
+    "acc5": "Acc@5"
+  },
+  "methods": [
+    {
+      "method": "semantic_search",
+      "mrr": 0.2867647058823529,
+      "acc1": 0.23529411764705882,
+      "acc3": 0.3235294117647059,
+      "acc5": 0.35294117647058826,
+      "avg_elapsed_ms": 1363.096176470588,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 1.0,
+          "acc1": 1.0,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 422.235
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.14423076923076922,
+          "acc1": 0.07692307692307693,
+          "acc3": 0.19230769230769232,
+          "acc5": 0.23076923076923078,
+          "avg_elapsed_ms": 1584.4484615384617
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.6666666666666666,
+          "acc1": 0.6666666666666666,
+          "acc3": 0.6666666666666666,
+          "acc5": 0.6666666666666666,
+          "avg_elapsed_ms": 717.5233333333334
+        }
+      },
+      "rows": [
+        {
+          "query": "query rows from a database model",
+          "query_type": "natural_language",
+          "expected_symbol": "QuerySet",
+          "expected_file_suffix": "db/models/query.py",
+          "rank": null,
+          "elapsed_ms": 1941.1,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "query",
+            "file": "db/models/query.py"
+          }
+        },
+        {
+          "query": "default manager that provides access to objects",
+          "query_type": "natural_language",
+          "expected_symbol": "Manager",
+          "expected_file_suffix": "db/models/manager.py",
+          "rank": null,
+          "elapsed_ms": 1781.2,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "_default_manager",
+            "file": "db/models/base.py"
+          }
+        },
+        {
+          "query": "base class for all database models",
+          "query_type": "natural_language",
+          "expected_symbol": "Model",
+          "expected_file_suffix": "db/models/base.py",
+          "rank": null,
+          "elapsed_ms": 1759.67,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "ModelBase",
+            "file": "db/models/base.py"
+          }
+        },
+        {
+          "query": "declare a foreign-key relationship to another model",
+          "query_type": "natural_language",
+          "expected_symbol": "ForeignKey",
+          "expected_file_suffix": "db/models/fields/related.py",
+          "rank": null,
+          "elapsed_ms": 1836.39,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "_foreign_key_constraints",
+            "file": "db/backends/oracle/operations.py"
+          }
+        },
+        {
+          "query": "HTTP response with body headers and status",
+          "query_type": "natural_language",
+          "expected_symbol": "HttpResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": null,
+          "elapsed_ms": 1253.63,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "body",
+            "file": "http/request.py"
+          }
+        },
+        {
+          "query": "return a JSON encoded response to the client",
+          "query_type": "natural_language",
+          "expected_symbol": "JsonResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": null,
+          "elapsed_ms": 2052.59,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "_encode_json",
+            "file": "test/client.py"
+          }
+        },
+        {
+          "query": "object representing an incoming HTTP request",
+          "query_type": "natural_language",
+          "expected_symbol": "HttpRequest",
+          "expected_file_suffix": "http/request.py",
+          "rank": null,
+          "elapsed_ms": 1893.23,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "_get_edited_object_pks",
+            "file": "contrib/admin/options.py"
+          }
+        },
+        {
+          "query": "render a template with a context into a response",
+          "query_type": "natural_language",
+          "expected_symbol": "render",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": null,
+          "elapsed_ms": 1769.62,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "context",
+            "file": "template/response.py"
+          }
+        },
+        {
+          "query": "get a model instance or raise 404",
+          "query_type": "natural_language",
+          "expected_symbol": "get_object_or_404",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": 1,
+          "elapsed_ms": 1825.63,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "get_object_or_404",
+            "file": "shortcuts.py"
+          }
+        },
+        {
+          "query": "issue an HTTP redirect to a URL or view",
+          "query_type": "natural_language",
+          "expected_symbol": "redirect",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": 4,
+          "elapsed_ms": 2285.23,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "redirect_to_str",
+            "file": "http/response.py"
+          }
+        },
+        {
+          "query": "match a URL path against the URL configuration",
+          "query_type": "natural_language",
+          "expected_symbol": "resolve",
+          "expected_file_suffix": "urls/base.py",
+          "rank": null,
+          "elapsed_ms": 936.16,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "match_url",
+            "file": "contrib/admin/templatetags/admin_urls.py"
+          }
+        },
+        {
+          "query": "look up a URL path from its view name",
+          "query_type": "natural_language",
+          "expected_symbol": "reverse",
+          "expected_file_suffix": "urls/base.py",
+          "rank": null,
+          "elapsed_ms": 922.6,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "view",
+            "file": "views/generic/base.py"
+          }
+        },
+        {
+          "query": "mount a sub-URL configuration into the URL tree",
+          "query_type": "natural_language",
+          "expected_symbol": "include",
+          "expected_file_suffix": "urls/conf.py",
+          "rank": null,
+          "elapsed_ms": 1005.33,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "urls",
+            "file": "contrib/admin/sites.py"
+          }
+        },
+        {
+          "query": "log a user in for the current session",
+          "query_type": "natural_language",
+          "expected_symbol": "login",
+          "expected_file_suffix": "contrib/auth/__init__.py",
+          "rank": 2,
+          "elapsed_ms": 1872.89,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "login",
+            "file": "contrib/admin/sites.py"
+          }
+        },
+        {
+          "query": "log a user out and clear the session",
+          "query_type": "natural_language",
+          "expected_symbol": "logout",
+          "expected_file_suffix": "contrib/auth/__init__.py",
+          "rank": 2,
+          "elapsed_ms": 1007.25,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "logout",
+            "file": "contrib/admin/sites.py"
+          }
+        },
+        {
+          "query": "verify a username and password against backends",
+          "query_type": "natural_language",
+          "expected_symbol": "authenticate",
+          "expected_file_suffix": "contrib/auth/__init__.py",
+          "rank": null,
+          "elapsed_ms": 1997.8,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "verify",
+            "file": "contrib/auth/hashers.py"
+          }
+        },
+        {
+          "query": "require a logged in user to access a view",
+          "query_type": "natural_language",
+          "expected_symbol": "login_required",
+          "expected_file_suffix": "contrib/auth/decorators.py",
+          "rank": null,
+          "elapsed_ms": 1601.3,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "view",
+            "file": "views/generic/base.py"
+          }
+        },
+        {
+          "query": "check that a plain password matches a stored hash",
+          "query_type": "natural_language",
+          "expected_symbol": "check_password",
+          "expected_file_suffix": "contrib/auth/hashers.py",
+          "rank": null,
+          "elapsed_ms": 991.43,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "check",
+            "file": "contrib/admin/options.py"
+          }
+        },
+        {
+          "query": "hash a password for storage in the database",
+          "query_type": "natural_language",
+          "expected_symbol": "make_password",
+          "expected_file_suffix": "contrib/auth/hashers.py",
+          "rank": null,
+          "elapsed_ms": 1972.06,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "__hash__",
+            "file": "db/models/manager.py"
+          }
+        },
+        {
+          "query": "generic base class for all class-based views",
+          "query_type": "natural_language",
+          "expected_symbol": "View",
+          "expected_file_suffix": "views/generic/base.py",
+          "rank": 2,
+          "elapsed_ms": 1030.54,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "BaseDetailView",
+            "file": "views/generic/detail.py"
+          }
+        },
+        {
+          "query": "display a paginated list of model instances",
+          "query_type": "natural_language",
+          "expected_symbol": "ListView",
+          "expected_file_suffix": "views/generic/list.py",
+          "rank": null,
+          "elapsed_ms": 1689.69,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "display",
+            "file": "template/defaulttags.py"
+          }
+        },
+        {
+          "query": "display a single object retrieved from a model",
+          "query_type": "natural_language",
+          "expected_symbol": "DetailView",
+          "expected_file_suffix": "views/generic/detail.py",
+          "rank": null,
+          "elapsed_ms": 1946.89,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "display",
+            "file": "template/defaulttags.py"
+          }
+        },
+        {
+          "query": "render a template without any extra view logic",
+          "query_type": "natural_language",
+          "expected_symbol": "TemplateView",
+          "expected_file_suffix": "views/generic/base.py",
+          "rank": null,
+          "elapsed_ms": 1032.34,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "render",
+            "file": "template/backends/dummy.py"
+          }
+        },
+        {
+          "query": "exempt a view from CSRF protection",
+          "query_type": "natural_language",
+          "expected_symbol": "csrf_exempt",
+          "expected_file_suffix": "views/decorators/csrf.py",
+          "rank": 1,
+          "elapsed_ms": 1714.23,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "csrf_exempt",
+            "file": "views/decorators/csrf.py"
+          }
+        },
+        {
+          "query": "declarative form with field validation",
+          "query_type": "natural_language",
+          "expected_symbol": "Form",
+          "expected_file_suffix": "forms/forms.py",
+          "rank": null,
+          "elapsed_ms": 1798.57,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "form_valid",
+            "file": "views/generic/edit.py"
+          }
+        },
+        {
+          "query": "form that is bound to a model for create and update",
+          "query_type": "natural_language",
+          "expected_symbol": "ModelForm",
+          "expected_file_suffix": "forms/models.py",
+          "rank": null,
+          "elapsed_ms": 1278.29,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "_update",
+            "file": "db/models/query.py"
+          }
+        },
+        {
+          "query": "get object or 404",
+          "query_type": "short_phrase",
+          "expected_symbol": "get_object_or_404",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": 1,
+          "elapsed_ms": 1406.1,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "get_object_or_404",
+            "file": "shortcuts.py"
+          }
+        },
+        {
+          "query": "login required",
+          "query_type": "short_phrase",
+          "expected_symbol": "login_required",
+          "expected_file_suffix": "contrib/auth/decorators.py",
+          "rank": 1,
+          "elapsed_ms": 544.74,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "login_required",
+            "file": "contrib/auth/decorators.py"
+          }
+        },
+        {
+          "query": "http response",
+          "query_type": "short_phrase",
+          "expected_symbol": "HttpResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": null,
+          "elapsed_ms": 527.2,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "response",
+            "file": "views/generic/base.py"
+          }
+        },
+        {
+          "query": "query set",
+          "query_type": "short_phrase",
+          "expected_symbol": "QuerySet",
+          "expected_file_suffix": "db/models/query.py",
+          "rank": null,
+          "elapsed_ms": 555.47,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "queryset",
+            "file": "db/models/query.py"
+          }
+        },
+        {
+          "query": "reverse url",
+          "query_type": "short_phrase",
+          "expected_symbol": "reverse",
+          "expected_file_suffix": "urls/base.py",
+          "rank": 1,
+          "elapsed_ms": 626.15,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "reverse",
+            "file": "urls/base.py"
+          }
+        },
+        {
+          "query": "make password",
+          "query_type": "short_phrase",
+          "expected_symbol": "make_password",
+          "expected_file_suffix": "contrib/auth/hashers.py",
+          "rank": 1,
+          "elapsed_ms": 645.48,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "make_password",
+            "file": "contrib/auth/hashers.py"
+          }
+        },
+        {
+          "query": "QuerySet",
+          "query_type": "identifier",
+          "expected_symbol": "QuerySet",
+          "expected_file_suffix": "db/models/query.py",
+          "rank": 1,
+          "elapsed_ms": 442.42,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "QuerySet",
+            "file": "db/models/query.py"
+          }
+        },
+        {
+          "query": "HttpResponse",
+          "query_type": "identifier",
+          "expected_symbol": "HttpResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": 1,
+          "elapsed_ms": 402.05,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "HttpResponse",
+            "file": "http/response.py"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context_no_semantic",
+      "mrr": 0.13539795228436202,
+      "acc1": 0.08823529411764706,
+      "acc3": 0.11764705882352941,
+      "acc5": 0.20588235294117646,
+      "avg_elapsed_ms": 186.25441176470588,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 0.5,
+          "acc1": 0.5,
+          "acc3": 0.5,
+          "acc5": 0.5,
+          "avg_elapsed_ms": 145.97500000000002
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.04436655298724264,
+          "acc1": 0.0,
+          "acc3": 0.038461538461538464,
+          "acc5": 0.07692307692307693,
+          "avg_elapsed_ms": 194.1273076923077
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.4083333333333334,
+          "acc1": 0.3333333333333333,
+          "acc3": 0.3333333333333333,
+          "acc5": 0.6666666666666666,
+          "avg_elapsed_ms": 165.565
+        }
+      },
+      "rows": [
+        {
+          "query": "query rows from a database model",
+          "query_type": "natural_language",
+          "expected_symbol": "QuerySet",
+          "expected_file_suffix": "db/models/query.py",
+          "rank": null,
+          "elapsed_ms": 234.32,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "del_query",
+            "file": "db/models/query.py"
+          }
+        },
+        {
+          "query": "default manager that provides access to objects",
+          "query_type": "natural_language",
+          "expected_symbol": "Manager",
+          "expected_file_suffix": "db/models/manager.py",
+          "rank": 7,
+          "elapsed_ms": 230.84,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "ManagerDescriptor",
+            "file": "db/models/manager.py"
+          }
+        },
+        {
+          "query": "base class for all database models",
+          "query_type": "natural_language",
+          "expected_symbol": "Model",
+          "expected_file_suffix": "db/models/base.py",
+          "rank": null,
+          "elapsed_ms": 218.43,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "prepare_database_save",
+            "file": "db/models/base.py"
+          }
+        },
+        {
+          "query": "declare a foreign-key relationship to another model",
+          "query_type": "natural_language",
+          "expected_symbol": "ForeignKey",
+          "expected_file_suffix": "db/models/fields/related.py",
+          "rank": 4,
+          "elapsed_ms": 236.9,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "foreign_key",
+            "file": "db/backends/sqlite3/base.py"
+          }
+        },
+        {
+          "query": "HTTP response with body headers and status",
+          "query_type": "natural_language",
+          "expected_symbol": "HttpResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": null,
+          "elapsed_ms": 187.92,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "serialize_headers",
+            "file": "http/response.py"
+          }
+        },
+        {
+          "query": "return a JSON encoded response to the client",
+          "query_type": "natural_language",
+          "expected_symbol": "JsonResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": null,
+          "elapsed_ms": 200.01,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "client",
+            "file": "core/cache/backends/redis.py"
+          }
+        },
+        {
+          "query": "object representing an incoming HTTP request",
+          "query_type": "natural_language",
+          "expected_symbol": "HttpRequest",
+          "expected_file_suffix": "http/request.py",
+          "rank": null,
+          "elapsed_ms": 190.31,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "parse_http_date",
+            "file": "utils/http.py"
+          }
+        },
+        {
+          "query": "render a template with a context into a response",
+          "query_type": "natural_language",
+          "expected_symbol": "render",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": null,
+          "elapsed_ms": 185.32,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "RenderContext",
+            "file": "template/context.py"
+          }
+        },
+        {
+          "query": "get a model instance or raise 404",
+          "query_type": "natural_language",
+          "expected_symbol": "get_object_or_404",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": 6,
+          "elapsed_ms": 188.95,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "get_for_model",
+            "file": "contrib/contenttypes/models.py"
+          }
+        },
+        {
+          "query": "issue an HTTP redirect to a URL or view",
+          "query_type": "natural_language",
+          "expected_symbol": "redirect",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": 12,
+          "elapsed_ms": 198.34,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "redirect_to",
+            "file": "contrib/auth/views.py"
+          }
+        },
+        {
+          "query": "match a URL path against the URL configuration",
+          "query_type": "natural_language",
+          "expected_symbol": "resolve",
+          "expected_file_suffix": "urls/base.py",
+          "rank": null,
+          "elapsed_ms": 177.18,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "match_url",
+            "file": "contrib/admin/templatetags/admin_urls.py"
+          }
+        },
+        {
+          "query": "look up a URL path from its view name",
+          "query_type": "natural_language",
+          "expected_symbol": "reverse",
+          "expected_file_suffix": "urls/base.py",
+          "rank": null,
+          "elapsed_ms": 182.75,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "from_",
+            "file": "db/models/fields/related.py"
+          }
+        },
+        {
+          "query": "mount a sub-URL configuration into the URL tree",
+          "query_type": "natural_language",
+          "expected_symbol": "include",
+          "expected_file_suffix": "urls/conf.py",
+          "rank": null,
+          "elapsed_ms": 188.11,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "use_returning_into",
+            "file": "db/backends/oracle/base.py"
+          }
+        },
+        {
+          "query": "log a user in for the current session",
+          "query_type": "natural_language",
+          "expected_symbol": "login",
+          "expected_file_suffix": "contrib/auth/__init__.py",
+          "rank": null,
+          "elapsed_ms": 200.32,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "_session",
+            "file": "contrib/sessions/backends/base.py"
+          }
+        },
+        {
+          "query": "log a user out and clear the session",
+          "query_type": "natural_language",
+          "expected_symbol": "logout",
+          "expected_file_suffix": "contrib/auth/__init__.py",
+          "rank": null,
+          "elapsed_ms": 175.37,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "_session",
+            "file": "contrib/sessions/backends/base.py"
+          }
+        },
+        {
+          "query": "verify a username and password against backends",
+          "query_type": "natural_language",
+          "expected_symbol": "authenticate",
+          "expected_file_suffix": "contrib/auth/__init__.py",
+          "rank": null,
+          "elapsed_ms": 197.14,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "task_backends",
+            "file": "tasks/__init__.py"
+          }
+        },
+        {
+          "query": "require a logged in user to access a view",
+          "query_type": "natural_language",
+          "expected_symbol": "login_required",
+          "expected_file_suffix": "contrib/auth/decorators.py",
+          "rank": null,
+          "elapsed_ms": 196.74,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "user_logged_in",
+            "file": "contrib/auth/signals.py"
+          }
+        },
+        {
+          "query": "check that a plain password matches a stored hash",
+          "query_type": "natural_language",
+          "expected_symbol": "check_password",
+          "expected_file_suffix": "contrib/auth/hashers.py",
+          "rank": null,
+          "elapsed_ms": 175.55,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "cmatches",
+            "file": "utils/translation/template.py"
+          }
+        },
+        {
+          "query": "hash a password for storage in the database",
+          "query_type": "natural_language",
+          "expected_symbol": "make_password",
+          "expected_file_suffix": "contrib/auth/hashers.py",
+          "rank": null,
+          "elapsed_ms": 223.71,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "hash_",
+            "file": "contrib/auth/hashers.py"
+          }
+        },
+        {
+          "query": "generic base class for all class-based views",
+          "query_type": "natural_language",
+          "expected_symbol": "View",
+          "expected_file_suffix": "views/generic/base.py",
+          "rank": null,
+          "elapsed_ms": 166.78,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "BaseDeleteView",
+            "file": "views/generic/edit.py"
+          }
+        },
+        {
+          "query": "display a paginated list of model instances",
+          "query_type": "natural_language",
+          "expected_symbol": "ListView",
+          "expected_file_suffix": "views/generic/list.py",
+          "rank": null,
+          "elapsed_ms": 192.21,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "list_",
+            "file": "http/request.py"
+          }
+        },
+        {
+          "query": "display a single object retrieved from a model",
+          "query_type": "natural_language",
+          "expected_symbol": "DetailView",
+          "expected_file_suffix": "views/generic/detail.py",
+          "rank": null,
+          "elapsed_ms": 194.63,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "from_",
+            "file": "db/models/fields/related.py"
+          }
+        },
+        {
+          "query": "render a template without any extra view logic",
+          "query_type": "natural_language",
+          "expected_symbol": "TemplateView",
+          "expected_file_suffix": "views/generic/base.py",
+          "rank": null,
+          "elapsed_ms": 157.68,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "set_many",
+            "file": "core/cache/backends/redis.py"
+          }
+        },
+        {
+          "query": "exempt a view from CSRF protection",
+          "query_type": "natural_language",
+          "expected_symbol": "csrf_exempt",
+          "expected_file_suffix": "views/decorators/csrf.py",
+          "rank": 3,
+          "elapsed_ms": 187.84,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "from_",
+            "file": "db/models/fields/related.py"
+          }
+        },
+        {
+          "query": "declarative form with field validation",
+          "query_type": "natural_language",
+          "expected_symbol": "Form",
+          "expected_file_suffix": "forms/forms.py",
+          "rank": 7,
+          "elapsed_ms": 187.93,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "Field",
+            "file": "db/models/fields/__init__.py"
+          }
+        },
+        {
+          "query": "form that is bound to a model for create and update",
+          "query_type": "natural_language",
+          "expected_symbol": "ModelForm",
+          "expected_file_suffix": "forms/models.py",
+          "rank": 29,
+          "elapsed_ms": 172.03,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "_update",
+            "file": "db/models/query.py"
+          }
+        },
+        {
+          "query": "get object or 404",
+          "query_type": "short_phrase",
+          "expected_symbol": "get_object_or_404",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": 1,
+          "elapsed_ms": 180.35,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "get_object_or_404",
+            "file": "shortcuts.py"
+          }
+        },
+        {
+          "query": "login required",
+          "query_type": "short_phrase",
+          "expected_symbol": "login_required",
+          "expected_file_suffix": "contrib/auth/decorators.py",
+          "rank": 1,
+          "elapsed_ms": 163.26,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "login_required",
+            "file": "contrib/auth/decorators.py"
+          }
+        },
+        {
+          "query": "http response",
+          "query_type": "short_phrase",
+          "expected_symbol": "HttpResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": 4,
+          "elapsed_ms": 160.62,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "HttpResponseNotFound",
+            "file": "http/response.py"
+          }
+        },
+        {
+          "query": "query set",
+          "query_type": "short_phrase",
+          "expected_symbol": "QuerySet",
+          "expected_file_suffix": "db/models/query.py",
+          "rank": null,
+          "elapsed_ms": 167.01,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "set",
+            "file": "core/cache/backends/redis.py"
+          }
+        },
+        {
+          "query": "reverse url",
+          "query_type": "short_phrase",
+          "expected_symbol": "reverse",
+          "expected_file_suffix": "urls/base.py",
+          "rank": 5,
+          "elapsed_ms": 165.48,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "url",
+            "file": "contrib/admin/options.py"
+          }
+        },
+        {
+          "query": "make password",
+          "query_type": "short_phrase",
+          "expected_symbol": "make_password",
+          "expected_file_suffix": "contrib/auth/hashers.py",
+          "rank": null,
+          "elapsed_ms": 156.67,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "make_aware",
+            "file": "utils/timezone.py"
+          }
+        },
+        {
+          "query": "QuerySet",
+          "query_type": "identifier",
+          "expected_symbol": "QuerySet",
+          "expected_file_suffix": "db/models/query.py",
+          "rank": null,
+          "elapsed_ms": 147.4,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "queryset",
+            "file": "contrib/contenttypes/fields.py"
+          }
+        },
+        {
+          "query": "HttpResponse",
+          "query_type": "identifier",
+          "expected_symbol": "HttpResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": 1,
+          "elapsed_ms": 144.55,
+          "candidate_count": 13,
+          "top_candidate": {
+            "name": "HttpResponse",
+            "file": "http/response.py"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context",
+      "mrr": 0.28844812434777833,
+      "acc1": 0.23529411764705882,
+      "acc3": 0.29411764705882354,
+      "acc5": 0.35294117647058826,
+      "avg_elapsed_ms": 287.31,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 0.5,
+          "acc1": 0.5,
+          "acc3": 0.5,
+          "acc5": 0.5,
+          "avg_elapsed_ms": 137.58499999999998
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.17527831645478703,
+          "acc1": 0.11538461538461539,
+          "acc3": 0.19230769230769232,
+          "acc5": 0.23076923076923078,
+          "avg_elapsed_ms": 299.6334615384616
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.7083333333333334,
+          "acc1": 0.6666666666666666,
+          "acc3": 0.6666666666666666,
+          "acc5": 0.8333333333333334,
+          "avg_elapsed_ms": 283.81666666666666
+        }
+      },
+      "rows": [
+        {
+          "query": "query rows from a database model",
+          "query_type": "natural_language",
+          "expected_symbol": "QuerySet",
+          "expected_file_suffix": "db/models/query.py",
+          "rank": null,
+          "elapsed_ms": 298.4,
+          "candidate_count": 36,
+          "top_candidate": {
+            "name": "fetch_returned_rows",
+            "file": "db/backends/base/operations.py"
+          }
+        },
+        {
+          "query": "default manager that provides access to objects",
+          "query_type": "natural_language",
+          "expected_symbol": "Manager",
+          "expected_file_suffix": "db/models/manager.py",
+          "rank": 18,
+          "elapsed_ms": 293.69,
+          "candidate_count": 34,
+          "top_candidate": {
+            "name": "_default_manager",
+            "file": "db/models/base.py"
+          }
+        },
+        {
+          "query": "base class for all database models",
+          "query_type": "natural_language",
+          "expected_symbol": "Model",
+          "expected_file_suffix": "db/models/base.py",
+          "rank": 5,
+          "elapsed_ms": 295.52,
+          "candidate_count": 34,
+          "top_candidate": {
+            "name": "ModelBase",
+            "file": "db/models/base.py"
+          }
+        },
+        {
+          "query": "declare a foreign-key relationship to another model",
+          "query_type": "natural_language",
+          "expected_symbol": "ForeignKey",
+          "expected_file_suffix": "db/models/fields/related.py",
+          "rank": 7,
+          "elapsed_ms": 306.86,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "fk",
+            "file": "forms/models.py"
+          }
+        },
+        {
+          "query": "HTTP response with body headers and status",
+          "query_type": "natural_language",
+          "expected_symbol": "HttpResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": null,
+          "elapsed_ms": 283.02,
+          "candidate_count": 36,
+          "top_candidate": {
+            "name": "ResponseHeaders",
+            "file": "http/response.py"
+          }
+        },
+        {
+          "query": "return a JSON encoded response to the client",
+          "query_type": "natural_language",
+          "expected_symbol": "JsonResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": null,
+          "elapsed_ms": 305.94,
+          "candidate_count": 35,
+          "top_candidate": {
+            "name": "_encode_json",
+            "file": "test/client.py"
+          }
+        },
+        {
+          "query": "object representing an incoming HTTP request",
+          "query_type": "natural_language",
+          "expected_symbol": "HttpRequest",
+          "expected_file_suffix": "http/request.py",
+          "rank": null,
+          "elapsed_ms": 311.8,
+          "candidate_count": 34,
+          "top_candidate": {
+            "name": "encoding",
+            "file": "http/request.py"
+          }
+        },
+        {
+          "query": "render a template with a context into a response",
+          "query_type": "natural_language",
+          "expected_symbol": "render",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": null,
+          "elapsed_ms": 307.7,
+          "candidate_count": 35,
+          "top_candidate": {
+            "name": "context",
+            "file": "template/response.py"
+          }
+        },
+        {
+          "query": "get a model instance or raise 404",
+          "query_type": "natural_language",
+          "expected_symbol": "get_object_or_404",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": 3,
+          "elapsed_ms": 295.16,
+          "candidate_count": 33,
+          "top_candidate": {
+            "name": "get_model",
+            "file": "apps/registry.py"
+          }
+        },
+        {
+          "query": "issue an HTTP redirect to a URL or view",
+          "query_type": "natural_language",
+          "expected_symbol": "redirect",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": 17,
+          "elapsed_ms": 319.75,
+          "candidate_count": 34,
+          "top_candidate": {
+            "name": "get_redirect_url",
+            "file": "contrib/auth/views.py"
+          }
+        },
+        {
+          "query": "match a URL path against the URL configuration",
+          "query_type": "natural_language",
+          "expected_symbol": "resolve",
+          "expected_file_suffix": "urls/base.py",
+          "rank": null,
+          "elapsed_ms": 281.67,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "match",
+            "file": "urls/resolvers.py"
+          }
+        },
+        {
+          "query": "look up a URL path from its view name",
+          "query_type": "natural_language",
+          "expected_symbol": "reverse",
+          "expected_file_suffix": "urls/base.py",
+          "rank": null,
+          "elapsed_ms": 288.93,
+          "candidate_count": 34,
+          "top_candidate": {
+            "name": "view_path",
+            "file": "urls/resolvers.py"
+          }
+        },
+        {
+          "query": "mount a sub-URL configuration into the URL tree",
+          "query_type": "natural_language",
+          "expected_symbol": "include",
+          "expected_file_suffix": "urls/conf.py",
+          "rank": null,
+          "elapsed_ms": 315.38,
+          "candidate_count": 35,
+          "top_candidate": {
+            "name": "check_url_config",
+            "file": "core/checks/urls.py"
+          }
+        },
+        {
+          "query": "log a user in for the current session",
+          "query_type": "natural_language",
+          "expected_symbol": "login",
+          "expected_file_suffix": "contrib/auth/__init__.py",
+          "rank": 1,
+          "elapsed_ms": 307.73,
+          "candidate_count": 34,
+          "top_candidate": {
+            "name": "login",
+            "file": "contrib/auth/__init__.py"
+          }
+        },
+        {
+          "query": "log a user out and clear the session",
+          "query_type": "natural_language",
+          "expected_symbol": "logout",
+          "expected_file_suffix": "contrib/auth/__init__.py",
+          "rank": 2,
+          "elapsed_ms": 283.0,
+          "candidate_count": 36,
+          "top_candidate": {
+            "name": "logout",
+            "file": "contrib/admin/sites.py"
+          }
+        },
+        {
+          "query": "verify a username and password against backends",
+          "query_type": "natural_language",
+          "expected_symbol": "authenticate",
+          "expected_file_suffix": "contrib/auth/__init__.py",
+          "rank": null,
+          "elapsed_ms": 307.38,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "verify",
+            "file": "contrib/auth/hashers.py"
+          }
+        },
+        {
+          "query": "require a logged in user to access a view",
+          "query_type": "natural_language",
+          "expected_symbol": "login_required",
+          "expected_file_suffix": "contrib/auth/decorators.py",
+          "rank": 10,
+          "elapsed_ms": 302.27,
+          "candidate_count": 34,
+          "top_candidate": {
+            "name": "view",
+            "file": "views/generic/base.py"
+          }
+        },
+        {
+          "query": "check that a plain password matches a stored hash",
+          "query_type": "natural_language",
+          "expected_symbol": "check_password",
+          "expected_file_suffix": "contrib/auth/hashers.py",
+          "rank": 6,
+          "elapsed_ms": 274.34,
+          "candidate_count": 36,
+          "top_candidate": {
+            "name": "render_password_as_hash",
+            "file": "contrib/auth/templatetags/auth.py"
+          }
+        },
+        {
+          "query": "hash a password for storage in the database",
+          "query_type": "natural_language",
+          "expected_symbol": "make_password",
+          "expected_file_suffix": "contrib/auth/hashers.py",
+          "rank": null,
+          "elapsed_ms": 311.23,
+          "candidate_count": 36,
+          "top_candidate": {
+            "name": "__hash__",
+            "file": "db/models/manager.py"
+          }
+        },
+        {
+          "query": "generic base class for all class-based views",
+          "query_type": "natural_language",
+          "expected_symbol": "View",
+          "expected_file_suffix": "views/generic/base.py",
+          "rank": 1,
+          "elapsed_ms": 285.5,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "View",
+            "file": "views/generic/base.py"
+          }
+        },
+        {
+          "query": "display a paginated list of model instances",
+          "query_type": "natural_language",
+          "expected_symbol": "ListView",
+          "expected_file_suffix": "views/generic/list.py",
+          "rank": null,
+          "elapsed_ms": 311.58,
+          "candidate_count": 37,
+          "top_candidate": {
+            "name": "model",
+            "file": "contrib/postgres/fields/array.py"
+          }
+        },
+        {
+          "query": "display a single object retrieved from a model",
+          "query_type": "natural_language",
+          "expected_symbol": "DetailView",
+          "expected_file_suffix": "views/generic/detail.py",
+          "rank": null,
+          "elapsed_ms": 311.29,
+          "candidate_count": 36,
+          "top_candidate": {
+            "name": "model",
+            "file": "views/generic/detail.py"
+          }
+        },
+        {
+          "query": "render a template without any extra view logic",
+          "query_type": "natural_language",
+          "expected_symbol": "TemplateView",
+          "expected_file_suffix": "views/generic/base.py",
+          "rank": null,
+          "elapsed_ms": 285.3,
+          "candidate_count": 37,
+          "top_candidate": {
+            "name": "render",
+            "file": "template/backends/dummy.py"
+          }
+        },
+        {
+          "query": "exempt a view from CSRF protection",
+          "query_type": "natural_language",
+          "expected_symbol": "csrf_exempt",
+          "expected_file_suffix": "views/decorators/csrf.py",
+          "rank": 1,
+          "elapsed_ms": 306.39,
+          "candidate_count": 33,
+          "top_candidate": {
+            "name": "csrf_exempt",
+            "file": "views/decorators/csrf.py"
+          }
+        },
+        {
+          "query": "declarative form with field validation",
+          "query_type": "natural_language",
+          "expected_symbol": "Form",
+          "expected_file_suffix": "forms/forms.py",
+          "rank": null,
+          "elapsed_ms": 307.26,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "form_valid",
+            "file": "views/generic/edit.py"
+          }
+        },
+        {
+          "query": "form that is bound to a model for create and update",
+          "query_type": "natural_language",
+          "expected_symbol": "ModelForm",
+          "expected_file_suffix": "forms/models.py",
+          "rank": null,
+          "elapsed_ms": 293.38,
+          "candidate_count": 37,
+          "top_candidate": {
+            "name": "_do_update",
+            "file": "db/models/base.py"
+          }
+        },
+        {
+          "query": "get object or 404",
+          "query_type": "short_phrase",
+          "expected_symbol": "get_object_or_404",
+          "expected_file_suffix": "shortcuts.py",
+          "rank": 1,
+          "elapsed_ms": 292.62,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "get_object_or_404",
+            "file": "shortcuts.py"
+          }
+        },
+        {
+          "query": "login required",
+          "query_type": "short_phrase",
+          "expected_symbol": "login_required",
+          "expected_file_suffix": "contrib/auth/decorators.py",
+          "rank": 1,
+          "elapsed_ms": 291.12,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "login_required",
+            "file": "contrib/auth/decorators.py"
+          }
+        },
+        {
+          "query": "http response",
+          "query_type": "short_phrase",
+          "expected_symbol": "HttpResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": 4,
+          "elapsed_ms": 278.36,
+          "candidate_count": 33,
+          "top_candidate": {
+            "name": "response",
+            "file": "views/generic/base.py"
+          }
+        },
+        {
+          "query": "query set",
+          "query_type": "short_phrase",
+          "expected_symbol": "QuerySet",
+          "expected_file_suffix": "db/models/query.py",
+          "rank": null,
+          "elapsed_ms": 277.49,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "queryset",
+            "file": "db/models/query.py"
+          }
+        },
+        {
+          "query": "reverse url",
+          "query_type": "short_phrase",
+          "expected_symbol": "reverse",
+          "expected_file_suffix": "urls/base.py",
+          "rank": 1,
+          "elapsed_ms": 295.52,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "reverse",
+            "file": "urls/base.py"
+          }
+        },
+        {
+          "query": "make password",
+          "query_type": "short_phrase",
+          "expected_symbol": "make_password",
+          "expected_file_suffix": "contrib/auth/hashers.py",
+          "rank": 1,
+          "elapsed_ms": 267.79,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "make_password",
+            "file": "contrib/auth/hashers.py"
+          }
+        },
+        {
+          "query": "QuerySet",
+          "query_type": "identifier",
+          "expected_symbol": "QuerySet",
+          "expected_file_suffix": "db/models/query.py",
+          "rank": null,
+          "elapsed_ms": 138.47,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "queryset",
+            "file": "contrib/contenttypes/fields.py"
+          }
+        },
+        {
+          "query": "HttpResponse",
+          "query_type": "identifier",
+          "expected_symbol": "HttpResponse",
+          "expected_file_suffix": "http/response.py",
+          "rank": 1,
+          "elapsed_ms": 136.7,
+          "candidate_count": 13,
+          "top_candidate": {
+            "name": "HttpResponse",
+            "file": "http/response.py"
+          }
+        }
+      ]
+    }
+  ],
+  "hybrid_uplift": {
+    "mrr_delta": 0.1530501720634163,
+    "acc1_delta": 0.14705882352941174,
+    "acc3_delta": 0.17647058823529413,
+    "acc5_delta": 0.1470588235294118
+  },
+  "hybrid_uplift_by_query_type": {
+    "identifier": {
+      "mrr_delta": 0.0,
+      "acc1_delta": 0.0,
+      "acc3_delta": 0.0,
+      "acc5_delta": 0.0
+    },
+    "natural_language": {
+      "mrr_delta": 0.1309117634675444,
+      "acc1_delta": 0.11538461538461539,
+      "acc3_delta": 0.15384615384615385,
+      "acc5_delta": 0.15384615384615385
+    },
+    "short_phrase": {
+      "mrr_delta": 0.3,
+      "acc1_delta": 0.3333333333333333,
+      "acc3_delta": 0.3333333333333333,
+      "acc5_delta": 0.16666666666666674
+    }
+  }
+}


### PR DESCRIPTION
## Summary

§8.18 documented the Phase 3g \`django/django\` measurement in PR #36 but the dataset and four result JSONs were left as untracked files. This commit lands the raw measurement artifacts so §8.18 is reproducible from a clean checkout.

## Files

- \`benchmarks/embedding-quality-dataset-django.json\` — 34 queries (26 NL + 6 short_phrase + 2 identifier)
- \`benchmarks/embedding-quality-v1.6-phase3g-django-{baseline,2e-only,2b2c-only,stacked}.json\` — four-arm result JSONs

## Numbers match §8.18 exactly

| arm         | hybrid MRR | Δ abs      | Δ rel  |
|-------------|-----------:|-----------:|-------:|
| baseline    |   0.293677 |          — |      — |
| 2e only     |   0.293677 |  +0.000000 | +0.0 % |
| 2b+2c only  |   0.285940 |  −0.007737 | −2.6 % |
| stacked     |   0.288448 |  −0.005229 | −1.8 % |

Per-query: 4 improved / 6 regressed / 24 unchanged (stacked vs baseline).

## Scope

- **No code changes**. No schema changes. No doc changes.
- Pure data landing of artifacts §8.18 already references.
- Confirms Python negative direction in a second distinct regime (semantic-dominant framework, not just the small \`requests\` app library).

## Test plan

- [x] Dataset shape verified: 26 NL + 6 short + 2 identifier = 34
- [x] All 34 expected file paths exist under \`/tmp/django-src/django\`
- [x] Aggregate MRRs match §8.18 table to 6-digit precision
- [x] No build/test impact — data-only commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)