### PR TITLE
chore(release): v1.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.2] — 2026-04-12
+
+### Release summary
+
+Scoring hot-path performance: eliminate 5 000 String allocations per `get_ranked_context` call on a 1 000-symbol codebase, plus a God Object decomposition first step.
+
+### Performance
+
+- **Hoist `joined_snake` from per-candidate loop** (`scoring.rs`, `ranking.rs`): the snake_case form of the query (e.g. "rename symbol" → "rename_symbol") was recomputed identically for every candidate. Now computed once in the caller. Eliminates 1 000 allocs/query.
+- **Zero-alloc ASCII case-insensitive scoring** (`scoring.rs`): replace 4 × `to_lowercase()` per candidate with `contains_ascii_ci()` / `eq_ascii_ci()` byte-window comparisons. Code identifiers are ASCII — ASCII folding is correct and allocation-free. Eliminates 4 000 allocs/query.
+
+Combined per-`get_ranked_context` allocation reduction on a 1 000-symbol codebase:
+
+| stage                    |    allocs |
+| ------------------------ | --------: |
+| v1.6.1                   |     6 000 |
+| After joined_snake hoist |     5 000 |
+| After ASCII CI scoring   | **1 000** |
+
+### Refactored
+
+- **`extract_symbol_hint` free fn** (`state.rs`, `mutation_gate.rs`): extracted from `AppState` impl — the function never used `&self`. First incremental step toward decomposing the state.rs God Object (identified via CodeLens `find_misplaced_code`, avg_similarity 0.389 — top outlier).
+
 ## [1.6.1] — 2026-04-12
 
 ### Release summary

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,7 +265,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "codelens-engine"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "anyhow",
  "criterion",
@@ -328,7 +328,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-mcp"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "Apache-2.0"
-version = "1.6.1"
+version = "1.6.2"
 description = "Pure Rust MCP server for code intelligence — 89 tools (+6 semantic), 25 languages, tree-sitter-first, 50-87% fewer tokens"
 repository = "https://github.com/mupozg823/codelens-mcp-plugin"
 homepage = "https://github.com/mupozg823/codelens-mcp-plugin"


### PR DESCRIPTION
Version bump + CHANGELOG for scoring hot-path perf + refactor. See CHANGELOG.md [1.6.2].