### PR TITLE
chore(release): v1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,40 +7,67 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Measured (Phase 3d — JS/TS evidence upgrade via `microsoft/typescript`)
+## [1.6.1] — 2026-04-12
 
-Second external-repo measurement for the JS/TS branch of `language_supports_nl_stack`. §8.13 Phase 3c added `ts` / `typescript` / `tsx` / `js` / `javascript` / `jsx` based on a single dataset (`facebook/jest`, +7.3 % hybrid MRR, 24 queries) and explicitly labelled the evidence "single-dataset moderate confidence". Phase 3d replays the methodology on **`microsoft/typescript`** (the TypeScript compiler itself), upgrading the evidence tier to **"two-dataset strong confidence"**.
+### Release summary
 
-- **Target**: `/tmp/typescript/src` — 709 production `.ts` source files (1.9 × jest's 380), spanning compiler / services / server / jsTyping / harness. `/tests` (50 k+ fixture files) deliberately excluded — fixtures would bias the index toward intentional syntax errors.
-- **Dataset**: 34 hand-built queries in `benchmarks/embedding-quality-dataset-typescript.json` (42 % larger than jest). 26 NL + 6 short_phrase + 2 identifier. Spans five compiler subsystems: pipeline (createProgram, createSourceFile, createScanner, createPrinter, createTypeChecker, forEachChild, getLineStarts), diagnostics (getSyntacticDiagnostics, getSemanticDiagnostics, getSuggestionDiagnostics), language service (createLanguageService, getCompletionsAtPosition, getDefinitionAtPosition, findReferences, getCodeFixesAtPosition), editor server (getRenameInfo, getFormattingEditsForRange, getOutliningSpans, getSignatureHelpItems), and core types (SyntaxKind, SourceFile, NodeFlags, FlowFlags, ScriptTarget, ModuleKind, TypeChecker).
-- **Four-arm A/B result**:
+Phase 2m language-gated sparse auto-disable, 10-dataset measurement matrix closure, and dispatch hot-path perf. Three themes:
 
-  | arm         |   hybrid MRR |        Δ rel | NL sub-MRR |   sh sub-MRR | id sub-MRR |
-  | ----------- | -----------: | -----------: | ---------: | -----------: | ---------: |
-  | baseline    |     0.098355 |            — |   0.019644 |     0.138889 |   1.000000 |
-  | 2e only     |     0.088551 |  **−10.0 %** |   0.019644 |     0.083333 |   1.000000 |
-  | 2b+2c only  |     0.200980 | **+104.3 %** |   0.153846 |     0.138889 |   1.000000 |
-  | **stacked** | **0.200980** | **+104.3 %** |   0.153846 | **0.138889** |   1.000000 |
+1. **Phase 2m: JS/TS sparse auto-disable** — the v1.5 Phase 2e sparse re-ranker is now auto-disabled on JS/TS while Phase 2b/2c embedding hints remain auto-on. Evidence: 8-dataset unified analysis (§8.19) showed Phase 2e as 2/2 positive on Rust (+1.2 % to +6.2 %), 1/4 positive on TS/JS (+1.3 % jest-only, −10.0 % typescript, −0.8 % next-js, 0.0 % react-core), and 0/2 positive on Python (−2.4 % requests, 0.0 % django). Explicit `CODELENS_RANK_SPARSE_TERM_WEIGHT=1` still overrides the auto-gate for users who want to force it on.
+2. **10-dataset measurement matrix** — seven new external-repo measurements (§8.15–§8.20) plus a unified Phase 2e evidence section (§8.19). Pattern: 6 positive / 2 inert / 2 negative. The `benchmarks/embedding-quality-matrix.py` script auto-aggregates the full matrix from versioned result JSONs and is now integrated into CI as a completeness gate.
+3. **Dispatch hot-path perf** — two allocation wins: zero-alloc structural hash for doom-loop detection (replaces per-field `v.to_string()`) and in-place Stage 4 text truncation (replaces `chars().take().collect::<String>()` + `format!()`). Non-async response serialization also skips an intermediate `serde_json::Value` allocation by going directly `struct → String`.
 
-- **Largest relative lift any external-repo measurement has produced**: +104.3 %. Compare to ripgrep (+15.2 %), jest (+7.3 %), Rust 436-query (+7.1 %), Rust 89-query (+2.4 %). Absolute lift +0.103 is comparable to ripgrep's +0.070, but on a smaller baseline (0.098 vs 0.459). Phase 2e is **−10.0 %** alone (first explicitly negative Phase 2e measurement on any dataset), and stacked = 2b+2c-only because Phase 2e contributes zero signal on top.
-- **Per-query decomposition — zero regressions**: 34 total queries → **6 improvements / 0 regressions / 28 unchanged** under the stacked arm. All six improvements move a baseline ranking toward rank 1 (`getLineStarts` 6→2, `getSyntacticDiagnostics` 10→1, `getSuggestionDiagnostics` 15→3, `createLanguageService` 23→6, `SourceFile` 14→1, `ModuleKind` 16→1). The 20 NL queries that stay `None` in both arms are retrieval failures (candidate pool never includes the target) — unfixable by any v1.5 re-ranking knob, a model-level issue for Phase 2d.
-- **Why so much larger than jest?** Three compounding factors: (1) low baseline floor (0.098 vs jest's 0.155) makes relative gains look dramatic; (2) TypeScript compiler files are enormous (`checker.ts` ~50 k lines, `parser.ts` ~10 k) and baseline `extract_leading_doc` captures only the first few lines — Phase 2b recovers signal from hundreds of lines of JSDoc and inline comments that the baseline missed by construction; (3) TypeScript is heavily JSDoc-annotated, and Phase 2b's comment extractor normalizes these into NL-shaped tokens that embed well against natural-language queries.
-- **Reader guidance**: treat jest and TypeScript as a **range**, not a single number. v1.5 stack lift on TS/JS is somewhere between **+7.3 % (jest) and +104 % (TypeScript)**, with the actual lift depending on file size distribution and JSDoc density. A typical Next.js app with short files will land near jest; a compiler / language server / editor extension with heavy docs will land near TypeScript.
-- **Updated six-dataset matrix**:
+### Changed
 
-  | Dataset                       | Language  | baseline MRR | stacked MRR |      Δ abs |        Δ rel |
-  | ----------------------------- | --------- | -----------: | ----------: | ---------: | -----------: |
-  | 89-query self                 | Rust      |        0.572 |       0.586 |     +0.014 |       +2.4 % |
-  | 436-query self                | Rust      |       0.0476 |      0.0510 |    +0.0034 |       +7.1 % |
-  | ripgrep external              | Rust      |        0.459 |       0.529 |     +0.070 |      +15.2 % |
-  | requests external             | Python    |        0.584 |       0.495 |     −0.089 |      −15.2 % |
-  | jest external                 | TS/JS     |        0.155 |       0.166 |     +0.011 |       +7.3 % |
-  | **typescript external (new)** | **TS/JS** |    **0.098** |   **0.201** | **+0.103** | **+104.3 %** |
+- **Phase 2m sparse-weighting language split** (`crates/codelens-engine/src/embedding/mod.rs`, `crates/codelens-engine/src/symbols/scoring.rs`):
+  - New `language_supports_sparse_weighting(lang)` fn — allows Rust / C / C++ / Go / Java / Kotlin / Scala / C# only. Excludes TS/JS/Python and everything else.
+  - New `auto_sparse_should_enable()` fn — combines the §8.11 auto gate with the narrower sparse-supported-lang classifier.
+  - `sparse_weighting_enabled()` now falls through to `auto_sparse_should_enable()` instead of `auto_hint_should_enable()`. Single-line behavioral change.
+  - Phase 2b/2c auto-on behaviour on JS/TS is **unchanged** — `language_supports_nl_stack` still includes ts/typescript/tsx/js/javascript/jsx.
 
-  Pattern: 5 positive : 1 negative across three measurement-backed language families. JS/TS classification upgraded to **two-dataset strong confidence**.
+### Performance
 
-- **No code changes in this phase**. `language_supports_nl_stack` already contains the JS/TS entries from §8.13; Phase 3d is pure measurement + documentation. The §8.13 "Limitations acknowledged" item ("Still only one TS dataset, Phase 3d on microsoft/typescript would firm up the evidence") is now resolved.
-- **Artefacts**: `benchmarks/embedding-quality-v1.6-phase3d-typescript-{baseline,2e-only,2b2c-only,stacked}.json`. Dataset: `benchmarks/embedding-quality-dataset-typescript.json`. Full §8.15 write-up with per-query rank tables, large-lift attribution, and limitations in [`docs/benchmarks.md` §8.15](docs/benchmarks.md).
+- **Zero-alloc structural hash for doom-loop detection** (`dispatch.rs`): recursive discriminator-byte walk over `serde_json::Value` replaces per-field `v.to_string()` serialization. Eliminates 3–N string allocations per MCP tool dispatch. 14 new tests.
+- **In-place Stage 4 text truncation** (`dispatch_response_support.rs`): `text.truncate(byte_idx) + push_str("...[truncated]")` replaces `chars().take().collect::<String>()` + `format!()`. Zero new allocations.
+- **Skip double-serialization** (`dispatch_response_support.rs`): non-async response path now goes `struct → String` directly via `serde_json::to_string(resp)` instead of `struct → Value → String`. Saves one full JSON tree allocation per response.
+
+### Fixed
+
+- **Semantic-off build hygiene**: added `#[cfg(feature = "semantic")]` gates to `error.rs`, `output_schemas.rs`, `symbols.rs`, `metrics_config.rs`, `project_ops.rs`, `integration_tests.rs` to eliminate 12 dead-code warnings and 3 compile errors when building with `--no-default-features`.
+- **Stale crate name**: `CLAUDE.md`, `EVAL_CONTRACT.md`, `scripts/quality-gate.sh` all referenced `codelens-core` instead of `codelens-engine`. Corrected.
+
+### Measured
+
+- **§8.15 Phase 3d**: `microsoft/typescript` (34 queries, 709 files). +104.3 % hybrid MRR — largest lift. Upgraded JS/TS to "two-dataset strong confidence".
+- **§8.16 Phase 3e**: `vercel/next.js` (34 queries, 1 564 files, median 61 LOC). **Null result** (0.0 % stacked). First "typical app" measurement — v1.5 stack is mechanism-inert on short-file codebases.
+- **§8.17 Phase 3f**: `facebook/react` production subtree (34 queries, 30 files, 4 035 LOC). **Stronger null** — every arm row-for-row identical to baseline.
+- **§8.18 Phase 3g**: `django/django` (34 queries, 902 files, median 61 LOC). −1.8 % stacked. Python's second negative, confirming `requests` direction in a different regime.
+- **§8.19 Phase 2n**: unified Phase 2e-only evidence across 8 datasets. By-language: Rust 2/2 positive, TS/JS 1/4 positive, Python 0/2 positive. Formal decision audit validates Phase 2m Policy C.
+- **§8.20 Phase 3h**: `tokio-rs/axum` (34 queries, 109 files, median 201 LOC). +0.2 % stacked (marginal). Rust 3/3 positive streak holds but narrows expected benefit for framework libraries to ~0 %.
+
+### Infrastructure
+
+- `benchmarks/embedding-quality-matrix.py` — auto-aggregates phase3 matrix from result JSONs. Supports `--require-datasets` completeness gate and `--include-unregistered` for exploratory datasets.
+- CI: matrix validation step in `.github/workflows/ci.yml` + artifact upload.
+- CI: `quality-gate.sh` Phase3 matrix gate for local/CI/build modes.
+- CI: no-semantic parity checks enforce `cargo test --no-default-features` green.
+
+### Ten-dataset baseline matrix (stacked vs baseline)
+
+| Dataset        | Lang / archetype      | baseline | stacked |    Δ rel |
+| -------------- | --------------------- | -------: | ------: | -------: |
+| 89-query self  | Rust / self           |    0.572 |   0.586 |   +2.4 % |
+| 436-query self | Rust / self           |   0.0476 |  0.0510 |   +7.1 % |
+| ripgrep        | Rust / tooling        |    0.459 |   0.529 |  +15.2 % |
+| requests       | Python / app lib      |    0.584 |   0.495 |  −15.2 % |
+| django         | Python / framework    |    0.294 |   0.288 |   −1.8 % |
+| jest           | TS/JS / tooling       |    0.155 |   0.166 |   +7.3 % |
+| typescript     | TS/JS / compiler      |    0.098 |   0.201 | +104.3 % |
+| next-js        | TS/JS / typical app   |    0.198 |   0.196 |   −0.8 % |
+| react-core     | TS/JS / short runtime |    0.123 |   0.123 |   +0.0 % |
+| axum           | Rust / framework lib  |    0.281 |   0.281 |   +0.2 % |
+
+Pattern: **6 positive / 2 inert / 2 negative**. The v1.5 stack lifts tooling/compiler code and is neutral-to-inert on typical app/runtime code. Python is consistently negative.
 
 ## [1.6.0] — 2026-04-12
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,7 +265,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "codelens-engine"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "anyhow",
  "criterion",
@@ -328,7 +328,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-mcp"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "Apache-2.0"
-version = "1.6.0"
+version = "1.6.1"
 description = "Pure Rust MCP server for code intelligence — 89 tools (+6 semantic), 25 languages, tree-sitter-first, 50-87% fewer tokens"
 repository = "https://github.com/mupozg823/codelens-mcp-plugin"
 homepage = "https://github.com/mupozg823/codelens-mcp-plugin"


### PR DESCRIPTION
## v1.6.1 Release

**Phase 2m sparse-gate split + 10-dataset matrix closure + dispatch perf**

### Headline changes since v1.6.0

1. **Phase 2m**: JS/TS sparse re-ranker auto-disabled (Phase 2b/2c auto-on stays). Evidence: 8-dataset unified analysis, Rust 2/2 positive, TS/JS 1/4 positive, Python 0/2 positive.
2. **10-dataset measurement matrix** (§8.15–§8.20): typescript (+104.3%), next-js (0.0%), react-core (0.0%), django (−1.8%), axum (+0.2%) — plus unified evidence §8.19 closing the Phase 2e arc.
3. **Dispatch perf**: zero-alloc structural hash for doom-loop detection + in-place Stage 4 truncation + skip double-serialization in non-async response path.
4. **Build hygiene**: semantic-off `#[cfg]` gates, `codelens-core` → `codelens-engine` rename fix.
5. **CI**: matrix completeness gate + no-semantic parity checks.

### Files changed (vs v1.6.0)

- `Cargo.toml` / `Cargo.lock`: version 1.6.0 → 1.6.1
- `CHANGELOG.md`: new [1.6.1] section with full release notes

### Test plan

- [x] `cargo check` — green (v1.6.1 compiles)
- [x] All code/test changes already landed and tested in PRs #36–#42
- [x] This PR is version bump + changelog only

🤖 Generated with [Claude Code](https://claude.com/claude-code)