### PR TITLE
feat(mcp): add CODELENS_VERBOSE_TEXT to mirror full payload to content text

### DIFF
--- a/crates/codelens-mcp/src/dispatch/response_support.rs
+++ b/crates/codelens-mcp/src/dispatch/response_support.rs
@@ -232,8 +232,19 @@ fn format_structured_response(resp: &ToolCallResponse) -> String {
 
     // Data: summarized mirror of the structured payload for text-only clients.
     // The full machine-readable body remains in `structuredContent`.
+    // Opt-in: CODELENS_VERBOSE_TEXT=1 copies the full data (no summarization),
+    // so human UIs that only render `content[0].text` see the same payload
+    // the agent sees in `structuredContent`.
     if let Some(ref data) = resp.data {
-        out.insert("data".to_owned(), summarize_text_data_for_response(data));
+        let data_value = if std::env::var("CODELENS_VERBOSE_TEXT")
+            .map(|v| matches!(v.as_str(), "1" | "true" | "on" | "yes"))
+            .unwrap_or(false)
+        {
+            data.clone()
+        } else {
+            summarize_text_data_for_response(data)
+        };
+        out.insert("data".to_owned(), data_value);
     }
 
     // Suggested next tools (preserve original key for compatibility)


### PR DESCRIPTION
## Problem

Human UIs (Claude Code, Codex, Cursor) typically render only `content[0].text` from an MCP tool result. Agents meanwhile consume `structuredContent`, which carries the full body. CodeLens's `format_structured_response` currently **summarizes** the `data` field before placing it in `text` (via `summarize_text_data_for_response`), so the human-visible view is significantly thinner than what the agent sees.

In practice this showed up as tool calls labelled "CodeLens calling" with little visible output, obscuring what CodeLens actually returned.

## Change

`crates/codelens-mcp/src/dispatch/response_support.rs`: inside `format_structured_response`, the `data` field now respects an opt-in env var:

```
CODELENS_VERBOSE_TEXT = 1 | true | on | yes
```

When set, `data.clone()` is inserted verbatim into the text payload. `structuredContent` is unchanged (agents still get the full body, identical to before). When unset, the existing `summarize_text_data_for_response` path runs — **default behavior is identical to main**.

+12 / -1, single file.

## Usage

Claude Code `mcp.json` example:

```json
{
  "mcpServers": {
    "codelens": {
      "command": "codelens-mcp",
      "env": { "CODELENS_VERBOSE_TEXT": "1" }
    }
  }
}
```

Same pattern for Codex/Cursor MCP config. No server restart needed beyond the normal MCP client reconnect.

## Test plan

- [x] `cargo check -p codelens-mcp` — clean
- [x] `cargo test -p codelens-mcp --bin codelens-mcp --features http` — 263 pass, 1 flaky HTTP port-contention test (`analysis_jobs_follow_session_bound_project_scope`) that passes in isolation and is unrelated to this diff
- [x] Manual: default behavior unchanged when env var unset (verified via code inspection — summarize path still runs)
- [ ] Manual: set env var locally → observe Claude Code UI shows full payload instead of summary (needs user verification after merge + binary rebuild)

## Non-goals

- No markdown pretty-rendering (option B from our discussion). Current PR is option A — mirror agent data as JSON. If we want a human-readable markdown surface later, it can go in a separate PR.
- No change to compression thresholds, tool tier, or `_meta["anthropic/maxResultSizeChars"]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)