### PR TITLE
feat(coordination): instrument Mutex<HashMap> contention before sharding

### DIFF
--- a/crates/codelens-mcp/src/agent_coordination.rs
+++ b/crates/codelens-mcp/src/agent_coordination.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
+use std::time::Instant;
 
 const DEFAULT_COORDINATION_TTL_SECS: u64 = 5 * 60;
 const MAX_COORDINATION_TTL_SECS: u64 = 60 * 60;
@@ -55,6 +57,30 @@ pub(crate) struct CoordinationCounts {
     pub active_claims: usize,
 }
 
+/// Read-only snapshot of `Mutex<HashMap>` contention metrics on the
+/// coordination store. Captured to validate (or refute) the hypothesis
+/// that the single-mutex design becomes a hot path before adding
+/// per-project sharding. All values are cumulative since process start.
+#[derive(Debug, Clone, Default, Serialize)]
+pub(crate) struct CoordinationLockStats {
+    pub acquire_count: u64,
+    pub wait_total_micros: u64,
+    pub wait_max_micros: u64,
+}
+
+impl CoordinationLockStats {
+    /// Cheap derived metric — average wait per acquire in microseconds.
+    /// Returns 0 when no acquisitions have happened yet, which keeps the
+    /// payload predictable for empty sessions.
+    pub fn avg_wait_micros(&self) -> u64 {
+        if self.acquire_count == 0 {
+            0
+        } else {
+            self.wait_total_micros / self.acquire_count
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default, Serialize)]
 pub(crate) struct CoordinationSnapshot {
     pub agents: Vec<AgentWorkEntry>,
@@ -70,18 +96,51 @@ struct ProjectCoordinationState {
 
 pub(crate) struct AgentCoordinationStore {
     entries: Mutex<HashMap<String, ProjectCoordinationState>>,
+    lock_acquire_count: AtomicU64,
+    lock_wait_total_micros: AtomicU64,
+    lock_wait_max_micros: AtomicU64,
 }
 
 impl AgentCoordinationStore {
     pub(crate) fn new() -> Self {
         Self {
             entries: Mutex::new(HashMap::new()),
+            lock_acquire_count: AtomicU64::new(0),
+            lock_wait_total_micros: AtomicU64::new(0),
+            lock_wait_max_micros: AtomicU64::new(0),
         }
     }
 
     fn prune_project(project: &mut ProjectCoordinationState, now_ms: u64) {
         project.agents.retain(|_, entry| entry.expires_at > now_ms);
         project.claims.retain(|_, entry| entry.expires_at > now_ms);
+    }
+
+    /// Acquire the inner mutex while measuring how long the caller waited.
+    /// Centralizes the contention instrumentation so every call site goes
+    /// through the same path (and the only one that touches the atomics).
+    fn lock_entries(&self) -> std::sync::MutexGuard<'_, HashMap<String, ProjectCoordinationState>> {
+        let started = Instant::now();
+        let guard = self
+            .entries
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let waited_us = started.elapsed().as_micros() as u64;
+        self.lock_acquire_count.fetch_add(1, Ordering::Relaxed);
+        self.lock_wait_total_micros
+            .fetch_add(waited_us, Ordering::Relaxed);
+        self.lock_wait_max_micros
+            .fetch_max(waited_us, Ordering::Relaxed);
+        guard
+    }
+
+    /// Read-only snapshot of contention counters. Cheap — three atomic loads.
+    pub(crate) fn lock_stats(&self) -> CoordinationLockStats {
+        CoordinationLockStats {
+            acquire_count: self.lock_acquire_count.load(Ordering::Relaxed),
+            wait_total_micros: self.lock_wait_total_micros.load(Ordering::Relaxed),
+            wait_max_micros: self.lock_wait_max_micros.load(Ordering::Relaxed),
+        }
     }
 
     pub(crate) fn register_agent_work(
@@ -104,10 +163,7 @@ impl AgentCoordinationStore {
             intent: intent.to_owned(),
             expires_at,
         };
-        let mut entries = self
-            .entries
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut entries = self.lock_entries();
         let project = entries.entry(scope.to_owned()).or_default();
         Self::prune_project(project, now_ms());
         project.agents.insert(session_id.to_owned(), entry.clone());
@@ -127,10 +183,7 @@ impl AgentCoordinationStore {
     ) -> FileClaimEntry {
         let ttl_secs = normalize_ttl_secs(ttl_secs.unwrap_or(DEFAULT_COORDINATION_TTL_SECS));
         let expires_at = now_ms().saturating_add(ttl_secs * 1000);
-        let mut entries = self
-            .entries
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut entries = self.lock_entries();
         let project = entries.entry(scope.to_owned()).or_default();
         Self::prune_project(project, now_ms());
         let registered_agent = project.agents.get(session_id).cloned();
@@ -177,10 +230,7 @@ impl AgentCoordinationStore {
         session_id: &str,
         paths: &[String],
     ) -> (Vec<String>, Option<FileClaimEntry>) {
-        let mut entries = self
-            .entries
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut entries = self.lock_entries();
         let Some(project) = entries.get_mut(scope) else {
             return (Vec::new(), None);
         };
@@ -211,10 +261,7 @@ impl AgentCoordinationStore {
         session_id: &str,
         target_paths: &[String],
     ) -> Vec<FileClaimEntry> {
-        let mut entries = self
-            .entries
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut entries = self.lock_entries();
         let Some(project) = entries.get_mut(scope) else {
             return Vec::new();
         };
@@ -269,10 +316,7 @@ impl AgentCoordinationStore {
     }
 
     pub(crate) fn snapshot(&self, scope: &str) -> CoordinationSnapshot {
-        let mut entries = self
-            .entries
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut entries = self.lock_entries();
         let Some(project) = entries.get_mut(scope) else {
             return CoordinationSnapshot::default();
         };
@@ -289,5 +333,39 @@ impl AgentCoordinationStore {
             agents,
             claims,
         }
+    }
+}
+
+#[cfg(test)]
+mod lock_stats_tests {
+    use super::*;
+
+    #[test]
+    fn lock_stats_increment_on_each_acquire() {
+        let store = AgentCoordinationStore::new();
+        let stats0 = store.lock_stats();
+        assert_eq!(stats0.acquire_count, 0);
+        assert_eq!(stats0.wait_total_micros, 0);
+        assert_eq!(stats0.wait_max_micros, 0);
+        assert_eq!(stats0.avg_wait_micros(), 0);
+
+        store.register_agent_work("/p", "s1", "a", "b", "w", "intent", Some(60));
+        store.claim_files("/p", "s1", "a", "b", "w", vec!["f.rs".into()], "r", Some(60));
+        let after_two = store.lock_stats();
+        assert_eq!(
+            after_two.acquire_count, 2,
+            "register + claim should each acquire once"
+        );
+
+        let _ = store.snapshot("/p");
+        let after_three = store.lock_stats();
+        assert_eq!(after_three.acquire_count, 3);
+        assert!(after_three.wait_max_micros >= after_three.avg_wait_micros());
+    }
+
+    #[test]
+    fn avg_wait_micros_is_zero_when_never_acquired() {
+        let store = AgentCoordinationStore::new();
+        assert_eq!(store.lock_stats().avg_wait_micros(), 0);
     }
 }

--- a/crates/codelens-mcp/src/session_metrics_payload.rs
+++ b/crates/codelens-mcp/src/session_metrics_payload.rs
@@ -1,5 +1,5 @@
 use crate::AppState;
-use serde_json::{Map, Value, json};
+use serde_json::{json, Map, Value};
 
 pub(crate) struct SessionMetricsPayload {
     pub(crate) session: Map<String, Value>,
@@ -13,6 +13,7 @@ pub(crate) fn build_session_metrics_payload(state: &AppState) -> SessionMetricsP
     let watcher_failure_health = state.watcher_failure_health();
     let coordination = state
         .coordination_counts_for_session(&crate::session_context::SessionRequestContext::default());
+    let coordination_lock = state.coordination_lock_stats();
 
     let mut session_json = Map::new();
     session_json.insert("total_calls".to_owned(), json!(session.total_calls));
@@ -51,6 +52,22 @@ pub(crate) fn build_session_metrics_payload(state: &AppState) -> SessionMetricsP
     session_json.insert(
         "active_coordination_claims".to_owned(),
         json!(coordination.active_claims),
+    );
+    session_json.insert(
+        "coordination_lock_acquire_count".to_owned(),
+        json!(coordination_lock.acquire_count),
+    );
+    session_json.insert(
+        "coordination_lock_wait_total_micros".to_owned(),
+        json!(coordination_lock.wait_total_micros),
+    );
+    session_json.insert(
+        "coordination_lock_wait_max_micros".to_owned(),
+        json!(coordination_lock.wait_max_micros),
+    );
+    session_json.insert(
+        "coordination_lock_avg_wait_micros".to_owned(),
+        json!(coordination_lock.avg_wait_micros()),
     );
     session_json.insert("retry_count".to_owned(), json!(session.retry_count));
     session_json.insert(
@@ -249,39 +266,31 @@ pub(crate) fn build_session_metrics_payload(state: &AppState) -> SessionMetricsP
     );
     session_json.insert(
         "watcher_running".to_owned(),
-        json!(
-            watcher_stats
-                .as_ref()
-                .map(|stats| stats.running)
-                .unwrap_or(false)
-        ),
+        json!(watcher_stats
+            .as_ref()
+            .map(|stats| stats.running)
+            .unwrap_or(false)),
     );
     session_json.insert(
         "watcher_events_processed".to_owned(),
-        json!(
-            watcher_stats
-                .as_ref()
-                .map(|stats| stats.events_processed)
-                .unwrap_or(0)
-        ),
+        json!(watcher_stats
+            .as_ref()
+            .map(|stats| stats.events_processed)
+            .unwrap_or(0)),
     );
     session_json.insert(
         "watcher_files_reindexed".to_owned(),
-        json!(
-            watcher_stats
-                .as_ref()
-                .map(|stats| stats.files_reindexed)
-                .unwrap_or(0)
-        ),
+        json!(watcher_stats
+            .as_ref()
+            .map(|stats| stats.files_reindexed)
+            .unwrap_or(0)),
     );
     session_json.insert(
         "watcher_lock_contention_batches".to_owned(),
-        json!(
-            watcher_stats
-                .as_ref()
-                .map(|stats| stats.lock_contention_batches)
-                .unwrap_or(0)
-        ),
+        json!(watcher_stats
+            .as_ref()
+            .map(|stats| stats.lock_contention_batches)
+            .unwrap_or(0)),
     );
     session_json.insert(
         "watcher_index_failures".to_owned(),

--- a/crates/codelens-mcp/src/state.rs
+++ b/crates/codelens-mcp/src/state.rs
@@ -36,7 +36,8 @@ pub(crate) fn preflight_ttl_ms() -> u64 {
 }
 
 pub(crate) use crate::agent_coordination::{
-    ActiveAgentEntry, AgentWorkEntry, CoordinationCounts, CoordinationSnapshot, FileClaimEntry,
+    ActiveAgentEntry, AgentWorkEntry, CoordinationCounts, CoordinationLockStats,
+    CoordinationSnapshot, FileClaimEntry,
 };
 pub(crate) use crate::client_profile::{ClientProfile, EffortLevel};
 pub(crate) use crate::runtime_types::{

--- a/crates/codelens-mcp/src/state/coordination.rs
+++ b/crates/codelens-mcp/src/state/coordination.rs
@@ -6,8 +6,8 @@ use crate::error::CodeLensError;
 use crate::session_context::SessionRequestContext;
 
 use super::{
-    ActiveAgentEntry, AgentWorkEntry, AppState, CoordinationCounts, CoordinationSnapshot,
-    FileClaimEntry,
+    ActiveAgentEntry, AgentWorkEntry, AppState, CoordinationCounts, CoordinationLockStats,
+    CoordinationSnapshot, FileClaimEntry,
 };
 
 const DEFAULT_COORDINATION_TTL_SECS: u64 = 5 * 60;
@@ -212,5 +212,14 @@ impl AppState {
         session: &SessionRequestContext,
     ) -> CoordinationCounts {
         self.coordination_snapshot_for_session(session).counts
+    }
+
+    /// Cumulative `Mutex<HashMap>` contention counters on the coordination
+    /// store. Process-global (not per-session) — the counters track the
+    /// shared mutex itself, not any one caller. Surfaced through session
+    /// metrics so an operator can decide whether the single-mutex design
+    /// needs to be sharded before adding any new structure.
+    pub(crate) fn coordination_lock_stats(&self) -> CoordinationLockStats {
+        self.coord_store.lock_stats()
     }
 }


### PR DESCRIPTION
## Summary

Adds three atomic counters and a centralized `lock_entries()` helper on `AgentCoordinationStore` so we can decide — with data — whether the single-mutex design becomes a real hot path before splitting it. **No behavior change, no new locking, no new abstraction.**

## Why now

Per the project review: \"do not add new abstraction; let existing types carry through to efficiency.\" Sharding the coordination mutex is a real design lever, but it's premature without measurement. This PR adds only the measurement needed to falsify or confirm that contention is worth chasing.

## Counters (cumulative since process start)

| Field | Source | Cost |
|---|---|---|
| `coordination_lock_acquire_count` | `AtomicU64::fetch_add(1, Relaxed)` | 1 atomic |
| `coordination_lock_wait_total_micros` | `Instant::elapsed().as_micros()` | 1 atomic |
| `coordination_lock_wait_max_micros` | `AtomicU64::fetch_max` | 1 atomic |
| `coordination_lock_avg_wait_micros` | derived in `CoordinationLockStats::avg_wait_micros()` | constant |

All five existing call sites (`register_agent_work`, `claim_files`, `release_files`, `overlapping_claims`, `snapshot`) now go through one helper. The existing poisoned-mutex recovery (`unwrap_or_else(|p| p.into_inner())`) is preserved.

## Surfaces

- `AppState::coordination_lock_stats()` — read-only snapshot
- `codelens://stats/token-efficiency` resource — four new fields under `session.*`

## Test plan

- [x] `cargo check -p codelens-mcp`
- [x] `cargo test -p codelens-mcp lock_stats -- --test-threads=1` — 2 new unit tests pass
- [x] `cargo test -p codelens-mcp -- --test-threads=1` — **224/224 pass**
- [ ] CI Ubuntu / macOS / Windows

## Decision criteria for follow-up sharding

After this lands, observe in real sessions over time:

- If `coordination_lock_avg_wait_micros < 100` and `coordination_lock_wait_max_micros < 1000`: no change warranted.
- If `avg > 100` or `max > 1000` under realistic concurrency: per-project sharding becomes justified.
- If `acquire_count` is high but waits are negligible: lock isn't the bottleneck.

This PR deliberately does not pre-judge any of those outcomes.

## Relationship to other PRs

Independent of #77 (additive `suggested_next_calls`) and #78 (selective preview-first trim). All three target different axes of the same review feedback and can land in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)