### PR TITLE
perf(engine): skip per-entry JSON serialization in budget pruning

### DIFF
--- a/crates/codelens-engine/src/symbols/ranking.rs
+++ b/crates/codelens-engine/src/symbols/ranking.rs
@@ -460,8 +460,19 @@ pub(crate) fn prune_to_budget(
             body,
             relevance_score: score,
         };
-        // serde_json::to_string should not fail for this struct, but handle gracefully
-        let entry_size = serde_json::to_string(&entry).map(|s| s.len()).unwrap_or(0);
+        // Estimate entry size from field lengths directly instead of
+        // serializing to JSON and measuring the string. This avoids one
+        // full serde_json::to_string round-trip per selected entry
+        // (~50 entries × ~300 bytes each = ~15 KB of wasted JSON work).
+        // The constant 80 covers JSON keys, braces, commas, and the
+        // integer relevance_score field. This is a budget-stopping
+        // heuristic, not an exact measurement — a ±20% error is fine.
+        let entry_size = entry.name.len()
+            + entry.kind.len()
+            + entry.file.len()
+            + entry.signature.len()
+            + entry.body.as_ref().map(|b| b.len()).unwrap_or(0)
+            + 80;
         if remaining < entry_size && !selected.is_empty() {
             break;
         }


### PR DESCRIPTION
## Summary

\`prune_to_budget\` was calling \`serde_json::to_string(&entry)\` on every selected entry **just to measure its serialized size**. The String was immediately dropped. For 50 entries × ~300 bytes: ~15 KB of wasted JSON work per \`get_ranked_context\` call.

### Before
\`\`\`rust
let entry_size = serde_json::to_string(&entry).map(|s| s.len()).unwrap_or(0);
\`\`\`

### After
\`\`\`rust
let entry_size = entry.name.len() + entry.kind.len() + entry.file.len()
    + entry.signature.len() + entry.body.as_ref().map(|b| b.len()).unwrap_or(0) + 80;
\`\`\`

O(1) field-length sum replaces O(entry_size) JSON serialization. The constant 80 covers JSON overhead (keys, braces, commas). ±20% accuracy is sufficient — this is a budget-stopping heuristic.

## Test plan
- [x] \`cargo test -p codelens-engine\` → **260 passed**
- [x] \`cargo test -p codelens-mcp\` → **169 passed**
- [x] \`cargo clippy\` — clean
- [x] 1 file / +13 / −2

🤖 Generated with [Claude Code](https://claude.com/claude-code)