### PR TITLE
perf(mcp): zero-alloc structural hash for dispatch doom-loop detector

### DIFF
--- a/crates/codelens-mcp/src/dispatch.rs
+++ b/crates/codelens-mcp/src/dispatch.rs
@@ -398,6 +398,100 @@ fn validate_required_params(
     Ok(())
 }
 
+// ── Doom-loop argument hashing ─────────────────────────────────────────
+
+/// Routing metadata keys that must be excluded from the doom-loop hash
+/// so that identical semantic tool calls with different routing profiles
+/// are still detected as consecutive repeats.
+const DOOM_LOOP_SKIP_KEYS: &[&str] = &["_profile", "_compact"];
+
+/// Zero-allocation recursive hash for a JSON argument value.
+///
+/// Walks the value tree using one discriminator byte per node and hashes
+/// primitive payloads directly, avoiding the `v.to_string()` per-field
+/// allocation pattern that was used by the inline hasher previously.
+/// Numbers still go through their canonical string form (because
+/// `serde_json::Number` does not implement `Hash` for f64 soundness
+/// reasons), but a typical tool call's numeric payloads are very small
+/// — five to ten bytes at most — so the remaining allocations are
+/// bounded and noise-sized.
+///
+/// The hash is intentionally stable within a process and across
+/// semantically equivalent argument shapes, but not stable across
+/// processes or serde_json versions. That matches the existing
+/// doom-loop contract: the hash is only used as a key in an in-memory
+/// session map for "same tool+args called consecutively" detection.
+///
+/// Determinism on object iteration relies on
+/// `serde_json`'s `preserve_order` feature, which is enabled in the
+/// workspace `Cargo.toml`.
+fn hash_json_value<H: std::hash::Hasher>(value: &serde_json::Value, hasher: &mut H) {
+    use std::hash::Hash;
+    match value {
+        serde_json::Value::Null => 0u8.hash(hasher),
+        serde_json::Value::Bool(b) => {
+            1u8.hash(hasher);
+            b.hash(hasher);
+        }
+        serde_json::Value::Number(n) => {
+            2u8.hash(hasher);
+            // `Number` does not implement `Hash` directly. Its canonical
+            // string form is what serde_json uses for Display, so we use
+            // the same form here to stay consistent with the previous
+            // `v.to_string()` behaviour for numeric primitives.
+            n.to_string().hash(hasher);
+        }
+        serde_json::Value::String(s) => {
+            3u8.hash(hasher);
+            s.hash(hasher);
+        }
+        serde_json::Value::Array(arr) => {
+            4u8.hash(hasher);
+            arr.len().hash(hasher);
+            for item in arr {
+                hash_json_value(item, hasher);
+            }
+        }
+        serde_json::Value::Object(obj) => {
+            5u8.hash(hasher);
+            obj.len().hash(hasher);
+            for (k, v) in obj {
+                k.hash(hasher);
+                hash_json_value(v, hasher);
+            }
+        }
+    }
+}
+
+/// Hash the top-level argument object for doom-loop repeat detection.
+///
+/// At the top level, keys listed in [`DOOM_LOOP_SKIP_KEYS`] are ignored
+/// so that a routing-metadata change alone (e.g. switching profiles)
+/// does not mask an otherwise-identical consecutive call. Nested objects
+/// are hashed in full via [`hash_json_value`] — only the top-level
+/// skip-list applies.
+fn hash_args_for_doom_loop(arguments: &serde_json::Value) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    if let Some(obj) = arguments.as_object() {
+        5u8.hash(&mut hasher);
+        // We intentionally do NOT hash obj.len() here: after the skip
+        // filter the live key count might differ from the raw length,
+        // and the iteration below already stops the hash from colliding
+        // across disjoint key sets because each present key is hashed.
+        for (k, v) in obj {
+            if DOOM_LOOP_SKIP_KEYS.contains(&k.as_str()) {
+                continue;
+            }
+            k.hash(&mut hasher);
+            hash_json_value(v, &mut hasher);
+        }
+    } else {
+        hash_json_value(arguments, &mut hasher);
+    }
+    hasher.finish()
+}
+
 // ── Dispatch entry point ───────────────────────────────────────────────
 
 pub(crate) fn dispatch_tool(
@@ -422,25 +516,11 @@ pub(crate) fn dispatch_tool(
     let start = std::time::Instant::now();
     state.push_recent_tool_for_session(session, name);
 
-    // Doom-loop detection: hash arguments, check consecutive repeat count
-    let args_hash = {
-        use std::hash::{Hash, Hasher};
-        let mut hasher = std::collections::hash_map::DefaultHasher::new();
-        // Hash arguments excluding routing metadata (_profile, _compact)
-        // so identical semantic calls with different profiles are still detected.
-        // Iterate sorted keys to avoid clone + remove overhead.
-        if let Some(obj) = arguments.as_object() {
-            for (k, v) in obj {
-                if k != "_profile" && k != "_compact" {
-                    k.hash(&mut hasher);
-                    v.to_string().hash(&mut hasher);
-                }
-            }
-        } else {
-            arguments.to_string().hash(&mut hasher);
-        }
-        hasher.finish()
-    };
+    // Doom-loop detection: hash arguments (structurally, zero-alloc for
+    // primitives and nested objects), check consecutive repeat count.
+    // See `hash_args_for_doom_loop` + `hash_json_value` for the walk
+    // rules and the DOOM_LOOP_SKIP_KEYS top-level exclusion list.
+    let args_hash = hash_args_for_doom_loop(arguments);
     let (doom_count, doom_rapid) = state.doom_loop_count_for_session(session, name, args_hash);
 
     // Track file access for session-aware ranking boost
@@ -630,6 +710,119 @@ pub(crate) fn dispatch_tool(
         Err(error) => {
             build_error_response(name, error, gate_failure, &active_surface, state, start, id)
         }
+    }
+}
+
+#[cfg(test)]
+mod doom_loop_hash_tests {
+    use super::hash_args_for_doom_loop;
+    use serde_json::json;
+
+    #[test]
+    fn identical_args_produce_identical_hash() {
+        let a = json!({"file_path": "src/lib.rs", "include_body": true, "max_matches": 5});
+        let b = json!({"file_path": "src/lib.rs", "include_body": true, "max_matches": 5});
+        assert_eq!(hash_args_for_doom_loop(&a), hash_args_for_doom_loop(&b));
+    }
+
+    #[test]
+    fn different_string_values_produce_different_hash() {
+        let a = json!({"file_path": "src/lib.rs"});
+        let b = json!({"file_path": "src/main.rs"});
+        assert_ne!(hash_args_for_doom_loop(&a), hash_args_for_doom_loop(&b));
+    }
+
+    #[test]
+    fn different_numeric_values_produce_different_hash() {
+        let a = json!({"max_matches": 5});
+        let b = json!({"max_matches": 10});
+        assert_ne!(hash_args_for_doom_loop(&a), hash_args_for_doom_loop(&b));
+    }
+
+    #[test]
+    fn different_bool_values_produce_different_hash() {
+        let a = json!({"include_body": true});
+        let b = json!({"include_body": false});
+        assert_ne!(hash_args_for_doom_loop(&a), hash_args_for_doom_loop(&b));
+    }
+
+    #[test]
+    fn top_level_profile_is_excluded_from_hash() {
+        let a = json!({"file_path": "src/lib.rs", "_profile": "planner-readonly"});
+        let b = json!({"file_path": "src/lib.rs", "_profile": "builder-minimal"});
+        assert_eq!(hash_args_for_doom_loop(&a), hash_args_for_doom_loop(&b));
+    }
+
+    #[test]
+    fn top_level_compact_is_excluded_from_hash() {
+        let a = json!({"file_path": "src/lib.rs", "_compact": true});
+        let b = json!({"file_path": "src/lib.rs", "_compact": false});
+        assert_eq!(hash_args_for_doom_loop(&a), hash_args_for_doom_loop(&b));
+    }
+
+    #[test]
+    fn top_level_skip_keys_coexist_with_content_keys_correctly() {
+        let bare = json!({"file_path": "src/lib.rs"});
+        let with_profile = json!({"file_path": "src/lib.rs", "_profile": "builder-minimal"});
+        assert_eq!(
+            hash_args_for_doom_loop(&bare),
+            hash_args_for_doom_loop(&with_profile)
+        );
+    }
+
+    #[test]
+    fn nested_objects_contribute_to_hash() {
+        let a = json!({"options": {"recursive": true}});
+        let b = json!({"options": {"recursive": false}});
+        assert_ne!(hash_args_for_doom_loop(&a), hash_args_for_doom_loop(&b));
+    }
+
+    #[test]
+    fn arrays_contribute_to_hash() {
+        let a = json!({"paths": ["a.rs", "b.rs"]});
+        let b = json!({"paths": ["a.rs", "c.rs"]});
+        assert_ne!(hash_args_for_doom_loop(&a), hash_args_for_doom_loop(&b));
+    }
+
+    #[test]
+    fn array_order_contributes_to_hash() {
+        let a = json!({"paths": ["a.rs", "b.rs"]});
+        let b = json!({"paths": ["b.rs", "a.rs"]});
+        assert_ne!(hash_args_for_doom_loop(&a), hash_args_for_doom_loop(&b));
+    }
+
+    #[test]
+    fn non_object_arguments_are_still_hashed() {
+        let a = json!("bare_string_arg");
+        let b = json!("different_string_arg");
+        assert_ne!(hash_args_for_doom_loop(&a), hash_args_for_doom_loop(&b));
+    }
+
+    #[test]
+    fn nested_profile_key_is_not_skipped() {
+        // Only the *top-level* _profile key is routing metadata.
+        // A nested key happening to be named `_profile` is real payload
+        // and must contribute to the hash.
+        let a = json!({"meta": {"_profile": "a"}});
+        let b = json!({"meta": {"_profile": "b"}});
+        assert_ne!(hash_args_for_doom_loop(&a), hash_args_for_doom_loop(&b));
+    }
+
+    #[test]
+    fn integer_vs_float_zero_differ() {
+        // serde_json::Number preserves the written form; 0 and 0.0 have
+        // different canonical strings, so they must produce different
+        // hashes. This matches the previous `v.to_string()` behaviour.
+        let a = json!({"n": 0});
+        let b = json!({"n": 0.0});
+        assert_ne!(hash_args_for_doom_loop(&a), hash_args_for_doom_loop(&b));
+    }
+
+    #[test]
+    fn null_and_missing_keys_differ() {
+        let a = json!({"field": null});
+        let b = json!({});
+        assert_ne!(hash_args_for_doom_loop(&a), hash_args_for_doom_loop(&b));
     }
 }
 


### PR DESCRIPTION
## Summary

Replace the inline per-field \`v.to_string()\` hash in \`dispatch_tool\` with a zero-allocation structural walk over \`serde_json::Value\`. Every MCP tool dispatch previously paid N small allocations to hash its arguments (one \`format!(\"{}\", value)\` per top-level field); this PR removes them while keeping the doom-loop contract identical.

## Motivation (discovered via CodeLens)

This was identified using CodeLens workflow tools dogfooding the plugin against its own codebase:

1. \`mcp__codelens__analyze_change_request(task=\"Identify optimization opportunities in the MCP dispatch hot path\", profile_hint=\"planner-readonly\")\` ranked \`dispatch_tool\` at score 100 as the primary target, with \`DISPATCH_TABLE\` and \`effective_budget_for_tool\` as secondary anchors (analysis-1775951334907-1).
2. \`mcp__codelens__verify_change_readiness(task=..., changed_files=[\"crates/codelens-mcp/src/dispatch.rs\"], profile_hint=\"builder-minimal\")\` returned readiness 1.0 with 0 blockers.
3. Reading \`dispatch_tool\` surfaced the inline closure:
   \`\`\`rust
   let args_hash = {
       let mut hasher = DefaultHasher::new();
       if let Some(obj) = arguments.as_object() {
           for (k, v) in obj {
               if k != \"_profile\" && k != \"_compact\" {
                   k.hash(&mut hasher);
                   v.to_string().hash(&mut hasher); // alloc per field
               }
           }
       } else {
           arguments.to_string().hash(&mut hasher); // alloc full payload
       }
       hasher.finish()
   };
   \`\`\`

Each \`v.to_string()\` call is a full \`format!(\"{}\", v)\` — it routes through \`serde_json::Value\`'s Display impl which serializes to a fresh \`String\`. For a typical tool call like \`{\"file_path\": \"...\", \"include_body\": true, \"max_matches\": 5}\`, that is 3 small allocations **per dispatch**, before the handler has even started. For a tool call whose argument is a single JSON value (non-object), the fallback branch allocates the entire payload once.

## Change

Two small helpers land above \`dispatch_tool\`:

- **\`hash_json_value(value: &Value, hasher: &mut impl Hasher)\`** — recursive walk. Writes one discriminator byte per node (Null / Bool / Number / String / Array / Object), hashes primitive payloads directly, and recurses into arrays and objects. Arrays record their length so \`[a, b]\` and \`[b, a]\` produce different hashes. Objects rely on serde_json's \`preserve_order\` feature (already enabled in workspace Cargo.toml) for deterministic iteration.

- **\`hash_args_for_doom_loop(arguments: &Value) -> u64\`** — top-level entry point used by \`dispatch_tool\`. Applies the \`_profile\` / \`_compact\` skip list at the top level only (hoisted into \`DOOM_LOOP_SKIP_KEYS\` so the contract is grep-discoverable) and delegates everything else to \`hash_json_value\`.

The only remaining allocation on the hot path is \`n.to_string()\` for \`serde_json::Number\`, which is 5–10 bytes for typical integer tool arguments and is unavoidable at the current Rust serde_json API surface (\`Number\` does not implement \`Hash\` directly for f64 soundness reasons).

Per-dispatch allocation change:

| shape                              | before | after |
|------------------------------------|-------:|------:|
| object with 3 primitive fields     |      3 |     0 |
| object with 2 fields + 1 number    |      3 |     1 |
| object with nested object payload  |      1 big alloc per top-level field |  1 small per number leaf |
| non-object (rare fallback)         |      1 big alloc over full payload   |  0 or 1 per leaf |

## Semantics

**No observable change**. The doom-loop map is in-memory-only (never persisted, never exchanged across processes). The only contract is \"same args within a session → same hash, different args → different hash\", and both implementations satisfy it. The hash bytes are different between old and new code, but that is by design — stability across processes was never promised.

## Test plan

14 new unit tests in \`dispatch::doom_loop_hash_tests\` (unconditional, runs in both default and \`--no-default-features\` builds):

- \`identical_args_produce_identical_hash\`
- \`different_string_values_produce_different_hash\`
- \`different_numeric_values_produce_different_hash\`
- \`different_bool_values_produce_different_hash\`
- \`top_level_profile_is_excluded_from_hash\`
- \`top_level_compact_is_excluded_from_hash\`
- \`top_level_skip_keys_coexist_with_content_keys_correctly\`
- \`nested_objects_contribute_to_hash\`
- \`arrays_contribute_to_hash\`
- \`array_order_contributes_to_hash\`
- \`non_object_arguments_are_still_hashed\`
- \`nested_profile_key_is_not_skipped\` — only the top-level \`_profile\` key is routing metadata; a nested field that happens to be named \`_profile\` is payload and must contribute to the hash
- \`integer_vs_float_zero_differ\` — \`0\` vs \`0.0\` have different canonical strings under serde_json Display; the new hasher must preserve that distinction
- \`null_and_missing_keys_differ\`

Full suite results:

- \`cargo test -p codelens-mcp\` → **169 passed**, 0 failed (was 155 + 14 new)
- \`cargo test -p codelens-mcp --no-default-features\` → **156 passed**, 0 failed (was 142 + 14 new)
- \`cargo test -p codelens-engine\` → **260 passed**, 0 failed (unchanged)

## Scope

- 1 file changed, +212 / −19
- No public API changes
- No schema changes
- No dependency changes
- No behaviour change for any existing tool, dispatch path, or response shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)