### PR TITLE
docs(bench): re-anchor retrieval-quality numbers on commit 84c825d (Phase R3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Docs
 
 - README: replaced two stale "zero runtime dependencies" claims with the accurate "single self-contained binary, ships its own SQLite, vector store, and ONNX runtime" wording that the opening paragraph already uses (PR #64 fixed the opener; this closes the two remaining occurrences in the comparison table and the 25-languages section).
+- README retrieval-quality table re-anchored on commit `84c825d` (2026-04-15). Self-benchmark now reports Hybrid MRR **0.758** (was 0.841 on v1.9.23), Semantic 0.732 (was 0.798), Lexical 0.601 — two independent runs produced identical numbers. The table now documents the three ranking methods side by side (lexical / semantic / hybrid) instead of only the hybrid-vs-semantic delta, and makes explicit that cross-project numbers were not re-measured this cycle. The older anecdote "self MRR rises to 0.841 with bridges" is removed because bridges are the default path on the benchmark dataset already.
+
+### Refactor
+
+- Removed the single-impl `EmbeddingStore` trait (-113 net LOC). `SqliteVecStore` is now used directly as the concrete store field on `EmbeddingEngine`. The trait was never surfaced via `pub use` in `lib.rs`, so no public API breaks. The unused `clear()` method was also dropped because it existed only to satisfy the former trait contract.
 
 ## [1.7.0] — 2026-04-12
 

--- a/README.md
+++ b/README.md
@@ -234,19 +234,21 @@ Optional embedding-based code search (feature-gated: `semantic`):
 - 2-tier NL→code bridging: generic core (15 entries) + auto-generated project bridges (`.codelens/bridges.json`)
 - Multi-language test symbol filtering: Python, JS/TS, Go, Java, Kotlin, Ruby
 
-### Retrieval Quality (v1.9.23)
+### Retrieval Quality
 
-| Project            | Language | Hybrid MRR | Semantic MRR | Queries |
-| ------------------ | -------- | ---------- | ------------ | ------- |
-| Self (CodeLens)    | Rust     | **0.841**  | 0.798        | 104     |
-| Role (adversarial) | Rust     | **0.962**  | 0.900        | 70      |
-| Flask              | Python   | 0.563      | **0.577**    | 20      |
-| curl               | C        | **0.623**  | 0.555        | 18      |
+Self-benchmark re-measured on commit `84c825d` (2026-04-15), model `MiniLM-L12-CodeSearchNet-INT8` (SHA256 prefix `ef1d1e9c`), dataset `benchmarks/embedding-quality-dataset-self.json` (104 queries). Two independent runs produced identical numbers (0% variance).
 
-6-language benchmark matrix: Rust (self/axum/ripgrep), Python (django/requests), TS/JS (jest/next-js/react-core/typescript), Go (gin), Java (gson), C (curl).
+| Method                            | MRR@10    | Acc@1   | Acc@3   | Avg ms  |
+| --------------------------------- | --------- | ------- | ------- | ------- |
+| Lexical only (no semantic)        | 0.601     | 54%     | 68%     | 41      |
+| Semantic only                     | 0.732     | 68%     | 80%     | 450     |
+| **Hybrid** (`get_ranked_context`) | **0.758** | **71%** | **82%** | **123** |
 
-> Generic bridge only — no project-specific tuning. Hybrid > lexical in all languages.
-> With project bridges (`.codelens/bridges.json`): self MRR rises to 0.841.
+Hybrid uplift over lexical: **+0.157 MRR, +17% Acc@1**. Semantic alone beats lexical but hybrid beats semantic by blending both signals.
+
+Cross-project matrix (6 languages, last run v1.9.23 line — not re-measured this cycle): Rust (self / axum / ripgrep), Python (django / requests), TS/JS (jest / next-js / react-core / typescript), Go (gin), Java (gson), C (curl). Historical hybrid numbers for those projects are tracked in `benchmarks/embedding-quality-phase3-matrix.json`.
+
+> 2-tier NL→code bridges: generic core (15 entries) + auto-generated project bridges (`.codelens/bridges.json`). The self-benchmark above runs with both tiers active.
 
 ```bash
 # Measure on your project


### PR DESCRIPTION
## Summary

Phase **R3** of the post-7ad84ca roadmap. Documentation only, zero code changes. Re-anchors the README retrieval-quality table on a verifiable commit so future ranking PRs have a real regression gate.

## Before

README "Retrieval Quality" section was labelled `(v1.9.23)` with Self hybrid MRR **0.841** / semantic 0.798. That measurement is 5 release cycles old, the commit hash wasn't recorded, and the underlying model / dataset / bridges have all shifted.

## Measured on commit `84c825d` (2026-04-15)

Model: `MiniLM-L12-CodeSearchNet-INT8` (SHA256 prefix `ef1d1e9c`)
Dataset: `benchmarks/embedding-quality-dataset-self.json` (104 queries)
`.codelens/bridges.json` present (default project setup)

| Method                | MRR@10 | Acc@1 | Acc@3 | Avg ms |
| --------------------- | ------ | ----- | ----- | ------ |
| Lexical only          | 0.601  | 54%   | 68%   | 41     |
| Semantic only         | 0.732  | 68%   | 80%   | 450    |
| **Hybrid (get_ranked_context)** | **0.758** | **71%** | **82%** | **123** |

Hybrid uplift over lexical: **+0.157 MRR, +17% Acc@1**. Two independent runs (standard + `--isolated-copy`) produced **identical** numbers (0% variance).

## Presentation changes

- Header: `(v1.9.23)` → explicit commit hash + date + model hash caption. Now reproducible.
- Row shape: old table was "Hybrid vs Semantic" for 4 projects. New table is "Lexical / Semantic / Hybrid" for self so the uplift source is readable at a glance.
- Cross-project matrix marked "not re-measured this cycle" — historical numbers remain in `benchmarks/embedding-quality-phase3-matrix.json`.
- Removed "With project bridges … self MRR rises to 0.841" — bridges are already active on the self-dataset run, so the sentence was misleading framing.

## Test plan

- [x] `python3 benchmarks/embedding-quality.py . --dataset benchmarks/embedding-quality-dataset-self.json ...` — Hybrid 0.758
- [x] Same with `--isolated-copy` — Hybrid 0.758 (stable, 0% variance)
- [x] No code changed; `cargo check` / `cargo test` left undisturbed

## Non-goals

- No new benchmark harness (honors 검증 없이 메타 인프라 금지).
- No cross-project matrix refresh (those numbers require separate per-project dataset prep; out of scope for this 1-file documentation PR).
- No attempt to restore the 0.841 number by cherry-picking a different dataset / bridge config — the goal is honest anchoring to current behavior, not to preserve a historical high-water mark.

## Relationship to other PRs

- Builds on PR #71 (R1 deprecation) + PR #72 (R2 trait removal), already merged.
- Closes out the 3-phase R1 → R2 → R3 roadmap from `sparkling-foraging-creek.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)