### PR TITLE
chore(bench): tighten phase3 matrix gate and no-semantic hygiene

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,13 @@ jobs:
             --markdown-output benchmarks/embedding-quality-summary.md | tee benchmarks/embedding-quality-ci.txt
           cat benchmarks/embedding-quality-summary.md >> "$GITHUB_STEP_SUMMARY"
 
+      - name: external phase3 matrix summary
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          python3 benchmarks/embedding-quality-matrix.py \
+            --require-datasets ripgrep,requests,jest,typescript,next-js,react-core,django,axum
+          cat benchmarks/embedding-quality-phase3-matrix.md >> "$GITHUB_STEP_SUMMARY"
+
       - name: upload benchmark artifacts
         if: matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v4
@@ -104,3 +111,5 @@ jobs:
             benchmarks/embedding-quality-results.json
             benchmarks/embedding-quality-ci.txt
             benchmarks/embedding-quality-summary.md
+            benchmarks/embedding-quality-phase3-matrix.json
+            benchmarks/embedding-quality-phase3-matrix.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@
 
 ```bash
 cargo check
-cargo test -p codelens-core
+cargo test -p codelens-engine
 cargo test -p codelens-mcp
 # Extended:
 cargo test -p codelens-mcp --features http

--- a/EVAL_CONTRACT.md
+++ b/EVAL_CONTRACT.md
@@ -3,7 +3,7 @@
 ## Local Stop-Hook Gate
 
 - `cargo check`
-- `cargo test -p codelens-core`
+- `cargo test -p codelens-engine`
 - `cargo test -p codelens-mcp`
 
 ## Local Extended Gate
@@ -19,7 +19,7 @@
 
 ## Build Workflow Gate
 
-- `cargo test -p codelens-core`
+- `cargo test -p codelens-engine`
 - `cargo test -p codelens-mcp -- --skip returns_lsp_diagnostics --skip returns_workspace_symbols --skip returns_rename_plan`
 - `cargo build --release`
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -143,13 +143,14 @@ python3 benchmarks/embedding-quality.py . \
 
 ```bash
 python3 benchmarks/embedding-quality-matrix.py \
