### PR TITLE
docs(bench): §8.20 Phase 3h — Rust framework library validation on tokio-rs/axum

### DIFF
--- a/benchmarks/embedding-quality-dataset-axum.json
+++ b/benchmarks/embedding-quality-dataset-axum.json
@@ -1,0 +1,206 @@
+[
+  {
+    "query": "HTTP request router and main entry point",
+    "expected_symbol": "Router",
+    "expected_file_suffix": "axum/routing/mod.rs",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "trait for types that can become an HTTP response",
+    "expected_symbol": "IntoResponse",
+    "expected_file_suffix": "axum-core/response/into_response.rs",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "trait to extract data from an incoming request",
+    "expected_symbol": "FromRequest",
+    "expected_file_suffix": "axum-core/extract/mod.rs",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "extract a subset of request parts without consuming the body",
+    "expected_symbol": "FromRequestParts",
+    "expected_file_suffix": "axum-core/extract/mod.rs",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "trait for request handlers",
+    "expected_symbol": "Handler",
+    "expected_file_suffix": "axum/handler/mod.rs",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "additional response parts that can be inserted",
+    "expected_symbol": "IntoResponseParts",
+    "expected_file_suffix": "axum-core/response/into_response_parts.rs",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "a JSON extractor and response body wrapper",
+    "expected_symbol": "Json",
+    "expected_file_suffix": "axum/json.rs",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "method router for a single path with multiple verbs",
+    "expected_symbol": "MethodRouter",
+    "expected_file_suffix": "axum/routing/method_routing.rs",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "URL path parameter extractor",
+    "expected_symbol": "Path",
+    "expected_file_suffix": "axum/extract/path/mod.rs",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "URL query string extractor",
+    "expected_symbol": "Query",
+    "expected_file_suffix": "axum/extract/query.rs",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "shared application state extractor",
+    "expected_symbol": "State",
+    "expected_file_suffix": "axum/extract/state.rs",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "form data extractor from the request body",
+    "expected_symbol": "Form",
+    "expected_file_suffix": "axum/form.rs",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "request scoped extension data",
+    "expected_symbol": "Extension",
+    "expected_file_suffix": "axum/extension.rs",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "multipart form data extractor",
+    "expected_symbol": "Multipart",
+    "expected_file_suffix": "axum/extract/multipart.rs",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "websocket upgrade from an HTTP request",
+    "expected_symbol": "WebSocketUpgrade",
+    "expected_file_suffix": "axum/extract/ws.rs",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "active websocket connection",
+    "expected_symbol": "WebSocket",
+    "expected_file_suffix": "axum/extract/ws.rs",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "HTTP redirect response helper",
+    "expected_symbol": "Redirect",
+    "expected_file_suffix": "axum/response/redirect.rs",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "HTML response body wrapper",
+    "expected_symbol": "Html",
+    "expected_file_suffix": "axum/response/mod.rs",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "server sent events response stream",
+    "expected_symbol": "Sse",
+    "expected_file_suffix": "axum/response/sse.rs",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "start an HTTP server bound to a listener",
+    "expected_symbol": "serve",
+    "expected_file_suffix": "axum/serve/mod.rs",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "add a route to a specific path on the router",
+    "expected_symbol": "route",
+    "expected_file_suffix": "axum/routing/mod.rs",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "mount another router under a path prefix",
+    "expected_symbol": "nest",
+    "expected_file_suffix": "axum/routing/mod.rs",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "combine another router into this one",
+    "expected_symbol": "merge",
+    "expected_file_suffix": "axum/routing/mod.rs",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "catch all fallback handler for unmatched routes",
+    "expected_symbol": "fallback",
+    "expected_file_suffix": "axum/routing/mod.rs",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "inject typed state into the router",
+    "expected_symbol": "with_state",
+    "expected_file_suffix": "axum/routing/mod.rs",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "handle a route with a custom method filter",
+    "expected_symbol": "on",
+    "expected_file_suffix": "axum/routing/method_routing.rs",
+    "query_type": "natural_language"
+  },
+  {
+    "query": "json body",
+    "expected_symbol": "Json",
+    "expected_file_suffix": "axum/json.rs",
+    "query_type": "short_phrase"
+  },
+  {
+    "query": "method router",
+    "expected_symbol": "MethodRouter",
+    "expected_file_suffix": "axum/routing/method_routing.rs",
+    "query_type": "short_phrase"
+  },
+  {
+    "query": "into response",
+    "expected_symbol": "IntoResponse",
+    "expected_file_suffix": "axum-core/response/into_response.rs",
+    "query_type": "short_phrase"
+  },
+  {
+    "query": "websocket upgrade",
+    "expected_symbol": "WebSocketUpgrade",
+    "expected_file_suffix": "axum/extract/ws.rs",
+    "query_type": "short_phrase"
+  },
+  {
+    "query": "serve listener",
+    "expected_symbol": "serve",
+    "expected_file_suffix": "axum/serve/mod.rs",
+    "query_type": "short_phrase"
+  },
+  {
+    "query": "path extractor",
+    "expected_symbol": "Path",
+    "expected_file_suffix": "axum/extract/path/mod.rs",
+    "query_type": "short_phrase"
+  },
+  {
+    "query": "Router",
+    "expected_symbol": "Router",
+    "expected_file_suffix": "axum/routing/mod.rs",
+    "query_type": "identifier"
+  },
+  {
+    "query": "IntoResponse",
+    "expected_symbol": "IntoResponse",
+    "expected_file_suffix": "axum-core/response/into_response.rs",
+    "query_type": "identifier"
+  }
+]

