### PR TITLE
refactor(mcp): extract extract_symbol_hint from AppState to free fn

### DIFF
--- a/crates/codelens-mcp/src/mutation_gate.rs
+++ b/crates/codelens-mcp/src/mutation_gate.rs
@@ -216,7 +216,7 @@ pub(crate) fn evaluate_mutation_gate(
                 false,
             ));
         }
-        let Some(mutation_symbol) = state.extract_symbol_hint(arguments) else {
+        let Some(mutation_symbol) = crate::state::extract_symbol_hint(arguments) else {
             return Err(mutation_gate_failure(
                 name,
                 format!(

--- a/crates/codelens-mcp/src/state.rs
+++ b/crates/codelens-mcp/src/state.rs
@@ -531,23 +531,6 @@ impl AppState {
         targets
     }
 
-    pub(crate) fn extract_symbol_hint(&self, arguments: &Value) -> Option<String> {
-        for key in [
-            "name_path",
-            "symbol",
-            "symbol_name",
-            "name",
-            "function_name",
-        ] {
-            if let Some(value) = arguments.get(key).and_then(|entry| entry.as_str()) {
-                let trimmed = value.trim();
-                if !trimmed.is_empty() {
-                    return Some(trimmed.to_owned());
-                }
-            }
-        }
-        None
-    }
 
     pub(crate) fn record_recent_preflight_from_payload(
         &self,
@@ -567,7 +550,7 @@ impl AppState {
             surface,
             Self::now_ms(),
             self.extract_target_paths(arguments),
-            self.extract_symbol_hint(arguments),
+            extract_symbol_hint(arguments),
             payload,
         );
     }
@@ -1497,6 +1480,32 @@ impl AppState {
             .set_created_at_for_test(analysis_id, created_at_ms)
             .map_err(|e| CodeLensError::Internal(e.into()))
     }
+}
+
+// ── Free functions (extracted from AppState for SRP) ─────────────────
+
+/// Extract a symbol name hint from tool arguments by checking a priority
+/// list of common field names (`name_path`, `symbol`, `symbol_name`,
+/// `name`, `function_name`).
+///
+/// This is a pure function that does not need `AppState` — it was
+/// originally an `&self` method but never referenced `self`.
+pub(crate) fn extract_symbol_hint(arguments: &Value) -> Option<String> {
+    for key in [
+        "name_path",
+        "symbol",
+        "symbol_name",
+        "name",
+        "function_name",
+    ] {
+        if let Some(value) = arguments.get(key).and_then(|entry| entry.as_str()) {
+            let trimmed = value.trim();
+            if !trimmed.is_empty() {
+                return Some(trimmed.to_owned());
+            }
+        }
+    }
+    None
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

CodeLens `find_misplaced_code` identified `extract_symbol_hint` as the top outlier in `state.rs` (avg_similarity 0.389 — lowest in the file). The function was an `&self` method on `AppState` but **never referenced `self`** — it is a pure function.

Move to a module-level `pub(crate) fn` in `state.rs` and update the 2 callers:
- `state.rs` `record_recent_preflight_from_payload`: `self.extract_symbol_hint(args)` → `extract_symbol_hint(args)`
- `mutation_gate.rs` `evaluate_rename_gate`: `state.extract_symbol_hint(args)` → `crate::state::extract_symbol_hint(args)`

First incremental step toward decomposing the `state.rs` God Object (30+ methods, `refactor_safety_report` readiness 0.375).

## Test plan
- [x] `cargo test -p codelens-mcp` → **169 passed, 0 failed**
- [x] `cargo check` — clean
- [x] 2 files / +28 / −19

🤖 Generated with [Claude Code](https://claude.com/claude-code)