### PR TITLE
feat(dispatch): additive suggested_next_calls with pre-filled arguments

### DIFF
--- a/crates/codelens-mcp/src/dispatch/response.rs
+++ b/crates/codelens-mcp/src/dispatch/response.rs
@@ -3,12 +3,12 @@ use super::response_support::{
     effective_budget_for_tool, max_result_size_chars_for_tool, routing_hint_for_payload,
     success_jsonrpc_response, text_payload_for_response,
 };
-use crate::AppState;
 use crate::error::CodeLensError;
-use crate::mutation_gate::{MutationGateAllowance, MutationGateFailure, is_verifier_source_tool};
-use crate::protocol::{JsonRpcResponse, ToolCallResponse, ToolResponseMeta};
-use crate::tool_defs::{ToolSurface, tool_definition};
+use crate::mutation_gate::{is_verifier_source_tool, MutationGateAllowance, MutationGateFailure};
+use crate::protocol::{JsonRpcResponse, SuggestedNextCall, ToolCallResponse, ToolResponseMeta};
+use crate::tool_defs::{tool_definition, ToolSurface};
 use crate::tools;
+use crate::AppState;
 use serde_json::json;
 
 pub(crate) struct SuccessResponseInput<'a> {
@@ -132,6 +132,10 @@ pub(crate) fn build_success_response(input: SuccessResponseInput<'_>) -> JsonRpc
 
     if let Some(ref next_tools) = resp.suggested_next_tools {
         resp.suggestion_reasons = Some(tools::suggestion_reasons_for(next_tools, name));
+        let calls = build_suggested_next_calls(name, arguments, next_tools, resp.data.as_ref());
+        if !calls.is_empty() {
+            resp.suggested_next_calls = Some(calls);
+        }
     }
 
     if compact {
@@ -216,4 +220,114 @@ pub(crate) fn build_error_response(
             "isError": true
         }),
     )
+}
+
+/// Build the additive `suggested_next_calls` list for the current response.
+///
+/// Additive companion to `suggested_next_tools` — never replaces it. Pre-fills
+/// `arguments` for follow-up tools the server can unambiguously derive from
+/// (a) the current call's own arguments, and (b) the fresh payload (most
+/// usefully `analysis_id`). Applies only to the four high-value workflow
+/// origins: `verify_change_readiness`, `analyze_change_request`,
+/// `impact_report`, `safe_rename_report`. Other origins stay with the
+/// existing string-only `suggested_next_tools`.
+fn build_suggested_next_calls(
+    current_tool: &str,
+    current_args: &serde_json::Value,
+    next_tools: &[String],
+    payload: Option<&serde_json::Value>,
+) -> Vec<SuggestedNextCall> {
+    let analysis_id = payload
+        .and_then(|p| p.get("analysis_id"))
+        .and_then(|v| v.as_str());
+    let task = current_args.get("task").and_then(|v| v.as_str());
+    let changed_files = current_args.get("changed_files").cloned();
+    let file_path = current_args
+        .get("file_path")
+        .and_then(|v| v.as_str())
+        .or_else(|| current_args.get("relative_path").and_then(|v| v.as_str()));
+    let symbol = current_args
+        .get("symbol")
+        .and_then(|v| v.as_str())
+        .or_else(|| current_args.get("symbol_name").and_then(|v| v.as_str()))
+        .or_else(|| current_args.get("name").and_then(|v| v.as_str()));
+    let new_name = current_args.get("new_name").and_then(|v| v.as_str());
+
+    let mut calls = Vec::new();
+    for next in next_tools.iter().take(3) {
+        let call = match (current_tool, next.as_str()) {
+            ("verify_change_readiness", "get_analysis_section") => analysis_id.map(|aid| {
+                SuggestedNextCall {
+                    tool: "get_analysis_section".to_owned(),
+                    arguments: json!({
+                        "analysis_id": aid,
+                        "section": "verifier_diagnostics",
+                    }),
+                    reason: "Expand the diagnostics section of this readiness report instead of re-running verifier work.".to_owned(),
+                }
+            }),
+            ("analyze_change_request", "verify_change_readiness") => task.map(|t| {
+                let mut args = json!({ "task": t });
+                if let Some(cf) = changed_files.clone() {
+                    args["changed_files"] = cf;
+                }
+                SuggestedNextCall {
+                    tool: "verify_change_readiness".to_owned(),
+                    arguments: args,
+                    reason: "Gate the same task through the verifier before any edit.".to_owned(),
+                }
+            }),
+            ("impact_report", "diff_aware_references") => changed_files.clone().map(|cf| {
+                SuggestedNextCall {
+                    tool: "diff_aware_references".to_owned(),
+                    arguments: json!({ "changed_files": cf }),
+                    reason: "Drill into classified references for the same file set without re-running impact.".to_owned(),
+                }
+            }),
+            ("impact_report", "verify_change_readiness") => task.map(|t| {
+                let mut args = json!({ "task": t });
+                if let Some(cf) = changed_files.clone() {
+                    args["changed_files"] = cf;
+                }
+                SuggestedNextCall {
+                    tool: "verify_change_readiness".to_owned(),
+                    arguments: args,
+                    reason: "Promote the impact evidence into a readiness verdict for the same scope.".to_owned(),
+                }
+            }),
+            ("safe_rename_report", "rename_symbol") => {
+                match (file_path, symbol) {
+                    (Some(fp), Some(sym)) => {
+                        let mut args = json!({
+                            "file_path": fp,
+                            "symbol_name": sym,
+                            "dry_run": true,
+                        });
+                        if let Some(nn) = new_name {
+                            args["new_name"] = json!(nn);
+                        }
+                        Some(SuggestedNextCall {
+                            tool: "rename_symbol".to_owned(),
+                            arguments: args,
+                            reason: "Execute the rename previewed here; keep `dry_run=true` until diagnostics pass.".to_owned(),
+                        })
+                    }
+                    _ => None,
+                }
+            }
+            // Generic fallback: any workflow tool that hands out an analysis_id
+            // can be followed by get_analysis_section with the correct handle.
+            (_, "get_analysis_section") => analysis_id.map(|aid| SuggestedNextCall {
+                tool: "get_analysis_section".to_owned(),
+                arguments: json!({ "analysis_id": aid, "section": "summary" }),
+                reason: "Pull the summary section of this handle instead of re-running the workflow."
+                    .to_owned(),
+            }),
+            _ => None,
+        };
+        if let Some(c) = call {
+            calls.push(c);
+        }
+    }
+    calls
 }