--- a/benchmarks/embedding-quality-v1.6-phase3h-axum-2b2c-only.json
+++ b/benchmarks/embedding-quality-v1.6-phase3h-axum-2b2c-only.json
@@ -1,0 +1,1487 @@
+{
+  "project": "/tmp/axum-bench",
+  "benchmark_project": "/var/folders/z0/0tcbss795xsdp75jmr_t9_kh0000gn/T/codelens-embed-quality-6olnmgfv/axum-bench",
+  "isolated_copy": true,
+  "binary": "/Users/bagjaeseog/codelens-mcp-plugin/target/release/codelens-mcp",
+  "embedding_model": "MiniLM-L12-CodeSearchNet-INT8",
+  "runtime_model": {
+    "model_dir": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch",
+    "model_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/model.onnx",
+    "config_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/config.json",
+    "sha256": "ef1d1e9cfa72e4929f5b9faea17d8704b23a2530aadebf0d464a4cc7750920b3",
+    "size_bytes": 34000281,
+    "num_hidden_layers": 12,
+    "hidden_size": 384
+  },
+  "dataset_path": "/Users/bagjaeseog/codelens-mcp-plugin/benchmarks/embedding-quality-dataset-axum.json",
+  "dataset_size": 34,
+  "ranking_cutoff": 10,
+  "metric_labels": {
+    "mrr": "MRR@10",
+    "acc1": "Acc@1",
+    "acc3": "Acc@3",
+    "acc5": "Acc@5"
+  },
+  "methods": [
+    {
+      "method": "semantic_search",
+      "mrr": 0.19215686274509802,
+      "acc1": 0.14705882352941177,
+      "acc3": 0.23529411764705882,
+      "acc5": 0.2647058823529412,
+      "avg_elapsed_ms": 224.4414705882353,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 1.0,
+          "acc1": 1.0,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 125.92
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.09743589743589744,
+          "acc1": 0.07692307692307693,
+          "acc3": 0.11538461538461539,
+          "acc5": 0.15384615384615385,
+          "avg_elapsed_ms": 252.14769230769232
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.3333333333333333,
+          "acc1": 0.16666666666666666,
+          "acc3": 0.5,
+          "acc5": 0.5,
+          "avg_elapsed_ms": 137.22166666666666
+        }
+      },
+      "rows": [
+        {
+          "query": "HTTP request router and main entry point",
+          "query_type": "natural_language",
+          "expected_symbol": "Router",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": null,
+          "elapsed_ms": 201.62,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "echo_app",
+            "file": "axum/extract/ws.rs"
+          }
+        },
+        {
+          "query": "trait for types that can become an HTTP response",
+          "query_type": "natural_language",
+          "expected_symbol": "IntoResponse",
+          "expected_file_suffix": "axum-core/response/into_response.rs",
+          "rank": null,
+          "elapsed_ms": 165.22,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "make_response",
+            "file": "axum/form.rs"
+          }
+        },
+        {
+          "query": "trait to extract data from an incoming request",
+          "query_type": "natural_language",
+          "expected_symbol": "FromRequest",
+          "expected_file_suffix": "axum-core/extract/mod.rs",
+          "rank": null,
+          "elapsed_ms": 199.59,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "extract",
+            "file": "axum-core/ext_traits/request.rs"
+          }
+        },
+        {
+          "query": "extract a subset of request parts without consuming the body",
+          "query_type": "natural_language",
+          "expected_symbol": "FromRequestParts",
+          "expected_file_suffix": "axum-core/extract/mod.rs",
+          "rank": null,
+          "elapsed_ms": 166.66,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "extract_parts",
+            "file": "axum-core/ext_traits/request.rs"
+          }
+        },
+        {
+          "query": "trait for request handlers",
+          "query_type": "natural_language",
+          "expected_symbol": "Handler",
+          "expected_file_suffix": "axum/handler/mod.rs",
+          "rank": null,
+          "elapsed_ms": 177.25,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "format_str_from_path",
+            "file": "axum-macros/typed_path.rs"
+          }
+        },
+        {
+          "query": "additional response parts that can be inserted",
+          "query_type": "natural_language",
+          "expected_symbol": "IntoResponseParts",
+          "expected_file_suffix": "axum-core/response/into_response_parts.rs",
+          "rank": null,
+          "elapsed_ms": 197.13,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "into_response_parts",
+            "file": "axum-core/response/mod.rs"
+          }
+        },
+        {
+          "query": "a JSON extractor and response body wrapper",
+          "query_type": "natural_language",
+          "expected_symbol": "Json",
+          "expected_file_suffix": "axum/json.rs",
+          "rank": null,
+          "elapsed_ms": 314.16,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "extract",
+            "file": "axum-core/ext_traits/request.rs"
+          }
+        },
+        {
+          "query": "method router for a single path with multiple verbs",
+          "query_type": "natural_language",
+          "expected_symbol": "MethodRouter",
+          "expected_file_suffix": "axum/routing/method_routing.rs",
+          "rank": null,
+          "elapsed_ms": 1410.87,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "method_routing",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "URL path parameter extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "Path",
+          "expected_file_suffix": "axum/extract/path/mod.rs",
+          "rank": null,
+          "elapsed_ms": 482.23,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "check_extractor_count",
+            "file": "axum-macros/debug_handler.rs"
+          }
+        },
+        {
+          "query": "URL query string extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "Query",
+          "expected_file_suffix": "axum/extract/query.rs",
+          "rank": null,
+          "elapsed_ms": 201.3,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "from_extractor",
+            "file": "axum/middleware/from_extractor.rs"
+          }
+        },
+        {
+          "query": "shared application state extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "State",
+          "expected_file_suffix": "axum/extract/state.rs",
+          "rank": null,
+          "elapsed_ms": 188.95,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "from_extractor_with_state",
+            "file": "axum/middleware/from_extractor.rs"
+          }
+        },
+        {
+          "query": "form data extractor from the request body",
+          "query_type": "natural_language",
+          "expected_symbol": "Form",
+          "expected_file_suffix": "axum/form.rs",
+          "rank": null,
+          "elapsed_ms": 168.88,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "extract",
+            "file": "axum-core/ext_traits/request_parts.rs"
+          }
+        },
+        {
+          "query": "request scoped extension data",
+          "query_type": "natural_language",
+          "expected_symbol": "Extension",
+          "expected_file_suffix": "axum/extension.rs",
+          "rank": null,
+          "elapsed_ms": 169.58,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "status_header_array_extension_mixed_body",
+            "file": "axum/response/mod.rs"
+          }
+        },
+        {
+          "query": "multipart form data extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "Multipart",
+          "expected_file_suffix": "axum/extract/multipart.rs",
+          "rank": null,
+          "elapsed_ms": 187.91,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "test_from_extractor",
+            "file": "axum/middleware/from_extractor.rs"
+          }
+        },
+        {
+          "query": "websocket upgrade from an HTTP request",
+          "query_type": "natural_language",
+          "expected_symbol": "WebSocketUpgrade",
+          "expected_file_suffix": "axum/extract/ws.rs",
+          "rank": 3,
+          "elapsed_ms": 196.01,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "on_upgrade",
+            "file": "axum/extract/ws.rs"
+          }
+        },
+        {
+          "query": "active websocket connection",
+          "query_type": "natural_language",
+          "expected_symbol": "WebSocket",
+          "expected_file_suffix": "axum/extract/ws.rs",
+          "rank": null,
+          "elapsed_ms": 124.32,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "on_failed_upgrade",
+            "file": "axum/extract/ws.rs"
+          }
+        },
+        {
+          "query": "HTTP redirect response helper",
+          "query_type": "natural_language",
+          "expected_symbol": "Redirect",
+          "expected_file_suffix": "axum/response/redirect.rs",
+          "rank": null,
+          "elapsed_ms": 185.97,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "redirect",
+            "file": "axum/response/mod.rs"
+          }
+        },
+        {
+          "query": "HTML response body wrapper",
+          "query_type": "natural_language",
+          "expected_symbol": "Html",
+          "expected_file_suffix": "axum/response/mod.rs",
+          "rank": null,
+          "elapsed_ms": 168.35,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "deserialize_body",
+            "file": "axum-extra/extract/json_deserializer.rs"
+          }
+        },
+        {
+          "query": "server sent events response stream",
+          "query_type": "natural_language",
+          "expected_symbol": "Sse",
+          "expected_file_suffix": "axum/response/sse.rs",
+          "rank": null,
+          "elapsed_ms": 198.97,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "serve",
+            "file": "axum/serve/mod.rs"
+          }
+        },
+        {
+          "query": "start an HTTP server bound to a listener",
+          "query_type": "natural_language",
+          "expected_symbol": "serve",
+          "expected_file_suffix": "axum/serve/mod.rs",
+          "rank": null,
+          "elapsed_ms": 195.47,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "listener",
+            "file": "axum/serve/mod.rs"
+          }
+        },
+        {
+          "query": "add a route to a specific path on the router",
+          "query_type": "natural_language",
+          "expected_symbol": "route",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 5,
+          "elapsed_ms": 204.48,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "path_router",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "mount another router under a path prefix",
+          "query_type": "natural_language",
+          "expected_symbol": "nest",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": null,
+          "elapsed_ms": 207.18,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "path_router",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "combine another router into this one",
+          "query_type": "natural_language",
+          "expected_symbol": "merge",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": null,
+          "elapsed_ms": 205.3,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "combine",
+            "file": "axum-macros/from_request/attr.rs"
+          }
+        },
+        {
+          "query": "catch all fallback handler for unmatched routes",
+          "query_type": "natural_language",
+          "expected_symbol": "fallback",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 1,
+          "elapsed_ms": 185.68,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "fallback",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "inject typed state into the router",
+          "query_type": "natural_language",
+          "expected_symbol": "with_state",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 1,
+          "elapsed_ms": 212.29,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "with_state",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "handle a route with a custom method filter",
+          "query_type": "natural_language",
+          "expected_symbol": "on",
+          "expected_file_suffix": "axum/routing/method_routing.rs",
+          "rank": null,
+          "elapsed_ms": 240.47,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "method_filter",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "json body",
+          "query_type": "short_phrase",
+          "expected_symbol": "Json",
+          "expected_file_suffix": "axum/json.rs",
+          "rank": null,
+          "elapsed_ms": 135.03,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "json",
+            "file": "axum/lib.rs"
+          }
+        },
+        {
+          "query": "method router",
+          "query_type": "short_phrase",
+          "expected_symbol": "MethodRouter",
+          "expected_file_suffix": "axum/routing/method_routing.rs",
+          "rank": 2,
+          "elapsed_ms": 135.47,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "method_routing",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "into response",
+          "query_type": "short_phrase",
+          "expected_symbol": "IntoResponse",
+          "expected_file_suffix": "axum-core/response/into_response.rs",
+          "rank": null,
+          "elapsed_ms": 147.87,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "into_response",
+            "file": "axum-core/response/into_response.rs"
+          }
+        },
+        {
+          "query": "websocket upgrade",
+          "query_type": "short_phrase",
+          "expected_symbol": "WebSocketUpgrade",
+          "expected_file_suffix": "axum/extract/ws.rs",
+          "rank": 2,
+          "elapsed_ms": 127.45,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "WEBSOCKET",
+            "file": "axum/extract/ws.rs"
+          }
+        },
+        {
+          "query": "serve listener",
+          "query_type": "short_phrase",
+          "expected_symbol": "serve",
+          "expected_file_suffix": "axum/serve/mod.rs",
+          "rank": null,
+          "elapsed_ms": 135.55,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "listener",
+            "file": "axum/serve/mod.rs"
+          }
+        },
+        {
+          "query": "path extractor",
+          "query_type": "short_phrase",
+          "expected_symbol": "Path",
+          "expected_file_suffix": "axum/extract/path/mod.rs",
+          "rank": 1,
+          "elapsed_ms": 141.96,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "Path",
+            "file": "axum/extract/path/mod.rs"
+          }
+        },
+        {
+          "query": "Router",
+          "query_type": "identifier",
+          "expected_symbol": "Router",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 1,
+          "elapsed_ms": 121.65,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "Router",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "IntoResponse",
+          "query_type": "identifier",
+          "expected_symbol": "IntoResponse",
+          "expected_file_suffix": "axum-core/response/into_response.rs",
+          "rank": 1,
+          "elapsed_ms": 130.19,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "IntoResponse",
+            "file": "axum-core/response/into_response.rs"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context_no_semantic",
+      "mrr": 0.20316399286987522,
+      "acc1": 0.14705882352941177,
+      "acc3": 0.20588235294117646,
+      "acc5": 0.29411764705882354,
+      "avg_elapsed_ms": 22.085,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 1.0,
+          "acc1": 1.0,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 16.445
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.125,
+          "acc1": 0.07692307692307693,
+          "acc3": 0.15384615384615385,
+          "acc5": 0.19230769230769232,
+          "avg_elapsed_ms": 23.49730769230769
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.27626262626262627,
+          "acc1": 0.16666666666666666,
+          "acc3": 0.16666666666666666,
+          "acc5": 0.5,
+          "avg_elapsed_ms": 17.845
+        }
+      },
+      "rows": [
+        {
+          "query": "HTTP request router and main entry point",
+          "query_type": "natural_language",
+          "expected_symbol": "Router",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": null,
+          "elapsed_ms": 25.54,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "_",
+            "file": "axum/handler/service.rs"
+          }
+        },
+        {
+          "query": "trait for types that can become an HTTP response",
+          "query_type": "natural_language",
+          "expected_symbol": "IntoResponse",
+          "expected_file_suffix": "axum-core/response/into_response.rs",
+          "rank": null,
+          "elapsed_ms": 23.1,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "from_http_method",
+            "file": "axum/routing/method_filter.rs"
+          }
+        },
+        {
+          "query": "trait to extract data from an incoming request",
+          "query_type": "natural_language",
+          "expected_symbol": "FromRequest",
+          "expected_file_suffix": "axum-core/extract/mod.rs",
+          "rank": null,
+          "elapsed_ms": 25.74,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "from_extractor",
+            "file": "axum/middleware/from_extractor.rs"
+          }
+        },
+        {
+          "query": "extract a subset of request parts without consuming the body",
+          "query_type": "natural_language",
+          "expected_symbol": "FromRequestParts",
+          "expected_file_suffix": "axum-core/extract/mod.rs",
+          "rank": null,
+          "elapsed_ms": 22.64,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "request_parts",
+            "file": "axum-core/extract/mod.rs"
+          }
+        },
+        {
+          "query": "trait for request handlers",
+          "query_type": "natural_language",
+          "expected_symbol": "Handler",
+          "expected_file_suffix": "axum/handler/mod.rs",
+          "rank": 24,
+          "elapsed_ms": 23.07,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "RequestPartsExt",
+            "file": "axum-core/ext_traits/request_parts.rs"
+          }
+        },
+        {
+          "query": "additional response parts that can be inserted",
+          "query_type": "natural_language",
+          "expected_symbol": "IntoResponseParts",
+          "expected_file_suffix": "axum-core/response/into_response_parts.rs",
+          "rank": 1,
+          "elapsed_ms": 24.11,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "IntoResponseParts",
+            "file": "axum-core/response/into_response_parts.rs"
+          }
+        },
+        {
+          "query": "a JSON extractor and response body wrapper",
+          "query_type": "natural_language",
+          "expected_symbol": "Json",
+          "expected_file_suffix": "axum/json.rs",
+          "rank": null,
+          "elapsed_ms": 25.15,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "consume_body_to_json_requires_json_content_type",
+            "file": "axum-extra/extract/json_deserializer.rs"
+          }
+        },
+        {
+          "query": "method router for a single path with multiple verbs",
+          "query_type": "natural_language",
+          "expected_symbol": "MethodRouter",
+          "expected_file_suffix": "axum/routing/method_routing.rs",
+          "rank": null,
+          "elapsed_ms": 22.16,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "can_extract_nested_matched_path_with_prefix_and_suffix_in_middleware_on_nested_router",
+            "file": "axum/extract/matched_path.rs"
+          }
+        },
+        {
+          "query": "URL path parameter extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "Path",
+          "expected_file_suffix": "axum/extract/path/mod.rs",
+          "rank": null,
+          "elapsed_ms": 23.7,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "two_path_extractors",
+            "file": "axum/extract/path/mod.rs"
+          }
+        },
+        {
+          "query": "URL query string extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "Query",
+          "expected_file_suffix": "axum/extract/query.rs",
+          "rank": null,
+          "elapsed_ms": 24.34,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "test_parse_seq_tuple_string_parse",
+            "file": "axum/extract/path/de.rs"
+          }
+        },
+        {
+          "query": "shared application state extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "State",
+          "expected_file_suffix": "axum/extract/state.rs",
+          "rank": null,
+          "elapsed_ms": 25.14,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "from_extractor_with_state",
+            "file": "axum/middleware/from_extractor.rs"
+          }
+        },
+        {
+          "query": "form data extractor from the request body",
+          "query_type": "natural_language",
+          "expected_symbol": "Form",
+          "expected_file_suffix": "axum/form.rs",
+          "rank": null,
+          "elapsed_ms": 21.67,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "from_extractor",
+            "file": "axum/middleware/from_extractor.rs"
+          }
+        },
+        {
+          "query": "request scoped extension data",
+          "query_type": "natural_language",
+          "expected_symbol": "Extension",
+          "expected_file_suffix": "axum/extension.rs",
+          "rank": 3,
+          "elapsed_ms": 21.49,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "FromRequestContainerAttrs",
+            "file": "axum-macros/from_request/attr.rs"
+          }
+        },
+        {
+          "query": "multipart form data extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "Multipart",
+          "expected_file_suffix": "axum/extract/multipart.rs",
+          "rank": null,
+          "elapsed_ms": 22.84,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "from_extractor",
+            "file": "axum/middleware/from_extractor.rs"
+          }
+        },
+        {
+          "query": "websocket upgrade from an HTTP request",
+          "query_type": "natural_language",
+          "expected_symbol": "WebSocketUpgrade",
+          "expected_file_suffix": "axum/extract/ws.rs",
+          "rank": null,
+          "elapsed_ms": 24.62,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "from_http_method",
+            "file": "axum/routing/method_filter.rs"
+          }
+        },
+        {
+          "query": "active websocket connection",
+          "query_type": "natural_language",
+          "expected_symbol": "WebSocket",
+          "expected_file_suffix": "axum/extract/ws.rs",
+          "rank": 4,
+          "elapsed_ms": 18.74,
+          "candidate_count": 7,
+          "top_candidate": {
+            "name": "limit_connections",
+            "file": "axum/serve/listener.rs"
+          }
+        },
+        {
+          "query": "HTTP redirect response helper",
+          "query_type": "natural_language",
+          "expected_symbol": "Redirect",
+          "expected_file_suffix": "axum/response/redirect.rs",
+          "rank": null,
+          "elapsed_ms": 21.78,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "into_response",
+            "file": "axum/response/redirect.rs"
+          }
+        },
+        {
+          "query": "HTML response body wrapper",
+          "query_type": "natural_language",
+          "expected_symbol": "Html",
+          "expected_file_suffix": "axum/response/mod.rs",
+          "rank": null,
+          "elapsed_ms": 21.54,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "ResponseAxumBody",
+            "file": "axum/middleware/response_axum_body.rs"
+          }
+        },
+        {
+          "query": "server sent events response stream",
+          "query_type": "natural_language",
+          "expected_symbol": "Sse",
+          "expected_file_suffix": "axum/response/sse.rs",
+          "rank": null,
+          "elapsed_ms": 24.51,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "into_response",
+            "file": "axum-core/response/append_headers.rs"
+          }
+        },
+        {
+          "query": "start an HTTP server bound to a listener",
+          "query_type": "natural_language",
+          "expected_symbol": "serve",
+          "expected_file_suffix": "axum/serve/mod.rs",
+          "rank": null,
+          "elapsed_ms": 22.3,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "_",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "add a route to a specific path on the router",
+          "query_type": "natural_language",
+          "expected_symbol": "route",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 8,
+          "elapsed_ms": 25.29,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "can_extract_nested_matched_path_in_middleware_on_nested_router",
+            "file": "axum/extract/matched_path.rs"
+          }
+        },
+        {
+          "query": "mount another router under a path prefix",
+          "query_type": "natural_language",
+          "expected_symbol": "nest",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": null,
+          "elapsed_ms": 25.1,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "can_extract_nested_matched_path_with_prefix_in_middleware_on_nested_router",
+            "file": "axum/extract/matched_path.rs"
+          }
+        },
+        {
+          "query": "combine another router into this one",
+          "query_type": "natural_language",
+          "expected_symbol": "merge",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": null,
+          "elapsed_ms": 24.09,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "combine_unary_attribute",
+            "file": "axum-macros/attr_parsing.rs"
+          }
+        },
+        {
+          "query": "catch all fallback handler for unmatched routes",
+          "query_type": "natural_language",
+          "expected_symbol": "fallback",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 2,
+          "elapsed_ms": 22.23,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "_",
+            "file": "axum/handler/service.rs"
+          }
+        },
+        {
+          "query": "inject typed state into the router",
+          "query_type": "natural_language",
+          "expected_symbol": "with_state",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 1,
+          "elapsed_ms": 24.7,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "with_state",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "handle a route with a custom method filter",
+          "query_type": "natural_language",
+          "expected_symbol": "on",
+          "expected_file_suffix": "axum/routing/method_routing.rs",
+          "rank": null,
+          "elapsed_ms": 25.34,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "method_filter",
+            "file": "axum/routing/method_routing.rs"
+          }
+        },
+        {
+          "query": "json body",
+          "query_type": "short_phrase",
+          "expected_symbol": "Json",
+          "expected_file_suffix": "axum/json.rs",
+          "rank": 15,
+          "elapsed_ms": 18.67,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "consume_body_to_json_requires_json_content_type",
+            "file": "axum-extra/extract/json_deserializer.rs"
+          }
+        },
+        {
+          "query": "method router",
+          "query_type": "short_phrase",
+          "expected_symbol": "MethodRouter",
+          "expected_file_suffix": "axum/routing/method_routing.rs",
+          "rank": 5,
+          "elapsed_ms": 18.22,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "_",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "into response",
+          "query_type": "short_phrase",
+          "expected_symbol": "IntoResponse",
+          "expected_file_suffix": "axum-core/response/into_response.rs",
+          "rank": 20,
+          "elapsed_ms": 17.93,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "into_response",
+            "file": "axum-extra/response/erased_json.rs"
+          }
+        },
+        {
+          "query": "websocket upgrade",
+          "query_type": "short_phrase",
+          "expected_symbol": "WebSocketUpgrade",
+          "expected_file_suffix": "axum/extract/ws.rs",
+          "rank": 1,
+          "elapsed_ms": 16.27,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "WebSocketUpgrade",
+            "file": "axum/extract/ws.rs"
+          }
+        },
+        {
+          "query": "serve listener",
+          "query_type": "short_phrase",
+          "expected_symbol": "serve",
+          "expected_file_suffix": "axum/serve/mod.rs",
+          "rank": 4,
+          "elapsed_ms": 17.54,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "ListenerExt",
+            "file": "axum/serve/listener.rs"
+          }
+        },
+        {
+          "query": "path extractor",
+          "query_type": "short_phrase",
+          "expected_symbol": "Path",
+          "expected_file_suffix": "axum/extract/path/mod.rs",
+          "rank": 11,
+          "elapsed_ms": 18.44,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "two_path_extractors",
+            "file": "axum/extract/path/mod.rs"
+          }
+        },
+        {
+          "query": "Router",
+          "query_type": "identifier",
+          "expected_symbol": "Router",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 1,
+          "elapsed_ms": 16.76,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "Router",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "IntoResponse",
+          "query_type": "identifier",
+          "expected_symbol": "IntoResponse",
+          "expected_file_suffix": "axum-core/response/into_response.rs",
+          "rank": 1,
+          "elapsed_ms": 16.13,
+          "candidate_count": 5,
+          "top_candidate": {
+            "name": "IntoResponse",
+            "file": "axum-core/response/into_response.rs"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context",
+      "mrr": 0.28078948354557454,
+      "acc1": 0.17647058823529413,
+      "acc3": 0.2647058823529412,
+      "acc5": 0.4117647058823529,
+      "avg_elapsed_ms": 117.49117647058823,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 1.0,
+          "acc1": 1.0,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 16.29
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.1998785554057513,
+          "acc1": 0.11538461538461539,
+          "acc3": 0.15384615384615385,
+          "acc5": 0.3076923076923077,
+          "avg_elapsed_ms": 125.59461538461538
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.39166666666666666,
+          "acc1": 0.16666666666666666,
+          "acc3": 0.5,
+          "acc5": 0.6666666666666666,
+          "avg_elapsed_ms": 116.11
+        }
+      },
+      "rows": [
+        {
+          "query": "HTTP request router and main entry point",
+          "query_type": "natural_language",
+          "expected_symbol": "Router",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": null,
+          "elapsed_ms": 126.36,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "request_parts",
+            "file": "axum-core/ext_traits/mod.rs"
+          }
+        },
+        {
+          "query": "trait for types that can become an HTTP response",
+          "query_type": "natural_language",
+          "expected_symbol": "IntoResponse",
+          "expected_file_suffix": "axum-core/response/into_response.rs",
+          "rank": null,
+          "elapsed_ms": 129.21,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "response",
+            "file": "axum/lib.rs"
+          }
+        },
+        {
+          "query": "trait to extract data from an incoming request",
+          "query_type": "natural_language",
+          "expected_symbol": "FromRequest",
+          "expected_file_suffix": "axum-core/extract/mod.rs",
+          "rank": 8,
+          "elapsed_ms": 130.3,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "extract",
+            "file": "axum-core/ext_traits/request.rs"
+          }
+        },
+        {
+          "query": "extract a subset of request parts without consuming the body",
+          "query_type": "natural_language",
+          "expected_symbol": "FromRequestParts",
+          "expected_file_suffix": "axum-core/extract/mod.rs",
+          "rank": 21,
+          "elapsed_ms": 127.27,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "extract_parts",
+            "file": "axum-core/ext_traits/request.rs"
+          }
+        },
+        {
+          "query": "trait for request handlers",
+          "query_type": "natural_language",
+          "expected_symbol": "Handler",
+          "expected_file_suffix": "axum/handler/mod.rs",
+          "rank": 6,
+          "elapsed_ms": 129.26,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "handler",
+            "file": "axum/serve/mod.rs"
+          }
+        },
+        {
+          "query": "additional response parts that can be inserted",
+          "query_type": "natural_language",
+          "expected_symbol": "IntoResponseParts",
+          "expected_file_suffix": "axum-core/response/into_response_parts.rs",
+          "rank": 7,
+          "elapsed_ms": 129.05,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "into_response_parts",
+            "file": "axum-core/response/mod.rs"
+          }
+        },
+        {
+          "query": "a JSON extractor and response body wrapper",
+          "query_type": "natural_language",
+          "expected_symbol": "Json",
+          "expected_file_suffix": "axum/json.rs",
+          "rank": null,
+          "elapsed_ms": 129.91,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "extract",
+            "file": "axum-core/ext_traits/request_parts.rs"
+          }
+        },
+        {
+          "query": "method router for a single path with multiple verbs",
+          "query_type": "natural_language",
+          "expected_symbol": "MethodRouter",
+          "expected_file_suffix": "axum/routing/method_routing.rs",
+          "rank": 5,
+          "elapsed_ms": 125.43,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "method_routing",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "URL path parameter extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "Path",
+          "expected_file_suffix": "axum/extract/path/mod.rs",
+          "rank": 23,
+          "elapsed_ms": 128.08,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "url_params",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "URL query string extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "Query",
+          "expected_file_suffix": "axum/extract/query.rs",
+          "rank": null,
+          "elapsed_ms": 131.55,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "from_extractor",
+            "file": "axum/middleware/from_extractor.rs"
+          }
+        },
+        {
+          "query": "shared application state extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "State",
+          "expected_file_suffix": "axum/extract/state.rs",
+          "rank": 5,
+          "elapsed_ms": 131.58,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "from_extractor_with_state",
+            "file": "axum/middleware/from_extractor.rs"
+          }
+        },
+        {
+          "query": "form data extractor from the request body",
+          "query_type": "natural_language",
+          "expected_symbol": "Form",
+          "expected_file_suffix": "axum/form.rs",
+          "rank": null,
+          "elapsed_ms": 125.0,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "extract",
+            "file": "axum-core/ext_traits/request_parts.rs"
+          }
+        },
+        {
+          "query": "request scoped extension data",
+          "query_type": "natural_language",
+          "expected_symbol": "Extension",
+          "expected_file_suffix": "axum/extension.rs",
+          "rank": 4,
+          "elapsed_ms": 123.86,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "extension",
+            "file": "axum/lib.rs"
+          }
+        },
+        {
+          "query": "multipart form data extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "Multipart",
+          "expected_file_suffix": "axum/extract/multipart.rs",
+          "rank": 19,
+          "elapsed_ms": 122.16,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "extract",
+            "file": "axum-core/ext_traits/request_parts.rs"
+          }
+        },
+        {
+          "query": "websocket upgrade from an HTTP request",
+          "query_type": "natural_language",
+          "expected_symbol": "WebSocketUpgrade",
+          "expected_file_suffix": "axum/extract/ws.rs",
+          "rank": 3,
+          "elapsed_ms": 121.54,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "WEBSOCKET",
+            "file": "axum/extract/ws.rs"
+          }
+        },
+        {
+          "query": "active websocket connection",
+          "query_type": "natural_language",
+          "expected_symbol": "WebSocket",
+          "expected_file_suffix": "axum/extract/ws.rs",
+          "rank": 1,
+          "elapsed_ms": 117.03,
+          "candidate_count": 7,
+          "top_candidate": {
+            "name": "WebSocket",
+            "file": "axum/extract/ws.rs"
+          }
+        },
+        {
+          "query": "HTTP redirect response helper",
+          "query_type": "natural_language",
+          "expected_symbol": "Redirect",
+          "expected_file_suffix": "axum/response/redirect.rs",
+          "rank": 8,
+          "elapsed_ms": 121.63,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "redirect",
+            "file": "axum/response/mod.rs"
+          }
+        },
+        {
+          "query": "HTML response body wrapper",
+          "query_type": "natural_language",
+          "expected_symbol": "Html",
+          "expected_file_suffix": "axum/response/mod.rs",
+          "rank": null,
+          "elapsed_ms": 123.53,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "response_axum_body",
+            "file": "axum/middleware/mod.rs"
+          }
+        },
+        {
+          "query": "server sent events response stream",
+          "query_type": "natural_language",
+          "expected_symbol": "Sse",
+          "expected_file_suffix": "axum/response/sse.rs",
+          "rank": null,
+          "elapsed_ms": 123.07,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "Event",
+            "file": "axum/response/sse.rs"
+          }
+        },
+        {
+          "query": "start an HTTP server bound to a listener",
+          "query_type": "natural_language",
+          "expected_symbol": "serve",
+          "expected_file_suffix": "axum/serve/mod.rs",
+          "rank": 6,
+          "elapsed_ms": 123.02,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "listener",
+            "file": "axum/serve/mod.rs"
+          }
+        },
+        {
+          "query": "add a route to a specific path on the router",
+          "query_type": "natural_language",
+          "expected_symbol": "route",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 5,
+          "elapsed_ms": 125.49,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "path_router",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "mount another router under a path prefix",
+          "query_type": "natural_language",
+          "expected_symbol": "nest",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": null,
+          "elapsed_ms": 124.03,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "path_router",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "combine another router into this one",
+          "query_type": "natural_language",
+          "expected_symbol": "merge",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 13,
+          "elapsed_ms": 126.34,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "combine",
+            "file": "axum-macros/from_request/attr.rs"
+          }
+        },
+        {
+          "query": "catch all fallback handler for unmatched routes",
+          "query_type": "natural_language",
+          "expected_symbol": "fallback",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 1,
+          "elapsed_ms": 122.9,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "fallback",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "inject typed state into the router",
+          "query_type": "natural_language",
+          "expected_symbol": "with_state",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 1,
+          "elapsed_ms": 123.05,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "with_state",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "handle a route with a custom method filter",
+          "query_type": "natural_language",
+          "expected_symbol": "on",
+          "expected_file_suffix": "axum/routing/method_routing.rs",
+          "rank": 15,
+          "elapsed_ms": 124.81,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "method_filter",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "json body",
+          "query_type": "short_phrase",
+          "expected_symbol": "Json",
+          "expected_file_suffix": "axum/json.rs",
+          "rank": 10,
+          "elapsed_ms": 116.3,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "json",
+            "file": "axum/lib.rs"
+          }
+        },
+        {
+          "query": "method router",
+          "query_type": "short_phrase",
+          "expected_symbol": "MethodRouter",
+          "expected_file_suffix": "axum/routing/method_routing.rs",
+          "rank": 2,
+          "elapsed_ms": 114.61,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "method_routing",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "into response",
+          "query_type": "short_phrase",
+          "expected_symbol": "IntoResponse",
+          "expected_file_suffix": "axum-core/response/into_response.rs",
+          "rank": 20,
+          "elapsed_ms": 115.64,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "into_response",
+            "file": "axum-core/response/into_response.rs"
+          }
+        },
+        {
+          "query": "websocket upgrade",
+          "query_type": "short_phrase",
+          "expected_symbol": "WebSocketUpgrade",
+          "expected_file_suffix": "axum/extract/ws.rs",
+          "rank": 2,
+          "elapsed_ms": 113.4,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "WEBSOCKET",
+            "file": "axum/extract/ws.rs"
+          }
+        },
+        {
+          "query": "serve listener",
+          "query_type": "short_phrase",
+          "expected_symbol": "serve",
+          "expected_file_suffix": "axum/serve/mod.rs",
+          "rank": 5,
+          "elapsed_ms": 117.25,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "listener",
+            "file": "axum/serve/mod.rs"
+          }
+        },
+        {
+          "query": "path extractor",
+          "query_type": "short_phrase",
+          "expected_symbol": "Path",
+          "expected_file_suffix": "axum/extract/path/mod.rs",
+          "rank": 1,
+          "elapsed_ms": 119.46,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "Path",
+            "file": "axum/extract/path/mod.rs"
+          }
+        },
+        {
+          "query": "Router",
+          "query_type": "identifier",
+          "expected_symbol": "Router",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 1,
+          "elapsed_ms": 16.81,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "Router",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "IntoResponse",
+          "query_type": "identifier",
+          "expected_symbol": "IntoResponse",
+          "expected_file_suffix": "axum-core/response/into_response.rs",
+          "rank": 1,
+          "elapsed_ms": 15.77,
+          "candidate_count": 5,
+          "top_candidate": {
+            "name": "IntoResponse",
+            "file": "axum-core/response/into_response.rs"
+          }
+        }
+      ]
+    }
+  ],
+  "hybrid_uplift": {
+    "mrr_delta": 0.07762549067569932,
+    "acc1_delta": 0.02941176470588236,
+    "acc3_delta": 0.05882352941176472,
+    "acc5_delta": 0.11764705882352938
+  },
+  "hybrid_uplift_by_query_type": {
+    "identifier": {
+      "mrr_delta": 0.0,
+      "acc1_delta": 0.0,
+      "acc3_delta": 0.0,
+      "acc5_delta": 0.0
+    },
+    "natural_language": {
+      "mrr_delta": 0.07487855540575131,
+      "acc1_delta": 0.038461538461538464,
+      "acc3_delta": 0.0,
+      "acc5_delta": 0.11538461538461539
+    },
+    "short_phrase": {
+      "mrr_delta": 0.1154040404040404,
+      "acc1_delta": 0.0,
+      "acc3_delta": 0.33333333333333337,
+      "acc5_delta": 0.16666666666666663
+    }
+  }
+}

