### PR TITLE
fix(mcp): gate query_analysis test imports behind semantic feature

### DIFF
--- a/crates/codelens-mcp/src/tools/query_analysis.rs
+++ b/crates/codelens-mcp/src/tools/query_analysis.rs
@@ -701,14 +701,15 @@ fn expand_retrieval_query(query: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        analyze_retrieval_query, query_prefers_lexical_only, semantic_query_for_embedding_search,
-        semantic_query_for_retrieval,
+        analyze_retrieval_query, query_prefers_lexical_only, semantic_query_for_retrieval,
     };
     use std::{
         fs,
         time::{SystemTime, UNIX_EPOCH},
     };
 
+    #[cfg(feature = "semantic")]
+    use super::semantic_query_for_embedding_search;
     #[cfg(feature = "semantic")]
     use super::{rerank_semantic_matches, semantic_adjusted_score_parts};
     #[cfg(feature = "semantic")]

--- a/crates/codelens-mcp/src/tools/query_analysis.rs
+++ b/crates/codelens-mcp/src/tools/query_analysis.rs
@@ -703,10 +703,6 @@ mod tests {
     use super::{
         analyze_retrieval_query, query_prefers_lexical_only, semantic_query_for_retrieval,
     };
-    use std::{
-        fs,
-        time::{SystemTime, UNIX_EPOCH},
-    };
 
     #[cfg(feature = "semantic")]
     use super::semantic_query_for_embedding_search;
@@ -714,6 +710,11 @@ mod tests {
     use super::{rerank_semantic_matches, semantic_adjusted_score_parts};
     #[cfg(feature = "semantic")]
     use codelens_engine::SemanticMatch;
+    #[cfg(feature = "semantic")]
+    use std::{
+        fs,
+        time::{SystemTime, UNIX_EPOCH},
+    };
 
     #[test]
     fn identifier_queries_prefer_lexical_only() {
@@ -768,6 +769,7 @@ mod tests {
         assert!(semantic.contains("dispatch tool request"));
     }
 
+    #[cfg(feature = "semantic")]
     #[test]
     fn embedding_search_query_frames_natural_language_with_code_prefix() {
         let analysis =
@@ -777,6 +779,7 @@ mod tests {
         assert!(framed.contains("route an incoming tool request to the right handler"));
     }
 
+    #[cfg(feature = "semantic")]
     #[test]
     fn embedding_search_query_leaves_identifier_queries_unframed() {
         let analysis = analyze_retrieval_query("change_signature");
@@ -784,6 +787,7 @@ mod tests {
         assert_eq!(framed, "change_signature change signature");
     }
 
+    #[cfg(feature = "semantic")]
     #[test]
     fn embedding_search_query_bridges_nl_terms_to_code_vocabulary() {
         let analysis = analyze_retrieval_query("categorize a function by its purpose");
@@ -793,6 +797,7 @@ mod tests {
         assert!(framed.contains("classify"));
     }
 
+    #[cfg(feature = "semantic")]
     #[test]
     fn embedding_search_query_bridge_dedup_is_case_insensitive() {
         let analysis = analyze_retrieval_query(
@@ -808,6 +813,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "semantic")]
     #[test]
     fn embedding_search_query_does_not_apply_project_specific_bridge_without_project_root() {
         let analysis = analyze_retrieval_query("record which files were recently accessed");
@@ -815,6 +821,7 @@ mod tests {
         assert!(!framed.contains("record_file_access"));
     }
 
+    #[cfg(feature = "semantic")]
     #[test]
     fn embedding_search_query_applies_project_specific_bridge_from_project_file() {
         let dir = std::env::temp_dir().join(format!(


### PR DESCRIPTION
## Summary

- `crates/codelens-mcp/src/tools/query_analysis.rs` test module imported `semantic_query_for_embedding_search` and `std::{fs, time::{SystemTime, UNIX_EPOCH}}` unconditionally.
- Those items are only reachable with `--features semantic`, so `cargo test --no-default-features` (run by `scripts/quality-gate.sh` as the "no-semantic MCP gate" on Ubuntu/macOS CI) failed with `E0432: unresolved import super::semantic_query_for_embedding_search`.
- This is the **compile-error half** of main's red CI. The other half is the **session-metric runtime test failures** being fixed by PR #67.

## Change

- Move `semantic_query_for_embedding_search` and the `std::{fs, time::{SystemTime, UNIX_EPOCH}}` imports behind `#[cfg(feature = "semantic")]`.
- Attach `#[cfg(feature = "semantic")]` to the six `embedding_search_query_*` tests that depend on that function. The remaining 14 lexical tests run in both feature modes unchanged.

Single file, +11/-4.

## Test plan

- [x] `cargo check -p codelens-mcp --no-default-features --tests` — clean
- [x] `cargo check -p codelens-mcp --tests` — clean
- [x] `cargo test -p codelens-mcp --no-default-features --bin codelens-mcp tools::query_analysis::` — 14 passed, 0 failed, 177 filtered
- [x] `cargo test -p codelens-mcp --bin codelens-mcp tools::query_analysis::` — 29 passed, 0 failed, 188 filtered

## CI status

This PR's CI shows Ubuntu fail, but **not due to this diff** — the compile error this PR targets is fixed (confirmed in Ubuntu log). The remaining failures are the 14 `tests::protocol::*` / `tests::workflow::*` session-metric assertions that PR #67 (`codex/main-red-fix`) addresses via `output_schemas.rs` + `build.rs`.

## Relationship to other open PRs

- **Depends-on / complements PR #67**: main turns fully green only after both merge. Merge order does not matter — whichever merges first will let the other's CI refresh green on rebase.
- **Unblocks PR #64 / #66**: their CI failures are all downstream of main's red state.
- **Supersedes PR #65** for the Windows `lsp/tests.rs` concern (PR #67 includes the same fix). #65 can be closed after #67 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)