-  --require-datasets ripgrep,requests,jest,typescript,next-js,react-core,django
+  --require-datasets ripgrep,requests,jest,typescript,next-js,react-core,django,axum
 ```
 
 - JSON 요약: `benchmarks/embedding-quality-phase3-matrix.json`
 - Markdown 요약: `benchmarks/embedding-quality-phase3-matrix.md`
-- 목적: ripgrep / requests / jest / typescript / next-js / react-core / django 외부 측정값을 수동 표 대신 artefact에서 직접 집계
-- completeness gate: `--require-datasets ...` 를 주면 dataset 누락/예상 외 slug가 있으면 즉시 실패
+- 목적: ripgrep / requests / jest / typescript / next-js / react-core / django / axum 같은 **registry에 등록된 landed external datasets**를 수동 표 대신 artefact에서 직접 집계
+- completeness gate: `--require-datasets ...` 를 주면 registry에 등록된 canonical dataset 누락 시 즉시 실패
+- exploratory phase artefact까지 포함해 보려면 `--include-unregistered` 추가
 
 리포트는 전체 평균 외에 질의 유형별 MRR / Acc@k와 hybrid uplift도 같이 보여준다.
 

--- a/benchmarks/embedding-quality-matrix.py
+++ b/benchmarks/embedding-quality-matrix.py
@@ -49,6 +49,11 @@ DATASET_REGISTRY = {
         "language": "Python",
         "archetype": "framework",
     },
+    "axum": {
+        "label": "axum external",
+        "language": "Rust",
+        "archetype": "framework library",
+    },
 }
 
 FILENAME_RE = re.compile(
@@ -83,6 +88,11 @@ def parse_args() -> argparse.Namespace:
         "--require-datasets",
         default="",
         help="Comma-separated dataset slugs that must appear in the aggregated matrix.",
+    )
+    parser.add_argument(
+        "--include-unregistered",
+        action="store_true",
+        help="Include phase reports whose dataset slug is not present in DATASET_REGISTRY.",
     )
     return parser.parse_args()
 
@@ -129,8 +139,10 @@ def build_matrix(
     flat_threshold_pct: float,
     strong_threshold_pct: float,
     report_glob: str,
+    include_unregistered: bool,
 ) -> dict:
     groups: dict[tuple[str, str, str], dict[str, dict]] = {}
+    skipped_unregistered: list[dict] = []
     for path in paths:
         match = FILENAME_RE.match(path.name)
         if not match:
@@ -138,6 +150,16 @@ def build_matrix(
         info = match.groupdict()
         report = load_report(path)
         slug = dataset_slug_from_path(report["raw"]["dataset_path"])
+        if slug not in DATASET_REGISTRY and not include_unregistered:
+            skipped_unregistered.append(
+                {
+                    "path": str(path),
+                    "dataset_slug": slug,
+                    "phase": info["phase"],
+                    "version": info["version"],
+                }
+            )
+            continue
         key = (info["version"], info["phase"], slug)
         groups.setdefault(key, {})
         groups[key][info["arm"]] = report
@@ -211,6 +233,8 @@ def build_matrix(
         "flat_relative_threshold_pct": flat_threshold_pct,
         "strong_relative_threshold_pct": strong_threshold_pct,
         "dataset_count": len(rows),
+        "include_unregistered": include_unregistered,
+        "skipped_unregistered": skipped_unregistered,
         "effect_counts": counts,
         "rows": rows,
     }
@@ -284,6 +308,7 @@ def main() -> None:
         flat_threshold_pct=args.flat_relative_threshold_pct,
         strong_threshold_pct=args.strong_relative_threshold_pct,
         report_glob=args.glob,
+        include_unregistered=args.include_unregistered,
     )
 
     if args.require_datasets.strip():

--- a/benchmarks/embedding-quality-phase3-matrix.json
+++ b/benchmarks/embedding-quality-phase3-matrix.json
@@ -1,13 +1,15 @@
 {
   "report_glob": "benchmarks/embedding-quality-v1.*-phase3*-*.json",
-  "source_report_count": 28,
+  "source_report_count": 32,
   "flat_relative_threshold_pct": 1.0,
   "strong_relative_threshold_pct": 5.0,
-  "dataset_count": 7,
+  "dataset_count": 8,
+  "include_unregistered": false,
+  "skipped_unregistered": [],
   "effect_counts": {
     "positive": 3,
     "negative": 2,
-    "flat": 2
+    "flat": 3
   },
   "rows": [
     {
@@ -401,6 +403,62 @@
       "delta_abs": -0.005228758169934622,
       "delta_rel_pct": -1.780445953085617,
       "effect_band": "mild negative"
+    },
+    {
+      "version": "v1.6",
+      "phase": "phase3h",
+      "dataset_slug": "axum",
+      "label": "axum external",
+      "language": "Rust",
+      "archetype": "framework library",
+      "dataset_path": "/Users/bagjaeseog/codelens-mcp-plugin/benchmarks/embedding-quality-dataset-axum.json",
+      "dataset_size": 34,
+      "runtime_model": {
+        "model_dir": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch",
+        "model_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/model.onnx",
+        "config_path": "/Users/bagjaeseog/codelens-mcp-plugin/crates/codelens-engine/models/codesearch/config.json",
+        "sha256": "ef1d1e9cfa72e4929f5b9faea17d8704b23a2530aadebf0d464a4cc7750920b3",
+        "size_bytes": 34000281,
+        "num_hidden_layers": 12,
+        "hidden_size": 384
+      },
+      "arms": {
+        "baseline": {
+          "path": "benchmarks/embedding-quality-v1.6-phase3h-axum-baseline.json",
+          "hybrid_mrr": 0.28078948354557454,
+          "hybrid_acc1": 0.17647058823529413,
+          "hybrid_acc3": 0.2647058823529412,
+          "semantic_mrr": 0.19215686274509802,
+          "lexical_mrr": 0.20316399286987522
+        },
+        "2e-only": {
+          "path": "benchmarks/embedding-quality-v1.6-phase3h-axum-2e-only.json",
+          "hybrid_mrr": 0.28131469362960815,
+          "hybrid_acc1": 0.17647058823529413,
+          "hybrid_acc3": 0.2647058823529412,
+          "semantic_mrr": 0.19215686274509802,
+          "lexical_mrr": 0.21545390883626175
+        },
+        "2b2c-only": {
+          "path": "benchmarks/embedding-quality-v1.6-phase3h-axum-2b2c-only.json",
+          "hybrid_mrr": 0.28078948354557454,
+          "hybrid_acc1": 0.17647058823529413,
+          "hybrid_acc3": 0.2647058823529412,
+          "semantic_mrr": 0.19215686274509802,
+          "lexical_mrr": 0.20316399286987522
+        },
+        "stacked": {
+          "path": "benchmarks/embedding-quality-v1.6-phase3h-axum-stacked.json",
+          "hybrid_mrr": 0.28131469362960815,
+          "hybrid_acc1": 0.17647058823529413,
+          "hybrid_acc3": 0.2647058823529412,
+          "semantic_mrr": 0.19215686274509802,
+          "lexical_mrr": 0.21545390883626175
+        }
+      },
+      "delta_abs": 0.0005252100840336116,
+      "delta_rel_pct": 0.18704763348032066,
+      "effect_band": "flat"
     }
   ]
 }

--- a/benchmarks/embedding-quality-phase3-matrix.md
+++ b/benchmarks/embedding-quality-phase3-matrix.md
@@ -1,6 +1,6 @@
 # External Embedding Quality Matrix
 
-- Datasets: 7 (`positive=3`, `negative=2`, `flat=2`)
+- Datasets: 8 (`positive=3`, `negative=2`, `flat=3`)
 - Flat band: relative delta under `1.0%`
 - Strong band: relative delta at or above `5.0%`
 
@@ -13,6 +13,7 @@
 | phase3e | next-js external | TS/JS / typical app | 0.198 | 0.196 | 0.198 | 0.196 | -0.002 | -0.8% | flat |
 | phase3f | react-core external | TS/JS / short runtime | 0.123 | 0.123 | 0.123 | 0.123 | 0.000 | +0.0% | flat |
 | phase3g | django external | Python / framework | 0.294 | 0.294 | 0.286 | 0.288 | -0.005 | -1.8% | mild negative |
+| phase3h | axum external | Rust / framework library | 0.281 | 0.281 | 0.281 | 0.281 | 0.001 | +0.2% | flat |
 
 ## Artefacts
 
@@ -51,4 +52,9 @@
   - `2e-only`: `benchmarks/embedding-quality-v1.6-phase3g-django-2e-only.json`
   - `2b2c-only`: `benchmarks/embedding-quality-v1.6-phase3g-django-2b2c-only.json`
   - `stacked`: `benchmarks/embedding-quality-v1.6-phase3g-django-stacked.json`
+- `phase3h` / `axum external`
+  - `baseline`: `benchmarks/embedding-quality-v1.6-phase3h-axum-baseline.json`
+  - `2e-only`: `benchmarks/embedding-quality-v1.6-phase3h-axum-2e-only.json`
+  - `2b2c-only`: `benchmarks/embedding-quality-v1.6-phase3h-axum-2b2c-only.json`
+  - `stacked`: `benchmarks/embedding-quality-v1.6-phase3h-axum-stacked.json`
 

--- a/crates/codelens-mcp/src/error.rs
+++ b/crates/codelens-mcp/src/error.rs
@@ -23,6 +23,7 @@ pub enum CodeLensError {
 
     // ── Capability errors ─────────────────────────────────────────────
     /// Feature not available (e.g., semantic search without embeddings).
+    #[cfg(feature = "semantic")]
     #[error("Feature unavailable: {0}")]
     FeatureUnavailable(String),
 
@@ -79,6 +80,7 @@ impl CodeLensError {
             Self::NotFound(_) => -32000,
             Self::Validation(_) => -32003,
             // Capability errors
+            #[cfg(feature = "semantic")]
             Self::FeatureUnavailable(_) => -32002,
             Self::LanguageUnsupported { .. } => -32002,
             Self::LspNotAttached(_) => -32001,

--- a/crates/codelens-mcp/src/integration_tests.rs
+++ b/crates/codelens-mcp/src/integration_tests.rs
@@ -1207,6 +1207,7 @@ fn onboard_project_uses_existing_embedding_index_without_loading_engine() {
     assert_eq!(payload["data"]["semantic"]["loaded"], json!(false));
 }
 
+#[cfg(feature = "semantic")]
 #[test]
 fn impact_report_surfaces_unavailable_semantic_status() {
     let project = project_root();
@@ -1246,13 +1247,22 @@ fn impact_report_surfaces_unavailable_semantic_status() {
         json!({"analysis_id": analysis_id, "section": "semantic_status"}),
     );
     assert_eq!(section["success"], json!(true));
-    assert_eq!(section["data"]["content"]["status"], json!("unavailable"));
+    #[cfg(feature = "semantic")]
+    let expected_status = "unavailable";
+    #[cfg(not(feature = "semantic"))]
+    let expected_status = "not_compiled";
+    assert_eq!(section["data"]["content"]["status"], json!(expected_status));
+    #[cfg(feature = "semantic")]
+    let expected_reason_fragment = "index_embeddings";
+    #[cfg(not(feature = "semantic"))]
+    let expected_reason_fragment = "not compiled";
     assert!(section["data"]["content"]["reason"]
         .as_str()
         .unwrap_or("")
-        .contains("index_embeddings"));
+        .contains(expected_reason_fragment));
 }
 
+#[cfg(feature = "semantic")]
 #[test]
 fn impact_report_uses_existing_embedding_index_for_semantic_status() {
     if !embedding_model_available_for_test() {
@@ -3021,6 +3031,7 @@ fn builder_minimal_mutation_behavior_unchanged() {
     assert_eq!(payload["success"], json!(true));
 }
 
+#[cfg(feature = "semantic")]
 #[test]
 fn replace_content_reindexes_existing_embedding_index_when_engine_is_not_loaded() {
     if !embedding_model_available_for_test() {

--- a/crates/codelens-mcp/src/tool_defs/output_schemas.rs
+++ b/crates/codelens-mcp/src/tool_defs/output_schemas.rs
@@ -92,6 +92,7 @@ pub(super) fn ranked_context_output_schema() -> serde_json::Value {
     })
 }
 
+#[cfg(feature = "semantic")]
 pub(super) fn semantic_search_output_schema() -> serde_json::Value {
     json!({
         "type": "object",
@@ -425,6 +426,7 @@ pub(super) fn add_import_output_schema() -> serde_json::Value {
     })
 }
 
+#[cfg(feature = "semantic")]
 pub(super) fn find_similar_code_output_schema() -> serde_json::Value {
     json!({
         "type": "object",
@@ -452,6 +454,7 @@ pub(super) fn find_similar_code_output_schema() -> serde_json::Value {
     })
 }
 
+#[cfg(feature = "semantic")]
 pub(super) fn find_code_duplicates_output_schema() -> serde_json::Value {
     json!({
         "type": "object",
@@ -477,6 +480,7 @@ pub(super) fn find_code_duplicates_output_schema() -> serde_json::Value {
     })
 }
 
+#[cfg(feature = "semantic")]
 pub(super) fn classify_symbol_output_schema() -> serde_json::Value {
     json!({
         "type": "object",
@@ -497,6 +501,7 @@ pub(super) fn classify_symbol_output_schema() -> serde_json::Value {
     })
 }
 
+#[cfg(feature = "semantic")]
 pub(super) fn find_misplaced_code_output_schema() -> serde_json::Value {
     json!({
         "type": "object",

--- a/crates/codelens-mcp/src/tools/session/metrics_config.rs
+++ b/crates/codelens-mcp/src/tools/session/metrics_config.rs
@@ -1,12 +1,14 @@
 use crate::protocol::BackendKind;
 use crate::session_metrics_payload::build_session_metrics_payload;
 use crate::tool_defs::{
-    default_budget_for_preset, default_budget_for_profile, is_tool_in_surface, ToolPreset,
-    ToolProfile, ToolSurface,
+    default_budget_for_preset, default_budget_for_profile, ToolPreset, ToolProfile, ToolSurface,
 };
 use crate::tool_runtime::{success_meta, ToolResult};
 use crate::AppState;
 use serde_json::json;
+
+#[cfg(feature = "semantic")]
+use crate::tool_defs::is_tool_in_surface;
 
 /// Return `true` when the given LSP binary is resolvable either via the
 /// daemon's inherited `PATH` (the `which` fast-path) or via a set of
@@ -81,18 +83,22 @@ pub(crate) enum SemanticSearchStatus {
     /// The `semantic_search` handler is reachable, either because the
     /// engine is already loaded in memory or because an on-disk index
     /// exists and the engine will be lazy-initialized on first call.
+    #[cfg(feature = "semantic")]
     Available,
     /// The bundled CodeSearchNet ONNX model file is missing or
     /// corrupt. User remediation: reinstall with a binary that ships
     /// the model, or set `CODELENS_MODEL_DIR`.
+    #[cfg(feature = "semantic")]
     ModelAssetsUnavailable,
     /// The active tool surface (preset or profile) does not include
     /// `semantic_search`. User remediation: switch profile via
     /// `set_profile` / `set_preset`, or use a client that activates a
     /// richer surface.
+    #[cfg(feature = "semantic")]
     NotInActiveSurface,
     /// The on-disk symbol index has no embedding rows yet. User
     /// remediation: call `index_embeddings` to build the index.
+    #[cfg(feature = "semantic")]
     IndexMissing,
     /// The binary was built without the `semantic` cargo feature.
     /// User remediation: rebuild with `cargo build --features semantic`.
@@ -112,13 +118,17 @@ pub(crate) enum SemanticSearchStatus {
 impl SemanticSearchStatus {
     pub(crate) fn reason_str(&self) -> Option<&'static str> {
         match self {
+            #[cfg(feature = "semantic")]
             Self::Available => None,
+            #[cfg(feature = "semantic")]
             Self::ModelAssetsUnavailable => Some(
                 "model assets unavailable — reinstall with bundled model or set CODELENS_MODEL_DIR",
             ),
+            #[cfg(feature = "semantic")]
             Self::NotInActiveSurface => Some(
                 "not in active surface — call set_profile/set_preset to include semantic_search",
             ),
+            #[cfg(feature = "semantic")]
             Self::IndexMissing => {
                 Some("index missing — call index_embeddings to build the embedding index")
             }
@@ -129,7 +139,14 @@ impl SemanticSearchStatus {
     }
 
     pub(crate) fn is_available(&self) -> bool {
-        matches!(self, Self::Available)
+        #[cfg(feature = "semantic")]
+        {
+            matches!(self, Self::Available)
+        }
+        #[cfg(not(feature = "semantic"))]
+        {
+            false
+        }
     }
 }
 
@@ -301,6 +318,7 @@ pub fn get_capabilities(state: &AppState, arguments: &serde_json::Value) -> Tool
     let semantic_status = determine_semantic_search_status(state, active_surface);
 
     let configured_embedding_model = codelens_engine::configured_embedding_model_name();
+    #[cfg(feature = "semantic")]
     let embedding_runtime = {
         let guard = state.embedding_ref();
         guard
@@ -308,6 +326,8 @@ pub fn get_capabilities(state: &AppState, arguments: &serde_json::Value) -> Tool
             .map(|engine| engine.runtime_info().clone())
             .unwrap_or_else(codelens_engine::configured_embedding_runtime_info)
     };
+    #[cfg(not(feature = "semantic"))]
+    let embedding_runtime = codelens_engine::configured_embedding_runtime_info();
 
     #[cfg(feature = "semantic")]
     let embedding_index_info = {
@@ -751,6 +771,7 @@ mod capability_reporting_tests {
     /// Phase 4a AC2/AC4: the `SemanticSearchStatus::reason_str`
     /// mapping must emit a distinct remediation message for each
     /// non-available variant, and `None` for `Available`.
+    #[cfg(feature = "semantic")]
     #[test]
     fn semantic_search_status_reason_strings_are_distinct() {
         assert_eq!(SemanticSearchStatus::Available.reason_str(), None);
@@ -783,6 +804,7 @@ mod capability_reporting_tests {
 
     /// Phase 4a AC3: `is_available` returns true only for
     /// `Available`.
+    #[cfg(feature = "semantic")]
     #[test]
     fn semantic_search_status_is_available_only_for_available_variant() {
         assert!(SemanticSearchStatus::Available.is_available());
@@ -795,6 +817,7 @@ mod capability_reporting_tests {
     /// Phase 4a AC4: both Codex profiles must now expose
     /// `semantic_search` and `index_embeddings`. This guards against
     /// accidental removal in future preset edits.
+    #[cfg(feature = "semantic")]
     #[test]
     fn planner_readonly_and_builder_minimal_expose_semantic_search() {
         use crate::tool_defs::{is_tool_in_surface, ToolProfile, ToolSurface};

--- a/crates/codelens-mcp/src/tools/session/project_ops.rs
+++ b/crates/codelens-mcp/src/tools/session/project_ops.rs
@@ -98,6 +98,11 @@ pub fn activate_project(state: &AppState, arguments: &serde_json::Value) -> Tool
         state.set_token_budget(auto_budget);
     }
 
+    #[cfg(feature = "semantic")]
+    let embedding_ready = state.embedding_ref().is_some();
+    #[cfg(not(feature = "semantic"))]
+    let embedding_ready = false;
+
     Ok((
         json!({
             "activated": true,
@@ -112,7 +117,7 @@ pub fn activate_project(state: &AppState, arguments: &serde_json::Value) -> Tool
             "auto_surface": auto_label,
             "auto_budget": auto_budget,
             "indexed_files": file_count,
-            "embedding_ready": state.embedding_ref().is_some()
+            "embedding_ready": embedding_ready
         }),
         success_meta(BackendKind::Session, 1.0),
     ))

--- a/crates/codelens-mcp/src/tools/symbols.rs
+++ b/crates/codelens-mcp/src/tools/symbols.rs
@@ -93,10 +93,12 @@ pub(crate) fn semantic_query_for_retrieval(query: &str) -> String {
     trimmed.to_owned()
 }
 
+#[cfg(feature = "semantic")]
 fn is_natural_language_semantic_query(query: &str) -> bool {
     query.split_whitespace().count() >= 4
 }
 
+#[cfg(feature = "semantic")]
 fn semantic_result_prior(query_lower: &str, result: &SemanticMatch) -> f64 {
     if !is_natural_language_semantic_query(query_lower) {
         return 0.0;
@@ -191,15 +193,18 @@ fn semantic_result_prior(query_lower: &str, result: &SemanticMatch) -> f64 {
     prior.clamp(-0.10_f64, 0.19_f64)
 }
 
+#[cfg(feature = "semantic")]
 fn semantic_adjusted_score_with_lower(query_lower: &str, result: &SemanticMatch) -> (f64, f64) {
     let prior = semantic_result_prior(query_lower, result);
     (prior, result.score + prior)
 }
 
+#[cfg(feature = "semantic")]
 pub(crate) fn semantic_adjusted_score_parts(query: &str, result: &SemanticMatch) -> (f64, f64) {
     semantic_adjusted_score_with_lower(&query.to_ascii_lowercase(), result)
 }
 
+#[cfg(feature = "semantic")]
 pub(crate) fn rerank_semantic_matches(
     query: &str,
     mut results: Vec<SemanticMatch>,
@@ -1119,11 +1124,13 @@ fn count_word_occurrences(line: &str, needle: &str) -> i32 {
 mod tests {
     use super::{
         annotate_ranked_context_provenance, merge_semantic_ranked_entries,
-        query_prefers_lexical_only, semantic_adjusted_score_parts, semantic_query_for_retrieval,
-        truncate_body_preview,
+        query_prefers_lexical_only, semantic_query_for_retrieval, truncate_body_preview,
     };
     use codelens_engine::{RankedContextEntry, RankedContextResult, SemanticMatch};
     use serde_json::json;
+
+    #[cfg(feature = "semantic")]
+    use super::semantic_adjusted_score_parts;
 
     #[test]
     fn identifier_queries_prefer_lexical_only() {
@@ -1275,6 +1282,7 @@ mod tests {
         assert!(!semantic.contains("run_stdio"));
     }
 
+    #[cfg(feature = "semantic")]
     #[test]
     fn semantic_adjusted_score_exposes_positive_prior_for_dispatch_entrypoint() {
         let match_ = SemanticMatch {
@@ -1295,6 +1303,7 @@ mod tests {
         assert!(adjusted > match_.score);
     }
 
+    #[cfg(feature = "semantic")]
     #[test]
     fn semantic_prior_is_bounded_for_high_bonus_entrypoints() {
         let match_ = SemanticMatch {

--- a/scripts/quality-gate.sh
+++ b/scripts/quality-gate.sh
@@ -90,12 +90,15 @@ RUN_PY_GATE=0
 RUN_HTTP_GATE=0
 RUN_CLIPPY_GATE=0
 RUN_RELEASE_GATE=0
+RUN_PHASE3_MATRIX_GATE=0
+PHASE3_REQUIRED_DATASETS="ripgrep,requests,jest,typescript,next-js,react-core,django,axum"
 
 if [[ "$MODE" == "ci" ]]; then
 	RUN_RUST_GATE=1
 	RUN_PY_GATE=1
 	RUN_CLIPPY_GATE=1
 	RUN_RELEASE_GATE=1
+	RUN_PHASE3_MATRIX_GATE=1
 elif [[ "$MODE" == "build" ]]; then
 	RUN_RUST_GATE=1
 	RUN_RELEASE_GATE=1
@@ -106,6 +109,14 @@ else
 
 	if matches_any "benchmarks/*.py" "benchmarks/**/*.py" "scripts/*.py"; then
 		RUN_PY_GATE=1
+	fi
+
+	if matches_any "benchmarks/embedding-quality-matrix.py" \
+		"benchmarks/embedding-quality-v1.*-phase3*.json" \
+		"benchmarks/embedding-quality-dataset-*.json" \
+		"benchmarks/README.md" \
+		"docs/benchmarks.md"; then
+		RUN_PHASE3_MATRIX_GATE=1
 	fi
 
 	if matches_any "crates/codelens-mcp/src/server/*" "crates/codelens-mcp/src/transport*" "crates/codelens-mcp/src/resources*" "crates/codelens-mcp/src/dispatch*" "crates/codelens-mcp/src/session*" "crates/codelens-mcp/src/*http*" "crates/codelens-mcp/src/*resource*" "crates/codelens-mcp/src/state.rs"; then
@@ -142,6 +153,16 @@ if [[ "$RUN_PY_GATE" -eq 1 ]]; then
 	fi
 fi
 
+if [[ "$RUN_PHASE3_MATRIX_GATE" -eq 1 ]]; then
+	if has_cmd python3; then
+		echo "[gate] validating external phase3 embedding matrix"
+		python3 benchmarks/embedding-quality-matrix.py \
+			--require-datasets "$PHASE3_REQUIRED_DATASETS" >/dev/null
+	else
+		echo "[gate] python3 not installed; skipping phase3 matrix gate."
+	fi
+fi
+
 if [[ "$RUN_RUST_GATE" -eq 1 ]]; then
 	if ! has_cmd cargo; then
 		echo "[gate] cargo not installed; cannot run Rust gate."
@@ -151,16 +172,16 @@ if [[ "$RUN_RUST_GATE" -eq 1 ]]; then
 	if [[ "$MODE" == "ci" ]]; then
 		echo "[gate] running CI Rust gate from EVAL_CONTRACT.md"
 		cargo check
-		cargo test -p codelens-core
+		cargo test -p codelens-engine
 		cargo test -p codelens-mcp
 	elif [[ "$MODE" == "build" ]]; then
 		echo "[gate] running build workflow Rust gate from EVAL_CONTRACT.md"
-		cargo test -p codelens-core
+		cargo test -p codelens-engine
 		cargo test -p codelens-mcp -- --skip returns_lsp_diagnostics --skip returns_workspace_symbols --skip returns_rename_plan
 	else
 		echo "[gate] running local stop-hook Rust gate from EVAL_CONTRACT.md"
 		cargo check
-		cargo test -p codelens-core
+		cargo test -p codelens-engine
 		cargo test -p codelens-mcp
 	fi
 


### PR DESCRIPTION
## Summary
- align the generated phase3 matrix and completeness gate with the landed axum Phase 3h dataset
- wire the canonical matrix into local/CI quality gates and regenerate the matrix artefacts
- fix no-semantic build/test hygiene by feature-gating semantic-only symbols and tests

## Verification
- ./scripts/quality-gate.sh --mode local
- cargo build -p codelens-mcp --release --no-default-features
- cargo test -p codelens-mcp --no-default-features