--- a/benchmarks/embedding-quality-v1.6-phase3h-axum-2e-only.json
+++ b/benchmarks/embedding-quality-v1.6-phase3h-axum-2e-only.json
@@ -1,0 +1,1487 @@
+{
+  "project": "/tmp/axum-bench",
+  "benchmark_project": "/var/folders/z0/0tcbss795xsdp75jmr_t9_kh0000gn/T/codelens-embed-quality-qomdmaw1/axum-bench",
+  "isolated_copy": true,
+  "binary": "/Users/bagjaeseog/codelens-mcp-plugin/target/release/codelens-mcp",
+  "embedding_model": "MiniLM-L12-CodeSearchNet-INT8",
+  "runtime_model": {
+    "model_dir": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch",
+    "model_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/model.onnx",
+    "config_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/config.json",
+    "sha256": "ef1d1e9cfa72e4929f5b9faea17d8704b23a2530aadebf0d464a4cc7750920b3",
+    "size_bytes": 34000281,
+    "num_hidden_layers": 12,
+    "hidden_size": 384
+  },
+  "dataset_path": "/Users/bagjaeseog/codelens-mcp-plugin/benchmarks/embedding-quality-dataset-axum.json",
+  "dataset_size": 34,
+  "ranking_cutoff": 10,
+  "metric_labels": {
+    "mrr": "MRR@10",
+    "acc1": "Acc@1",
+    "acc3": "Acc@3",
+    "acc5": "Acc@5"
+  },
+  "methods": [
+    {
+      "method": "semantic_search",
+      "mrr": 0.19215686274509802,
+      "acc1": 0.14705882352941177,
+      "acc3": 0.23529411764705882,
+      "acc5": 0.2647058823529412,
+      "avg_elapsed_ms": 239.88323529411764,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 1.0,
+          "acc1": 1.0,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 117.72
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.09743589743589744,
+          "acc1": 0.07692307692307693,
+          "acc3": 0.11538461538461539,
+          "acc5": 0.15384615384615385,
+          "avg_elapsed_ms": 274.43115384615385
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.3333333333333333,
+          "acc1": 0.16666666666666666,
+          "acc3": 0.5,
+          "acc5": 0.5,
+          "avg_elapsed_ms": 130.89666666666668
+        }
+      },
+      "rows": [
+        {
+          "query": "HTTP request router and main entry point",
+          "query_type": "natural_language",
+          "expected_symbol": "Router",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": null,
+          "elapsed_ms": 179.24,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "echo_app",
+            "file": "axum/extract/ws.rs"
+          }
+        },
+        {
+          "query": "trait for types that can become an HTTP response",
+          "query_type": "natural_language",
+          "expected_symbol": "IntoResponse",
+          "expected_file_suffix": "axum-core/response/into_response.rs",
+          "rank": null,
+          "elapsed_ms": 164.04,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "make_response",
+            "file": "axum/form.rs"
+          }
+        },
+        {
+          "query": "trait to extract data from an incoming request",
+          "query_type": "natural_language",
+          "expected_symbol": "FromRequest",
+          "expected_file_suffix": "axum-core/extract/mod.rs",
+          "rank": null,
+          "elapsed_ms": 195.59,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "extract",
+            "file": "axum-core/ext_traits/request.rs"
+          }
+        },
+        {
+          "query": "extract a subset of request parts without consuming the body",
+          "query_type": "natural_language",
+          "expected_symbol": "FromRequestParts",
+          "expected_file_suffix": "axum-core/extract/mod.rs",
+          "rank": null,
+          "elapsed_ms": 166.22,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "extract_parts",
+            "file": "axum-core/ext_traits/request.rs"
+          }
+        },
+        {
+          "query": "trait for request handlers",
+          "query_type": "natural_language",
+          "expected_symbol": "Handler",
+          "expected_file_suffix": "axum/handler/mod.rs",
+          "rank": null,
+          "elapsed_ms": 174.29,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "format_str_from_path",
+            "file": "axum-macros/typed_path.rs"
+          }
+        },
+        {
+          "query": "additional response parts that can be inserted",
+          "query_type": "natural_language",
+          "expected_symbol": "IntoResponseParts",
+          "expected_file_suffix": "axum-core/response/into_response_parts.rs",
+          "rank": null,
+          "elapsed_ms": 183.11,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "into_response_parts",
+            "file": "axum-core/response/mod.rs"
+          }
+        },
+        {
+          "query": "a JSON extractor and response body wrapper",
+          "query_type": "natural_language",
+          "expected_symbol": "Json",
+          "expected_file_suffix": "axum/json.rs",
+          "rank": null,
+          "elapsed_ms": 198.77,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "extract",
+            "file": "axum-core/ext_traits/request.rs"
+          }
+        },
+        {
+          "query": "method router for a single path with multiple verbs",
+          "query_type": "natural_language",
+          "expected_symbol": "MethodRouter",
+          "expected_file_suffix": "axum/routing/method_routing.rs",
+          "rank": null,
+          "elapsed_ms": 160.66,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "method_routing",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "URL path parameter extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "Path",
+          "expected_file_suffix": "axum/extract/path/mod.rs",
+          "rank": null,
+          "elapsed_ms": 175.16,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "check_extractor_count",
+            "file": "axum-macros/debug_handler.rs"
+          }
+        },
+        {
+          "query": "URL query string extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "Query",
+          "expected_file_suffix": "axum/extract/query.rs",
+          "rank": null,
+          "elapsed_ms": 187.91,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "from_extractor",
+            "file": "axum/middleware/from_extractor.rs"
+          }
+        },
+        {
+          "query": "shared application state extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "State",
+          "expected_file_suffix": "axum/extract/state.rs",
+          "rank": null,
+          "elapsed_ms": 178.06,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "from_extractor_with_state",
+            "file": "axum/middleware/from_extractor.rs"
+          }
+        },
+        {
+          "query": "form data extractor from the request body",
+          "query_type": "natural_language",
+          "expected_symbol": "Form",
+          "expected_file_suffix": "axum/form.rs",
+          "rank": null,
+          "elapsed_ms": 160.31,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "extract",
+            "file": "axum-core/ext_traits/request_parts.rs"
+          }
+        },
+        {
+          "query": "request scoped extension data",
+          "query_type": "natural_language",
+          "expected_symbol": "Extension",
+          "expected_file_suffix": "axum/extension.rs",
+          "rank": null,
+          "elapsed_ms": 161.65,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "status_header_array_extension_mixed_body",
+            "file": "axum/response/mod.rs"
+          }
+        },
+        {
+          "query": "multipart form data extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "Multipart",
+          "expected_file_suffix": "axum/extract/multipart.rs",
+          "rank": null,
+          "elapsed_ms": 231.96,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "test_from_extractor",
+            "file": "axum/middleware/from_extractor.rs"
+          }
+        },
+        {
+          "query": "websocket upgrade from an HTTP request",
+          "query_type": "natural_language",
+          "expected_symbol": "WebSocketUpgrade",
+          "expected_file_suffix": "axum/extract/ws.rs",
+          "rank": 3,
+          "elapsed_ms": 1578.54,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "on_upgrade",
+            "file": "axum/extract/ws.rs"
+          }
+        },
+        {
+          "query": "active websocket connection",
+          "query_type": "natural_language",
+          "expected_symbol": "WebSocket",
+          "expected_file_suffix": "axum/extract/ws.rs",
+          "rank": null,
+          "elapsed_ms": 407.89,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "on_failed_upgrade",
+            "file": "axum/extract/ws.rs"
+          }
+        },
+        {
+          "query": "HTTP redirect response helper",
+          "query_type": "natural_language",
+          "expected_symbol": "Redirect",
+          "expected_file_suffix": "axum/response/redirect.rs",
+          "rank": null,
+          "elapsed_ms": 510.76,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "redirect",
+            "file": "axum/response/mod.rs"
+          }
+        },
+        {
+          "query": "HTML response body wrapper",
+          "query_type": "natural_language",
+          "expected_symbol": "Html",
+          "expected_file_suffix": "axum/response/mod.rs",
+          "rank": null,
+          "elapsed_ms": 520.5,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "deserialize_body",
+            "file": "axum-extra/extract/json_deserializer.rs"
+          }
+        },
+        {
+          "query": "server sent events response stream",
+          "query_type": "natural_language",
+          "expected_symbol": "Sse",
+          "expected_file_suffix": "axum/response/sse.rs",
+          "rank": null,
+          "elapsed_ms": 194.92,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "serve",
+            "file": "axum/serve/mod.rs"
+          }
+        },
+        {
+          "query": "start an HTTP server bound to a listener",
+          "query_type": "natural_language",
+          "expected_symbol": "serve",
+          "expected_file_suffix": "axum/serve/mod.rs",
+          "rank": null,
+          "elapsed_ms": 199.79,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "listener",
+            "file": "axum/serve/mod.rs"
+          }
+        },
+        {
+          "query": "add a route to a specific path on the router",
+          "query_type": "natural_language",
+          "expected_symbol": "route",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 5,
+          "elapsed_ms": 206.32,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "path_router",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "mount another router under a path prefix",
+          "query_type": "natural_language",
+          "expected_symbol": "nest",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": null,
+          "elapsed_ms": 203.06,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "path_router",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "combine another router into this one",
+          "query_type": "natural_language",
+          "expected_symbol": "merge",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": null,
+          "elapsed_ms": 203.94,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "combine",
+            "file": "axum-macros/from_request/attr.rs"
+          }
+        },
+        {
+          "query": "catch all fallback handler for unmatched routes",
+          "query_type": "natural_language",
+          "expected_symbol": "fallback",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 1,
+          "elapsed_ms": 180.71,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "fallback",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "inject typed state into the router",
+          "query_type": "natural_language",
+          "expected_symbol": "with_state",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 1,
+          "elapsed_ms": 207.6,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "with_state",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "handle a route with a custom method filter",
+          "query_type": "natural_language",
+          "expected_symbol": "on",
+          "expected_file_suffix": "axum/routing/method_routing.rs",
+          "rank": null,
+          "elapsed_ms": 204.21,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "method_filter",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "json body",
+          "query_type": "short_phrase",
+          "expected_symbol": "Json",
+          "expected_file_suffix": "axum/json.rs",
+          "rank": null,
+          "elapsed_ms": 129.87,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "json",
+            "file": "axum/lib.rs"
+          }
+        },
+        {
+          "query": "method router",
+          "query_type": "short_phrase",
+          "expected_symbol": "MethodRouter",
+          "expected_file_suffix": "axum/routing/method_routing.rs",
+          "rank": 2,
+          "elapsed_ms": 131.13,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "method_routing",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "into response",
+          "query_type": "short_phrase",
+          "expected_symbol": "IntoResponse",
+          "expected_file_suffix": "axum-core/response/into_response.rs",
+          "rank": null,
+          "elapsed_ms": 136.73,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "into_response",
+            "file": "axum-core/response/into_response.rs"
+          }
+        },
+        {
+          "query": "websocket upgrade",
+          "query_type": "short_phrase",
+          "expected_symbol": "WebSocketUpgrade",
+          "expected_file_suffix": "axum/extract/ws.rs",
+          "rank": 2,
+          "elapsed_ms": 125.93,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "WEBSOCKET",
+            "file": "axum/extract/ws.rs"
+          }
+        },
+        {
+          "query": "serve listener",
+          "query_type": "short_phrase",
+          "expected_symbol": "serve",
+          "expected_file_suffix": "axum/serve/mod.rs",
+          "rank": null,
+          "elapsed_ms": 132.51,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "listener",
+            "file": "axum/serve/mod.rs"
+          }
+        },
+        {
+          "query": "path extractor",
+          "query_type": "short_phrase",
+          "expected_symbol": "Path",
+          "expected_file_suffix": "axum/extract/path/mod.rs",
+          "rank": 1,
+          "elapsed_ms": 129.21,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "Path",
+            "file": "axum/extract/path/mod.rs"
+          }
+        },
+        {
+          "query": "Router",
+          "query_type": "identifier",
+          "expected_symbol": "Router",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 1,
+          "elapsed_ms": 118.66,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "Router",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "IntoResponse",
+          "query_type": "identifier",
+          "expected_symbol": "IntoResponse",
+          "expected_file_suffix": "axum-core/response/into_response.rs",
+          "rank": 1,
+          "elapsed_ms": 116.78,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "IntoResponse",
+            "file": "axum-core/response/into_response.rs"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context_no_semantic",
+      "mrr": 0.21545390883626175,
+      "acc1": 0.14705882352941177,
+      "acc3": 0.23529411764705882,
+      "acc5": 0.29411764705882354,
+      "avg_elapsed_ms": 21.48941176470588,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 1.0,
+          "acc1": 1.0,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 16.02
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.13942307692307693,
+          "acc1": 0.07692307692307693,
+          "acc3": 0.19230769230769232,
+          "acc5": 0.23076923076923078,
+          "avg_elapsed_ms": 22.818076923076923
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.2834054834054834,
+          "acc1": 0.16666666666666666,
+          "acc3": 0.16666666666666666,
+          "acc5": 0.3333333333333333,
+          "avg_elapsed_ms": 17.555
+        }
+      },
+      "rows": [
+        {
+          "query": "HTTP request router and main entry point",
+          "query_type": "natural_language",
+          "expected_symbol": "Router",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": null,
+          "elapsed_ms": 22.95,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "_",
+            "file": "axum/handler/service.rs"
+          }
+        },
+        {
+          "query": "trait for types that can become an HTTP response",
+          "query_type": "natural_language",
+          "expected_symbol": "IntoResponse",
+          "expected_file_suffix": "axum-core/response/into_response.rs",
+          "rank": null,
+          "elapsed_ms": 21.09,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "from_http_method",
+            "file": "axum/routing/method_filter.rs"
+          }
+        },
+        {
+          "query": "trait to extract data from an incoming request",
+          "query_type": "natural_language",
+          "expected_symbol": "FromRequest",
+          "expected_file_suffix": "axum-core/extract/mod.rs",
+          "rank": null,
+          "elapsed_ms": 24.63,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "from_extractor",
+            "file": "axum/middleware/from_extractor.rs"
+          }
+        },
+        {
+          "query": "extract a subset of request parts without consuming the body",
+          "query_type": "natural_language",
+          "expected_symbol": "FromRequestParts",
+          "expected_file_suffix": "axum-core/extract/mod.rs",
+          "rank": null,
+          "elapsed_ms": 21.67,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "request_parts",
+            "file": "axum-core/extract/mod.rs"
+          }
+        },
+        {
+          "query": "trait for request handlers",
+          "query_type": "natural_language",
+          "expected_symbol": "Handler",
+          "expected_file_suffix": "axum/handler/mod.rs",
+          "rank": 24,
+          "elapsed_ms": 22.7,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "RequestPartsExt",
+            "file": "axum-core/ext_traits/request_parts.rs"
+          }
+        },
+        {
+          "query": "additional response parts that can be inserted",
+          "query_type": "natural_language",
+          "expected_symbol": "IntoResponseParts",
+          "expected_file_suffix": "axum-core/response/into_response_parts.rs",
+          "rank": 1,
+          "elapsed_ms": 22.39,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "IntoResponseParts",
+            "file": "axum-core/response/into_response_parts.rs"
+          }
+        },
+        {
+          "query": "a JSON extractor and response body wrapper",
+          "query_type": "natural_language",
+          "expected_symbol": "Json",
+          "expected_file_suffix": "axum/json.rs",
+          "rank": null,
+          "elapsed_ms": 25.79,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "consume_body_to_json_requires_json_content_type",
+            "file": "axum-extra/extract/json_deserializer.rs"
+          }
+        },
+        {
+          "query": "method router for a single path with multiple verbs",
+          "query_type": "natural_language",
+          "expected_symbol": "MethodRouter",
+          "expected_file_suffix": "axum/routing/method_routing.rs",
+          "rank": null,
+          "elapsed_ms": 21.77,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "can_extract_nested_matched_path_with_prefix_and_suffix_in_middleware_on_nested_router",
+            "file": "axum/extract/matched_path.rs"
+          }
+        },
+        {
+          "query": "URL path parameter extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "Path",
+          "expected_file_suffix": "axum/extract/path/mod.rs",
+          "rank": null,
+          "elapsed_ms": 23.86,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "two_path_extractors",
+            "file": "axum/extract/path/mod.rs"
+          }
+        },
+        {
+          "query": "URL query string extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "Query",
+          "expected_file_suffix": "axum/extract/query.rs",
+          "rank": null,
+          "elapsed_ms": 24.67,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "test_parse_seq_tuple_string_parse",
+            "file": "axum/extract/path/de.rs"
+          }
+        },
+        {
+          "query": "shared application state extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "State",
+          "expected_file_suffix": "axum/extract/state.rs",
+          "rank": null,
+          "elapsed_ms": 22.8,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "from_extractor_with_state",
+            "file": "axum/middleware/from_extractor.rs"
+          }
+        },
+        {
+          "query": "form data extractor from the request body",
+          "query_type": "natural_language",
+          "expected_symbol": "Form",
+          "expected_file_suffix": "axum/form.rs",
+          "rank": null,
+          "elapsed_ms": 20.97,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "works_with_request_body_limit",
+            "file": "axum/middleware/from_extractor.rs"
+          }
+        },
+        {
+          "query": "request scoped extension data",
+          "query_type": "natural_language",
+          "expected_symbol": "Extension",
+          "expected_file_suffix": "axum/extension.rs",
+          "rank": 3,
+          "elapsed_ms": 20.47,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "FromRequestContainerAttrs",
+            "file": "axum-macros/from_request/attr.rs"
+          }
+        },
+        {
+          "query": "multipart form data extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "Multipart",
+          "expected_file_suffix": "axum/extract/multipart.rs",
+          "rank": null,
+          "elapsed_ms": 22.5,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "multipart",
+            "file": "axum/test_helpers/test_client.rs"
+          }
+        },
+        {
+          "query": "websocket upgrade from an HTTP request",
+          "query_type": "natural_language",
+          "expected_symbol": "WebSocketUpgrade",
+          "expected_file_suffix": "axum/extract/ws.rs",
+          "rank": null,
+          "elapsed_ms": 23.56,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "from_http_method",
+            "file": "axum/routing/method_filter.rs"
+          }
+        },
+        {
+          "query": "active websocket connection",
+          "query_type": "natural_language",
+          "expected_symbol": "WebSocket",
+          "expected_file_suffix": "axum/extract/ws.rs",
+          "rank": 4,
+          "elapsed_ms": 18.26,
+          "candidate_count": 7,
+          "top_candidate": {
+            "name": "limit_connections",
+            "file": "axum/serve/listener.rs"
+          }
+        },
+        {
+          "query": "HTTP redirect response helper",
+          "query_type": "natural_language",
+          "expected_symbol": "Redirect",
+          "expected_file_suffix": "axum/response/redirect.rs",
+          "rank": null,
+          "elapsed_ms": 22.78,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "into_response",
+            "file": "axum/response/redirect.rs"
+          }
+        },
+        {
+          "query": "HTML response body wrapper",
+          "query_type": "natural_language",
+          "expected_symbol": "Html",
+          "expected_file_suffix": "axum/response/mod.rs",
+          "rank": null,
+          "elapsed_ms": 21.8,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "ResponseAxumBody",
+            "file": "axum/middleware/response_axum_body.rs"
+          }
+        },
+        {
+          "query": "server sent events response stream",
+          "query_type": "natural_language",
+          "expected_symbol": "Sse",
+          "expected_file_suffix": "axum/response/sse.rs",
+          "rank": null,
+          "elapsed_ms": 22.89,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "into_response",
+            "file": "axum-core/response/append_headers.rs"
+          }
+        },
+        {
+          "query": "start an HTTP server bound to a listener",
+          "query_type": "natural_language",
+          "expected_symbol": "serve",
+          "expected_file_suffix": "axum/serve/mod.rs",
+          "rank": null,
+          "elapsed_ms": 22.05,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "_",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "add a route to a specific path on the router",
+          "query_type": "natural_language",
+          "expected_symbol": "route",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 2,
+          "elapsed_ms": 24.99,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "path_for_nested_route",
+            "file": "axum/routing/path_router.rs"
+          }
+        },
+        {
+          "query": "mount another router under a path prefix",
+          "query_type": "natural_language",
+          "expected_symbol": "nest",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": null,
+          "elapsed_ms": 24.3,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "can_extract_nested_matched_path_with_prefix_and_suffix_in_middleware_on_nested_router",
+            "file": "axum/extract/matched_path.rs"
+          }
+        },
+        {
+          "query": "combine another router into this one",
+          "query_type": "natural_language",
+          "expected_symbol": "merge",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": null,
+          "elapsed_ms": 23.95,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "combine_unary_attribute",
+            "file": "axum-macros/attr_parsing.rs"
+          }
+        },
+        {
+          "query": "catch all fallback handler for unmatched routes",
+          "query_type": "natural_language",
+          "expected_symbol": "fallback",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 2,
+          "elapsed_ms": 22.29,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "_",
+            "file": "axum/handler/service.rs"
+          }
+        },
+        {
+          "query": "inject typed state into the router",
+          "query_type": "natural_language",
+          "expected_symbol": "with_state",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 1,
+          "elapsed_ms": 23.26,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "with_state",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "handle a route with a custom method filter",
+          "query_type": "natural_language",
+          "expected_symbol": "on",
+          "expected_file_suffix": "axum/routing/method_routing.rs",
+          "rank": null,
+          "elapsed_ms": 24.88,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "method_filter",
+            "file": "axum/routing/method_routing.rs"
+          }
+        },
+        {
+          "query": "json body",
+          "query_type": "short_phrase",
+          "expected_symbol": "Json",
+          "expected_file_suffix": "axum/json.rs",
+          "rank": 7,
+          "elapsed_ms": 18.05,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "consume_body_to_json_requires_json_content_type",
+            "file": "axum-extra/extract/json_deserializer.rs"
+          }
+        },
+        {
+          "query": "method router",
+          "query_type": "short_phrase",
+          "expected_symbol": "MethodRouter",
+          "expected_file_suffix": "axum/routing/method_routing.rs",
+          "rank": 6,
+          "elapsed_ms": 17.53,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "building_complex_router",
+            "file": "axum/routing/method_routing.rs"
+          }
+        },
+        {
+          "query": "into response",
+          "query_type": "short_phrase",
+          "expected_symbol": "IntoResponse",
+          "expected_file_suffix": "axum-core/response/into_response.rs",
+          "rank": 20,
+          "elapsed_ms": 18.54,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "into_response",
+            "file": "axum-extra/response/erased_json.rs"
+          }
+        },
+        {
+          "query": "websocket upgrade",
+          "query_type": "short_phrase",
+          "expected_symbol": "WebSocketUpgrade",
+          "expected_file_suffix": "axum/extract/ws.rs",
+          "rank": 1,
+          "elapsed_ms": 16.27,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "WebSocketUpgrade",
+            "file": "axum/extract/ws.rs"
+          }
+        },
+        {
+          "query": "serve listener",
+          "query_type": "short_phrase",
+          "expected_symbol": "serve",
+          "expected_file_suffix": "axum/serve/mod.rs",
+          "rank": 4,
+          "elapsed_ms": 17.04,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "ListenerExt",
+            "file": "axum/serve/listener.rs"
+          }
+        },
+        {
+          "query": "path extractor",
+          "query_type": "short_phrase",
+          "expected_symbol": "Path",
+          "expected_file_suffix": "axum/extract/path/mod.rs",
+          "rank": 11,
+          "elapsed_ms": 17.9,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "two_path_extractors",
+            "file": "axum/extract/path/mod.rs"
+          }
+        },
+        {
+          "query": "Router",
+          "query_type": "identifier",
+          "expected_symbol": "Router",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 1,
+          "elapsed_ms": 16.59,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "Router",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "IntoResponse",
+          "query_type": "identifier",
+          "expected_symbol": "IntoResponse",
+          "expected_file_suffix": "axum-core/response/into_response.rs",
+          "rank": 1,
+          "elapsed_ms": 15.45,
+          "candidate_count": 5,
+          "top_candidate": {
+            "name": "IntoResponse",
+            "file": "axum-core/response/into_response.rs"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context",
+      "mrr": 0.28131469362960815,
+      "acc1": 0.17647058823529413,
+      "acc3": 0.2647058823529412,
+      "acc5": 0.4117647058823529,
+      "avg_elapsed_ms": 118.53911764705882,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 1.0,
+          "acc1": 1.0,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 15.98
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.20056536859256452,
+          "acc1": 0.11538461538461539,
+          "acc3": 0.15384615384615385,
+          "acc5": 0.3076923076923077,
+          "avg_elapsed_ms": 126.21153846153847
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.39166666666666666,
+          "acc1": 0.16666666666666666,
+          "acc3": 0.5,
+          "acc5": 0.6666666666666666,
+          "avg_elapsed_ms": 119.47833333333334
+        }
+      },
+      "rows": [
+        {
+          "query": "HTTP request router and main entry point",
+          "query_type": "natural_language",
+          "expected_symbol": "Router",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": null,
+          "elapsed_ms": 124.34,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "request_parts",
+            "file": "axum-core/ext_traits/mod.rs"
+          }
+        },
+        {
+          "query": "trait for types that can become an HTTP response",
+          "query_type": "natural_language",
+          "expected_symbol": "IntoResponse",
+          "expected_file_suffix": "axum-core/response/into_response.rs",
+          "rank": null,
+          "elapsed_ms": 120.69,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "response",
+            "file": "axum/lib.rs"
+          }
+        },
+        {
+          "query": "trait to extract data from an incoming request",
+          "query_type": "natural_language",
+          "expected_symbol": "FromRequest",
+          "expected_file_suffix": "axum-core/extract/mod.rs",
+          "rank": 8,
+          "elapsed_ms": 125.62,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "extract",
+            "file": "axum-core/ext_traits/request.rs"
+          }
+        },
+        {
+          "query": "extract a subset of request parts without consuming the body",
+          "query_type": "natural_language",
+          "expected_symbol": "FromRequestParts",
+          "expected_file_suffix": "axum-core/extract/mod.rs",
+          "rank": 21,
+          "elapsed_ms": 123.58,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "extract_parts",
+            "file": "axum-core/ext_traits/request.rs"
+          }
+        },
+        {
+          "query": "trait for request handlers",
+          "query_type": "natural_language",
+          "expected_symbol": "Handler",
+          "expected_file_suffix": "axum/handler/mod.rs",
+          "rank": 6,
+          "elapsed_ms": 122.48,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "handler",
+            "file": "axum/serve/mod.rs"
+          }
+        },
+        {
+          "query": "additional response parts that can be inserted",
+          "query_type": "natural_language",
+          "expected_symbol": "IntoResponseParts",
+          "expected_file_suffix": "axum-core/response/into_response_parts.rs",
+          "rank": 7,
+          "elapsed_ms": 122.91,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "into_response_parts",
+            "file": "axum-core/response/mod.rs"
+          }
+        },
+        {
+          "query": "a JSON extractor and response body wrapper",
+          "query_type": "natural_language",
+          "expected_symbol": "Json",
+          "expected_file_suffix": "axum/json.rs",
+          "rank": null,
+          "elapsed_ms": 126.08,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "extract",
+            "file": "axum-core/ext_traits/request_parts.rs"
+          }
+        },
+        {
+          "query": "method router for a single path with multiple verbs",
+          "query_type": "natural_language",
+          "expected_symbol": "MethodRouter",
+          "expected_file_suffix": "axum/routing/method_routing.rs",
+          "rank": 5,
+          "elapsed_ms": 121.37,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "method_routing",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "URL path parameter extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "Path",
+          "expected_file_suffix": "axum/extract/path/mod.rs",
+          "rank": 23,
+          "elapsed_ms": 123.57,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "url_params",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "URL query string extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "Query",
+          "expected_file_suffix": "axum/extract/query.rs",
+          "rank": null,
+          "elapsed_ms": 122.27,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "from_extractor",
+            "file": "axum/middleware/from_extractor.rs"
+          }
+        },
+        {
+          "query": "shared application state extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "State",
+          "expected_file_suffix": "axum/extract/state.rs",
+          "rank": 5,
+          "elapsed_ms": 121.89,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "from_extractor_with_state",
+            "file": "axum/middleware/from_extractor.rs"
+          }
+        },
+        {
+          "query": "form data extractor from the request body",
+          "query_type": "natural_language",
+          "expected_symbol": "Form",
+          "expected_file_suffix": "axum/form.rs",
+          "rank": null,
+          "elapsed_ms": 122.41,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "extract",
+            "file": "axum-core/ext_traits/request_parts.rs"
+          }
+        },
+        {
+          "query": "request scoped extension data",
+          "query_type": "natural_language",
+          "expected_symbol": "Extension",
+          "expected_file_suffix": "axum/extension.rs",
+          "rank": 4,
+          "elapsed_ms": 122.03,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "extension",
+            "file": "axum/lib.rs"
+          }
+        },
+        {
+          "query": "multipart form data extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "Multipart",
+          "expected_file_suffix": "axum/extract/multipart.rs",
+          "rank": 19,
+          "elapsed_ms": 125.28,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "extract",
+            "file": "axum-core/ext_traits/request_parts.rs"
+          }
+        },
+        {
+          "query": "websocket upgrade from an HTTP request",
+          "query_type": "natural_language",
+          "expected_symbol": "WebSocketUpgrade",
+          "expected_file_suffix": "axum/extract/ws.rs",
+          "rank": 3,
+          "elapsed_ms": 126.26,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "WEBSOCKET",
+            "file": "axum/extract/ws.rs"
+          }
+        },
+        {
+          "query": "active websocket connection",
+          "query_type": "natural_language",
+          "expected_symbol": "WebSocket",
+          "expected_file_suffix": "axum/extract/ws.rs",
+          "rank": 1,
+          "elapsed_ms": 120.82,
+          "candidate_count": 7,
+          "top_candidate": {
+            "name": "WebSocket",
+            "file": "axum/extract/ws.rs"
+          }
+        },
+        {
+          "query": "HTTP redirect response helper",
+          "query_type": "natural_language",
+          "expected_symbol": "Redirect",
+          "expected_file_suffix": "axum/response/redirect.rs",
+          "rank": 7,
+          "elapsed_ms": 164.98,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "redirect",
+            "file": "axum/response/mod.rs"
+          }
+        },
+        {
+          "query": "HTML response body wrapper",
+          "query_type": "natural_language",
+          "expected_symbol": "Html",
+          "expected_file_suffix": "axum/response/mod.rs",
+          "rank": null,
+          "elapsed_ms": 128.17,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "response_axum_body",
+            "file": "axum/middleware/mod.rs"
+          }
+        },
+        {
+          "query": "server sent events response stream",
+          "query_type": "natural_language",
+          "expected_symbol": "Sse",
+          "expected_file_suffix": "axum/response/sse.rs",
+          "rank": null,
+          "elapsed_ms": 127.46,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "Event",
+            "file": "axum/response/sse.rs"
+          }
+        },
+        {
+          "query": "start an HTTP server bound to a listener",
+          "query_type": "natural_language",
+          "expected_symbol": "serve",
+          "expected_file_suffix": "axum/serve/mod.rs",
+          "rank": 6,
+          "elapsed_ms": 125.57,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "listener",
+            "file": "axum/serve/mod.rs"
+          }
+        },
+        {
+          "query": "add a route to a specific path on the router",
+          "query_type": "natural_language",
+          "expected_symbol": "route",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 5,
+          "elapsed_ms": 126.8,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "path_router",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "mount another router under a path prefix",
+          "query_type": "natural_language",
+          "expected_symbol": "nest",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": null,
+          "elapsed_ms": 125.47,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "path_router",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "combine another router into this one",
+          "query_type": "natural_language",
+          "expected_symbol": "merge",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 13,
+          "elapsed_ms": 129.36,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "combine",
+            "file": "axum-macros/from_request/attr.rs"
+          }
+        },
+        {
+          "query": "catch all fallback handler for unmatched routes",
+          "query_type": "natural_language",
+          "expected_symbol": "fallback",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 1,
+          "elapsed_ms": 129.08,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "fallback",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "inject typed state into the router",
+          "query_type": "natural_language",
+          "expected_symbol": "with_state",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 1,
+          "elapsed_ms": 128.29,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "with_state",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "handle a route with a custom method filter",
+          "query_type": "natural_language",
+          "expected_symbol": "on",
+          "expected_file_suffix": "axum/routing/method_routing.rs",
+          "rank": 15,
+          "elapsed_ms": 124.72,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "method_filter",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "json body",
+          "query_type": "short_phrase",
+          "expected_symbol": "Json",
+          "expected_file_suffix": "axum/json.rs",
+          "rank": 10,
+          "elapsed_ms": 118.56,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "json",
+            "file": "axum/lib.rs"
+          }
+        },
+        {
+          "query": "method router",
+          "query_type": "short_phrase",
+          "expected_symbol": "MethodRouter",
+          "expected_file_suffix": "axum/routing/method_routing.rs",
+          "rank": 2,
+          "elapsed_ms": 121.29,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "method_routing",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "into response",
+          "query_type": "short_phrase",
+          "expected_symbol": "IntoResponse",
+          "expected_file_suffix": "axum-core/response/into_response.rs",
+          "rank": 20,
+          "elapsed_ms": 119.97,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "into_response",
+            "file": "axum-core/response/into_response.rs"
+          }
+        },
+        {
+          "query": "websocket upgrade",
+          "query_type": "short_phrase",
+          "expected_symbol": "WebSocketUpgrade",
+          "expected_file_suffix": "axum/extract/ws.rs",
+          "rank": 2,
+          "elapsed_ms": 118.49,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "WEBSOCKET",
+            "file": "axum/extract/ws.rs"
+          }
+        },
+        {
+          "query": "serve listener",
+          "query_type": "short_phrase",
+          "expected_symbol": "serve",
+          "expected_file_suffix": "axum/serve/mod.rs",
+          "rank": 5,
+          "elapsed_ms": 119.55,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "listener",
+            "file": "axum/serve/mod.rs"
+          }
+        },
+        {
+          "query": "path extractor",
+          "query_type": "short_phrase",
+          "expected_symbol": "Path",
+          "expected_file_suffix": "axum/extract/path/mod.rs",
+          "rank": 1,
+          "elapsed_ms": 119.01,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "Path",
+            "file": "axum/extract/path/mod.rs"
+          }
+        },
+        {
+          "query": "Router",
+          "query_type": "identifier",
+          "expected_symbol": "Router",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 1,
+          "elapsed_ms": 17.05,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "Router",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "IntoResponse",
+          "query_type": "identifier",
+          "expected_symbol": "IntoResponse",
+          "expected_file_suffix": "axum-core/response/into_response.rs",
+          "rank": 1,
+          "elapsed_ms": 14.91,
+          "candidate_count": 5,
+          "top_candidate": {
+            "name": "IntoResponse",
+            "file": "axum-core/response/into_response.rs"
+          }
+        }
+      ]
+    }
+  ],
+  "hybrid_uplift": {
+    "mrr_delta": 0.0658607847933464,
+    "acc1_delta": 0.02941176470588236,
+    "acc3_delta": 0.02941176470588236,
+    "acc5_delta": 0.11764705882352938
+  },
+  "hybrid_uplift_by_query_type": {
+    "identifier": {
+      "mrr_delta": 0.0,
+      "acc1_delta": 0.0,
+      "acc3_delta": 0.0,
+      "acc5_delta": 0.0
+    },
+    "natural_language": {
+      "mrr_delta": 0.06114229166948759,
+      "acc1_delta": 0.038461538461538464,
+      "acc3_delta": -0.038461538461538464,
+      "acc5_delta": 0.07692307692307693
+    },
+    "short_phrase": {
+      "mrr_delta": 0.10826118326118328,
+      "acc1_delta": 0.0,
+      "acc3_delta": 0.33333333333333337,
+      "acc5_delta": 0.3333333333333333
+    }
+  }
+}

