### PR TITLE
docs(bench): §8.19 Phase 2n — unified Phase 2e evidence + matrix auto-aggregator

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -139,6 +139,18 @@ python3 benchmarks/embedding-quality.py . \
   - 4-arm A/B 측정 완료 — 전체 결과와 해석은 `docs/benchmarks.md` §8.18 참조
   - arm별 결과 파일: `benchmarks/embedding-quality-v1.6-phase3g-django-{baseline,2e-only,2b2c-only,stacked}.json`
 
+외부 phase matrix 자동 집계:
+
+```bash
+python3 benchmarks/embedding-quality-matrix.py \
+  --require-datasets ripgrep,requests,jest,typescript,next-js,react-core,django
+```
+
+- JSON 요약: `benchmarks/embedding-quality-phase3-matrix.json`
+- Markdown 요약: `benchmarks/embedding-quality-phase3-matrix.md`
+- 목적: ripgrep / requests / jest / typescript / next-js / react-core / django 외부 측정값을 수동 표 대신 artefact에서 직접 집계
+- completeness gate: `--require-datasets ...` 를 주면 dataset 누락/예상 외 slug가 있으면 즉시 실패
+
 리포트는 전체 평균 외에 질의 유형별 MRR / Acc@k와 hybrid uplift도 같이 보여준다.
 
 현재 정책:

--- a/benchmarks/embedding-quality-matrix.py
+++ b/benchmarks/embedding-quality-matrix.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Aggregate external embedding-quality reports into a phase matrix.
+
+This exists to stop hand-maintained phase tables from drifting as more
+external datasets are added. It scans the versioned phase3 report files,
+groups the four benchmark arms for each dataset, and emits a compact JSON
+and markdown summary that can be referenced from docs or review notes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import math
+import re
+from pathlib import Path
+
+
+ARM_ORDER = ("baseline", "2e-only", "2b2c-only", "stacked")
+HYBRID_METHOD = "get_ranked_context"
+DEFAULT_GLOB = "benchmarks/embedding-quality-v1.*-phase3*-*.json"
+
+DATASET_REGISTRY = {
+    "ripgrep": {"label": "ripgrep external", "language": "Rust", "archetype": "tooling"},
+    "requests": {
+        "label": "requests external",
+        "language": "Python",
+        "archetype": "app library",
+    },
+    "jest": {"label": "jest external", "language": "TS/JS", "archetype": "tooling"},
+    "typescript": {
+        "label": "typescript external",
+        "language": "TS/JS",
+        "archetype": "compiler",
+    },
+    "next-js": {
+        "label": "next-js external",
+        "language": "TS/JS",
+        "archetype": "typical app",
+    },
+    "react-core": {
+        "label": "react-core external",
+        "language": "TS/JS",
+        "archetype": "short runtime",
+    },
+    "django": {
+        "label": "django external",
+        "language": "Python",
+        "archetype": "framework",
+    },
+}
+
+FILENAME_RE = re.compile(
+    r"embedding-quality-(?P<version>v\d+\.\d+)-(?P<phase>phase3[a-z])-(?P<slug>.+)-(?P<arm>baseline|2e-only|2b2c-only|stacked)\.json$"
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--glob", default=DEFAULT_GLOB)
+    parser.add_argument(
+        "--output-json",
+        default="benchmarks/embedding-quality-phase3-matrix.json",
+    )
+    parser.add_argument(
+        "--output-md",
+        default="benchmarks/embedding-quality-phase3-matrix.md",
+    )
+    parser.add_argument(
+        "--flat-relative-threshold-pct",
+        type=float,
+        default=1.0,
+        help="Relative delta band treated as flat/inert.",
+    )
+    parser.add_argument(
+        "--strong-relative-threshold-pct",
+        type=float,
+        default=5.0,
+        help="Relative delta band treated as strong positive/negative.",
+    )
+    parser.add_argument(
+        "--require-datasets",
+        default="",
+        help="Comma-separated dataset slugs that must appear in the aggregated matrix.",
+    )
+    return parser.parse_args()
+
+
+def load_report(path: Path) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    methods = {method["method"]: method for method in data.get("methods", [])}
+    hybrid = methods.get(HYBRID_METHOD)
+    if hybrid is None:
+        raise SystemExit(f"{path}: missing {HYBRID_METHOD}")
+    return {
+        "path": str(path),
+        "raw": data,
+        "methods": methods,
+        "hybrid": hybrid,
+    }
+
+
+def dataset_slug_from_path(dataset_path: str) -> str:
+    name = Path(dataset_path).name
+    prefix = "embedding-quality-dataset-"
+    suffix = ".json"
+    if name.startswith(prefix) and name.endswith(suffix):
+        return name[len(prefix) : -len(suffix)]
+    return Path(dataset_path).stem
+
+
+def effect_band(delta_rel_pct: float | None, flat_threshold_pct: float, strong_threshold_pct: float) -> str:
+    if delta_rel_pct is None or math.isnan(delta_rel_pct):
+        return "undefined"
+    if abs(delta_rel_pct) < flat_threshold_pct:
+        return "flat"
+    if delta_rel_pct >= strong_threshold_pct:
+        return "strong positive"
+    if delta_rel_pct > 0:
+        return "mild positive"
+    if delta_rel_pct <= -strong_threshold_pct:
+        return "strong negative"
+    return "mild negative"
+
+
+def build_matrix(
+    paths: list[Path],
+    flat_threshold_pct: float,
+    strong_threshold_pct: float,
+    report_glob: str,
+) -> dict:
+    groups: dict[tuple[str, str, str], dict[str, dict]] = {}
+    for path in paths:
+        match = FILENAME_RE.match(path.name)
+        if not match:
+            continue
+        info = match.groupdict()
+        report = load_report(path)
+        slug = dataset_slug_from_path(report["raw"]["dataset_path"])
+        key = (info["version"], info["phase"], slug)
+        groups.setdefault(key, {})
+        groups[key][info["arm"]] = report
+
+    rows = []
+    for (version, phase, slug), arms in sorted(groups.items(), key=lambda item: item[0][1]):
+        missing = [arm for arm in ARM_ORDER if arm not in arms]
+        if missing:
+            raise SystemExit(f"{version}/{phase}/{slug}: missing arms {missing}")
+
+        first = arms["baseline"]["raw"]
+        dataset_size = first["dataset_size"]
+        dataset_path = first["dataset_path"]
+        for arm in ARM_ORDER[1:]:
+            report = arms[arm]["raw"]
+            if report["dataset_size"] != dataset_size:
+                raise SystemExit(f"{version}/{phase}/{slug}: dataset_size mismatch")
+            if report["dataset_path"] != dataset_path:
+                raise SystemExit(f"{version}/{phase}/{slug}: dataset_path mismatch")
+
+        baseline = arms["baseline"]["hybrid"]["mrr"]
+        stacked = arms["stacked"]["hybrid"]["mrr"]
+        delta_abs = stacked - baseline
+        delta_rel_pct = None if baseline == 0 else (delta_abs / baseline) * 100.0
+        registry = DATASET_REGISTRY.get(slug, {})
+
+        rows.append(
+            {
+                "version": version,
+                "phase": phase,
+                "dataset_slug": slug,
+                "label": registry.get("label", slug),
+                "language": registry.get("language", "unknown"),
+                "archetype": registry.get("archetype", "unknown"),
+                "dataset_path": dataset_path,
+                "dataset_size": dataset_size,
+                "runtime_model": first.get("runtime_model"),
+                "arms": {
+                    arm: {
+                        "path": arms[arm]["path"],
+                        "hybrid_mrr": arms[arm]["hybrid"]["mrr"],
+                        "hybrid_acc1": arms[arm]["hybrid"]["acc1"],
+                        "hybrid_acc3": arms[arm]["hybrid"]["acc3"],
+                        "semantic_mrr": arms[arm]["methods"]["semantic_search"]["mrr"],
+                        "lexical_mrr": arms[arm]["methods"]["get_ranked_context_no_semantic"]["mrr"],
+                    }
+                    for arm in ARM_ORDER
+                },
+                "delta_abs": delta_abs,
+                "delta_rel_pct": delta_rel_pct,
+                "effect_band": effect_band(
+                    delta_rel_pct,
+                    flat_threshold_pct=flat_threshold_pct,
+                    strong_threshold_pct=strong_threshold_pct,
+                ),
+            }
+        )
+
+    counts = {"positive": 0, "negative": 0, "flat": 0}
+    for row in rows:
+        if row["effect_band"].endswith("positive"):
+            counts["positive"] += 1
+        elif row["effect_band"].endswith("negative"):
+            counts["negative"] += 1
+        else:
+            counts["flat"] += 1
+
+    return {
+        "report_glob": report_glob,
+        "source_report_count": len(paths),
+        "flat_relative_threshold_pct": flat_threshold_pct,
+        "strong_relative_threshold_pct": strong_threshold_pct,
+        "dataset_count": len(rows),
+        "effect_counts": counts,
+        "rows": rows,
+    }
+
+
+def fmt(value: float | None, digits: int = 3) -> str:
+    if value is None:
+        return "—"
+    return f"{value:.{digits}f}"
+
+
+def fmt_rel_pct(value: float | None) -> str:
+    if value is None:
+        return "—"
+    sign = "+" if value >= 0 else ""
+    return f"{sign}{value:.1f}%"
+
+
+def render_markdown(summary: dict) -> str:
+    lines: list[str] = []
+    a = lines.append
+
+    a("# External Embedding Quality Matrix")
+    a("")
+    a(
+        f"- Datasets: {summary['dataset_count']} (`positive={summary['effect_counts']['positive']}`, "
+        f"`negative={summary['effect_counts']['negative']}`, `flat={summary['effect_counts']['flat']}`)"
+    )
+    a(
+        f"- Flat band: relative delta under `{summary['flat_relative_threshold_pct']:.1f}%`"
+    )
+    a(
+        f"- Strong band: relative delta at or above `{summary['strong_relative_threshold_pct']:.1f}%`"
+    )
+    a("")
+    a("| Phase | Dataset | Language / archetype | Baseline | 2e | 2b+2c | Stacked | Δ abs | Δ rel | Band |")
+    a("|---|---|---|---:|---:|---:|---:|---:|---:|---|")
+    for row in summary["rows"]:
+        arms = row["arms"]
+        a(
+            f"| {row['phase']} | {row['label']} | {row['language']} / {row['archetype']} | "
+            f"{fmt(arms['baseline']['hybrid_mrr'])} | "
+            f"{fmt(arms['2e-only']['hybrid_mrr'])} | "
+            f"{fmt(arms['2b2c-only']['hybrid_mrr'])} | "
+            f"{fmt(arms['stacked']['hybrid_mrr'])} | "
+            f"{fmt(row['delta_abs'])} | "
+            f"{fmt_rel_pct(row['delta_rel_pct'])} | "
+            f"{row['effect_band']} |"
+        )
+
+    a("")
+    a("## Artefacts")
+    a("")
+    for row in summary["rows"]:
+        a(f"- `{row['phase']}` / `{row['label']}`")
+        for arm in ARM_ORDER:
+            a(f"  - `{arm}`: `{row['arms'][arm]['path']}`")
+
+    a("")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    args = parse_args()
+    paths = [Path(path) for path in sorted(glob.glob(args.glob))]
+    if not paths:
+        raise SystemExit(f"no files matched: {args.glob}")
+
+    summary = build_matrix(
+        paths,
+        flat_threshold_pct=args.flat_relative_threshold_pct,
+        strong_threshold_pct=args.strong_relative_threshold_pct,
+        report_glob=args.glob,
+    )
+
+    if args.require_datasets.strip():
+        expected = {
+            item.strip()
+            for item in args.require_datasets.split(",")
+            if item.strip()
+        }
+        actual = {row["dataset_slug"] for row in summary["rows"]}
+        missing = sorted(expected - actual)
+        unexpected = sorted(actual - expected)
+        if missing or unexpected:
+            problems = []
+            if missing:
+                problems.append(f"missing={missing}")
+            if unexpected:
+                problems.append(f"unexpected={unexpected}")
+            raise SystemExit("dataset set mismatch: " + ", ".join(problems))
+
+    output_json = Path(args.output_json)
+    output_md = Path(args.output_md)
+    output_json.write_text(json.dumps(summary, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    output_md.write_text(render_markdown(summary) + "\n", encoding="utf-8")
+    print(json.dumps(summary, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/embedding-quality-phase3-matrix.json
+++ b/benchmarks/embedding-quality-phase3-matrix.json
@@ -1,0 +1,406 @@
+{
+  "report_glob": "benchmarks/embedding-quality-v1.*-phase3*-*.json",
+  "source_report_count": 28,
+  "flat_relative_threshold_pct": 1.0,
+  "strong_relative_threshold_pct": 5.0,
+  "dataset_count": 7,
+  "effect_counts": {
+    "positive": 3,
+    "negative": 2,
+    "flat": 2
+  },
+  "rows": [
+    {
+      "version": "v1.5",
+      "phase": "phase3a",
+      "dataset_slug": "ripgrep",
+      "label": "ripgrep external",
+      "language": "Rust",
+      "archetype": "tooling",
+      "dataset_path": "/Users/bagjaeseog/codelens-mcp-plugin/benchmarks/embedding-quality-dataset-ripgrep.json",
+      "dataset_size": 24,
+      "runtime_model": {
+        "model_dir": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch",
+        "model_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/model.onnx",
+        "config_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/config.json",
+        "sha256": "ef1d1e9cfa72e4929f5b9faea17d8704b23a2530aadebf0d464a4cc7750920b3",
+        "size_bytes": 34000281,
+        "num_hidden_layers": 12,
+        "hidden_size": 384
+      },
+      "arms": {
+        "baseline": {
+          "path": "benchmarks/embedding-quality-v1.5-phase3a-ripgrep-baseline.json",
+          "hybrid_mrr": 0.45937500000000003,
+          "hybrid_acc1": 0.25,
+          "hybrid_acc3": 0.5833333333333334,
+          "semantic_mrr": 0.4052579365079365,
+          "lexical_mrr": 0.32799168424168423
+        },
+        "2e-only": {
+          "path": "benchmarks/embedding-quality-v1.5-phase3a-ripgrep-2e-only.json",
+          "hybrid_mrr": 0.48784722222222227,
+          "hybrid_acc1": 0.2916666666666667,
+          "hybrid_acc3": 0.625,
+          "semantic_mrr": 0.4052579365079365,
+          "lexical_mrr": 0.38453930328930325
+        },
+        "2b2c-only": {
+          "path": "benchmarks/embedding-quality-v1.5-phase3a-ripgrep-2b2c-only.json",
+          "hybrid_mrr": 0.5104166666666666,
+          "hybrid_acc1": 0.2916666666666667,
+          "hybrid_acc3": 0.6666666666666666,
+          "semantic_mrr": 0.3972222222222222,
+          "lexical_mrr": 0.32799168424168423
+        },
+        "stacked": {
+          "path": "benchmarks/embedding-quality-v1.5-phase3a-ripgrep-stacked.json",
+          "hybrid_mrr": 0.5291666666666667,
+          "hybrid_acc1": 0.3333333333333333,
+          "hybrid_acc3": 0.6666666666666666,
+          "semantic_mrr": 0.3972222222222222,
+          "lexical_mrr": 0.38453930328930325
+        }
+      },
+      "delta_abs": 0.06979166666666664,
+      "delta_rel_pct": 15.192743764172329,
+      "effect_band": "strong positive"
+    },
+    {
+      "version": "v1.5",
+      "phase": "phase3b",
+      "dataset_slug": "requests",
+      "label": "requests external",
+      "language": "Python",
+      "archetype": "app library",
+      "dataset_path": "/Users/bagjaeseog/codelens-mcp-plugin/benchmarks/embedding-quality-dataset-requests.json",
+      "dataset_size": 24,
+      "runtime_model": {
+        "model_dir": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch",
+        "model_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/model.onnx",
+        "config_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/config.json",
+        "sha256": "ef1d1e9cfa72e4929f5b9faea17d8704b23a2530aadebf0d464a4cc7750920b3",
+        "size_bytes": 34000281,
+        "num_hidden_layers": 12,
+        "hidden_size": 384
+      },
+      "arms": {
+        "baseline": {
+          "path": "benchmarks/embedding-quality-v1.5-phase3b-requests-baseline.json",
+          "hybrid_mrr": 0.5837009803921568,
+          "hybrid_acc1": 0.4166666666666667,
+          "hybrid_acc3": 0.7083333333333334,
+          "semantic_mrr": 0.5409722222222222,
+          "lexical_mrr": 0.3945034497666076
+        },
+        "2e-only": {
+          "path": "benchmarks/embedding-quality-v1.5-phase3b-requests-2e-only.json",
+          "hybrid_mrr": 0.5697475749559083,
+          "hybrid_acc1": 0.4166666666666667,
+          "hybrid_acc3": 0.6666666666666666,
+          "semantic_mrr": 0.5409722222222222,
+          "lexical_mrr": 0.4041369084132242
+        },
+        "2b2c-only": {
+          "path": "benchmarks/embedding-quality-v1.5-phase3b-requests-2b2c-only.json",
+          "hybrid_mrr": 0.5215166369578134,
+          "hybrid_acc1": 0.3333333333333333,
+          "hybrid_acc3": 0.7083333333333334,
+          "semantic_mrr": 0.39351851851851855,
+          "lexical_mrr": 0.3945034497666076
+        },
+        "stacked": {
+          "path": "benchmarks/embedding-quality-v1.5-phase3b-requests-stacked.json",
+          "hybrid_mrr": 0.49482293169793173,
+          "hybrid_acc1": 0.3333333333333333,
+          "hybrid_acc3": 0.625,
+          "semantic_mrr": 0.39351851851851855,
+          "lexical_mrr": 0.4041369084132242
+        }
+      },
+      "delta_abs": -0.08887804869422505,
+      "delta_rel_pct": -15.226640296974104,
+      "effect_band": "strong negative"
+    },
+    {
+      "version": "v1.5",
+      "phase": "phase3c",
+      "dataset_slug": "jest",
+      "label": "jest external",
+      "language": "TS/JS",
+      "archetype": "tooling",
+      "dataset_path": "/Users/bagjaeseog/codelens-mcp-plugin/benchmarks/embedding-quality-dataset-jest.json",
+      "dataset_size": 24,
+      "runtime_model": {
+        "model_dir": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch",
+        "model_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/model.onnx",
+        "config_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/config.json",
+        "sha256": "ef1d1e9cfa72e4929f5b9faea17d8704b23a2530aadebf0d464a4cc7750920b3",
+        "size_bytes": 34000281,
+        "num_hidden_layers": 12,
+        "hidden_size": 384
+      },
+      "arms": {
+        "baseline": {
+          "path": "benchmarks/embedding-quality-v1.5-phase3c-jest-baseline.json",
+          "hybrid_mrr": 0.1545848267622461,
+          "hybrid_acc1": 0.041666666666666664,
+          "hybrid_acc3": 0.20833333333333334,
+          "semantic_mrr": 0.08680555555555557,
+          "lexical_mrr": 0.15476190476190477
+        },
+        "2e-only": {
+          "path": "benchmarks/embedding-quality-v1.5-phase3c-jest-2e-only.json",
+          "hybrid_mrr": 0.15666816009557946,
+          "hybrid_acc1": 0.041666666666666664,
+          "hybrid_acc3": 0.20833333333333334,
+          "semantic_mrr": 0.08680555555555557,
+          "lexical_mrr": 0.16170634920634921
+        },
+        "2b2c-only": {
+          "path": "benchmarks/embedding-quality-v1.5-phase3c-jest-2b2c-only.json",
+          "hybrid_mrr": 0.16372007808499744,
+          "hybrid_acc1": 0.041666666666666664,
+          "hybrid_acc3": 0.20833333333333334,
+          "semantic_mrr": 0.08888888888888889,
+          "lexical_mrr": 0.15476190476190477
+        },
+        "stacked": {
+          "path": "benchmarks/embedding-quality-v1.5-phase3c-jest-stacked.json",
+          "hybrid_mrr": 0.16580341141833077,
+          "hybrid_acc1": 0.041666666666666664,
+          "hybrid_acc3": 0.20833333333333334,
+          "semantic_mrr": 0.08888888888888889,
+          "lexical_mrr": 0.16170634920634921
+        }
+      },
+      "delta_abs": 0.011218584656084662,
+      "delta_rel_pct": 7.2572353257794315,
+      "effect_band": "strong positive"
+    },
+    {
+      "version": "v1.6",
+      "phase": "phase3d",
+      "dataset_slug": "typescript",
+      "label": "typescript external",
+      "language": "TS/JS",
+      "archetype": "compiler",
+      "dataset_path": "/Users/bagjaeseog/codelens-mcp-plugin/benchmarks/embedding-quality-dataset-typescript.json",
+      "dataset_size": 34,
+      "runtime_model": {
+        "model_dir": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch",
+        "model_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/model.onnx",
+        "config_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/config.json",
+        "sha256": "ef1d1e9cfa72e4929f5b9faea17d8704b23a2530aadebf0d464a4cc7750920b3",
+        "size_bytes": 34000281,
+        "num_hidden_layers": 12,
+        "hidden_size": 384
+      },
+      "arms": {
+        "baseline": {
+          "path": "benchmarks/embedding-quality-v1.6-phase3d-typescript-baseline.json",
+          "hybrid_mrr": 0.0983551029107295,
+          "hybrid_acc1": 0.058823529411764705,
+          "hybrid_acc3": 0.08823529411764706,
+          "semantic_mrr": 0.17091503267973857,
+          "lexical_mrr": 0.1201155462184874
+        },
+        "2e-only": {
+          "path": "benchmarks/embedding-quality-v1.6-phase3d-typescript-2e-only.json",
+          "hybrid_mrr": 0.08855118134210206,
+          "hybrid_acc1": 0.058823529411764705,
+          "hybrid_acc3": 0.058823529411764705,
+          "semantic_mrr": 0.17091503267973857,
+          "lexical_mrr": 0.1397233893557423
+        },
+        "2b2c-only": {
+          "path": "benchmarks/embedding-quality-v1.6-phase3d-typescript-2b2c-only.json",
+          "hybrid_mrr": 0.20098039215686272,
+          "hybrid_acc1": 0.14705882352941177,
+          "hybrid_acc3": 0.23529411764705882,
+          "semantic_mrr": 0.17091503267973857,
+          "lexical_mrr": 0.1201155462184874
+        },
+        "stacked": {
+          "path": "benchmarks/embedding-quality-v1.6-phase3d-typescript-stacked.json",
+          "hybrid_mrr": 0.20098039215686272,
+          "hybrid_acc1": 0.14705882352941177,
+          "hybrid_acc3": 0.23529411764705882,
+          "semantic_mrr": 0.17091503267973857,
+          "lexical_mrr": 0.1397233893557423
+        }
+      },
+      "delta_abs": 0.10262528924613322,
+      "delta_rel_pct": 104.34160120729017,
+      "effect_band": "strong positive"
+    },
+    {
+      "version": "v1.6",
+      "phase": "phase3e",
+      "dataset_slug": "next-js",
+      "label": "next-js external",
+      "language": "TS/JS",
+      "archetype": "typical app",
+      "dataset_path": "/Users/bagjaeseog/codelens-mcp-plugin/benchmarks/embedding-quality-dataset-next-js.json",
+      "dataset_size": 34,
+      "runtime_model": {
+        "model_dir": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch",
+        "model_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/model.onnx",
+        "config_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/config.json",
+        "sha256": "ef1d1e9cfa72e4929f5b9faea17d8704b23a2530aadebf0d464a4cc7750920b3",
+        "size_bytes": 34000281,
+        "num_hidden_layers": 12,
+        "hidden_size": 384
+      },
+      "arms": {
+        "baseline": {
+          "path": "benchmarks/embedding-quality-v1.6-phase3e-next-js-baseline.json",
+          "hybrid_mrr": 0.19785660675753555,
+          "hybrid_acc1": 0.14705882352941177,
+          "hybrid_acc3": 0.20588235294117646,
+          "semantic_mrr": 0.14640522875816994,
+          "lexical_mrr": 0.22940513644323435
+        },
+        "2e-only": {
+          "path": "benchmarks/embedding-quality-v1.6-phase3e-next-js-2e-only.json",
+          "hybrid_mrr": 0.19620761720219923,
+          "hybrid_acc1": 0.14705882352941177,
+          "hybrid_acc3": 0.20588235294117646,
+          "semantic_mrr": 0.14640522875816994,
+          "lexical_mrr": 0.23124140006879945
+        },
+        "2b2c-only": {
+          "path": "benchmarks/embedding-quality-v1.6-phase3e-next-js-2b2c-only.json",
+          "hybrid_mrr": 0.19785660675753555,
+          "hybrid_acc1": 0.14705882352941177,
+          "hybrid_acc3": 0.20588235294117646,
+          "semantic_mrr": 0.14640522875816994,
+          "lexical_mrr": 0.22940513644323435
+        },
+        "stacked": {
+          "path": "benchmarks/embedding-quality-v1.6-phase3e-next-js-stacked.json",
+          "hybrid_mrr": 0.19620761720219923,
+          "hybrid_acc1": 0.14705882352941177,
+          "hybrid_acc3": 0.20588235294117646,
+          "semantic_mrr": 0.14640522875816994,
+          "lexical_mrr": 0.23124140006879945
+        }
+      },
+      "delta_abs": -0.001648989555336322,
+      "delta_rel_pct": -0.8334265821899419,
+      "effect_band": "flat"
+    },
+    {
+      "version": "v1.6",
+      "phase": "phase3f",
+      "dataset_slug": "react-core",
+      "label": "react-core external",
+      "language": "TS/JS",
+      "archetype": "short runtime",
+      "dataset_path": "/Users/bagjaeseog/codelens-mcp-plugin/benchmarks/embedding-quality-dataset-react-core.json",
+      "dataset_size": 34,
+      "runtime_model": {
+        "model_dir": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch",
+        "model_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/model.onnx",
+        "config_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/config.json",
+        "sha256": "ef1d1e9cfa72e4929f5b9faea17d8704b23a2530aadebf0d464a4cc7750920b3",
+        "size_bytes": 34000281,
+        "num_hidden_layers": 12,
+        "hidden_size": 384
+      },
+      "arms": {
+        "baseline": {
+          "path": "benchmarks/embedding-quality-v1.6-phase3f-react-core-baseline.json",
+          "hybrid_mrr": 0.12254901960784315,
+          "hybrid_acc1": 0.11764705882352941,
+          "hybrid_acc3": 0.11764705882352941,
+          "semantic_mrr": 0.12254901960784315,
+          "lexical_mrr": 0.08431372549019608
+        },
+        "2e-only": {
+          "path": "benchmarks/embedding-quality-v1.6-phase3f-react-core-2e-only.json",
+          "hybrid_mrr": 0.12254901960784315,
+          "hybrid_acc1": 0.11764705882352941,
+          "hybrid_acc3": 0.11764705882352941,
+          "semantic_mrr": 0.12254901960784315,
+          "lexical_mrr": 0.08431372549019608
+        },
+        "2b2c-only": {
+          "path": "benchmarks/embedding-quality-v1.6-phase3f-react-core-2b2c-only.json",
+          "hybrid_mrr": 0.12254901960784315,
+          "hybrid_acc1": 0.11764705882352941,
+          "hybrid_acc3": 0.11764705882352941,
+          "semantic_mrr": 0.12254901960784315,
+          "lexical_mrr": 0.08431372549019608
+        },
+        "stacked": {
+          "path": "benchmarks/embedding-quality-v1.6-phase3f-react-core-stacked.json",
+          "hybrid_mrr": 0.12254901960784315,
+          "hybrid_acc1": 0.11764705882352941,
+          "hybrid_acc3": 0.11764705882352941,
+          "semantic_mrr": 0.12254901960784315,
+          "lexical_mrr": 0.08431372549019608
+        }
+      },
+      "delta_abs": 0.0,
+      "delta_rel_pct": 0.0,
+      "effect_band": "flat"
+    },
+    {
+      "version": "v1.6",
+      "phase": "phase3g",
+      "dataset_slug": "django",
+      "label": "django external",
+      "language": "Python",
+      "archetype": "framework",
+      "dataset_path": "/Users/bagjaeseog/codelens-mcp-plugin/benchmarks/embedding-quality-dataset-django.json",
+      "dataset_size": 34,
+      "runtime_model": {
+        "model_dir": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch",
+        "model_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/model.onnx",
+        "config_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/config.json",
+        "sha256": "ef1d1e9cfa72e4929f5b9faea17d8704b23a2530aadebf0d464a4cc7750920b3",
+        "size_bytes": 34000281,
+        "num_hidden_layers": 12,
+        "hidden_size": 384
+      },
+      "arms": {
+        "baseline": {
+          "path": "benchmarks/embedding-quality-v1.6-phase3g-django-baseline.json",
+          "hybrid_mrr": 0.29367688251771296,
+          "hybrid_acc1": 0.23529411764705882,
+          "hybrid_acc3": 0.3235294117647059,
+          "semantic_mrr": 0.28508403361344536,
+          "lexical_mrr": 0.1339273640490679
+        },
+        "2e-only": {
+          "path": "benchmarks/embedding-quality-v1.6-phase3g-django-2e-only.json",
+          "hybrid_mrr": 0.29367688251771296,
+          "hybrid_acc1": 0.23529411764705882,
+          "hybrid_acc3": 0.3235294117647059,
+          "semantic_mrr": 0.28508403361344536,
+          "lexical_mrr": 0.13539795228436202
+        },
+        "2b2c-only": {
+          "path": "benchmarks/embedding-quality-v1.6-phase3g-django-2b2c-only.json",
+          "hybrid_mrr": 0.2859398483100905,
+          "hybrid_acc1": 0.23529411764705882,
+          "hybrid_acc3": 0.29411764705882354,
+          "semantic_mrr": 0.2867647058823529,
+          "lexical_mrr": 0.1339273640490679
+        },
+        "stacked": {
+          "path": "benchmarks/embedding-quality-v1.6-phase3g-django-stacked.json",
+          "hybrid_mrr": 0.28844812434777833,
+          "hybrid_acc1": 0.23529411764705882,
+          "hybrid_acc3": 0.29411764705882354,
+          "semantic_mrr": 0.2867647058823529,
+          "lexical_mrr": 0.13539795228436202
+        }
+      },
+      "delta_abs": -0.005228758169934622,
+      "delta_rel_pct": -1.780445953085617,
+      "effect_band": "mild negative"
+    }
+  ]
+}

--- a/benchmarks/embedding-quality-phase3-matrix.md
+++ b/benchmarks/embedding-quality-phase3-matrix.md
@@ -1,0 +1,54 @@
+# External Embedding Quality Matrix
+
+- Datasets: 7 (`positive=3`, `negative=2`, `flat=2`)
+- Flat band: relative delta under `1.0%`
+- Strong band: relative delta at or above `5.0%`
+
+| Phase | Dataset | Language / archetype | Baseline | 2e | 2b+2c | Stacked | Δ abs | Δ rel | Band |
+|---|---|---|---:|---:|---:|---:|---:|---:|---|
+| phase3a | ripgrep external | Rust / tooling | 0.459 | 0.488 | 0.510 | 0.529 | 0.070 | +15.2% | strong positive |
+| phase3b | requests external | Python / app library | 0.584 | 0.570 | 0.522 | 0.495 | -0.089 | -15.2% | strong negative |
+| phase3c | jest external | TS/JS / tooling | 0.155 | 0.157 | 0.164 | 0.166 | 0.011 | +7.3% | strong positive |
+| phase3d | typescript external | TS/JS / compiler | 0.098 | 0.089 | 0.201 | 0.201 | 0.103 | +104.3% | strong positive |
+| phase3e | next-js external | TS/JS / typical app | 0.198 | 0.196 | 0.198 | 0.196 | -0.002 | -0.8% | flat |
+| phase3f | react-core external | TS/JS / short runtime | 0.123 | 0.123 | 0.123 | 0.123 | 0.000 | +0.0% | flat |
+| phase3g | django external | Python / framework | 0.294 | 0.294 | 0.286 | 0.288 | -0.005 | -1.8% | mild negative |
+
+## Artefacts
+
+- `phase3a` / `ripgrep external`
+  - `baseline`: `benchmarks/embedding-quality-v1.5-phase3a-ripgrep-baseline.json`
+  - `2e-only`: `benchmarks/embedding-quality-v1.5-phase3a-ripgrep-2e-only.json`
+  - `2b2c-only`: `benchmarks/embedding-quality-v1.5-phase3a-ripgrep-2b2c-only.json`
+  - `stacked`: `benchmarks/embedding-quality-v1.5-phase3a-ripgrep-stacked.json`
+- `phase3b` / `requests external`
+  - `baseline`: `benchmarks/embedding-quality-v1.5-phase3b-requests-baseline.json`
+  - `2e-only`: `benchmarks/embedding-quality-v1.5-phase3b-requests-2e-only.json`
+  - `2b2c-only`: `benchmarks/embedding-quality-v1.5-phase3b-requests-2b2c-only.json`
+  - `stacked`: `benchmarks/embedding-quality-v1.5-phase3b-requests-stacked.json`
+- `phase3c` / `jest external`
+  - `baseline`: `benchmarks/embedding-quality-v1.5-phase3c-jest-baseline.json`
+  - `2e-only`: `benchmarks/embedding-quality-v1.5-phase3c-jest-2e-only.json`
+  - `2b2c-only`: `benchmarks/embedding-quality-v1.5-phase3c-jest-2b2c-only.json`
+  - `stacked`: `benchmarks/embedding-quality-v1.5-phase3c-jest-stacked.json`
+- `phase3d` / `typescript external`
+  - `baseline`: `benchmarks/embedding-quality-v1.6-phase3d-typescript-baseline.json`
+  - `2e-only`: `benchmarks/embedding-quality-v1.6-phase3d-typescript-2e-only.json`
+  - `2b2c-only`: `benchmarks/embedding-quality-v1.6-phase3d-typescript-2b2c-only.json`
+  - `stacked`: `benchmarks/embedding-quality-v1.6-phase3d-typescript-stacked.json`
+- `phase3e` / `next-js external`
+  - `baseline`: `benchmarks/embedding-quality-v1.6-phase3e-next-js-baseline.json`
+  - `2e-only`: `benchmarks/embedding-quality-v1.6-phase3e-next-js-2e-only.json`
+  - `2b2c-only`: `benchmarks/embedding-quality-v1.6-phase3e-next-js-2b2c-only.json`
+  - `stacked`: `benchmarks/embedding-quality-v1.6-phase3e-next-js-stacked.json`
+- `phase3f` / `react-core external`
+  - `baseline`: `benchmarks/embedding-quality-v1.6-phase3f-react-core-baseline.json`
+  - `2e-only`: `benchmarks/embedding-quality-v1.6-phase3f-react-core-2e-only.json`
+  - `2b2c-only`: `benchmarks/embedding-quality-v1.6-phase3f-react-core-2b2c-only.json`
+  - `stacked`: `benchmarks/embedding-quality-v1.6-phase3f-react-core-stacked.json`
+- `phase3g` / `django external`
+  - `baseline`: `benchmarks/embedding-quality-v1.6-phase3g-django-baseline.json`
+  - `2e-only`: `benchmarks/embedding-quality-v1.6-phase3g-django-2e-only.json`
+  - `2b2c-only`: `benchmarks/embedding-quality-v1.6-phase3g-django-2b2c-only.json`
+  - `stacked`: `benchmarks/embedding-quality-v1.6-phase3g-django-stacked.json`
+

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1831,21 +1831,21 @@ python3 benchmarks/embedding-quality.py /tmp/next-js/packages/next/src --isolate
 
 **Dataset**: 34 hand-built queries in `benchmarks/embedding-quality-dataset-react-core.json`, again keeping the §8.15 / §8.16 shape for apples-to-apples comparison: **26 `natural_language` + 6 `short_phrase` + 2 `identifier`**. The symbols cover the public React surface that ordinary users search for:
 
-| Area                  | Example queries                                                                 | Count |
-| --------------------- | ------------------------------------------------------------------------------- | ----: |
-| Core hooks            | `useState`, `useEffect`, `useMemo`, `useTransition`, `useDeferredValue`, ...   |    16 |
-| Element / ref API     | `createRef`, `createElement`, `cloneElement`, `isValidElement`, `forwardRef`   |     5 |
-| Context / memo / lazy | `createContext`, `memo`, `lazy`                                                 |     3 |
-| Transitions / testing | `startTransition`, `act`                                                        |     2 |
-| Short phrases + ids   | `state hook`, `lazy component`, `useState`, `createElement`                     |     8 |
+| Area                  | Example queries                                                              | Count |
+| --------------------- | ---------------------------------------------------------------------------- | ----: |
+| Core hooks            | `useState`, `useEffect`, `useMemo`, `useTransition`, `useDeferredValue`, ... |    16 |
+| Element / ref API     | `createRef`, `createElement`, `cloneElement`, `isValidElement`, `forwardRef` |     5 |
+| Context / memo / lazy | `createContext`, `memo`, `lazy`                                              |     3 |
+| Transitions / testing | `startTransition`, `act`                                                     |     2 |
+| Short phrases + ids   | `state hook`, `lazy component`, `useState`, `createElement`                  |     8 |
 
 **Measurement**:
 
-| arm         |   hybrid MRR | Δ abs vs baseline | Δ rel | semantic MRR | lexical-only MRR |
-| ----------- | -----------: | ----------------: | ----: | -----------: | ---------------: |
-| baseline    |     0.122549 |                 — |     — |     0.122549 |         0.084314 |
-| 2e only     |     0.122549 |          0.000000 | +0.0 % |     0.122549 |         0.084314 |
-| 2b+2c only  |     0.122549 |          0.000000 | +0.0 % |     0.122549 |         0.084314 |
+| arm         |   hybrid MRR | Δ abs vs baseline |      Δ rel | semantic MRR | lexical-only MRR |
+| ----------- | -----------: | ----------------: | ---------: | -----------: | ---------------: |
+| baseline    |     0.122549 |                 — |          — |     0.122549 |         0.084314 |
+| 2e only     |     0.122549 |          0.000000 |     +0.0 % |     0.122549 |         0.084314 |
+| 2b+2c only  |     0.122549 |          0.000000 |     +0.0 % |     0.122549 |         0.084314 |
 | **stacked** | **0.122549** |      **0.000000** | **+0.0 %** | **0.122549** |     **0.084314** |
 
 This is a **stronger null result than Next.js**. In Phase 3e, the aggregate moved by a small amount under `2e`. In Phase 3f, **every arm is row-for-row identical to baseline across all three methods** (`semantic_search`, `get_ranked_context_no_semantic`, and `get_ranked_context`). There are **zero per-query rank changes** and **zero top-candidate changes** between baseline and any candidate arm.
@@ -1880,21 +1880,21 @@ This is almost a pure retrieval-floor dataset. The stack has nothing to work wit
   - `createRef` `5 → 6`
   - `createElement` `2 → 1`
   - `cloneElement` `6 → 1`
-  Everything else is either a miss in both paths or the same rank in both.
+    Everything else is either a miss in both paths or the same rank in both.
 
 So the React core result says something narrower but stronger than §8.16: **on short-file JS runtime code, the v1.5 stack is not mildly weaker or mildly stronger; it is functionally inert.**
 
 **Updated eight-dataset baseline matrix**:
 
-| Dataset                              | Language / archetype     | baseline MRR | stacked MRR |      Δ abs |      Δ rel |
-| ------------------------------------ | ------------------------ | -----------: | ----------: | ---------: | ---------: |
-| 89-query self                        | Rust / self              |        0.572 |       0.586 |     +0.014 |     +2.4 % |
-| 436-query self                       | Rust / self              |       0.0476 |      0.0510 |    +0.0034 |     +7.1 % |
-| ripgrep external                     | Rust / tooling           |        0.459 |       0.529 |     +0.070 |    +15.2 % |
-| requests external                    | Python / app library     |        0.584 |       0.495 |     −0.089 |    −15.2 % |
-| jest external                        | TS/JS / tooling          |        0.155 |       0.166 |     +0.011 |     +7.3 % |
-| typescript external                  | TS/JS / compiler         |        0.098 |       0.201 |     +0.103 |   +104.3 % |
-| next-js external                     | TS/JS / typical app      |        0.198 |       0.196 |     −0.002 |     −0.8 % |
+| Dataset                              | Language / archetype      | baseline MRR | stacked MRR |      Δ abs |      Δ rel |
+| ------------------------------------ | ------------------------- | -----------: | ----------: | ---------: | ---------: |
+| 89-query self                        | Rust / self               |        0.572 |       0.586 |     +0.014 |     +2.4 % |
+| 436-query self                       | Rust / self               |       0.0476 |      0.0510 |    +0.0034 |     +7.1 % |
+| ripgrep external                     | Rust / tooling            |        0.459 |       0.529 |     +0.070 |    +15.2 % |
+| requests external                    | Python / app library      |        0.584 |       0.495 |     −0.089 |    −15.2 % |
+| jest external                        | TS/JS / tooling           |        0.155 |       0.166 |     +0.011 |     +7.3 % |
+| typescript external                  | TS/JS / compiler          |        0.098 |       0.201 |     +0.103 |   +104.3 % |
+| next-js external                     | TS/JS / typical app       |        0.198 |       0.196 |     −0.002 |     −0.8 % |
 | **react-core external (new, §8.17)** | **TS/JS / short runtime** |    **0.123** |   **0.123** | **+0.000** | **+0.0 %** |
 
 Pattern: **5 positive / 1 negative / 2 inert**. The positive JS/TS evidence is now clearly concentrated in **tooling/compiler-style** code, while the two shortest-file runtime/app-style datasets measured so far are inert.
@@ -1969,21 +1969,21 @@ python3 benchmarks/embedding-quality.py /tmp/react-core-bench --isolated-copy \
 
 **Dataset**: 34 hand-built queries in `benchmarks/embedding-quality-dataset-django.json`, keeping the now-standard external-repo shape for direct comparison: **26 `natural_language` + 6 `short_phrase` + 2 `identifier`**. Coverage spans four framework surfaces:
 
-| Area                 | Example targets                                                   | Count |
-| -------------------- | ----------------------------------------------------------------- | ----: |
-| ORM / model layer    | `QuerySet`, `Manager`, `Model`, `ForeignKey`                      |    10 |
-| HTTP / shortcuts     | `HttpRequest`, `HttpResponse`, `JsonResponse`, `redirect`, `render` |     8 |
+| Area                 | Example targets                                                           | Count |
+| -------------------- | ------------------------------------------------------------------------- | ----: |
+| ORM / model layer    | `QuerySet`, `Manager`, `Model`, `ForeignKey`                              |    10 |
+| HTTP / shortcuts     | `HttpRequest`, `HttpResponse`, `JsonResponse`, `redirect`, `render`       |     8 |
 | URL + auth           | `reverse`, `resolve`, `login`, `logout`, `authenticate`, `login_required` |     8 |
-| Views / forms / misc | `View`, `ListView`, `DetailView`, `Form`, `ModelForm`, `csrf_exempt` |     8 |
+| Views / forms / misc | `View`, `ListView`, `DetailView`, `Form`, `ModelForm`, `csrf_exempt`      |     8 |
 
 **Measurement**:
 
-| arm         |   hybrid MRR | Δ abs vs baseline | Δ rel | semantic MRR | lexical-only MRR |
-| ----------- | -----------: | ----------------: | ----: | -----------: | ---------------: |
-| baseline    |     0.293677 |                 — |     — |     0.285084 |         0.133927 |
-| 2e only     |     0.293677 |          0.000000 | +0.0 % |     0.285084 |         0.135398 |
-| 2b+2c only  |     0.285940 |         -0.007737 | -2.6 % |     0.286765 |         0.133927 |
-| **stacked** | **0.288448** |      **-0.005229** | **-1.8 %** | **0.286765** |     **0.135398** |
+| arm         |   hybrid MRR | Δ abs vs baseline |      Δ rel | semantic MRR | lexical-only MRR |
+| ----------- | -----------: | ----------------: | ---------: | -----------: | ---------------: |
+| baseline    |     0.293677 |                 — |          — |     0.285084 |         0.133927 |
+| 2e only     |     0.293677 |          0.000000 |     +0.0 % |     0.285084 |         0.135398 |
+| 2b+2c only  |     0.285940 |         -0.007737 |     -2.6 % |     0.286765 |         0.133927 |
+| **stacked** | **0.288448** |     **-0.005229** | **-1.8 %** | **0.286765** |     **0.135398** |
 
 Django is a **third regime**, distinct from both Next.js and TypeScript:
 
@@ -2020,27 +2020,33 @@ Representative stacked changes:
 
 The query-type split explains the sign:
 
-| query type          | baseline hybrid MRR | stacked hybrid MRR |      Δ |
-| ------------------- | ------------------: | -----------------: | -----: |
-| natural_language    |            0.172501 |           0.175278 | +0.0028 |
-| short_phrase        |            0.750000 |           0.708333 | -0.0417 |
-| identifier          |            0.500000 |           0.500000 | +0.0000 |
+| query type       | baseline hybrid MRR | stacked hybrid MRR |       Δ |
+| ---------------- | ------------------: | -----------------: | ------: |
+| natural_language |            0.172501 |           0.175278 | +0.0028 |
+| short_phrase     |            0.750000 |           0.708333 | -0.0417 |
+| identifier       |            0.500000 |           0.500000 | +0.0000 |
 
 So Django is not "uniformly worse"; it is more specific than that. The stack rescues a handful of natural-language framework lookups, but the gain is too small to offset short-phrase regressions on queries that Django's baseline already handled reasonably well.
 
 **Updated nine-dataset baseline matrix**:
 
-| Dataset                           | Language / archetype      | baseline MRR | stacked MRR |      Δ abs |      Δ rel |
-| --------------------------------- | ------------------------- | -----------: | ----------: | ---------: | ---------: |
-| 89-query self                     | Rust / self               |        0.572 |       0.586 |     +0.014 |     +2.4 % |
-| 436-query self                    | Rust / self               |       0.0476 |      0.0510 |    +0.0034 |     +7.1 % |
-| ripgrep external                  | Rust / tooling            |        0.459 |       0.529 |     +0.070 |    +15.2 % |
-| requests external                 | Python / app library      |        0.584 |       0.495 |     -0.089 |    -15.2 % |
-| **django external (new, §8.18)**  | **Python / framework**    |    **0.294** |   **0.288** | **-0.005** | **-1.8 %** |
-| jest external                     | TS/JS / tooling           |        0.155 |       0.166 |     +0.011 |     +7.3 % |
-| typescript external               | TS/JS / compiler          |        0.098 |       0.201 |     +0.103 |   +104.3 % |
-| next-js external                  | TS/JS / typical app       |        0.198 |       0.196 |     -0.002 |     -0.8 % |
-| react-core external               | TS/JS / short runtime     |        0.123 |       0.123 |     +0.000 |     +0.0 % |
+| Dataset                          | Language / archetype   | baseline MRR | stacked MRR |      Δ abs |      Δ rel |
+| -------------------------------- | ---------------------- | -----------: | ----------: | ---------: | ---------: |
+| 89-query self                    | Rust / self            |        0.572 |       0.586 |     +0.014 |     +2.4 % |
+| 436-query self                   | Rust / self            |       0.0476 |      0.0510 |    +0.0034 |     +7.1 % |
+| ripgrep external                 | Rust / tooling         |        0.459 |       0.529 |     +0.070 |    +15.2 % |
+| requests external                | Python / app library   |        0.584 |       0.495 |     -0.089 |    -15.2 % |
+| **django external (new, §8.18)** | **Python / framework** |    **0.294** |   **0.288** | **-0.005** | **-1.8 %** |
+| jest external                    | TS/JS / tooling        |        0.155 |       0.166 |     +0.011 |     +7.3 % |
+| typescript external              | TS/JS / compiler       |        0.098 |       0.201 |     +0.103 |   +104.3 % |
+| next-js external                 | TS/JS / typical app    |        0.198 |       0.196 |     -0.002 |     -0.8 % |
+| react-core external              | TS/JS / short runtime  |        0.123 |       0.123 |     +0.000 |     +0.0 % |
+
+Machine-generated counterpart: `python3 benchmarks/embedding-quality-matrix.py --require-datasets ripgrep,requests,jest,typescript,next-js,react-core,django`
+
+- JSON artefact: `benchmarks/embedding-quality-phase3-matrix.json`
+- Markdown artefact: `benchmarks/embedding-quality-phase3-matrix.md`
+- This does not replace the narrative analysis in §8.18, but it does make the arm-level matrix reproducible from the underlying benchmark JSONs instead of hand-maintained tables.
 
 Pattern is now **5 positive / 2 negative / 2 inert**.
 
@@ -2099,6 +2105,70 @@ python3 benchmarks/embedding-quality.py /tmp/django-src/django --isolated-copy \
 ```
 
 **Artefacts**: `benchmarks/embedding-quality-v1.6-phase3g-django-{baseline,2e-only,2b2c-only,stacked}.json`. Dataset: `benchmarks/embedding-quality-dataset-django.json`.
+
+### §8.19 — Phase 2n: unified Phase 2e-only evidence across 8 datasets, and the Phase 2m decision audit
+
+**Purpose**: Phase 2m (the §8.17 code change) narrowed the Phase 2e sparse re-ranker auto-gate to the Rust family of languages, after an evidence arc that spanned §8.12 → §8.13 → §8.15 → §8.16 → §8.17. That evidence arc was spread across seven measurement sections with different framings. This section collects the 2e-only column from every 4-arm A/B the project has ever run into a single narrative table so future decisions about Phase 2e (rollback, removal, further narrowing, or extension) can be made against one source of truth instead of reconstructing it from the phase-by-phase text.
+
+**Earlier sections compared the full stacked arm to the baseline**, which blends three effects (Phase 2b NL token extraction, Phase 2c API-call extraction, Phase 2e sparse re-rank). Phase 2m is exclusively about Phase 2e, so only the `2e-only vs baseline` delta is load-bearing here. Everything below uses **hybrid `get_ranked_context` MRR** so that numbers are directly comparable across sections.
+
+A machine-generated companion of this table lives at `benchmarks/embedding-quality-phase3-matrix.json` / `.md`, generated by `benchmarks/embedding-quality-matrix.py`. That script diffs the full stacked arm against baseline for each `phase3*` dataset. The table below covers a slightly different slice — Phase 2e-only specifically, including the §8.2 / §8.7 Rust measurements that predate the `phase3*` naming convention — so it is still hand-aggregated from the archived result JSONs. The two views agree on every dataset they both cover.
+
+**Eight-dataset unified table** (hybrid `get_ranked_context` MRR, 2e-only vs baseline):
+
+| § ref | Dataset                    | Archetype            | Lang | baseline | 2e-only |   Δ abs |       Δ rel |
+| ----- | -------------------------- | -------------------- | ---- | -------: | ------: | ------: | ----------: |
+| §8.2  | 89-query self (phase2e v2) | Rust / self          | rs   |   0.5716 |  0.5787 | +0.0071 |      +1.2 % |
+| §8.7  | ripgrep external           | Rust / tooling       | rs   |   0.4594 |  0.4878 | +0.0284 |  **+6.2 %** |
+| §8.8  | requests external          | Python / app library | py   |   0.5837 |  0.5697 | −0.0140 |      −2.4 % |
+| §8.13 | jest external              | TS / tooling         | ts   |   0.1546 |  0.1567 | +0.0021 |      +1.3 % |
+| §8.15 | typescript external        | TS / compiler        | ts   |   0.0984 |  0.0886 | −0.0098 | **−10.0 %** |
+| §8.16 | next-js external           | TS / typical app     | ts   |   0.1979 |  0.1962 | −0.0017 |      −0.8 % |
+| §8.17 | react-core external        | TS / short runtime   | ts   |   0.1225 |  0.1225 | +0.0000 |      +0.0 % |
+| §8.18 | django external            | Python / framework   | py   |   0.2937 |  0.2937 | +0.0000 |      +0.0 % |
+
+Every row is reproducible from an archived 4-arm result JSON: run `benchmarks/embedding-quality-matrix.py` for the seven `phase3*` rows, and read the `benchmarks/embedding-quality-v1.5-phase2e-v2-{baseline,on}.json` pair directly for the §8.2 row. None of the numbers are hand-copied from prior narrative sections.
+
+**By-language aggregation**:
+
+| Language family | Datasets | Positive | Zero/Inert | Negative |   Best |   Worst |
+| --------------- | -------: | -------: | ---------: | -------: | -----: | ------: |
+| Rust            |        2 |      2/2 |          0 |        0 | +6.2 % |  +1.2 % |
+| TypeScript / JS |        4 |      1/4 |        1/4 |      2/4 | +1.3 % | −10.0 % |
+| Python          |        2 |      0/2 |        1/2 |      1/2 |  0.0 % |  −2.4 % |
+
+**What this table actually says**:
+
+1. **Rust is unambiguously positive**. Both the 89-query self dataset and the external ripgrep dataset put Phase 2e on the correct side of zero. Rust is the only family in the table with a 2/2 positive record, and its best case (+6.2 %) is also the single largest positive Phase 2e contribution across all measured datasets. The Rust auto-on branch of Phase 2m is load-bearing evidence, not aspirational policy.
+2. **TypeScript / JS is mixed at best and net-negative at worst**. One marginal positive (jest, a test-tooling codebase), one zero, two negatives. The one positive is jest's **+1.3 %**, which is smaller in absolute terms than Rust's weakest positive — Rust self-89 at **+0.0071 absolute** vs jest at **+0.0021 absolute**. The worst case is the TypeScript compiler at **−10.0 %**, which is the single largest negative Phase 2e effect across all eight datasets, nearly three times the size of the next largest negative. Even without the follow-up app measurements, a narrow Rust-only auto-gate was defensible; with §8.16 and §8.17 added, keeping JS/TS in the 2e auto-gate would be indefensible.
+3. **Python is never positive**. One small negative, one exact zero. Phase 2m's JS/TS split happened to also match the Python story because `language_supports_nl_stack` already excludes Python, so Python never reaches the Phase 2e auto-on path in practice. The table makes it explicit: if Python were ever added back to `language_supports_nl_stack` (it is not on the roadmap), the 2e gate would still have to stay off on the current evidence.
+4. **Phase 2e is mechanism-inert when baseline hybrid MRR is already saturated against lexical signal**. react-core (0.1225 → 0.1225) and django (0.2937 → 0.2937) both show Phase 2e producing literally zero change at full float precision, despite moving pure `get_ranked_context_no_semantic` slightly upward on some arms. The sparse re-ranker's output is already subsumed by the hybrid combiner on those corpora.
+
+**Phase 2m decision audit — should the Rust auto-on gate be kept, narrowed, or removed?**
+
+Three alternative policies were considered during the §8.17 review:
+
+- **Policy A — "Remove Phase 2e entirely"**. Cheap from a maintenance perspective; loses the 2/2 positive Rust signal (+0.0071 on self-89, +0.0284 on ripgrep). The absolute magnitudes are small on one dataset and non-trivial on the other. Removal would be a strictly net-negative move on measured Rust corpora, which is the archetype most project-internal users run CodeLens on.
+- **Policy B — "Narrow Rust auto-on to tooling only"**. Would require a new classifier (is this a Rust CLI / library / compiler / editor vs a Rust application?). Both measured Rust datasets are already in the tooling/self category, so the policy has no evidence base to calibrate against. Deferred until a Phase 3h Rust app measurement justifies or contradicts it.
+- **Policy C — "Keep current Phase 2m scope (Rust family on, JS/TS off, Python off, everything else off)"**. Matches every positive in the table and excludes every negative. This is what landed in PR #36 and is the status quo.
+
+Policy C is the minimum-commitment choice that the table supports. It also has the property that it can be revisited cheaply: all future decisions (removal, narrowing, or extension) are **one allowlist edit away** because the split lives in a pair of `language_supports_*` functions in `crates/codelens-engine/src/embedding/mod.rs`. No schema migration, no index rebuild, no MCP protocol change.
+
+**What would change this decision**:
+
+- A Rust application-style measurement (Phase 3h on `tokio-rs/axum`, `SergioBenitez/Rocket`, or a comparable non-tooling Rust framework) that lands Phase 2e as non-positive would reduce Rust's 2/2 streak to 2/3 and re-open Policy B as an evidence-backed option.
+- A future TypeScript / JavaScript measurement — e.g. a Vite + React production app, or a Node.js service — that lands Phase 2e as a large positive would push the TS/JS record to 2/5 positive. That would still not justify re-adding JS/TS to the auto-gate: the asymmetry from §8.15 (−10.0 %) is too large to overcome with a single new positive. Two separate large JS/TS positives would be needed.
+- A model swap (Phase 2d) that fundamentally changes the baseline candidate pool. The current Phase 2e contribution is a function of whether the re-ranker has useful slack above the lexical-only floor; a different embedding model could redraw that slack completely, which would make this entire table stale.
+
+**Pointer-forward**:
+
+§8.19 closes the §8.12 → §8.18 Phase 2e evidence arc. The phase candidates that remain open after this section are:
+
+1. **Phase 3h** — a Rust app-style dataset (counterpart to §8.16 / §8.17 for the Rust family). This is the only measurement that could move Policy B out of "deferred".
+2. **Phase 2d** — an embedding model swap addressing the retrieval-failure floor that §8.15 / §8.16 / §8.17 surfaced (15 / 26 NL queries unreachable on next-js, 29 / 34 on react-core). This is the largest potential quality lever remaining.
+3. **Operational hardening** — tracking items independent of the measurement campaign (the §8.14 language-switch process-scope limitation, Phase 4d single-instance guard follow-ups, etc.).
+
+None of these three change the §8.19 decision about the Phase 2m rollout. They all presuppose that the auto-gate split landed in PR #36 stays in place.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes the §8.12 → §8.18 Phase 2e evidence arc with two complementary additions: a machine-generated phase3 matrix infrastructure and a hand-written §8.19 policy narrative that references it.

## 1. Machine-generated phase3 matrix

- \`benchmarks/embedding-quality-matrix.py\` (314 lines) — scans \`benchmarks/embedding-quality-v1.{5,6}-phase3*-*.json\` files, groups 4 arms per dataset, computes hybrid deltas, emits JSON + markdown summaries. Supports \`--require-datasets\` as a completeness gate.
- \`benchmarks/embedding-quality-phase3-matrix.json\` + \`.md\` — checked-in outputs so reviewers can read the matrix without running the script.
- \`benchmarks/README.md\` — indexes the script + artefacts.

## 2. §8.19 unified Phase 2e narrative

New section \`§8.19 — Phase 2n: unified Phase 2e-only evidence across 8 datasets\`:

**Eight-dataset unified table** (hybrid \`get_ranked_context\` MRR, 2e-only vs baseline):

| § ref | Dataset                  | Archetype              | Lang | baseline | 2e-only |   Δ abs |     Δ rel |
| ----- | ------------------------ | ---------------------- | ---- | -------: | ------: | ------: | --------: |
| §8.2  | 89-query self            | Rust / self            | rs   |   0.5716 |  0.5787 | +0.0071 |    +1.2 % |
| §8.7  | ripgrep external         | Rust / tooling         | rs   |   0.4594 |  0.4878 | +0.0284 | **+6.2 %** |
| §8.8  | requests external        | Python / app library   | py   |   0.5837 |  0.5697 | −0.0140 |    −2.4 % |
| §8.13 | jest external            | TS / tooling           | ts   |   0.1546 |  0.1567 | +0.0021 |    +1.3 % |
| §8.15 | typescript external      | TS / compiler          | ts   |   0.0984 |  0.0886 | −0.0098 | **−10.0 %** |
| §8.16 | next-js external         | TS / typical app       | ts   |   0.1979 |  0.1962 | −0.0017 |    −0.8 % |
| §8.17 | react-core external      | TS / short runtime     | ts   |   0.1225 |  0.1225 | +0.0000 |    +0.0 % |
| §8.18 | django external          | Python / framework     | py   |   0.2937 |  0.2937 | +0.0000 |    +0.0 % |

**By-language**:

| Language family | Datasets | Positive | Zero/Inert | Negative |   Best |  Worst |
| --------------- | -------: | -------: | ---------: | -------: | -----: | -----: |
| Rust            |        2 |      2/2 |          0 |        0 | +6.2 % | +1.2 % |
| TS / JS         |        4 |      1/4 |        1/4 |      2/4 | +1.3 % | −10.0 % |
| Python          |        2 |      0/2 |        1/2 |      1/2 |  0.0 % |  −2.4 % |

**Phase 2m decision audit** — three alternative policies considered (remove entirely / narrow Rust to tooling / keep current scope), with evidence trade-offs. Policy C (keep current scope) is the minimum-commitment choice the table supports.

**What would change this decision**:

- A Rust app-style measurement (Phase 3h) landing non-positive on 2e.
- Two separate JS/TS positives (not just one) large enough to overcome the §8.15 −10 % asymmetry.
- A model swap (Phase 2d) that redraws the baseline candidate pool.

## Scope

- **No code changes**. No schema changes. No test changes.
- Pure docs / data / tooling commit.
- Matrix script is reproducible: \`python3 benchmarks/embedding-quality-matrix.py --require-datasets ripgrep,requests,jest,typescript,next-js,react-core,django\` regenerates both artefacts deterministically from the versioned result JSONs.

## Test plan

- [x] \`cargo check -p codelens-engine\` — green (sanity only, no code in scope)
- [x] Matrix script runs cleanly with completeness gate
- [x] Matrix script output agrees with §8.19 table on every dataset they both cover
- [x] All 8 §8.19 numbers cross-checked against source result JSONs

🤖 Generated with [Claude Code](https://claude.com/claude-code)