--- a/crates/codelens-mcp/src/dispatch/response_support.rs
+++ b/crates/codelens-mcp/src/dispatch/response_support.rs
@@ -259,6 +259,13 @@ fn format_structured_response(resp: &ToolCallResponse) -> String {
         {
             out.insert("suggestion_reasons".to_owned(), v);
         }
+        // Additive concrete-args companion — skipped when empty.
+        if let Some(ref calls) = resp.suggested_next_calls
+            && !calls.is_empty()
+            && let Ok(v) = serde_json::to_value(calls)
+        {
+            out.insert("suggested_next_calls".to_owned(), v);
+        }
     }
 
     // CI/batch mode: check if routing hint is Async (analysis handles)
@@ -343,6 +350,14 @@ fn slim_text_payload_for_async_job(
         resp.suggestion_reasons
             .as_ref()
             .and_then(|reasons| serde_json::to_value(reasons).ok()),
+    );
+    insert_if_present(
+        &mut payload,
+        "suggested_next_calls",
+        resp.suggested_next_calls
+            .as_ref()
+            .filter(|calls| !calls.is_empty())
+            .and_then(|calls| serde_json::to_value(calls).ok()),
     );
 
     let mut text_data = Map::new();
@@ -435,6 +450,14 @@ fn slim_text_payload_for_async_handle(
         resp.suggestion_reasons
             .as_ref()
             .and_then(|reasons| serde_json::to_value(reasons).ok()),
+    );
+    insert_if_present(
+        &mut payload,
+        "suggested_next_calls",
+        resp.suggested_next_calls
+            .as_ref()
+            .filter(|calls| !calls.is_empty())
+            .and_then(|calls| serde_json::to_value(calls).ok()),
     );
 
     let mut text_data = Map::new();

--- a/crates/codelens-mcp/src/integration_tests/workflow.rs
+++ b/crates/codelens-mcp/src/integration_tests/workflow.rs
@@ -1847,6 +1847,18 @@ fn verifier_tools_return_structured_content_payload() {
             .map(|items| !items.is_empty() && items.len() <= 3)
             .unwrap_or(false)
     );
+    assert!(readiness_text["suggested_next_calls"].is_array());
+    assert!(
+        readiness_text["suggested_next_calls"]
+            .as_array()
+            .map(|items| {
+                items.iter().any(|entry| {
+                    entry["tool"].as_str() == Some("get_analysis_section")
+                        && entry["arguments"]["analysis_id"].is_string()
+                })
+            })
+            .unwrap_or(false)
+    );
     assert_eq!(readiness_text["routing_hint"], json!("async"));
     assert!(readiness_text["data"].get("verifier_checks").is_none());
     assert!(readiness_text["data"].get("blockers").is_none());