--- a/benchmarks/embedding-quality-v1.6-phase3h-axum-baseline.json
+++ b/benchmarks/embedding-quality-v1.6-phase3h-axum-baseline.json
@@ -1,0 +1,1487 @@
+{
+  "project": "/tmp/axum-bench",
+  "benchmark_project": "/var/folders/z0/0tcbss795xsdp75jmr_t9_kh0000gn/T/codelens-embed-quality-yrz_9bqs/axum-bench",
+  "isolated_copy": true,
+  "binary": "/Users/bagjaeseog/codelens-mcp-plugin/target/release/codelens-mcp",
+  "embedding_model": "MiniLM-L12-CodeSearchNet-INT8",
+  "runtime_model": {
+    "model_dir": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch",
+    "model_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/model.onnx",
+    "config_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/config.json",
+    "sha256": "ef1d1e9cfa72e4929f5b9faea17d8704b23a2530aadebf0d464a4cc7750920b3",
+    "size_bytes": 34000281,
+    "num_hidden_layers": 12,
+    "hidden_size": 384
+  },
+  "dataset_path": "/Users/bagjaeseog/codelens-mcp-plugin/benchmarks/embedding-quality-dataset-axum.json",
+  "dataset_size": 34,
+  "ranking_cutoff": 10,
+  "metric_labels": {
+    "mrr": "MRR@10",
+    "acc1": "Acc@1",
+    "acc3": "Acc@3",
+    "acc5": "Acc@5"
+  },
+  "methods": [
+    {
+      "method": "semantic_search",
+      "mrr": 0.19215686274509802,
+      "acc1": 0.14705882352941177,
+      "acc3": 0.23529411764705882,
+      "acc5": 0.2647058823529412,
+      "avg_elapsed_ms": 248.44470588235296,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 1.0,
+          "acc1": 1.0,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 135.87
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.09743589743589744,
+          "acc1": 0.07692307692307693,
+          "acc3": 0.11538461538461539,
+          "acc5": 0.15384615384615385,
+          "avg_elapsed_ms": 280.8076923076923
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.3333333333333333,
+          "acc1": 0.16666666666666666,
+          "acc3": 0.5,
+          "acc5": 0.5,
+          "avg_elapsed_ms": 145.73
+        }
+      },
+      "rows": [
+        {
+          "query": "HTTP request router and main entry point",
+          "query_type": "natural_language",
+          "expected_symbol": "Router",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": null,
+          "elapsed_ms": 180.15,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "echo_app",
+            "file": "axum/extract/ws.rs"
+          }
+        },
+        {
+          "query": "trait for types that can become an HTTP response",
+          "query_type": "natural_language",
+          "expected_symbol": "IntoResponse",
+          "expected_file_suffix": "axum-core/response/into_response.rs",
+          "rank": null,
+          "elapsed_ms": 184.14,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "make_response",
+            "file": "axum/form.rs"
+          }
+        },
+        {
+          "query": "trait to extract data from an incoming request",
+          "query_type": "natural_language",
+          "expected_symbol": "FromRequest",
+          "expected_file_suffix": "axum-core/extract/mod.rs",
+          "rank": null,
+          "elapsed_ms": 226.08,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "extract",
+            "file": "axum-core/ext_traits/request.rs"
+          }
+        },
+        {
+          "query": "extract a subset of request parts without consuming the body",
+          "query_type": "natural_language",
+          "expected_symbol": "FromRequestParts",
+          "expected_file_suffix": "axum-core/extract/mod.rs",
+          "rank": null,
+          "elapsed_ms": 165.9,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "extract_parts",
+            "file": "axum-core/ext_traits/request.rs"
+          }
+        },
+        {
+          "query": "trait for request handlers",
+          "query_type": "natural_language",
+          "expected_symbol": "Handler",
+          "expected_file_suffix": "axum/handler/mod.rs",
+          "rank": null,
+          "elapsed_ms": 181.78,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "format_str_from_path",
+            "file": "axum-macros/typed_path.rs"
+          }
+        },
+        {
+          "query": "additional response parts that can be inserted",
+          "query_type": "natural_language",
+          "expected_symbol": "IntoResponseParts",
+          "expected_file_suffix": "axum-core/response/into_response_parts.rs",
+          "rank": null,
+          "elapsed_ms": 185.17,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "into_response_parts",
+            "file": "axum-core/response/mod.rs"
+          }
+        },
+        {
+          "query": "a JSON extractor and response body wrapper",
+          "query_type": "natural_language",
+          "expected_symbol": "Json",
+          "expected_file_suffix": "axum/json.rs",
+          "rank": null,
+          "elapsed_ms": 213.66,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "extract",
+            "file": "axum-core/ext_traits/request.rs"
+          }
+        },
+        {
+          "query": "method router for a single path with multiple verbs",
+          "query_type": "natural_language",
+          "expected_symbol": "MethodRouter",
+          "expected_file_suffix": "axum/routing/method_routing.rs",
+          "rank": null,
+          "elapsed_ms": 184.23,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "method_routing",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "URL path parameter extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "Path",
+          "expected_file_suffix": "axum/extract/path/mod.rs",
+          "rank": null,
+          "elapsed_ms": 185.56,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "check_extractor_count",
+            "file": "axum-macros/debug_handler.rs"
+          }
+        },
+        {
+          "query": "URL query string extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "Query",
+          "expected_file_suffix": "axum/extract/query.rs",
+          "rank": null,
+          "elapsed_ms": 189.42,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "from_extractor",
+            "file": "axum/middleware/from_extractor.rs"
+          }
+        },
+        {
+          "query": "shared application state extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "State",
+          "expected_file_suffix": "axum/extract/state.rs",
+          "rank": null,
+          "elapsed_ms": 176.34,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "from_extractor_with_state",
+            "file": "axum/middleware/from_extractor.rs"
+          }
+        },
+        {
+          "query": "form data extractor from the request body",
+          "query_type": "natural_language",
+          "expected_symbol": "Form",
+          "expected_file_suffix": "axum/form.rs",
+          "rank": null,
+          "elapsed_ms": 166.37,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "extract",
+            "file": "axum-core/ext_traits/request_parts.rs"
+          }
+        },
+        {
+          "query": "request scoped extension data",
+          "query_type": "natural_language",
+          "expected_symbol": "Extension",
+          "expected_file_suffix": "axum/extension.rs",
+          "rank": null,
+          "elapsed_ms": 183.95,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "status_header_array_extension_mixed_body",
+            "file": "axum/response/mod.rs"
+          }
+        },
+        {
+          "query": "multipart form data extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "Multipart",
+          "expected_file_suffix": "axum/extract/multipart.rs",
+          "rank": null,
+          "elapsed_ms": 199.85,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "test_from_extractor",
+            "file": "axum/middleware/from_extractor.rs"
+          }
+        },
+        {
+          "query": "websocket upgrade from an HTTP request",
+          "query_type": "natural_language",
+          "expected_symbol": "WebSocketUpgrade",
+          "expected_file_suffix": "axum/extract/ws.rs",
+          "rank": 3,
+          "elapsed_ms": 187.74,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "on_upgrade",
+            "file": "axum/extract/ws.rs"
+          }
+        },
+        {
+          "query": "active websocket connection",
+          "query_type": "natural_language",
+          "expected_symbol": "WebSocket",
+          "expected_file_suffix": "axum/extract/ws.rs",
+          "rank": null,
+          "elapsed_ms": 118.29,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "on_failed_upgrade",
+            "file": "axum/extract/ws.rs"
+          }
+        },
+        {
+          "query": "HTTP redirect response helper",
+          "query_type": "natural_language",
+          "expected_symbol": "Redirect",
+          "expected_file_suffix": "axum/response/redirect.rs",
+          "rank": null,
+          "elapsed_ms": 183.52,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "redirect",
+            "file": "axum/response/mod.rs"
+          }
+        },
+        {
+          "query": "HTML response body wrapper",
+          "query_type": "natural_language",
+          "expected_symbol": "Html",
+          "expected_file_suffix": "axum/response/mod.rs",
+          "rank": null,
+          "elapsed_ms": 312.87,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "deserialize_body",
+            "file": "axum-extra/extract/json_deserializer.rs"
+          }
+        },
+        {
+          "query": "server sent events response stream",
+          "query_type": "natural_language",
+          "expected_symbol": "Sse",
+          "expected_file_suffix": "axum/response/sse.rs",
+          "rank": null,
+          "elapsed_ms": 1518.2,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "serve",
+            "file": "axum/serve/mod.rs"
+          }
+        },
+        {
+          "query": "start an HTTP server bound to a listener",
+          "query_type": "natural_language",
+          "expected_symbol": "serve",
+          "expected_file_suffix": "axum/serve/mod.rs",
+          "rank": null,
+          "elapsed_ms": 458.36,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "listener",
+            "file": "axum/serve/mod.rs"
+          }
+        },
+        {
+          "query": "add a route to a specific path on the router",
+          "query_type": "natural_language",
+          "expected_symbol": "route",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 5,
+          "elapsed_ms": 551.59,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "path_router",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "mount another router under a path prefix",
+          "query_type": "natural_language",
+          "expected_symbol": "nest",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": null,
+          "elapsed_ms": 321.91,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "path_router",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "combine another router into this one",
+          "query_type": "natural_language",
+          "expected_symbol": "merge",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": null,
+          "elapsed_ms": 366.97,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "combine",
+            "file": "axum-macros/from_request/attr.rs"
+          }
+        },
+        {
+          "query": "catch all fallback handler for unmatched routes",
+          "query_type": "natural_language",
+          "expected_symbol": "fallback",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 1,
+          "elapsed_ms": 209.04,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "fallback",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "inject typed state into the router",
+          "query_type": "natural_language",
+          "expected_symbol": "with_state",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 1,
+          "elapsed_ms": 222.07,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "with_state",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "handle a route with a custom method filter",
+          "query_type": "natural_language",
+          "expected_symbol": "on",
+          "expected_file_suffix": "axum/routing/method_routing.rs",
+          "rank": null,
+          "elapsed_ms": 227.84,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "method_filter",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "json body",
+          "query_type": "short_phrase",
+          "expected_symbol": "Json",
+          "expected_file_suffix": "axum/json.rs",
+          "rank": null,
+          "elapsed_ms": 140.4,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "json",
+            "file": "axum/lib.rs"
+          }
+        },
+        {
+          "query": "method router",
+          "query_type": "short_phrase",
+          "expected_symbol": "MethodRouter",
+          "expected_file_suffix": "axum/routing/method_routing.rs",
+          "rank": 2,
+          "elapsed_ms": 151.24,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "method_routing",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "into response",
+          "query_type": "short_phrase",
+          "expected_symbol": "IntoResponse",
+          "expected_file_suffix": "axum-core/response/into_response.rs",
+          "rank": null,
+          "elapsed_ms": 135.56,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "into_response",
+            "file": "axum-core/response/into_response.rs"
+          }
+        },
+        {
+          "query": "websocket upgrade",
+          "query_type": "short_phrase",
+          "expected_symbol": "WebSocketUpgrade",
+          "expected_file_suffix": "axum/extract/ws.rs",
+          "rank": 2,
+          "elapsed_ms": 135.08,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "WEBSOCKET",
+            "file": "axum/extract/ws.rs"
+          }
+        },
+        {
+          "query": "serve listener",
+          "query_type": "short_phrase",
+          "expected_symbol": "serve",
+          "expected_file_suffix": "axum/serve/mod.rs",
+          "rank": null,
+          "elapsed_ms": 143.71,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "listener",
+            "file": "axum/serve/mod.rs"
+          }
+        },
+        {
+          "query": "path extractor",
+          "query_type": "short_phrase",
+          "expected_symbol": "Path",
+          "expected_file_suffix": "axum/extract/path/mod.rs",
+          "rank": 1,
+          "elapsed_ms": 168.39,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "Path",
+            "file": "axum/extract/path/mod.rs"
+          }
+        },
+        {
+          "query": "Router",
+          "query_type": "identifier",
+          "expected_symbol": "Router",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 1,
+          "elapsed_ms": 138.47,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "Router",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "IntoResponse",
+          "query_type": "identifier",
+          "expected_symbol": "IntoResponse",
+          "expected_file_suffix": "axum-core/response/into_response.rs",
+          "rank": 1,
+          "elapsed_ms": 133.27,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "IntoResponse",
+            "file": "axum-core/response/into_response.rs"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context_no_semantic",
+      "mrr": 0.20316399286987522,
+      "acc1": 0.14705882352941177,
+      "acc3": 0.20588235294117646,
+      "acc5": 0.29411764705882354,
+      "avg_elapsed_ms": 23.178235294117645,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 1.0,
+          "acc1": 1.0,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 22.3
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.125,
+          "acc1": 0.07692307692307693,
+          "acc3": 0.15384615384615385,
+          "acc5": 0.19230769230769232,
+          "avg_elapsed_ms": 24.012307692307694
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.27626262626262627,
+          "acc1": 0.16666666666666666,
+          "acc3": 0.16666666666666666,
+          "acc5": 0.5,
+          "avg_elapsed_ms": 19.856666666666666
+        }
+      },
+      "rows": [
+        {
+          "query": "HTTP request router and main entry point",
+          "query_type": "natural_language",
+          "expected_symbol": "Router",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": null,
+          "elapsed_ms": 26.18,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "_",
+            "file": "axum/handler/service.rs"
+          }
+        },
+        {
+          "query": "trait for types that can become an HTTP response",
+          "query_type": "natural_language",
+          "expected_symbol": "IntoResponse",
+          "expected_file_suffix": "axum-core/response/into_response.rs",
+          "rank": null,
+          "elapsed_ms": 25.03,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "from_http_method",
+            "file": "axum/routing/method_filter.rs"
+          }
+        },
+        {
+          "query": "trait to extract data from an incoming request",
+          "query_type": "natural_language",
+          "expected_symbol": "FromRequest",
+          "expected_file_suffix": "axum-core/extract/mod.rs",
+          "rank": null,
+          "elapsed_ms": 24.4,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "from_extractor",
+            "file": "axum/middleware/from_extractor.rs"
+          }
+        },
+        {
+          "query": "extract a subset of request parts without consuming the body",
+          "query_type": "natural_language",
+          "expected_symbol": "FromRequestParts",
+          "expected_file_suffix": "axum-core/extract/mod.rs",
+          "rank": null,
+          "elapsed_ms": 22.24,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "request_parts",
+            "file": "axum-core/extract/mod.rs"
+          }
+        },
+        {
+          "query": "trait for request handlers",
+          "query_type": "natural_language",
+          "expected_symbol": "Handler",
+          "expected_file_suffix": "axum/handler/mod.rs",
+          "rank": 24,
+          "elapsed_ms": 22.79,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "RequestPartsExt",
+            "file": "axum-core/ext_traits/request_parts.rs"
+          }
+        },
+        {
+          "query": "additional response parts that can be inserted",
+          "query_type": "natural_language",
+          "expected_symbol": "IntoResponseParts",
+          "expected_file_suffix": "axum-core/response/into_response_parts.rs",
+          "rank": 1,
+          "elapsed_ms": 23.42,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "IntoResponseParts",
+            "file": "axum-core/response/into_response_parts.rs"
+          }
+        },
+        {
+          "query": "a JSON extractor and response body wrapper",
+          "query_type": "natural_language",
+          "expected_symbol": "Json",
+          "expected_file_suffix": "axum/json.rs",
+          "rank": null,
+          "elapsed_ms": 27.16,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "consume_body_to_json_requires_json_content_type",
+            "file": "axum-extra/extract/json_deserializer.rs"
+          }
+        },
+        {
+          "query": "method router for a single path with multiple verbs",
+          "query_type": "natural_language",
+          "expected_symbol": "MethodRouter",
+          "expected_file_suffix": "axum/routing/method_routing.rs",
+          "rank": null,
+          "elapsed_ms": 22.12,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "can_extract_nested_matched_path_with_prefix_and_suffix_in_middleware_on_nested_router",
+            "file": "axum/extract/matched_path.rs"
+          }
+        },
+        {
+          "query": "URL path parameter extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "Path",
+          "expected_file_suffix": "axum/extract/path/mod.rs",
+          "rank": null,
+          "elapsed_ms": 25.61,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "two_path_extractors",
+            "file": "axum/extract/path/mod.rs"
+          }
+        },
+        {
+          "query": "URL query string extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "Query",
+          "expected_file_suffix": "axum/extract/query.rs",
+          "rank": null,
+          "elapsed_ms": 25.22,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "test_parse_seq_tuple_string_parse",
+            "file": "axum/extract/path/de.rs"
+          }
+        },
+        {
+          "query": "shared application state extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "State",
+          "expected_file_suffix": "axum/extract/state.rs",
+          "rank": null,
+          "elapsed_ms": 24.49,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "from_extractor_with_state",
+            "file": "axum/middleware/from_extractor.rs"
+          }
+        },
+        {
+          "query": "form data extractor from the request body",
+          "query_type": "natural_language",
+          "expected_symbol": "Form",
+          "expected_file_suffix": "axum/form.rs",
+          "rank": null,
+          "elapsed_ms": 24.03,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "from_extractor",
+            "file": "axum/middleware/from_extractor.rs"
+          }
+        },
+        {
+          "query": "request scoped extension data",
+          "query_type": "natural_language",
+          "expected_symbol": "Extension",
+          "expected_file_suffix": "axum/extension.rs",
+          "rank": 3,
+          "elapsed_ms": 23.47,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "FromRequestContainerAttrs",
+            "file": "axum-macros/from_request/attr.rs"
+          }
+        },
+        {
+          "query": "multipart form data extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "Multipart",
+          "expected_file_suffix": "axum/extract/multipart.rs",
+          "rank": null,
+          "elapsed_ms": 24.85,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "from_extractor",
+            "file": "axum/middleware/from_extractor.rs"
+          }
+        },
+        {
+          "query": "websocket upgrade from an HTTP request",
+          "query_type": "natural_language",
+          "expected_symbol": "WebSocketUpgrade",
+          "expected_file_suffix": "axum/extract/ws.rs",
+          "rank": null,
+          "elapsed_ms": 24.33,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "from_http_method",
+            "file": "axum/routing/method_filter.rs"
+          }
+        },
+        {
+          "query": "active websocket connection",
+          "query_type": "natural_language",
+          "expected_symbol": "WebSocket",
+          "expected_file_suffix": "axum/extract/ws.rs",
+          "rank": 4,
+          "elapsed_ms": 18.53,
+          "candidate_count": 7,
+          "top_candidate": {
+            "name": "limit_connections",
+            "file": "axum/serve/listener.rs"
+          }
+        },
+        {
+          "query": "HTTP redirect response helper",
+          "query_type": "natural_language",
+          "expected_symbol": "Redirect",
+          "expected_file_suffix": "axum/response/redirect.rs",
+          "rank": null,
+          "elapsed_ms": 23.06,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "into_response",
+            "file": "axum/response/redirect.rs"
+          }
+        },
+        {
+          "query": "HTML response body wrapper",
+          "query_type": "natural_language",
+          "expected_symbol": "Html",
+          "expected_file_suffix": "axum/response/mod.rs",
+          "rank": null,
+          "elapsed_ms": 21.37,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "ResponseAxumBody",
+            "file": "axum/middleware/response_axum_body.rs"
+          }
+        },
+        {
+          "query": "server sent events response stream",
+          "query_type": "natural_language",
+          "expected_symbol": "Sse",
+          "expected_file_suffix": "axum/response/sse.rs",
+          "rank": null,
+          "elapsed_ms": 24.24,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "into_response",
+            "file": "axum-core/response/append_headers.rs"
+          }
+        },
+        {
+          "query": "start an HTTP server bound to a listener",
+          "query_type": "natural_language",
+          "expected_symbol": "serve",
+          "expected_file_suffix": "axum/serve/mod.rs",
+          "rank": null,
+          "elapsed_ms": 22.86,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "_",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "add a route to a specific path on the router",
+          "query_type": "natural_language",
+          "expected_symbol": "route",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 8,
+          "elapsed_ms": 25.59,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "can_extract_nested_matched_path_in_middleware_on_nested_router",
+            "file": "axum/extract/matched_path.rs"
+          }
+        },
+        {
+          "query": "mount another router under a path prefix",
+          "query_type": "natural_language",
+          "expected_symbol": "nest",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": null,
+          "elapsed_ms": 25.28,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "can_extract_nested_matched_path_with_prefix_in_middleware_on_nested_router",
+            "file": "axum/extract/matched_path.rs"
+          }
+        },
+        {
+          "query": "combine another router into this one",
+          "query_type": "natural_language",
+          "expected_symbol": "merge",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": null,
+          "elapsed_ms": 24.62,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "combine_unary_attribute",
+            "file": "axum-macros/attr_parsing.rs"
+          }
+        },
+        {
+          "query": "catch all fallback handler for unmatched routes",
+          "query_type": "natural_language",
+          "expected_symbol": "fallback",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 2,
+          "elapsed_ms": 22.88,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "_",
+            "file": "axum/handler/service.rs"
+          }
+        },
+        {
+          "query": "inject typed state into the router",
+          "query_type": "natural_language",
+          "expected_symbol": "with_state",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 1,
+          "elapsed_ms": 25.54,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "with_state",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "handle a route with a custom method filter",
+          "query_type": "natural_language",
+          "expected_symbol": "on",
+          "expected_file_suffix": "axum/routing/method_routing.rs",
+          "rank": null,
+          "elapsed_ms": 25.01,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "method_filter",
+            "file": "axum/routing/method_routing.rs"
+          }
+        },
+        {
+          "query": "json body",
+          "query_type": "short_phrase",
+          "expected_symbol": "Json",
+          "expected_file_suffix": "axum/json.rs",
+          "rank": 15,
+          "elapsed_ms": 19.04,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "consume_body_to_json_requires_json_content_type",
+            "file": "axum-extra/extract/json_deserializer.rs"
+          }
+        },
+        {
+          "query": "method router",
+          "query_type": "short_phrase",
+          "expected_symbol": "MethodRouter",
+          "expected_file_suffix": "axum/routing/method_routing.rs",
+          "rank": 5,
+          "elapsed_ms": 18.77,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "_",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "into response",
+          "query_type": "short_phrase",
+          "expected_symbol": "IntoResponse",
+          "expected_file_suffix": "axum-core/response/into_response.rs",
+          "rank": 20,
+          "elapsed_ms": 17.38,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "into_response",
+            "file": "axum-extra/response/erased_json.rs"
+          }
+        },
+        {
+          "query": "websocket upgrade",
+          "query_type": "short_phrase",
+          "expected_symbol": "WebSocketUpgrade",
+          "expected_file_suffix": "axum/extract/ws.rs",
+          "rank": 1,
+          "elapsed_ms": 16.42,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "WebSocketUpgrade",
+            "file": "axum/extract/ws.rs"
+          }
+        },
+        {
+          "query": "serve listener",
+          "query_type": "short_phrase",
+          "expected_symbol": "serve",
+          "expected_file_suffix": "axum/serve/mod.rs",
+          "rank": 4,
+          "elapsed_ms": 18.29,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "ListenerExt",
+            "file": "axum/serve/listener.rs"
+          }
+        },
+        {
+          "query": "path extractor",
+          "query_type": "short_phrase",
+          "expected_symbol": "Path",
+          "expected_file_suffix": "axum/extract/path/mod.rs",
+          "rank": 11,
+          "elapsed_ms": 29.24,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "two_path_extractors",
+            "file": "axum/extract/path/mod.rs"
+          }
+        },
+        {
+          "query": "Router",
+          "query_type": "identifier",
+          "expected_symbol": "Router",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 1,
+          "elapsed_ms": 27.59,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "Router",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "IntoResponse",
+          "query_type": "identifier",
+          "expected_symbol": "IntoResponse",
+          "expected_file_suffix": "axum-core/response/into_response.rs",
+          "rank": 1,
+          "elapsed_ms": 17.01,
+          "candidate_count": 5,
+          "top_candidate": {
+            "name": "IntoResponse",
+            "file": "axum-core/response/into_response.rs"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context",
+      "mrr": 0.28078948354557454,
+      "acc1": 0.17647058823529413,
+      "acc3": 0.2647058823529412,
+      "acc5": 0.4117647058823529,
+      "avg_elapsed_ms": 123.80088235294119,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 1.0,
+          "acc1": 1.0,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 16.185000000000002
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.1998785554057513,
+          "acc1": 0.11538461538461539,
+          "acc3": 0.15384615384615385,
+          "acc5": 0.3076923076923077,
+          "avg_elapsed_ms": 132.96576923076924
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.39166666666666666,
+          "acc1": 0.16666666666666666,
+          "acc3": 0.5,
+          "acc5": 0.6666666666666666,
+          "avg_elapsed_ms": 119.95833333333333
+        }
+      },
+      "rows": [
+        {
+          "query": "HTTP request router and main entry point",
+          "query_type": "natural_language",
+          "expected_symbol": "Router",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": null,
+          "elapsed_ms": 129.4,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "request_parts",
+            "file": "axum-core/ext_traits/mod.rs"
+          }
+        },
+        {
+          "query": "trait for types that can become an HTTP response",
+          "query_type": "natural_language",
+          "expected_symbol": "IntoResponse",
+          "expected_file_suffix": "axum-core/response/into_response.rs",
+          "rank": null,
+          "elapsed_ms": 129.23,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "response",
+            "file": "axum/lib.rs"
+          }
+        },
+        {
+          "query": "trait to extract data from an incoming request",
+          "query_type": "natural_language",
+          "expected_symbol": "FromRequest",
+          "expected_file_suffix": "axum-core/extract/mod.rs",
+          "rank": 8,
+          "elapsed_ms": 130.83,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "extract",
+            "file": "axum-core/ext_traits/request.rs"
+          }
+        },
+        {
+          "query": "extract a subset of request parts without consuming the body",
+          "query_type": "natural_language",
+          "expected_symbol": "FromRequestParts",
+          "expected_file_suffix": "axum-core/extract/mod.rs",
+          "rank": 21,
+          "elapsed_ms": 133.38,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "extract_parts",
+            "file": "axum-core/ext_traits/request.rs"
+          }
+        },
+        {
+          "query": "trait for request handlers",
+          "query_type": "natural_language",
+          "expected_symbol": "Handler",
+          "expected_file_suffix": "axum/handler/mod.rs",
+          "rank": 6,
+          "elapsed_ms": 131.17,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "handler",
+            "file": "axum/serve/mod.rs"
+          }
+        },
+        {
+          "query": "additional response parts that can be inserted",
+          "query_type": "natural_language",
+          "expected_symbol": "IntoResponseParts",
+          "expected_file_suffix": "axum-core/response/into_response_parts.rs",
+          "rank": 7,
+          "elapsed_ms": 129.55,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "into_response_parts",
+            "file": "axum-core/response/mod.rs"
+          }
+        },
+        {
+          "query": "a JSON extractor and response body wrapper",
+          "query_type": "natural_language",
+          "expected_symbol": "Json",
+          "expected_file_suffix": "axum/json.rs",
+          "rank": null,
+          "elapsed_ms": 133.07,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "extract",
+            "file": "axum-core/ext_traits/request_parts.rs"
+          }
+        },
+        {
+          "query": "method router for a single path with multiple verbs",
+          "query_type": "natural_language",
+          "expected_symbol": "MethodRouter",
+          "expected_file_suffix": "axum/routing/method_routing.rs",
+          "rank": 5,
+          "elapsed_ms": 129.58,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "method_routing",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "URL path parameter extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "Path",
+          "expected_file_suffix": "axum/extract/path/mod.rs",
+          "rank": 23,
+          "elapsed_ms": 128.86,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "url_params",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "URL query string extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "Query",
+          "expected_file_suffix": "axum/extract/query.rs",
+          "rank": null,
+          "elapsed_ms": 169.18,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "from_extractor",
+            "file": "axum/middleware/from_extractor.rs"
+          }
+        },
+        {
+          "query": "shared application state extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "State",
+          "expected_file_suffix": "axum/extract/state.rs",
+          "rank": 5,
+          "elapsed_ms": 130.92,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "from_extractor_with_state",
+            "file": "axum/middleware/from_extractor.rs"
+          }
+        },
+        {
+          "query": "form data extractor from the request body",
+          "query_type": "natural_language",
+          "expected_symbol": "Form",
+          "expected_file_suffix": "axum/form.rs",
+          "rank": null,
+          "elapsed_ms": 126.74,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "extract",
+            "file": "axum-core/ext_traits/request_parts.rs"
+          }
+        },
+        {
+          "query": "request scoped extension data",
+          "query_type": "natural_language",
+          "expected_symbol": "Extension",
+          "expected_file_suffix": "axum/extension.rs",
+          "rank": 4,
+          "elapsed_ms": 130.01,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "extension",
+            "file": "axum/lib.rs"
+          }
+        },
+        {
+          "query": "multipart form data extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "Multipart",
+          "expected_file_suffix": "axum/extract/multipart.rs",
+          "rank": 19,
+          "elapsed_ms": 134.93,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "extract",
+            "file": "axum-core/ext_traits/request_parts.rs"
+          }
+        },
+        {
+          "query": "websocket upgrade from an HTTP request",
+          "query_type": "natural_language",
+          "expected_symbol": "WebSocketUpgrade",
+          "expected_file_suffix": "axum/extract/ws.rs",
+          "rank": 3,
+          "elapsed_ms": 135.34,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "WEBSOCKET",
+            "file": "axum/extract/ws.rs"
+          }
+        },
+        {
+          "query": "active websocket connection",
+          "query_type": "natural_language",
+          "expected_symbol": "WebSocket",
+          "expected_file_suffix": "axum/extract/ws.rs",
+          "rank": 1,
+          "elapsed_ms": 130.23,
+          "candidate_count": 7,
+          "top_candidate": {
+            "name": "WebSocket",
+            "file": "axum/extract/ws.rs"
+          }
+        },
+        {
+          "query": "HTTP redirect response helper",
+          "query_type": "natural_language",
+          "expected_symbol": "Redirect",
+          "expected_file_suffix": "axum/response/redirect.rs",
+          "rank": 8,
+          "elapsed_ms": 140.58,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "redirect",
+            "file": "axum/response/mod.rs"
+          }
+        },
+        {
+          "query": "HTML response body wrapper",
+          "query_type": "natural_language",
+          "expected_symbol": "Html",
+          "expected_file_suffix": "axum/response/mod.rs",
+          "rank": null,
+          "elapsed_ms": 133.47,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "response_axum_body",
+            "file": "axum/middleware/mod.rs"
+          }
+        },
+        {
+          "query": "server sent events response stream",
+          "query_type": "natural_language",
+          "expected_symbol": "Sse",
+          "expected_file_suffix": "axum/response/sse.rs",
+          "rank": null,
+          "elapsed_ms": 129.04,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "Event",
+            "file": "axum/response/sse.rs"
+          }
+        },
+        {
+          "query": "start an HTTP server bound to a listener",
+          "query_type": "natural_language",
+          "expected_symbol": "serve",
+          "expected_file_suffix": "axum/serve/mod.rs",
+          "rank": 6,
+          "elapsed_ms": 130.88,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "listener",
+            "file": "axum/serve/mod.rs"
+          }
+        },
+        {
+          "query": "add a route to a specific path on the router",
+          "query_type": "natural_language",
+          "expected_symbol": "route",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 5,
+          "elapsed_ms": 133.3,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "path_router",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "mount another router under a path prefix",
+          "query_type": "natural_language",
+          "expected_symbol": "nest",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": null,
+          "elapsed_ms": 133.77,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "path_router",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "combine another router into this one",
+          "query_type": "natural_language",
+          "expected_symbol": "merge",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 13,
+          "elapsed_ms": 132.5,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "combine",
+            "file": "axum-macros/from_request/attr.rs"
+          }
+        },
+        {
+          "query": "catch all fallback handler for unmatched routes",
+          "query_type": "natural_language",
+          "expected_symbol": "fallback",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 1,
+          "elapsed_ms": 128.61,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "fallback",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "inject typed state into the router",
+          "query_type": "natural_language",
+          "expected_symbol": "with_state",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 1,
+          "elapsed_ms": 130.15,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "with_state",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "handle a route with a custom method filter",
+          "query_type": "natural_language",
+          "expected_symbol": "on",
+          "expected_file_suffix": "axum/routing/method_routing.rs",
+          "rank": 15,
+          "elapsed_ms": 132.39,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "method_filter",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "json body",
+          "query_type": "short_phrase",
+          "expected_symbol": "Json",
+          "expected_file_suffix": "axum/json.rs",
+          "rank": 10,
+          "elapsed_ms": 120.64,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "json",
+            "file": "axum/lib.rs"
+          }
+        },
+        {
+          "query": "method router",
+          "query_type": "short_phrase",
+          "expected_symbol": "MethodRouter",
+          "expected_file_suffix": "axum/routing/method_routing.rs",
+          "rank": 2,
+          "elapsed_ms": 119.72,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "method_routing",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "into response",
+          "query_type": "short_phrase",
+          "expected_symbol": "IntoResponse",
+          "expected_file_suffix": "axum-core/response/into_response.rs",
+          "rank": 20,
+          "elapsed_ms": 120.38,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "into_response",
+            "file": "axum-core/response/into_response.rs"
+          }
+        },
+        {
+          "query": "websocket upgrade",
+          "query_type": "short_phrase",
+          "expected_symbol": "WebSocketUpgrade",
+          "expected_file_suffix": "axum/extract/ws.rs",
+          "rank": 2,
+          "elapsed_ms": 119.05,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "WEBSOCKET",
+            "file": "axum/extract/ws.rs"
+          }
+        },
+        {
+          "query": "serve listener",
+          "query_type": "short_phrase",
+          "expected_symbol": "serve",
+          "expected_file_suffix": "axum/serve/mod.rs",
+          "rank": 5,
+          "elapsed_ms": 118.79,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "listener",
+            "file": "axum/serve/mod.rs"
+          }
+        },
+        {
+          "query": "path extractor",
+          "query_type": "short_phrase",
+          "expected_symbol": "Path",
+          "expected_file_suffix": "axum/extract/path/mod.rs",
+          "rank": 1,
+          "elapsed_ms": 121.17,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "Path",
+            "file": "axum/extract/path/mod.rs"
+          }
+        },
+        {
+          "query": "Router",
+          "query_type": "identifier",
+          "expected_symbol": "Router",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 1,
+          "elapsed_ms": 16.41,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "Router",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "IntoResponse",
+          "query_type": "identifier",
+          "expected_symbol": "IntoResponse",
+          "expected_file_suffix": "axum-core/response/into_response.rs",
+          "rank": 1,
+          "elapsed_ms": 15.96,
+          "candidate_count": 5,
+          "top_candidate": {
+            "name": "IntoResponse",
+            "file": "axum-core/response/into_response.rs"
+          }
+        }
+      ]
+    }
+  ],
+  "hybrid_uplift": {
+    "mrr_delta": 0.07762549067569932,
+    "acc1_delta": 0.02941176470588236,
+    "acc3_delta": 0.05882352941176472,
+    "acc5_delta": 0.11764705882352938
+  },
+  "hybrid_uplift_by_query_type": {
+    "identifier": {
+      "mrr_delta": 0.0,
+      "acc1_delta": 0.0,
+      "acc3_delta": 0.0,
+      "acc5_delta": 0.0
+    },
+    "natural_language": {
+      "mrr_delta": 0.07487855540575131,
+      "acc1_delta": 0.038461538461538464,
+      "acc3_delta": 0.0,
+      "acc5_delta": 0.11538461538461539
+    },
+    "short_phrase": {
+      "mrr_delta": 0.1154040404040404,
+      "acc1_delta": 0.0,
+      "acc3_delta": 0.33333333333333337,
+      "acc5_delta": 0.16666666666666663
+    }
+  }
+}

