### PR TITLE
perf(engine): hoist joined_snake from per-candidate scoring loop

### DIFF
--- a/crates/codelens-engine/src/symbols/ranking.rs
+++ b/crates/codelens-engine/src/symbols/ranking.rs
@@ -340,10 +340,18 @@ pub(crate) fn rank_symbols(
     // Reusable key buffer to avoid per-symbol format! allocation
     let mut sem_key_buf = String::with_capacity(128);
 
+    // Pre-compute the snake_case form of the query once — `joined_snake`
+    // is used by score_symbol_with_lower for identifier matching (e.g.
+    // "rename symbol" → "rename_symbol"). It is query-derived and
+    // identical for every candidate, so hoisting it here eliminates one
+    // String allocation per candidate in the hot loop.
+    let joined_snake = query_lower.replace(|c: char| c.is_whitespace() || c == '-', "_");
+
     let mut scored: Vec<(SymbolInfo, i32)> = symbols
         .into_iter()
         .filter_map(|symbol| {
-            let text_score = score_symbol_with_lower(query, &query_lower, &symbol).unwrap_or(0);
+            let text_score =
+                score_symbol_with_lower(query, &query_lower, &joined_snake, &symbol).unwrap_or(0);
 
             // Semantic: cosine similarity via reusable buffer (no format! alloc)
             let sem_score = if has_semantic {

--- a/crates/codelens-engine/src/symbols/scoring.rs
+++ b/crates/codelens-engine/src/symbols/scoring.rs
@@ -94,13 +94,24 @@ fn split_camel_case(name: &str) -> Vec<String> {
 /// Accepts pre-computed `query_lower` to avoid repeated allocation
 /// when scoring many symbols against the same query.
 pub(crate) fn score_symbol(query: &str, symbol: &SymbolInfo) -> Option<i32> {
-    score_symbol_with_lower(query, &query.to_lowercase(), symbol)
+    let lower = query.to_lowercase();
+    let snake = lower.replace(|c: char| c.is_whitespace() || c == '-', "_");
+    score_symbol_with_lower(query, &lower, &snake, symbol)
 }
 
-/// Inner scoring with pre-lowercased query — call this from hot loops.
+/// Inner scoring with pre-lowercased query and pre-computed joined-snake
+/// form — call this from hot loops where both are invariant across
+/// candidates.
+///
+/// `joined_snake` is the query with whitespace/hyphens replaced by
+/// underscores, used for snake_case identifier matching (e.g.
+/// "rename symbol" → "rename_symbol"). It is query-derived and
+/// identical for every candidate, so computing it once in the caller
+/// eliminates one String allocation per candidate in the hot loop.
 pub(crate) fn score_symbol_with_lower(
     query: &str,
     query_lower: &str,
+    joined_snake: &str,
     symbol: &SymbolInfo,
 ) -> Option<i32> {
     // Exact full-query match (no allocation needed)
@@ -127,7 +138,8 @@ pub(crate) fn score_symbol_with_lower(
 
     // Check if query tokens form the symbol name when joined with underscore
     // e.g. "rename symbol" → "rename_symbol" → exact match bonus
-    let joined_snake = query_lower.replace(|c: char| c.is_whitespace() || c == '-', "_");
+    // `joined_snake` is pre-computed by the caller to avoid one String
+    // allocation per candidate in the hot loop.
     if name_lower == joined_snake {
         return Some(80);
     }


### PR DESCRIPTION
## Summary

`score_symbol_with_lower` was computing `query_lower.replace(|c| c.is_whitespace() || c == '-', \"_\")` on **every candidate** to support snake_case identifier matching. Since the result is purely query-derived and identical for all candidates, this was one unnecessary `String` allocation per candidate in the `get_ranked_context` hot loop.

### Change

- Add `joined_snake: &str` as a fourth parameter to `score_symbol_with_lower`
- The hot-loop caller (`ranking.rs` `rank_symbols_for_context`) now computes the snake form **once** before the `filter_map` iterator
- The convenience wrapper `score_symbol` pre-computes both `query_lower` and `joined_snake` internally (no call-site changes for non-hot-path callers)

### Impact

For a codebase with 1 000 indexed symbols: **eliminates 1 000 String allocations per `get_ranked_context` call**.

The remaining 5 per-candidate allocations (`name_lower`, `sig_lower`, `name_path_lower`, `path_lower`, `split_camel_case`) are candidate-derived and require `SymbolInfo` struct changes to eliminate — deferred to a separate PR.

## Test plan

- [x] `cargo test -p codelens-engine` → **260 passed, 0 failed**
- [x] `cargo test -p codelens-mcp` → **169 passed, 0 failed**
- [x] 2 files / +24 / −4. No semantic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)