@@ -2217,6 +2229,66 @@ fn low_level_chain_emits_composite_guidance_and_tracks_followthrough() {
             .unwrap_or_default()
             >= 1
     );
+}
+
+#[test]
+fn suggested_next_calls_forward_task_and_analysis_id() {
+    let project = project_root();
+    fs::write(
+        project.as_path().join("next_calls.py"),
+        "def widget():\n    return 7\n",
+    )
+    .unwrap();
+    let state = make_state(&project);
+
+    let analyze = call_tool(
+        &state,
+        "analyze_change_request",
+        json!({"task": "refactor widget safely", "changed_files": ["next_calls.py"]}),
+    );
+    let analyze_next_calls = analyze["suggested_next_calls"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        !analyze_next_calls.is_empty(),
+        "analyze_change_request should populate suggested_next_calls: {analyze}"
+    );
+    let verify_entry = analyze_next_calls
+        .iter()
+        .find(|call| call.get("tool").and_then(|v| v.as_str()) == Some("verify_change_readiness"))
+        .expect("verify_change_readiness should be forwarded with args");
+    assert_eq!(
+        verify_entry["arguments"]["task"].as_str(),
+        Some("refactor widget safely")
+    );
+    assert!(
+        verify_entry["arguments"]["changed_files"].is_array(),
+        "changed_files should be forwarded as array: {verify_entry}"
+    );
+
+    let verify = call_tool(
+        &state,
+        "verify_change_readiness",
+        json!({"task": "refactor widget safely", "changed_files": ["next_calls.py"]}),
+    );
+    let analysis_id = verify["data"]["analysis_id"]
+        .as_str()
+        .expect("verify_change_readiness should return analysis_id");
+    let verify_next_calls = verify["suggested_next_calls"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    if let Some(expand) = verify_next_calls
+        .iter()
+        .find(|call| call.get("tool").and_then(|v| v.as_str()) == Some("get_analysis_section"))
+    {
+        assert_eq!(
+            expand["arguments"]["analysis_id"].as_str(),
+            Some(analysis_id),
+            "get_analysis_section should forward the fresh analysis_id: {expand}"
+        );
+    }
 }
 
 #[test]

--- a/crates/codelens-mcp/src/protocol.rs
+++ b/crates/codelens-mcp/src/protocol.rs
@@ -82,6 +82,17 @@ pub struct ToolAnnotations {
     pub tier: Option<ToolTier>,
 }
 
+/// Concrete follow-up call paired with a `suggested_next_tools` entry.
+/// `arguments` is pre-filled with context that the client already has in hand
+/// (file paths, symbol names, task description, current `analysis_id`) so
+/// clients can forward-invoke without reconstructing the argument object.
+#[derive(Debug, Clone, Serialize)]
+pub struct SuggestedNextCall {
+    pub tool: String,
+    pub arguments: Value,
+    pub reason: String,
+}
+
 #[allow(dead_code)] // used by SSE transport for server→client push
 #[derive(Debug, Serialize)]
 pub struct JsonRpcNotification {
@@ -116,6 +127,13 @@ pub struct ToolCallResponse {
     pub token_estimate: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub suggested_next_tools: Option<Vec<String>>,
+    /// Additive companion to `suggested_next_tools`. Each entry carries the tool
+    /// name plus a concrete `arguments` object derived from the current call's
+    /// context (file/symbol/task/analysis_id), so clients can forward without
+    /// reconstructing args. Coexists with `suggested_next_tools` — neither
+    /// replaces the other.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub suggested_next_calls: Option<Vec<SuggestedNextCall>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub suggestion_reasons: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -345,6 +363,7 @@ impl ToolCallResponse {
             error: None,
             token_estimate: None,
             suggested_next_tools: None,
+            suggested_next_calls: None,
             suggestion_reasons: None,
             budget_hint: None,
             routing_hint: None,
@@ -366,6 +385,7 @@ impl ToolCallResponse {
             error: Some(message.into()),
             token_estimate: None,
             suggested_next_tools: None,
+            suggested_next_calls: None,
             suggestion_reasons: None,
             budget_hint: None,
             routing_hint: None,

--- a/crates/codelens-mcp/src/server/http_tests.rs
+++ b/crates/codelens-mcp/src/server/http_tests.rs
@@ -1212,6 +1212,18 @@ async fn verify_change_readiness_http_response_uses_slim_text_wrapper() {
             .unwrap_or(false)
     );
     assert!(text_payload["data"]["section_handles"].is_array());
+    assert!(text_payload["suggested_next_calls"].is_array());
+    assert!(
+        text_payload["suggested_next_calls"]
+            .as_array()
+            .map(|items| {
+                items.iter().any(|entry| {
+                    entry["tool"].as_str() == Some("get_analysis_section")
+                        && entry["arguments"]["analysis_id"].is_string()
+                })
+            })
+            .unwrap_or(false)
+    );
     assert_eq!(text_payload["routing_hint"], serde_json::json!("async"));
     assert!(text_payload["data"].get("verifier_checks").is_none());
     assert!(text_payload["data"].get("blockers").is_none());


### PR DESCRIPTION
## Summary

Additive companion to existing `suggested_next_tools: Option<Vec<String>>`. New field `suggested_next_calls: Option<Vec<{tool, arguments, reason}>>` pre-fills the `arguments` object for follow-up calls using (a) the current call's own inputs and (b) the fresh payload's `analysis_id`.

**Not a breaking change** — `suggested_next_tools` and `suggestion_reasons` are untouched. Clients that ignore the new field see no difference.

## Why

Measured gap: `composite_guidance_followthrough_rate ≈ 0.2` and `handle_reuse_rate ≈ 0`. Agents read the string list, then recompute arguments themselves (or skip). Pre-filling the concrete args closes that loop with zero contract break.

## Scope (deliberate)

Four high-value workflow origins only:

| current | next | forwarded args |
|---|---|---|
| `analyze_change_request` | `verify_change_readiness` | `task`, `changed_files` |
| `verify_change_readiness` | `get_analysis_section` | `analysis_id`, `section="verifier_diagnostics"` |
| `impact_report` | `diff_aware_references` / `verify_change_readiness` | `changed_files`, `task` |
| `safe_rename_report` | `rename_symbol` | `file_path`, `symbol_name`, `new_name`, `dry_run=true` |

Generic fallback: any workflow origin returning an `analysis_id` gets a `get_analysis_section` forward for cheap section expansion (keeps handle reuse cheap).

## Implementation notes

- `crates/codelens-mcp/src/protocol.rs`: new `SuggestedNextCall {tool, arguments, reason}` + `ToolCallResponse.suggested_next_calls: Option<Vec<SuggestedNextCall>>`
- `crates/codelens-mcp/src/dispatch/response.rs`: `build_suggested_next_calls()` called right after `suggestion_reasons_for`, only when `suggested_next_tools` is `Some`. Reads the fresh payload for `analysis_id` and the current args for task/file/symbol/new_name.
- `crates/codelens-mcp/src/dispatch/response_support.rs`: both slim async-handle wrappers and the generic text-payload wrapper now surface the field (empty-vec guarded).

## Test plan

- [x] `cargo check -p codelens-mcp`
- [x] `cargo test -p codelens-mcp -- --test-threads=1` — **223/223 pass**
- [x] New test `suggested_next_calls_forward_task_and_analysis_id`
  - `analyze_change_request` → `verify_change_readiness` entry with `arguments.task == "refactor widget safely"` and `arguments.changed_files` array
  - `verify_change_readiness` → if `get_analysis_section` suggested, `arguments.analysis_id` matches the fresh handle
- [x] `verify_change_readiness_http_response_uses_slim_text_wrapper` now also asserts `suggested_next_calls[*].tool == "get_analysis_section"` with an `analysis_id` arg in the slim HTTP wrapper
- [ ] CI Ubuntu / macOS / Windows

## What this doesn't do

- Doesn't modify or deprecate `suggested_next_tools` or `suggestion_reasons`. Purely additive.
- Doesn't change telemetry counters. (Orthogonal follow-up: tool-call `get_analysis_section` is already counted via `AppState::get_analysis_section` calling `record_analysis_read(true)`. Inspection confirmed no separate instrumentation gap.)
- Doesn't touch resource output schemas (the `suggested_next_tools` array schema stays the same).

## Follow-ups (not in this PR)

- Selective preview-first on high-payload handle reports (`impact_report` / `module_boundary_report` / `semantic_code_review` / `analyze_change_request`) — gated by `payload_estimate` threshold
- Display-layer summary compression for list-style tools (`get_ranked_context` etc.) — top-5 summary + `more_available` / `expand_hint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)