### PR TITLE
fix(engine): unblock Windows CI compile of lsp/tests.rs

### DIFF
--- a/crates/codelens-engine/src/lsp/tests.rs
+++ b/crates/codelens-engine/src/lsp/tests.rs
@@ -1,13 +1,12 @@
 use super::{
-    LspDiagnosticRequest, LspRenamePlanRequest, LspRequest, LspSessionPool,
-    LspTypeHierarchyRequest, LspWorkspaceSymbolRequest, default_lsp_args_for_command,
-    default_lsp_command_for_path, find_referencing_symbols_via_lsp, get_diagnostics_via_lsp,
-    get_rename_plan_via_lsp, get_type_hierarchy_via_lsp, search_workspace_symbols_via_lsp,
+    default_lsp_args_for_command, default_lsp_command_for_path, find_referencing_symbols_via_lsp,
+    get_diagnostics_via_lsp, get_rename_plan_via_lsp, get_type_hierarchy_via_lsp,
+    search_workspace_symbols_via_lsp, LspDiagnosticRequest, LspRenamePlanRequest, LspRequest,
+    LspSessionPool, LspTypeHierarchyRequest, LspWorkspaceSymbolRequest,
 };
 use crate::ProjectRoot;
 use serde_json::Value;
 use std::fs;
-use std::os::unix::fs::PermissionsExt;
 
 #[test]
 fn reads_references_from_mock_lsp() {
@@ -167,18 +166,14 @@ fn reads_type_hierarchy_from_mock_lsp() {
         hierarchy.get("fully_qualified_name"),
         Some(&Value::String("sample.Service".to_owned()))
     );
-    assert!(
-        hierarchy
-            .get("supertypes")
-            .and_then(Value::as_array)
-            .is_some_and(|items: &Vec<Value>| !items.is_empty())
-    );
-    assert!(
-        hierarchy
-            .get("subtypes")
-            .and_then(Value::as_array)
-            .is_some_and(|items: &Vec<Value>| !items.is_empty())
-    );
+    assert!(hierarchy
+        .get("supertypes")
+        .and_then(Value::as_array)
+        .is_some_and(|items: &Vec<Value>| !items.is_empty()));
+    assert!(hierarchy
+        .get("subtypes")
+        .and_then(Value::as_array)
+        .is_some_and(|items: &Vec<Value>| !items.is_empty()));
 }
 
 #[test]
@@ -235,10 +230,18 @@ fn default_lsp_args_are_derived_from_registry_by_command() {
     assert_eq!(default_lsp_args_for_command("metals"), Some(&[][..]));
 }
 
-fn chmod_exec(path: &std::path::Path) {
-    let mut perms = fs::metadata(path).expect("metadata").permissions();
-    perms.set_mode(0o755);
-    fs::set_permissions(path, perms).expect("chmod");
+fn chmod_exec(_path: &std::path::Path) {
+    // Mock LSP scripts only need an explicit executable bit on Unix-like
+    // systems. On Windows the test harness invokes the script through its
+    // interpreter (e.g. `python3 mock_lsp.py`), so the file mode is irrelevant
+    // and `std::os::unix::fs::PermissionsExt` is not available there.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(_path).expect("metadata").permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(_path, perms).expect("chmod");
+    }
 }
 
 fn temp_dir(prefix: &str) -> std::path::PathBuf {


### PR DESCRIPTION
## Summary

`crates/codelens-engine/src/lsp/tests.rs` imported `std::os::unix::fs::PermissionsExt` at the file top and called `Permissions::set_mode(0o755)` inside `chmod_exec`. Both APIs only exist on Unix, so the `windows-latest` job in `ci.yml` failed to compile every push to `main` with:

```
error[E0433]: failed to resolve: could not find `unix` in `os`
error[E0599]: no method named `set_mode` found for struct `std::fs::Permissions`
```

This PR moves the import inside the function body and gates the chmod on `#[cfg(unix)]`. The function becomes a documented no-op on Windows, which matches the existing test harness behaviour: mock LSP scripts there are invoked through their interpreter (e.g. `python3 mock_lsp.py`), so the executable bit is irrelevant.

The function parameter is renamed `_path` so the unused-variable warning is suppressed on the Windows branch where the body is empty.

## Verification

- `cargo check --workspace --tests` — clean on Unix (the `cfg(unix)` block is still active there, behaviour is unchanged).
- All other `PermissionsExt` / `set_mode(0o755)` call sites in this workspace are already wrapped in `#[cfg(unix)] { ... }` blocks (verified by grep across `crates/`):
  - `crates/codelens-mcp/src/integration_tests/lsp.rs:97-101, 184-188, 259-263`
  - `crates/codelens-mcp/src/integration_tests/workflow.rs:3334-3338`
  - `crates/codelens-mcp/src/server/http_tests.rs:2469-2473, 2699-2703`
  - `crates/codelens-mcp/src/server/transport_stdio.rs:610-614`
- Once #64 lands the `pull_request` trigger expansion, this PR will exercise the `windows-latest` job directly. Before that, this PR still triggers Windows CI because its base is `main`.

## Scope notes

- Does **not** address the Ubuntu-side workflow integration test failures (`stale_preflight_is_rejected` and the surrounding suite) that are also red on `main`. Those are expected to be fixed by the ongoing `codex/runtime-verification-matrix` work.
- Pure compile fix; no test logic, schema, or runtime behaviour is altered.

## Test plan

- [ ] CI windows-latest job builds successfully (the previous E0433/E0599 errors are gone).
- [ ] CI ubuntu/macos jobs remain unchanged (the active path for them is the same `cfg(unix)` body).
- [ ] No new clippy warnings introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)