### PR TITLE
perf(engine): reuse contains_ascii_ci in find_symbol

### DIFF
--- a/crates/codelens-engine/src/symbols/mod.rs
+++ b/crates/codelens-engine/src/symbols/mod.rs
@@ -521,7 +521,7 @@ pub fn find_symbol(
             let matched = if exact_match {
                 symbol.name == name
             } else {
-                symbol.name.to_lowercase().contains(&query)
+                scoring::contains_ascii_ci(&symbol.name, &query)
             };
             if matched {
                 results.push(to_symbol_info(symbol, usize::MAX));

--- a/crates/codelens-engine/src/symbols/scoring.rs
+++ b/crates/codelens-engine/src/symbols/scoring.rs
@@ -10,7 +10,7 @@ use super::types::SymbolInfo;
 /// which paid one `String` allocation per call. Since code identifiers
 /// in all 25 supported tree-sitter languages are ASCII, the ASCII-only
 /// comparison is both correct and faster than Unicode `to_lowercase`.
-fn contains_ascii_ci(haystack: &str, needle: &str) -> bool {
+pub(crate) fn contains_ascii_ci(haystack: &str, needle: &str) -> bool {
     let h = haystack.as_bytes();
     let n = needle.as_bytes();
     if n.len() > h.len() {


### PR DESCRIPTION
Eliminate per-symbol to_lowercase() in fuzzy find_symbol. Reuse contains_ascii_ci (promoted to pub(crate)). 2 files / +2 / −2. 260+170 tests pass.