### PR TITLE
perf(engine): pre-capacity make_symbol_id — exact alloc, no format! realloc

### DIFF
--- a/crates/codelens-engine/src/symbols/types.rs
+++ b/crates/codelens-engine/src/symbols/types.rs
@@ -73,8 +73,19 @@ pub struct SymbolInfo {
 }
 
 /// Construct a stable symbol ID: `{file_path}#{kind}:{name_path}`
+///
+/// Uses `String::with_capacity` to allocate the exact final size in
+/// one shot, avoiding the internal reallocation that `format!()` may
+/// do when it starts from an empty buffer and grows.
 pub fn make_symbol_id(file_path: &str, kind: &SymbolKind, name_path: &str) -> String {
-    format!("{}#{}:{}", file_path, kind.as_label(), name_path)
+    let label = kind.as_label();
+    let mut id = String::with_capacity(file_path.len() + 1 + label.len() + 1 + name_path.len());
+    id.push_str(file_path);
+    id.push('#');
+    id.push_str(label);
+    id.push(':');
+    id.push_str(name_path);
+    id
 }
 
 /// Parse a stable symbol ID. Returns `(file_path, kind_label, name_path)` or `None`.


### PR DESCRIPTION
## Summary

Replace \`format!(\"{}#{}:{}\", ...)\` with \`String::with_capacity\` + \`push_str\` in \`make_symbol_id\`. Pre-computes exact capacity, single allocation, zero reallocs.

Called at both index-time AND query-time (per result in find_symbol, get_symbols_overview, search_symbols_hybrid). For 50 query results: ~50 potential reallocs eliminated.

## Test plan
- [x] \`cargo test -p codelens-engine\` → **260 passed**
- [x] \`cargo test -p codelens-mcp\` → **169 passed**
- [x] 1 file / +12 / −1

🤖 Generated with [Claude Code](https://claude.com/claude-code)