--- a/benchmarks/embedding-quality-v1.6-phase3h-axum-stacked.json
+++ b/benchmarks/embedding-quality-v1.6-phase3h-axum-stacked.json
@@ -1,0 +1,1487 @@
+{
+  "project": "/tmp/axum-bench",
+  "benchmark_project": "/var/folders/z0/0tcbss795xsdp75jmr_t9_kh0000gn/T/codelens-embed-quality-u84_t77i/axum-bench",
+  "isolated_copy": true,
+  "binary": "/Users/bagjaeseog/codelens-mcp-plugin/target/release/codelens-mcp",
+  "embedding_model": "MiniLM-L12-CodeSearchNet-INT8",
+  "runtime_model": {
+    "model_dir": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch",
+    "model_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/model.onnx",
+    "config_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/config.json",
+    "sha256": "ef1d1e9cfa72e4929f5b9faea17d8704b23a2530aadebf0d464a4cc7750920b3",
+    "size_bytes": 34000281,
+    "num_hidden_layers": 12,
+    "hidden_size": 384
+  },
+  "dataset_path": "/Users/bagjaeseog/codelens-mcp-plugin/benchmarks/embedding-quality-dataset-axum.json",
+  "dataset_size": 34,
+  "ranking_cutoff": 10,
+  "metric_labels": {
+    "mrr": "MRR@10",
+    "acc1": "Acc@1",
+    "acc3": "Acc@3",
+    "acc5": "Acc@5"
+  },
+  "methods": [
+    {
+      "method": "semantic_search",
+      "mrr": 0.19215686274509802,
+      "acc1": 0.14705882352941177,
+      "acc3": 0.23529411764705882,
+      "acc5": 0.2647058823529412,
+      "avg_elapsed_ms": 166.9591176470588,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 1.0,
+          "acc1": 1.0,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 115.0
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.09743589743589744,
+          "acc1": 0.07692307692307693,
+          "acc3": 0.11538461538461539,
+          "acc5": 0.15384615384615385,
+          "avg_elapsed_ms": 180.7492307692308
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.3333333333333333,
+          "acc1": 0.16666666666666666,
+          "acc3": 0.5,
+          "acc5": 0.5,
+          "avg_elapsed_ms": 124.52166666666666
+        }
+      },
+      "rows": [
+        {
+          "query": "HTTP request router and main entry point",
+          "query_type": "natural_language",
+          "expected_symbol": "Router",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": null,
+          "elapsed_ms": 176.54,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "echo_app",
+            "file": "axum/extract/ws.rs"
+          }
+        },
+        {
+          "query": "trait for types that can become an HTTP response",
+          "query_type": "natural_language",
+          "expected_symbol": "IntoResponse",
+          "expected_file_suffix": "axum-core/response/into_response.rs",
+          "rank": null,
+          "elapsed_ms": 163.9,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "make_response",
+            "file": "axum/form.rs"
+          }
+        },
+        {
+          "query": "trait to extract data from an incoming request",
+          "query_type": "natural_language",
+          "expected_symbol": "FromRequest",
+          "expected_file_suffix": "axum-core/extract/mod.rs",
+          "rank": null,
+          "elapsed_ms": 200.95,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "extract",
+            "file": "axum-core/ext_traits/request.rs"
+          }
+        },
+        {
+          "query": "extract a subset of request parts without consuming the body",
+          "query_type": "natural_language",
+          "expected_symbol": "FromRequestParts",
+          "expected_file_suffix": "axum-core/extract/mod.rs",
+          "rank": null,
+          "elapsed_ms": 171.36,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "extract_parts",
+            "file": "axum-core/ext_traits/request.rs"
+          }
+        },
+        {
+          "query": "trait for request handlers",
+          "query_type": "natural_language",
+          "expected_symbol": "Handler",
+          "expected_file_suffix": "axum/handler/mod.rs",
+          "rank": null,
+          "elapsed_ms": 178.95,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "format_str_from_path",
+            "file": "axum-macros/typed_path.rs"
+          }
+        },
+        {
+          "query": "additional response parts that can be inserted",
+          "query_type": "natural_language",
+          "expected_symbol": "IntoResponseParts",
+          "expected_file_suffix": "axum-core/response/into_response_parts.rs",
+          "rank": null,
+          "elapsed_ms": 182.46,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "into_response_parts",
+            "file": "axum-core/response/mod.rs"
+          }
+        },
+        {
+          "query": "a JSON extractor and response body wrapper",
+          "query_type": "natural_language",
+          "expected_symbol": "Json",
+          "expected_file_suffix": "axum/json.rs",
+          "rank": null,
+          "elapsed_ms": 198.88,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "extract",
+            "file": "axum-core/ext_traits/request.rs"
+          }
+        },
+        {
+          "query": "method router for a single path with multiple verbs",
+          "query_type": "natural_language",
+          "expected_symbol": "MethodRouter",
+          "expected_file_suffix": "axum/routing/method_routing.rs",
+          "rank": null,
+          "elapsed_ms": 161.74,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "method_routing",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "URL path parameter extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "Path",
+          "expected_file_suffix": "axum/extract/path/mod.rs",
+          "rank": null,
+          "elapsed_ms": 177.84,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "check_extractor_count",
+            "file": "axum-macros/debug_handler.rs"
+          }
+        },
+        {
+          "query": "URL query string extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "Query",
+          "expected_file_suffix": "axum/extract/query.rs",
+          "rank": null,
+          "elapsed_ms": 195.64,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "from_extractor",
+            "file": "axum/middleware/from_extractor.rs"
+          }
+        },
+        {
+          "query": "shared application state extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "State",
+          "expected_file_suffix": "axum/extract/state.rs",
+          "rank": null,
+          "elapsed_ms": 185.61,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "from_extractor_with_state",
+            "file": "axum/middleware/from_extractor.rs"
+          }
+        },
+        {
+          "query": "form data extractor from the request body",
+          "query_type": "natural_language",
+          "expected_symbol": "Form",
+          "expected_file_suffix": "axum/form.rs",
+          "rank": null,
+          "elapsed_ms": 171.62,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "extract",
+            "file": "axum-core/ext_traits/request_parts.rs"
+          }
+        },
+        {
+          "query": "request scoped extension data",
+          "query_type": "natural_language",
+          "expected_symbol": "Extension",
+          "expected_file_suffix": "axum/extension.rs",
+          "rank": null,
+          "elapsed_ms": 171.05,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "status_header_array_extension_mixed_body",
+            "file": "axum/response/mod.rs"
+          }
+        },
+        {
+          "query": "multipart form data extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "Multipart",
+          "expected_file_suffix": "axum/extract/multipart.rs",
+          "rank": null,
+          "elapsed_ms": 180.69,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "test_from_extractor",
+            "file": "axum/middleware/from_extractor.rs"
+          }
+        },
+        {
+          "query": "websocket upgrade from an HTTP request",
+          "query_type": "natural_language",
+          "expected_symbol": "WebSocketUpgrade",
+          "expected_file_suffix": "axum/extract/ws.rs",
+          "rank": 3,
+          "elapsed_ms": 182.57,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "on_upgrade",
+            "file": "axum/extract/ws.rs"
+          }
+        },
+        {
+          "query": "active websocket connection",
+          "query_type": "natural_language",
+          "expected_symbol": "WebSocket",
+          "expected_file_suffix": "axum/extract/ws.rs",
+          "rank": null,
+          "elapsed_ms": 118.56,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "on_failed_upgrade",
+            "file": "axum/extract/ws.rs"
+          }
+        },
+        {
+          "query": "HTTP redirect response helper",
+          "query_type": "natural_language",
+          "expected_symbol": "Redirect",
+          "expected_file_suffix": "axum/response/redirect.rs",
+          "rank": null,
+          "elapsed_ms": 180.19,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "redirect",
+            "file": "axum/response/mod.rs"
+          }
+        },
+        {
+          "query": "HTML response body wrapper",
+          "query_type": "natural_language",
+          "expected_symbol": "Html",
+          "expected_file_suffix": "axum/response/mod.rs",
+          "rank": null,
+          "elapsed_ms": 164.43,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "deserialize_body",
+            "file": "axum-extra/extract/json_deserializer.rs"
+          }
+        },
+        {
+          "query": "server sent events response stream",
+          "query_type": "natural_language",
+          "expected_symbol": "Sse",
+          "expected_file_suffix": "axum/response/sse.rs",
+          "rank": null,
+          "elapsed_ms": 186.53,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "serve",
+            "file": "axum/serve/mod.rs"
+          }
+        },
+        {
+          "query": "start an HTTP server bound to a listener",
+          "query_type": "natural_language",
+          "expected_symbol": "serve",
+          "expected_file_suffix": "axum/serve/mod.rs",
+          "rank": null,
+          "elapsed_ms": 184.82,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "listener",
+            "file": "axum/serve/mod.rs"
+          }
+        },
+        {
+          "query": "add a route to a specific path on the router",
+          "query_type": "natural_language",
+          "expected_symbol": "route",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 5,
+          "elapsed_ms": 202.15,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "path_router",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "mount another router under a path prefix",
+          "query_type": "natural_language",
+          "expected_symbol": "nest",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": null,
+          "elapsed_ms": 199.83,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "path_router",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "combine another router into this one",
+          "query_type": "natural_language",
+          "expected_symbol": "merge",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": null,
+          "elapsed_ms": 197.46,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "combine",
+            "file": "axum-macros/from_request/attr.rs"
+          }
+        },
+        {
+          "query": "catch all fallback handler for unmatched routes",
+          "query_type": "natural_language",
+          "expected_symbol": "fallback",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 1,
+          "elapsed_ms": 177.29,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "fallback",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "inject typed state into the router",
+          "query_type": "natural_language",
+          "expected_symbol": "with_state",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 1,
+          "elapsed_ms": 194.61,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "with_state",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "handle a route with a custom method filter",
+          "query_type": "natural_language",
+          "expected_symbol": "on",
+          "expected_file_suffix": "axum/routing/method_routing.rs",
+          "rank": null,
+          "elapsed_ms": 193.81,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "method_filter",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "json body",
+          "query_type": "short_phrase",
+          "expected_symbol": "Json",
+          "expected_file_suffix": "axum/json.rs",
+          "rank": null,
+          "elapsed_ms": 125.2,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "json",
+            "file": "axum/lib.rs"
+          }
+        },
+        {
+          "query": "method router",
+          "query_type": "short_phrase",
+          "expected_symbol": "MethodRouter",
+          "expected_file_suffix": "axum/routing/method_routing.rs",
+          "rank": 2,
+          "elapsed_ms": 126.12,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "method_routing",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "into response",
+          "query_type": "short_phrase",
+          "expected_symbol": "IntoResponse",
+          "expected_file_suffix": "axum-core/response/into_response.rs",
+          "rank": null,
+          "elapsed_ms": 127.41,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "into_response",
+            "file": "axum-core/response/into_response.rs"
+          }
+        },
+        {
+          "query": "websocket upgrade",
+          "query_type": "short_phrase",
+          "expected_symbol": "WebSocketUpgrade",
+          "expected_file_suffix": "axum/extract/ws.rs",
+          "rank": 2,
+          "elapsed_ms": 117.1,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "WEBSOCKET",
+            "file": "axum/extract/ws.rs"
+          }
+        },
+        {
+          "query": "serve listener",
+          "query_type": "short_phrase",
+          "expected_symbol": "serve",
+          "expected_file_suffix": "axum/serve/mod.rs",
+          "rank": null,
+          "elapsed_ms": 123.89,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "listener",
+            "file": "axum/serve/mod.rs"
+          }
+        },
+        {
+          "query": "path extractor",
+          "query_type": "short_phrase",
+          "expected_symbol": "Path",
+          "expected_file_suffix": "axum/extract/path/mod.rs",
+          "rank": 1,
+          "elapsed_ms": 127.41,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "Path",
+            "file": "axum/extract/path/mod.rs"
+          }
+        },
+        {
+          "query": "Router",
+          "query_type": "identifier",
+          "expected_symbol": "Router",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 1,
+          "elapsed_ms": 114.53,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "Router",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "IntoResponse",
+          "query_type": "identifier",
+          "expected_symbol": "IntoResponse",
+          "expected_file_suffix": "axum-core/response/into_response.rs",
+          "rank": 1,
+          "elapsed_ms": 115.47,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "IntoResponse",
+            "file": "axum-core/response/into_response.rs"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context_no_semantic",
+      "mrr": 0.21545390883626175,
+      "acc1": 0.14705882352941177,
+      "acc3": 0.23529411764705882,
+      "acc5": 0.29411764705882354,
+      "avg_elapsed_ms": 20.960588235294118,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 1.0,
+          "acc1": 1.0,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 15.79
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.13942307692307693,
+          "acc1": 0.07692307692307693,
+          "acc3": 0.19230769230769232,
+          "acc5": 0.23076923076923078,
+          "avg_elapsed_ms": 22.161153846153848
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.2834054834054834,
+          "acc1": 0.16666666666666666,
+          "acc3": 0.16666666666666666,
+          "acc5": 0.3333333333333333,
+          "avg_elapsed_ms": 17.481666666666666
+        }
+      },
+      "rows": [
+        {
+          "query": "HTTP request router and main entry point",
+          "query_type": "natural_language",
+          "expected_symbol": "Router",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": null,
+          "elapsed_ms": 22.05,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "_",
+            "file": "axum/handler/service.rs"
+          }
+        },
+        {
+          "query": "trait for types that can become an HTTP response",
+          "query_type": "natural_language",
+          "expected_symbol": "IntoResponse",
+          "expected_file_suffix": "axum-core/response/into_response.rs",
+          "rank": null,
+          "elapsed_ms": 21.48,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "from_http_method",
+            "file": "axum/routing/method_filter.rs"
+          }
+        },
+        {
+          "query": "trait to extract data from an incoming request",
+          "query_type": "natural_language",
+          "expected_symbol": "FromRequest",
+          "expected_file_suffix": "axum-core/extract/mod.rs",
+          "rank": null,
+          "elapsed_ms": 23.37,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "from_extractor",
+            "file": "axum/middleware/from_extractor.rs"
+          }
+        },
+        {
+          "query": "extract a subset of request parts without consuming the body",
+          "query_type": "natural_language",
+          "expected_symbol": "FromRequestParts",
+          "expected_file_suffix": "axum-core/extract/mod.rs",
+          "rank": null,
+          "elapsed_ms": 21.55,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "request_parts",
+            "file": "axum-core/extract/mod.rs"
+          }
+        },
+        {
+          "query": "trait for request handlers",
+          "query_type": "natural_language",
+          "expected_symbol": "Handler",
+          "expected_file_suffix": "axum/handler/mod.rs",
+          "rank": 24,
+          "elapsed_ms": 21.95,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "RequestPartsExt",
+            "file": "axum-core/ext_traits/request_parts.rs"
+          }
+        },
+        {
+          "query": "additional response parts that can be inserted",
+          "query_type": "natural_language",
+          "expected_symbol": "IntoResponseParts",
+          "expected_file_suffix": "axum-core/response/into_response_parts.rs",
+          "rank": 1,
+          "elapsed_ms": 24.33,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "IntoResponseParts",
+            "file": "axum-core/response/into_response_parts.rs"
+          }
+        },
+        {
+          "query": "a JSON extractor and response body wrapper",
+          "query_type": "natural_language",
+          "expected_symbol": "Json",
+          "expected_file_suffix": "axum/json.rs",
+          "rank": null,
+          "elapsed_ms": 24.14,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "consume_body_to_json_requires_json_content_type",
+            "file": "axum-extra/extract/json_deserializer.rs"
+          }
+        },
+        {
+          "query": "method router for a single path with multiple verbs",
+          "query_type": "natural_language",
+          "expected_symbol": "MethodRouter",
+          "expected_file_suffix": "axum/routing/method_routing.rs",
+          "rank": null,
+          "elapsed_ms": 21.43,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "can_extract_nested_matched_path_with_prefix_and_suffix_in_middleware_on_nested_router",
+            "file": "axum/extract/matched_path.rs"
+          }
+        },
+        {
+          "query": "URL path parameter extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "Path",
+          "expected_file_suffix": "axum/extract/path/mod.rs",
+          "rank": null,
+          "elapsed_ms": 22.56,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "two_path_extractors",
+            "file": "axum/extract/path/mod.rs"
+          }
+        },
+        {
+          "query": "URL query string extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "Query",
+          "expected_file_suffix": "axum/extract/query.rs",
+          "rank": null,
+          "elapsed_ms": 22.68,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "test_parse_seq_tuple_string_parse",
+            "file": "axum/extract/path/de.rs"
+          }
+        },
+        {
+          "query": "shared application state extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "State",
+          "expected_file_suffix": "axum/extract/state.rs",
+          "rank": null,
+          "elapsed_ms": 22.04,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "from_extractor_with_state",
+            "file": "axum/middleware/from_extractor.rs"
+          }
+        },
+        {
+          "query": "form data extractor from the request body",
+          "query_type": "natural_language",
+          "expected_symbol": "Form",
+          "expected_file_suffix": "axum/form.rs",
+          "rank": null,
+          "elapsed_ms": 20.67,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "works_with_request_body_limit",
+            "file": "axum/middleware/from_extractor.rs"
+          }
+        },
+        {
+          "query": "request scoped extension data",
+          "query_type": "natural_language",
+          "expected_symbol": "Extension",
+          "expected_file_suffix": "axum/extension.rs",
+          "rank": 3,
+          "elapsed_ms": 20.01,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "FromRequestContainerAttrs",
+            "file": "axum-macros/from_request/attr.rs"
+          }
+        },
+        {
+          "query": "multipart form data extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "Multipart",
+          "expected_file_suffix": "axum/extract/multipart.rs",
+          "rank": null,
+          "elapsed_ms": 22.23,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "multipart",
+            "file": "axum/test_helpers/test_client.rs"
+          }
+        },
+        {
+          "query": "websocket upgrade from an HTTP request",
+          "query_type": "natural_language",
+          "expected_symbol": "WebSocketUpgrade",
+          "expected_file_suffix": "axum/extract/ws.rs",
+          "rank": null,
+          "elapsed_ms": 22.89,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "from_http_method",
+            "file": "axum/routing/method_filter.rs"
+          }
+        },
+        {
+          "query": "active websocket connection",
+          "query_type": "natural_language",
+          "expected_symbol": "WebSocket",
+          "expected_file_suffix": "axum/extract/ws.rs",
+          "rank": 4,
+          "elapsed_ms": 17.46,
+          "candidate_count": 7,
+          "top_candidate": {
+            "name": "limit_connections",
+            "file": "axum/serve/listener.rs"
+          }
+        },
+        {
+          "query": "HTTP redirect response helper",
+          "query_type": "natural_language",
+          "expected_symbol": "Redirect",
+          "expected_file_suffix": "axum/response/redirect.rs",
+          "rank": null,
+          "elapsed_ms": 21.26,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "into_response",
+            "file": "axum/response/redirect.rs"
+          }
+        },
+        {
+          "query": "HTML response body wrapper",
+          "query_type": "natural_language",
+          "expected_symbol": "Html",
+          "expected_file_suffix": "axum/response/mod.rs",
+          "rank": null,
+          "elapsed_ms": 20.18,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "ResponseAxumBody",
+            "file": "axum/middleware/response_axum_body.rs"
+          }
+        },
+        {
+          "query": "server sent events response stream",
+          "query_type": "natural_language",
+          "expected_symbol": "Sse",
+          "expected_file_suffix": "axum/response/sse.rs",
+          "rank": null,
+          "elapsed_ms": 22.43,
+          "candidate_count": 24,
+          "top_candidate": {
+            "name": "into_response",
+            "file": "axum-core/response/append_headers.rs"
+          }
+        },
+        {
+          "query": "start an HTTP server bound to a listener",
+          "query_type": "natural_language",
+          "expected_symbol": "serve",
+          "expected_file_suffix": "axum/serve/mod.rs",
+          "rank": null,
+          "elapsed_ms": 22.14,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "_",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "add a route to a specific path on the router",
+          "query_type": "natural_language",
+          "expected_symbol": "route",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 2,
+          "elapsed_ms": 24.5,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "path_for_nested_route",
+            "file": "axum/routing/path_router.rs"
+          }
+        },
+        {
+          "query": "mount another router under a path prefix",
+          "query_type": "natural_language",
+          "expected_symbol": "nest",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": null,
+          "elapsed_ms": 23.4,
+          "candidate_count": 22,
+          "top_candidate": {
+            "name": "can_extract_nested_matched_path_with_prefix_and_suffix_in_middleware_on_nested_router",
+            "file": "axum/extract/matched_path.rs"
+          }
+        },
+        {
+          "query": "combine another router into this one",
+          "query_type": "natural_language",
+          "expected_symbol": "merge",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": null,
+          "elapsed_ms": 23.2,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "combine_unary_attribute",
+            "file": "axum-macros/attr_parsing.rs"
+          }
+        },
+        {
+          "query": "catch all fallback handler for unmatched routes",
+          "query_type": "natural_language",
+          "expected_symbol": "fallback",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 2,
+          "elapsed_ms": 21.85,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "_",
+            "file": "axum/handler/service.rs"
+          }
+        },
+        {
+          "query": "inject typed state into the router",
+          "query_type": "natural_language",
+          "expected_symbol": "with_state",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 1,
+          "elapsed_ms": 23.39,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "with_state",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "handle a route with a custom method filter",
+          "query_type": "natural_language",
+          "expected_symbol": "on",
+          "expected_file_suffix": "axum/routing/method_routing.rs",
+          "rank": null,
+          "elapsed_ms": 23.0,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "method_filter",
+            "file": "axum/routing/method_routing.rs"
+          }
+        },
+        {
+          "query": "json body",
+          "query_type": "short_phrase",
+          "expected_symbol": "Json",
+          "expected_file_suffix": "axum/json.rs",
+          "rank": 7,
+          "elapsed_ms": 18.65,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "consume_body_to_json_requires_json_content_type",
+            "file": "axum-extra/extract/json_deserializer.rs"
+          }
+        },
+        {
+          "query": "method router",
+          "query_type": "short_phrase",
+          "expected_symbol": "MethodRouter",
+          "expected_file_suffix": "axum/routing/method_routing.rs",
+          "rank": 6,
+          "elapsed_ms": 16.87,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "building_complex_router",
+            "file": "axum/routing/method_routing.rs"
+          }
+        },
+        {
+          "query": "into response",
+          "query_type": "short_phrase",
+          "expected_symbol": "IntoResponse",
+          "expected_file_suffix": "axum-core/response/into_response.rs",
+          "rank": 20,
+          "elapsed_ms": 18.09,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "into_response",
+            "file": "axum-extra/response/erased_json.rs"
+          }
+        },
+        {
+          "query": "websocket upgrade",
+          "query_type": "short_phrase",
+          "expected_symbol": "WebSocketUpgrade",
+          "expected_file_suffix": "axum/extract/ws.rs",
+          "rank": 1,
+          "elapsed_ms": 16.58,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "WebSocketUpgrade",
+            "file": "axum/extract/ws.rs"
+          }
+        },
+        {
+          "query": "serve listener",
+          "query_type": "short_phrase",
+          "expected_symbol": "serve",
+          "expected_file_suffix": "axum/serve/mod.rs",
+          "rank": 4,
+          "elapsed_ms": 17.29,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "ListenerExt",
+            "file": "axum/serve/listener.rs"
+          }
+        },
+        {
+          "query": "path extractor",
+          "query_type": "short_phrase",
+          "expected_symbol": "Path",
+          "expected_file_suffix": "axum/extract/path/mod.rs",
+          "rank": 11,
+          "elapsed_ms": 17.41,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "two_path_extractors",
+            "file": "axum/extract/path/mod.rs"
+          }
+        },
+        {
+          "query": "Router",
+          "query_type": "identifier",
+          "expected_symbol": "Router",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 1,
+          "elapsed_ms": 16.2,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "Router",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "IntoResponse",
+          "query_type": "identifier",
+          "expected_symbol": "IntoResponse",
+          "expected_file_suffix": "axum-core/response/into_response.rs",
+          "rank": 1,
+          "elapsed_ms": 15.38,
+          "candidate_count": 5,
+          "top_candidate": {
+            "name": "IntoResponse",
+            "file": "axum-core/response/into_response.rs"
+          }
+        }
+      ]
+    },
+    {
+      "method": "get_ranked_context",
+      "mrr": 0.28131469362960815,
+      "acc1": 0.17647058823529413,
+      "acc3": 0.2647058823529412,
+      "acc5": 0.4117647058823529,
+      "avg_elapsed_ms": 116.87970588235294,
+      "by_query_type": {
+        "identifier": {
+          "count": 2,
+          "mrr": 1.0,
+          "acc1": 1.0,
+          "acc3": 1.0,
+          "acc5": 1.0,
+          "avg_elapsed_ms": 16.634999999999998
+        },
+        "natural_language": {
+          "count": 26,
+          "mrr": 0.20056536859256452,
+          "acc1": 0.11538461538461539,
+          "acc3": 0.15384615384615385,
+          "acc5": 0.3076923076923077,
+          "avg_elapsed_ms": 123.8296153846154
+        },
+        "short_phrase": {
+          "count": 6,
+          "mrr": 0.39166666666666666,
+          "acc1": 0.16666666666666666,
+          "acc3": 0.5,
+          "acc5": 0.6666666666666666,
+          "avg_elapsed_ms": 120.17833333333334
+        }
+      },
+      "rows": [
+        {
+          "query": "HTTP request router and main entry point",
+          "query_type": "natural_language",
+          "expected_symbol": "Router",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": null,
+          "elapsed_ms": 121.62,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "request_parts",
+            "file": "axum-core/ext_traits/mod.rs"
+          }
+        },
+        {
+          "query": "trait for types that can become an HTTP response",
+          "query_type": "natural_language",
+          "expected_symbol": "IntoResponse",
+          "expected_file_suffix": "axum-core/response/into_response.rs",
+          "rank": null,
+          "elapsed_ms": 125.52,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "response",
+            "file": "axum/lib.rs"
+          }
+        },
+        {
+          "query": "trait to extract data from an incoming request",
+          "query_type": "natural_language",
+          "expected_symbol": "FromRequest",
+          "expected_file_suffix": "axum-core/extract/mod.rs",
+          "rank": 8,
+          "elapsed_ms": 123.79,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "extract",
+            "file": "axum-core/ext_traits/request.rs"
+          }
+        },
+        {
+          "query": "extract a subset of request parts without consuming the body",
+          "query_type": "natural_language",
+          "expected_symbol": "FromRequestParts",
+          "expected_file_suffix": "axum-core/extract/mod.rs",
+          "rank": 21,
+          "elapsed_ms": 122.74,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "extract_parts",
+            "file": "axum-core/ext_traits/request.rs"
+          }
+        },
+        {
+          "query": "trait for request handlers",
+          "query_type": "natural_language",
+          "expected_symbol": "Handler",
+          "expected_file_suffix": "axum/handler/mod.rs",
+          "rank": 6,
+          "elapsed_ms": 120.15,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "handler",
+            "file": "axum/serve/mod.rs"
+          }
+        },
+        {
+          "query": "additional response parts that can be inserted",
+          "query_type": "natural_language",
+          "expected_symbol": "IntoResponseParts",
+          "expected_file_suffix": "axum-core/response/into_response_parts.rs",
+          "rank": 7,
+          "elapsed_ms": 119.89,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "into_response_parts",
+            "file": "axum-core/response/mod.rs"
+          }
+        },
+        {
+          "query": "a JSON extractor and response body wrapper",
+          "query_type": "natural_language",
+          "expected_symbol": "Json",
+          "expected_file_suffix": "axum/json.rs",
+          "rank": null,
+          "elapsed_ms": 127.79,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "extract",
+            "file": "axum-core/ext_traits/request_parts.rs"
+          }
+        },
+        {
+          "query": "method router for a single path with multiple verbs",
+          "query_type": "natural_language",
+          "expected_symbol": "MethodRouter",
+          "expected_file_suffix": "axum/routing/method_routing.rs",
+          "rank": 5,
+          "elapsed_ms": 122.42,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "method_routing",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "URL path parameter extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "Path",
+          "expected_file_suffix": "axum/extract/path/mod.rs",
+          "rank": 23,
+          "elapsed_ms": 124.67,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "url_params",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "URL query string extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "Query",
+          "expected_file_suffix": "axum/extract/query.rs",
+          "rank": null,
+          "elapsed_ms": 121.61,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "from_extractor",
+            "file": "axum/middleware/from_extractor.rs"
+          }
+        },
+        {
+          "query": "shared application state extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "State",
+          "expected_file_suffix": "axum/extract/state.rs",
+          "rank": 5,
+          "elapsed_ms": 119.0,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "from_extractor_with_state",
+            "file": "axum/middleware/from_extractor.rs"
+          }
+        },
+        {
+          "query": "form data extractor from the request body",
+          "query_type": "natural_language",
+          "expected_symbol": "Form",
+          "expected_file_suffix": "axum/form.rs",
+          "rank": null,
+          "elapsed_ms": 118.08,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "extract",
+            "file": "axum-core/ext_traits/request_parts.rs"
+          }
+        },
+        {
+          "query": "request scoped extension data",
+          "query_type": "natural_language",
+          "expected_symbol": "Extension",
+          "expected_file_suffix": "axum/extension.rs",
+          "rank": 4,
+          "elapsed_ms": 115.67,
+          "candidate_count": 28,
+          "top_candidate": {
+            "name": "extension",
+            "file": "axum/lib.rs"
+          }
+        },
+        {
+          "query": "multipart form data extractor",
+          "query_type": "natural_language",
+          "expected_symbol": "Multipart",
+          "expected_file_suffix": "axum/extract/multipart.rs",
+          "rank": 19,
+          "elapsed_ms": 120.19,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "extract",
+            "file": "axum-core/ext_traits/request_parts.rs"
+          }
+        },
+        {
+          "query": "websocket upgrade from an HTTP request",
+          "query_type": "natural_language",
+          "expected_symbol": "WebSocketUpgrade",
+          "expected_file_suffix": "axum/extract/ws.rs",
+          "rank": 3,
+          "elapsed_ms": 120.97,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "WEBSOCKET",
+            "file": "axum/extract/ws.rs"
+          }
+        },
+        {
+          "query": "active websocket connection",
+          "query_type": "natural_language",
+          "expected_symbol": "WebSocket",
+          "expected_file_suffix": "axum/extract/ws.rs",
+          "rank": 1,
+          "elapsed_ms": 115.44,
+          "candidate_count": 7,
+          "top_candidate": {
+            "name": "WebSocket",
+            "file": "axum/extract/ws.rs"
+          }
+        },
+        {
+          "query": "HTTP redirect response helper",
+          "query_type": "natural_language",
+          "expected_symbol": "Redirect",
+          "expected_file_suffix": "axum/response/redirect.rs",
+          "rank": 7,
+          "elapsed_ms": 119.98,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "redirect",
+            "file": "axum/response/mod.rs"
+          }
+        },
+        {
+          "query": "HTML response body wrapper",
+          "query_type": "natural_language",
+          "expected_symbol": "Html",
+          "expected_file_suffix": "axum/response/mod.rs",
+          "rank": null,
+          "elapsed_ms": 120.12,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "response_axum_body",
+            "file": "axum/middleware/mod.rs"
+          }
+        },
+        {
+          "query": "server sent events response stream",
+          "query_type": "natural_language",
+          "expected_symbol": "Sse",
+          "expected_file_suffix": "axum/response/sse.rs",
+          "rank": null,
+          "elapsed_ms": 120.82,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "Event",
+            "file": "axum/response/sse.rs"
+          }
+        },
+        {
+          "query": "start an HTTP server bound to a listener",
+          "query_type": "natural_language",
+          "expected_symbol": "serve",
+          "expected_file_suffix": "axum/serve/mod.rs",
+          "rank": 6,
+          "elapsed_ms": 123.24,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "listener",
+            "file": "axum/serve/mod.rs"
+          }
+        },
+        {
+          "query": "add a route to a specific path on the router",
+          "query_type": "natural_language",
+          "expected_symbol": "route",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 5,
+          "elapsed_ms": 128.51,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "path_router",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "mount another router under a path prefix",
+          "query_type": "natural_language",
+          "expected_symbol": "nest",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": null,
+          "elapsed_ms": 123.13,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "path_router",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "combine another router into this one",
+          "query_type": "natural_language",
+          "expected_symbol": "merge",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 13,
+          "elapsed_ms": 154.5,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "combine",
+            "file": "axum-macros/from_request/attr.rs"
+          }
+        },
+        {
+          "query": "catch all fallback handler for unmatched routes",
+          "query_type": "natural_language",
+          "expected_symbol": "fallback",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 1,
+          "elapsed_ms": 126.19,
+          "candidate_count": 31,
+          "top_candidate": {
+            "name": "fallback",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "inject typed state into the router",
+          "query_type": "natural_language",
+          "expected_symbol": "with_state",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 1,
+          "elapsed_ms": 130.21,
+          "candidate_count": 32,
+          "top_candidate": {
+            "name": "with_state",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "handle a route with a custom method filter",
+          "query_type": "natural_language",
+          "expected_symbol": "on",
+          "expected_file_suffix": "axum/routing/method_routing.rs",
+          "rank": 15,
+          "elapsed_ms": 133.32,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "method_filter",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "json body",
+          "query_type": "short_phrase",
+          "expected_symbol": "Json",
+          "expected_file_suffix": "axum/json.rs",
+          "rank": 10,
+          "elapsed_ms": 122.29,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "json",
+            "file": "axum/lib.rs"
+          }
+        },
+        {
+          "query": "method router",
+          "query_type": "short_phrase",
+          "expected_symbol": "MethodRouter",
+          "expected_file_suffix": "axum/routing/method_routing.rs",
+          "rank": 2,
+          "elapsed_ms": 121.82,
+          "candidate_count": 29,
+          "top_candidate": {
+            "name": "method_routing",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "into response",
+          "query_type": "short_phrase",
+          "expected_symbol": "IntoResponse",
+          "expected_file_suffix": "axum-core/response/into_response.rs",
+          "rank": 20,
+          "elapsed_ms": 121.84,
+          "candidate_count": 27,
+          "top_candidate": {
+            "name": "into_response",
+            "file": "axum-core/response/into_response.rs"
+          }
+        },
+        {
+          "query": "websocket upgrade",
+          "query_type": "short_phrase",
+          "expected_symbol": "WebSocketUpgrade",
+          "expected_file_suffix": "axum/extract/ws.rs",
+          "rank": 2,
+          "elapsed_ms": 117.14,
+          "candidate_count": 10,
+          "top_candidate": {
+            "name": "WEBSOCKET",
+            "file": "axum/extract/ws.rs"
+          }
+        },
+        {
+          "query": "serve listener",
+          "query_type": "short_phrase",
+          "expected_symbol": "serve",
+          "expected_file_suffix": "axum/serve/mod.rs",
+          "rank": 5,
+          "elapsed_ms": 121.39,
+          "candidate_count": 30,
+          "top_candidate": {
+            "name": "listener",
+            "file": "axum/serve/mod.rs"
+          }
+        },
+        {
+          "query": "path extractor",
+          "query_type": "short_phrase",
+          "expected_symbol": "Path",
+          "expected_file_suffix": "axum/extract/path/mod.rs",
+          "rank": 1,
+          "elapsed_ms": 116.59,
+          "candidate_count": 26,
+          "top_candidate": {
+            "name": "Path",
+            "file": "axum/extract/path/mod.rs"
+          }
+        },
+        {
+          "query": "Router",
+          "query_type": "identifier",
+          "expected_symbol": "Router",
+          "expected_file_suffix": "axum/routing/mod.rs",
+          "rank": 1,
+          "elapsed_ms": 17.48,
+          "candidate_count": 25,
+          "top_candidate": {
+            "name": "Router",
+            "file": "axum/routing/mod.rs"
+          }
+        },
+        {
+          "query": "IntoResponse",
+          "query_type": "identifier",
+          "expected_symbol": "IntoResponse",
+          "expected_file_suffix": "axum-core/response/into_response.rs",
+          "rank": 1,
+          "elapsed_ms": 15.79,
+          "candidate_count": 5,
+          "top_candidate": {
+            "name": "IntoResponse",
+            "file": "axum-core/response/into_response.rs"
+          }
+        }
+      ]
+    }
+  ],
+  "hybrid_uplift": {
+    "mrr_delta": 0.0658607847933464,
+    "acc1_delta": 0.02941176470588236,
+    "acc3_delta": 0.02941176470588236,
+    "acc5_delta": 0.11764705882352938
+  },
+  "hybrid_uplift_by_query_type": {
+    "identifier": {
+      "mrr_delta": 0.0,
+      "acc1_delta": 0.0,
+      "acc3_delta": 0.0,
+      "acc5_delta": 0.0
+    },
+    "natural_language": {
+      "mrr_delta": 0.06114229166948759,
+      "acc1_delta": 0.038461538461538464,
+      "acc3_delta": -0.038461538461538464,
+      "acc5_delta": 0.07692307692307693
+    },
+    "short_phrase": {
+      "mrr_delta": 0.10826118326118328,
+      "acc1_delta": 0.0,
+      "acc3_delta": 0.33333333333333337,
+      "acc5_delta": 0.3333333333333333
+    }
+  }
+}

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -2170,6 +2170,157 @@ Policy C is the minimum-commitment choice that the table supports. It also has t
 
 None of these three change the §8.19 decision about the Phase 2m rollout. They all presuppose that the auto-gate split landed in PR #36 stays in place.
 
