### PR TITLE
perf(mcp): in-place Stage 4 truncation + skip double-serialization in response path

### DIFF
--- a/crates/codelens-mcp/src/dispatch_response_support.rs
+++ b/crates/codelens-mcp/src/dispatch_response_support.rs
@@ -120,9 +120,15 @@ pub(crate) fn text_payload_for_response(
     resp: &ToolCallResponse,
     structured_content: Option<&Value>,
 ) -> String {
-    let payload = slim_text_payload_for_async_handle(resp, structured_content)
-        .unwrap_or_else(|| serde_json::to_value(resp).unwrap_or_else(|_| json!({})));
-    serde_json::to_string(&payload)
+    // Async handles get a slim payload that cherry-picks essential fields.
+    // For everything else, serialize the ToolCallResponse directly to
+    // String instead of going through an intermediate Value (saves one
+    // full JSON tree allocation on the common non-async path).
+    if let Some(slim) = slim_text_payload_for_async_handle(resp, structured_content) {
+        return serde_json::to_string(&slim)
+            .unwrap_or_else(|_| "{\"success\":false,\"error\":\"serialization failed\"}".to_owned());
+    }
+    serde_json::to_string(resp)
         .unwrap_or_else(|_| "{\"success\":false,\"error\":\"serialization failed\"}".to_owned())
 }
 
@@ -267,10 +273,17 @@ pub(crate) fn bounded_result_payload(
             structured_content = Some(summarize_structured_content(existing, 0));
         }
         if text.len() > max_chars {
-            text = format!(
-                "{}...[truncated]",
-                text.chars().take(max_chars).collect::<String>()
-            );
+            // In-place truncation: find the char boundary at max_chars,
+            // truncate the existing allocation, and append the marker —
+            // avoids the two intermediate String allocations that
+            // `chars().take().collect::<String>()` + `format!()` paid.
+            let byte_idx = text
+                .char_indices()
+                .nth(max_chars)
+                .map(|(i, _)| i)
+                .unwrap_or(text.len());
+            text.truncate(byte_idx);
+            text.push_str("...[truncated]");
         }
         truncated = true;
     } else {


### PR DESCRIPTION
## Summary

Two small allocation wins in the per-dispatch response builder, identified via CodeLens \`analyze_change_request\` (analysis-1775977802198-3 ranked \`bounded_result_payload\` and \`text_payload_for_response\` in the top-5 hot-path symbols).

### 1. In-place Stage 4 text truncation

**Before** (2 intermediate allocations):
\`\`\`rust
text = format!(
    "{}...[truncated]",
    text.chars().take(max_chars).collect::<String>()  // alloc #1
);                                                     // alloc #2
\`\`\`

**After** (0 new allocations):
\`\`\`rust
let byte_idx = text.char_indices().nth(max_chars)
    .map(|(i, _)| i).unwrap_or(text.len());
text.truncate(byte_idx);       // in-place, no alloc
text.push_str("...[truncated]");  // appends to existing capacity
\`\`\`

### 2. Skip intermediate Value in non-async response path

**Before** (\`struct → Value → String\`, 2-pass):
\`\`\`rust
let payload = serde_json::to_value(resp)?;  // alloc: full JSON tree
serde_json::to_string(&payload)?            // alloc: String from tree
\`\`\`

**After** (\`struct → String\`, 1-pass):
\`\`\`rust
serde_json::to_string(resp)?               // direct serialization
\`\`\`

The async-handle path still uses \`slim_text_payload_for_async_handle\` (cherry-picks fields into a slim Value). Only the common non-async fallback changed.

## Test plan

- [x] \`cargo test -p codelens-mcp\` → **169 passed, 0 failed**
- [x] \`cargo check -p codelens-mcp\` → clean
- [x] No public API / schema / behavior changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)