+### §8.20 — Phase 3h: Rust framework library on `tokio-rs/axum`
+
+**Hypothesis** (from §8.19 "What would change this decision"): Phase 2m's Policy B ("narrow Rust auto-on to tooling only") was deferred because every measured Rust dataset so far has been tooling / self-code — ripgrep (CLI tooling), 89-query self (CodeLens core), 436-query self (CodeLens augmented). If the Rust positive evidence is actually file-size-dependent rather than language-dependent (the same critique §8.16 / §8.17 applied to JS/TS), then a Rust _framework library_ with short-to-medium file sizes should look more like next-js / react-core than like ripgrep. Phase 3h tests that symmetrically.
+
+**Target repo**: `tokio-rs/axum` (depth-1 shallow clone). The measured subtree is a curated copy at `/tmp/axum-bench` that includes the four workspace crates most users point CodeLens at — `axum/src`, `axum-core/src`, `axum-extra/src`, `axum-macros/src` — with `examples/`, `benches/`, and `tests/` excluded. That leaves **109 source files** and **32 033 LOC**, median 201 LOC/file, max 1 723 LOC/file (`extract/ws.rs`). This is a deliberate size ladder check: next-js was a mega-framework at 1 564 files / 268 k LOC / median 61, react-core was a runtime slice at 30 files / 4 k LOC, and axum sits between them as a medium-file framework library.
+
+**Dataset**: 34 hand-built queries in `benchmarks/embedding-quality-dataset-axum.json`, keeping the §8.15 → §8.18 shape (26 NL + 6 short_phrase + 2 identifier) for direct comparison. Coverage spans the axum public API surface:
+
+| Area                | Example targets                                                                                                                  | Count |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ----: |
+| Core types / traits | `Router`, `IntoResponse`, `FromRequest`, `FromRequestParts`, `Handler`, `IntoResponseParts`, `Json`, `MethodRouter`              |     8 |
+| Extractors          | `Path`, `Query`, `State`, `Form`, `Extension`, `Multipart`, `WebSocketUpgrade`, `WebSocket`                                      |     8 |
+| Responses / serving | `Redirect`, `Html`, `Sse`, `serve`                                                                                               |     4 |
+| Router methods      | `route`, `nest`, `merge`, `fallback`, `with_state`, `on`                                                                         |     6 |
+| Short + identifier  | `json body`, `method router`, `into response`, `websocket upgrade`, `serve listener`, `path extractor`, `Router`, `IntoResponse` |     8 |
+
+**Measurement**:
+
+| arm         |   hybrid MRR | Δ abs vs baseline |      Δ rel | NL sub-MRR | short sub-MRR | identifier sub-MRR |
+| ----------- | -----------: | ----------------: | ---------: | ---------: | ------------: | -----------------: |
+| baseline    |     0.280789 |                 — |          — |   0.199912 |      0.391667 |           1.000000 |
+| 2e only     |     0.281315 |          +0.00053 | **+0.2 %** |   0.200591 |      0.391667 |           1.000000 |
+| 2b+2c only  |     0.280789 |           0.00000 |     +0.0 % |   0.199912 |      0.391667 |           1.000000 |
+| **stacked** | **0.281315** |      **+0.00053** | **+0.2 %** |   0.200591 |  **0.391667** |           1.000000 |
+
+**This is a marginally-positive result, dominated by noise**. The total absolute movement is `+0.00053` on 34 queries — a single rank-8 → rank-7 improvement on exactly one query (`Redirect` NL). Phase 2b+2c produces **exactly zero** hybrid movement at full float precision (`0.280789` identical in both arms), mirroring the §8.16 / §8.17 pattern on JS/TS apps. Phase 2e produces the same +0.00053 absolute lift both alone and stacked — which is also a single-rank-position change on the same query.
+
+**Per-query decomposition** (26 NL + 6 short + 2 identifier, stacked vs baseline):
+
+```
+NL queries (26 total): 1 improved, 0 regressed, 25 unchanged
+  Redirect  8 → 7  (Δ MRR +0.0179, the only non-zero contribution)
+
+short_phrase queries (6 total): 0 improved, 0 regressed (identical output)
+identifier queries (2 total, Router + IntoResponse): both rank-1 in every arm
+
+Total: 1 improved, 0 regressed, 33 unchanged.
+```
+
+**Baseline retrieval profile is surprisingly strong** — much stronger than the JS/TS app / runtime profile:
+
+| Dataset        | NL retrieval failures (None in all arms) | Top-10 hits (every arm) |
+| -------------- | ---------------------------------------: | ----------------------: |
+| react-core     |                                  22 / 26 |                  5 / 34 |
+| next-js        |                                  15 / 26 |                  7 / 34 |
+| **axum (new)** |                               **8 / 26** |             **20 / 34** |
+| typescript     |                                  20 / 26 |                  6 / 34 |
+
+So the baseline candidate pool on axum already contains the target for **59 %** of queries (vs next-js 21 %, react-core 15 %, typescript 18 %). The combine function is also doing real work: hybrid MRR (0.281) is meaningfully higher than semantic MRR (0.192) or lexical-only MRR (0.203), which is not what happened on next-js where hybrid 0.198 was _below_ lexical-only 0.229. Rust naming conventions + file organization + `pub fn` / `pub struct` directness are already handling most of the retrieval problem before Phase 2b/2c get a chance to help.
+
+**Three-dataset Rust 2e-only range**:
+
+| dataset                   | archetype         | median LOC | 2e-only Δ rel |
+| ------------------------- | ----------------- | ---------: | ------------: |
+| ripgrep external (§8.7)   | CLI tooling       |          ? |    **+6.2 %** |
+| 89-query self (§8.2)      | library / self    |          ? |        +1.2 % |
+| **axum external (§8.20)** | **framework lib** |    **201** |    **+0.2 %** |
+
+The gradient is monotonic: **the more "library / framework" (and the less "tooling / application binary") the codebase gets, the smaller the Phase 2e lift becomes**. This is the same direction JS/TS showed in §8.17 (react-core 0 %, next-js −0.8 %, jest +1.3 %, typescript −10.0 %), except Rust never crosses into negative territory. Rust's worst case in the measured corpus is `+0.0 %`, not `−10.0 %`.
+
+**Does this change the §8.19 Phase 2m decision?**
+
+No. The §8.19 "what would change this decision" criterion for Policy B ("narrow Rust auto-on to tooling only") was:
+
+> "A Rust application-style measurement (Phase 3h on `tokio-rs/axum`, `SergioBenitez/Rocket`, or a comparable non-tooling Rust framework) that lands Phase 2e as **non-positive** would reduce Rust's 2/2 streak to 2/3 and re-open Policy B as an evidence-backed option."
+
+axum is Rust, it is non-tooling, and Phase 2e is measured at **+0.2 %** — strictly positive, not non-positive. Rust's streak extends from 2/2 positive to **3/3 positive**. Policy B stays deferred because the evidence base for it still does not exist: no measured Rust corpus has yet produced a non-positive Phase 2e result.
+
+But the _expected benefit_ for end users has to narrow:
+
+- **Users with Rust tooling / CLI / compiler code** (cargo, ripgrep, rustc, rust-analyzer, bat, fd, tokei, helix, …) continue to see the original §8.7 / §8.12 win range of +1 % to +6 % on hybrid MRR.
+- **Users with Rust framework library code** (axum, actix-web, tower, tonic, …) will see near-zero benefit at the hybrid-MRR level. The mechanism is the same "baseline hybrid is already near-saturation" story from §8.16 / §8.17, just in a different language.
+- **Users with Rust application code** (tower-of-babel real web services, CLI apps built on these frameworks) remain unmeasured. Phase 3h addresses the Rust framework library slot; the Rust application slot is still open, but given the axum result it is now safe to _predict_ "probably near-zero, not large-negative".
+
+The marketing line narrows from "Phase 2m auto-on is positive on Rust" to "**Phase 2m auto-on ranges from neutral on Rust framework libraries to strongly positive on Rust tooling, with no measured negatives in any Rust regime**".
+
+**Updated ten-dataset baseline matrix** (full stacked arm vs baseline):
+
+| Dataset                        | Language / archetype         | baseline MRR | stacked MRR |      Δ abs |      Δ rel |
+| ------------------------------ | ---------------------------- | -----------: | ----------: | ---------: | ---------: |
+| 89-query self                  | Rust / self                  |        0.572 |       0.586 |     +0.014 |     +2.4 % |
+| 436-query self                 | Rust / self                  |       0.0476 |      0.0510 |    +0.0034 |     +7.1 % |
+| ripgrep external               | Rust / tooling               |        0.459 |       0.529 |     +0.070 |    +15.2 % |
+| requests external              | Python / app library         |        0.584 |       0.495 |     −0.089 |    −15.2 % |
+| django external                | Python / framework           |        0.294 |       0.288 |     −0.005 |     −1.8 % |
+| jest external                  | TS/JS / tooling              |        0.155 |       0.166 |     +0.011 |     +7.3 % |
+| typescript external            | TS/JS / compiler             |        0.098 |       0.201 |     +0.103 |   +104.3 % |
+| next-js external               | TS/JS / typical app          |        0.198 |       0.196 |     −0.002 |     −0.8 % |
+| react-core external            | TS/JS / short runtime        |        0.123 |       0.123 |     +0.000 |     +0.0 % |
+| **axum external (new, §8.20)** | **Rust / framework library** |    **0.281** |   **0.281** | **+0.001** | **+0.2 %** |
+
+Pattern: **6 positive / 2 inert / 2 negative**. Rust now contributes 3 positive + 1 near-zero, Python remains 0 positive / 2 negative, TS/JS remains bifurcated (2 positive tooling / 1 inert runtime / 1 small-negative app / 1 mega-positive compiler).
+
+**Reproduce**:
+
+```bash
+# Clone axum and materialize the bench subtree
+git clone --depth=1 https://github.com/tokio-rs/axum.git /tmp/axum
+mkdir -p /tmp/axum-bench
+rsync -a --delete --exclude '/target/' --exclude '/examples/' --exclude '**/tests/' --exclude '**/benches/' /tmp/axum/axum/src/ /tmp/axum-bench/axum/
+rsync -a --exclude 'tests/' --exclude 'benches/' /tmp/axum/axum-core/src/ /tmp/axum-bench/axum-core/
+rsync -a --exclude 'tests/' --exclude 'benches/' /tmp/axum/axum-extra/src/ /tmp/axum-bench/axum-extra/
+rsync -a --exclude 'tests/' /tmp/axum/axum-macros/src/ /tmp/axum-bench/axum-macros/
+
+# Arm 1: baseline
+CODELENS_MODEL_DIR=$(pwd)/crates/codelens-engine/models \
+CODELENS_BIN=./target/release/codelens-mcp \
+python3 benchmarks/embedding-quality.py /tmp/axum-bench --isolated-copy \
+  --dataset benchmarks/embedding-quality-dataset-axum.json \
+  --output benchmarks/embedding-quality-v1.6-phase3h-axum-baseline.json
+
+# Arm 2: Phase 2e only
+CODELENS_RANK_SPARSE_TERM_WEIGHT=1 \
+CODELENS_RANK_SPARSE_THRESHOLD=40 \
+CODELENS_RANK_SPARSE_MAX=40 \
+CODELENS_MODEL_DIR=$(pwd)/crates/codelens-engine/models \
+CODELENS_BIN=./target/release/codelens-mcp \
+python3 benchmarks/embedding-quality.py /tmp/axum-bench --isolated-copy \
+  --dataset benchmarks/embedding-quality-dataset-axum.json \
+  --output benchmarks/embedding-quality-v1.6-phase3h-axum-2e-only.json
+
+# Arm 3: Phase 2b + 2c only
+CODELENS_EMBED_HINT_INCLUDE_COMMENTS=1 \
+CODELENS_EMBED_HINT_INCLUDE_API_CALLS=1 \
+CODELENS_MODEL_DIR=$(pwd)/crates/codelens-engine/models \
+CODELENS_BIN=./target/release/codelens-mcp \
+python3 benchmarks/embedding-quality.py /tmp/axum-bench --isolated-copy \
+  --dataset benchmarks/embedding-quality-dataset-axum.json \
+  --output benchmarks/embedding-quality-v1.6-phase3h-axum-2b2c-only.json
+
+# Arm 4: stacked
+CODELENS_EMBED_HINT_INCLUDE_COMMENTS=1 \
+CODELENS_EMBED_HINT_INCLUDE_API_CALLS=1 \
+CODELENS_RANK_SPARSE_TERM_WEIGHT=1 \
+CODELENS_RANK_SPARSE_THRESHOLD=40 \
+CODELENS_RANK_SPARSE_MAX=40 \
+CODELENS_MODEL_DIR=$(pwd)/crates/codelens-engine/models \
+CODELENS_BIN=./target/release/codelens-mcp \
+python3 benchmarks/embedding-quality.py /tmp/axum-bench --isolated-copy \
+  --dataset benchmarks/embedding-quality-dataset-axum.json \
+  --output benchmarks/embedding-quality-v1.6-phase3h-axum-stacked.json
+```
+
+**Limitations acknowledged**:
+
+1. **axum is a framework library, not an application**. The §8.19 criterion called for "a Rust application-style measurement", and a framework library is the closest practical Rust analogue of Next.js (also a framework, not an app). A Rust end-user application measurement (a production web service built on axum, or a large CLI app built on clap) would be a cleaner fit for the "Rust app" slot, but the OSS Rust ecosystem is heavily biased toward libraries and tooling — pure application repos at the scale needed for a 34-query benchmark are rare.
+2. **Curated subtree excludes `examples/` and `tests/`**. Same methodology as §8.17 on react-core. A user who points CodeLens at the full axum checkout will see the examples/tests indexed, which would add some noise but is unlikely to change the Phase 2e / Phase 2b+2c sign.
+3. **Only one non-tooling Rust measurement so far**. `tokio` itself, `tower`, `tonic`, or `actix-web` would each add a second data point for the "Rust framework library" archetype. If any of them come out _non-positive_ on Phase 2e, §8.19 Policy B becomes evidence-backed. Deferred.
+
+**Artefacts**: `benchmarks/embedding-quality-v1.6-phase3h-axum-{baseline,2e-only,2b2c-only,stacked}.json`. Dataset: `benchmarks/embedding-quality-dataset-axum.json`.
+
 ---
 
 ## 9. See Also


### PR DESCRIPTION
## Summary

Adds §8.20: first **non-tooling** Rust external-repo measurement in the v1.6 campaign, directly addressing the §8.19 Policy B deferred decision.

**Target**: \`tokio-rs/axum\` curated subtree (`/tmp/axum-bench` with axum + axum-core + axum-extra + axum-macros, examples/tests/benches excluded) → **109 source files, 32 033 LOC, median 201 LOC/file**. First Rust external-repo benchmark whose file profile is "framework library" rather than CLI tooling or self-code.

**Dataset**: 34 queries (26 NL + 6 short + 2 identifier) covering axum's public API — Router/MethodRouter, IntoResponse/FromRequest/Handler traits, extractors (Path/Query/State/Form/Extension/Multipart/WebSocket), responses (Redirect/Html/Sse/serve), and Router methods (route/nest/merge/fallback/with_state/on).

## Result — marginally positive, noise-dominated

| arm        | hybrid MRR | Δ abs    | Δ rel  |
|------------|-----------:|---------:|-------:|
| baseline   |   0.280789 |        — |      — |
| 2e only    |   0.281315 | +0.00053 | +0.2 % |
| **2b+2c only** | **0.280789** | **0.00000** |  **+0.0 %** |
| stacked    |   0.281315 | +0.00053 | +0.2 % |

Phase 2b+2c produces **exactly zero** hybrid movement (full float precision identical to baseline). Phase 2e produces a single rank-8→rank-7 improvement on `Redirect` NL query — the sole non-zero contribution across all 34 queries.

Per-query: **1 improved, 0 regressed, 33 unchanged**.

## Rust 2e-only gradient across three archetypes

| dataset                | archetype        | 2e-only Δ rel |
|------------------------|------------------|--------------:|
| ripgrep external       | CLI tooling      |        **+6.2 %** |
| 89-query self          | library / self   |        +1.2 % |
| **axum external** (new) | **framework library** |    **+0.2 %** |

**Monotonic gradient**: more "library / framework", less "CLI tooling", the smaller the Phase 2e lift gets. Same direction as the §8.16 / §8.17 JS/TS finding — except **Rust never crosses into negative territory**. Rust's worst measured case is +0.0 %, not −10.0 %.

## Baseline retrieval is strong on Rust

Unlike next-js / react-core / typescript, axum's baseline candidate pool already contains the target for **59 %** of queries (20/34 top-10 hits). Rust naming conventions + `pub fn`/`pub struct` directness + file organization do most of the retrieval work before Phase 2b/2c get a chance to help.

| Dataset        | Top-10 hits (all arms) | NL retrieval failures |
|----------------|-----------------------:|----------------------:|
| react-core     |                5 / 34  |              22 / 26  |
| next-js        |                7 / 34  |              15 / 26  |
| typescript     |                6 / 34  |              20 / 26  |
| **axum (new)** |            **20 / 34** |            **8 / 26** |

## Phase 2m decision impact — none

§8.19 Policy B required a **non-positive** Rust app measurement. axum is +0.2 % — strictly positive, even if marginal. Rust's 2e-only streak extends 2/2 → **3/3 positive**. Policy B stays deferred.

**Expected user benefit narrows**:

- **Rust tooling / CLI / compiler** (cargo, ripgrep, rustc, rust-analyzer, bat, fd, tokei, helix): +1 % to +6 % (unchanged)
- **Rust framework libraries** (axum, actix-web, tower, tonic): **near-zero** (new bound)
- **Rust applications**: still unmeasured, but post-§8.20 safe to predict "near-zero, not large-negative"

Marketing line narrows from "Phase 2m auto-on is positive on Rust" to "**Phase 2m auto-on ranges from neutral on Rust framework libraries to strongly positive on Rust tooling, with no measured negatives in any Rust regime**".

## Updated ten-dataset baseline matrix

**6 positive / 2 inert / 2 negative**:

| Dataset                           | Lang / archetype         | baseline | stacked | Δ rel |
|-----------------------------------|--------------------------|---------:|--------:|------:|
| 89-query self                     | Rust / self              |    0.572 |   0.586 |  +2.4 % |
| 436-query self                    | Rust / self              |   0.0476 |  0.0510 |  +7.1 % |
| ripgrep external                  | Rust / tooling           |    0.459 |   0.529 | **+15.2 %** |
| requests external                 | Python / app lib         |    0.584 |   0.495 | **−15.2 %** |
| django external                   | Python / framework       |    0.294 |   0.288 |  −1.8 % |
| jest external                     | TS/JS / tooling          |    0.155 |   0.166 |  +7.3 % |
| typescript external               | TS/JS / compiler         |    0.098 |   0.201 | **+104.3 %** |
| next-js external                  | TS/JS / typical app      |    0.198 |   0.196 |  −0.8 % |
| react-core external               | TS/JS / short runtime    |    0.123 |   0.123 |  +0.0 % |
| **axum external** (new)           | **Rust / framework lib** |    0.281 |   0.281 |  **+0.2 %** |

## Scope

- **No code changes**. No dependency changes.
- Pure measurement update.
- \`language_supports_sparse_weighting\` classifier and Phase 2m auto-gate both unchanged.

## Test plan

- [x] 4 arms measured on curated axum-bench subtree with \`--isolated-copy\`, each after \`rm -rf .codelens\`
- [x] Per-query identity verified: baseline and 2b+2c-only identical at full float precision; 2e-only and stacked both show the single Redirect 8→7 improvement
- [x] All 34 expected file paths verified to exist under \`/tmp/axum-bench/\` before measurement

🤖 Generated with [Claude Code](https://claude.com/claude-code)