### PR TITLE
fix(workflows): tighten diagnose contract and normalize LSP commands

### DIFF
--- a/crates/codelens-engine/src/lib.rs
+++ b/crates/codelens-engine/src/lib.rs
@@ -51,8 +51,8 @@ pub use lsp::{
     LspWorkspaceSymbol, LspWorkspaceSymbolRequest, check_lsp_status, default_lsp_args_for_command,
     default_lsp_command_for_extension, default_lsp_command_for_path,
     find_referencing_symbols_via_lsp, get_diagnostics_via_lsp, get_lsp_recipe,
-    get_rename_plan_via_lsp, get_type_hierarchy_via_lsp, lsp_binary_exists,
-    search_workspace_symbols_via_lsp,
+    get_lsp_recipe_for_command, get_rename_plan_via_lsp, get_type_hierarchy_via_lsp,
+    lsp_binary_exists, search_workspace_symbols_via_lsp,
 };
 pub use project::{
     ProjectRoot, WorkspacePackage, compute_dominant_language, detect_frameworks,

--- a/crates/codelens-engine/src/lsp/mod.rs
+++ b/crates/codelens-engine/src/lsp/mod.rs
@@ -7,7 +7,7 @@ pub mod types;
 pub use registry::{
     LSP_RECIPES, LspRecipe, LspStatus, check_lsp_status, default_lsp_args_for_command,
     default_lsp_command_for_extension, default_lsp_command_for_path, get_lsp_recipe,
-    lsp_binary_exists,
+    get_lsp_recipe_for_command, lsp_binary_exists,
 };
 pub use session::LspSessionPool;
 pub use types::{

--- a/crates/codelens-engine/src/lsp/registry.rs
+++ b/crates/codelens-engine/src/lsp/registry.rs
@@ -357,6 +357,16 @@ pub fn get_lsp_recipe(extension: &str) -> Option<&'static LspRecipe> {
         .find(|r| r.extensions.contains(&ext.as_str()))
 }
 
+pub fn get_lsp_recipe_for_command(command: &str) -> Option<&'static LspRecipe> {
+    let binary = Path::new(command)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(command);
+    LSP_RECIPES
+        .iter()
+        .find(|recipe| recipe.binary_name == binary)
+}
+
 pub fn default_lsp_command_for_extension(extension: &str) -> Option<&'static str> {
     get_lsp_recipe(extension).map(|recipe| recipe.binary_name)
 }
@@ -369,8 +379,5 @@ pub fn default_lsp_command_for_path(file_path: &str) -> Option<&'static str> {
 }
 
 pub fn default_lsp_args_for_command(command: &str) -> Option<&'static [&'static str]> {
-    LSP_RECIPES
-        .iter()
-        .find(|recipe| recipe.binary_name == command)
-        .map(|recipe| recipe.args)
+    get_lsp_recipe_for_command(command).map(|recipe| recipe.args)
 }

--- a/crates/codelens-engine/src/lsp/tests.rs
+++ b/crates/codelens-engine/src/lsp/tests.rs
@@ -2,7 +2,8 @@ use super::{
     LspDiagnosticRequest, LspRenamePlanRequest, LspRequest, LspSessionPool,
     LspTypeHierarchyRequest, LspWorkspaceSymbolRequest, default_lsp_args_for_command,
     default_lsp_command_for_path, find_referencing_symbols_via_lsp, get_diagnostics_via_lsp,
-    get_rename_plan_via_lsp, get_type_hierarchy_via_lsp, search_workspace_symbols_via_lsp,
+    get_lsp_recipe_for_command, get_rename_plan_via_lsp, get_type_hierarchy_via_lsp,
+    search_workspace_symbols_via_lsp,
 };
 use crate::ProjectRoot;
 use serde_json::Value;
@@ -234,6 +235,18 @@ fn default_lsp_args_are_derived_from_registry_by_command() {
         Some(&["--stdio"][..])
     );
     assert_eq!(default_lsp_args_for_command("metals"), Some(&[][..]));
+    assert_eq!(
+        default_lsp_args_for_command("/opt/homebrew/bin/pyright-langserver"),
+        Some(&["--stdio"][..])
+    );
+}
+
+#[test]
+fn lsp_recipe_lookup_accepts_absolute_command_paths() {
+    let recipe = get_lsp_recipe_for_command("/opt/homebrew/bin/pyright-langserver")
+        .expect("recipe for pyright absolute path");
+    assert_eq!(recipe.server_name, "pyright");
+    assert_eq!(recipe.install_command, "npm install -g pyright");
 }
 
 fn chmod_exec(_path: &std::path::Path) {

--- a/crates/codelens-mcp/src/integration_tests/workflow.rs
+++ b/crates/codelens-mcp/src/integration_tests/workflow.rs
@@ -3176,12 +3176,7 @@ fn prepend_path(dir: &std::path::Path, original_path: &str) -> std::ffi::OsStrin
     std::env::join_paths(paths).expect("join PATH entries")
 }
 
-#[test]
-fn diagnose_issues_returns_structured_content() {
-    // diagnose_issues with a path delegates to get_file_diagnostics, which
-    // needs an LSP server.  We create a minimal python3-based mock named
-    // `pyright-langserver` (the default binary for .py files) in a temp bin
-    // directory and prepend it to PATH for the duration of the test.
+fn install_mock_pyright() -> std::path::PathBuf {
     let mock_lsp = concat!(
         "#!/usr/bin/env python3\n",
         "import sys, json\n",
@@ -3246,6 +3241,14 @@ fn diagnose_issues_returns_structured_content() {
         .unwrap();
     }
 
+    bin_dir
+}
+
+#[test]
+fn diagnose_issues_returns_structured_content() {
+    // diagnose_issues with file_path delegates to get_file_diagnostics.
+    let bin_dir = install_mock_pyright();
+
     let project = project_root();
     fs::write(
         project.as_path().join("diag_test.py"),
@@ -3262,7 +3265,11 @@ fn diagnose_issues_returns_structured_content() {
         std::env::set_var("PATH", &patched_path);
     }
 
-    let payload = call_tool(&state, "diagnose_issues", json!({"path": "diag_test.py"}));
+    let payload = call_tool(
+        &state,
+        "diagnose_issues",
+        json!({"file_path": "diag_test.py"}),
+    );
 
     // SAFETY: restoring PATH; still under PATH_MUTEX.
     unsafe {
@@ -3292,6 +3299,74 @@ fn diagnose_issues_returns_structured_content() {
             })
             .unwrap_or(false)
     );
+}
+
+#[test]
+fn diagnose_issues_directory_scope_returns_directory_summary() {
+    let bin_dir = install_mock_pyright();
+    let project = project_root();
+    fs::create_dir_all(project.as_path().join("src")).unwrap();
+    fs::write(
+        project.as_path().join("src/diag_test.py"),
+        "def hello():\n    return 1\n",
+    )
+    .unwrap();
+    fs::write(project.as_path().join("src/notes.txt"), "skip me\n").unwrap();
+    let state = make_state(&project);
+
+    let _guard = PATH_MUTEX.lock().unwrap_or_else(|p| p.into_inner());
+    let original_path = std::env::var("PATH").unwrap_or_default();
+    let patched_path = prepend_path(&bin_dir, &original_path);
+    unsafe {
+        std::env::set_var("PATH", &patched_path);
+    }
+
+    let payload = call_tool(&state, "diagnose_issues", json!({"path": "src"}));
+
+    unsafe {
+        std::env::set_var("PATH", original_path);
+    }
+
+    assert_eq!(payload["success"], json!(true));
+    assert_eq!(payload["data"]["workflow"], json!("diagnose_issues"));
+    assert_eq!(
+        payload["data"]["delegated_tool"],
+        json!("directory_diagnostics")
+    );
+    assert_eq!(payload["data"]["scope"], json!("directory"));
+    assert_eq!(payload["data"]["diagnosable_file_count"], json!(1));
+    assert_eq!(payload["data"]["returned_file_count"], json!(1));
+    assert_eq!(
+        payload["data"]["files"][0]["file_path"],
+        json!("src/diag_test.py")
+    );
+    assert!(
+        payload["data"]["skipped_files"]
+            .as_array()
+            .map(|items| items
+                .iter()
+                .any(|entry| entry["file_path"] == json!("src/notes.txt")))
+            .unwrap_or(false)
+    );
+}
+
+#[test]
+fn diagnose_issues_symbol_requires_file_target() {
+    let project = project_root();
+    let state = make_state(&project);
+
+    let missing_file =
+        crate::tools::workflows::diagnose_issues(&state, &json!({"symbol": "hello"}))
+            .expect_err("missing file_path should fail");
+    assert!(missing_file.to_string().contains("file_path"));
+
+    fs::create_dir_all(project.as_path().join("pkg")).unwrap();
+    let directory_target = crate::tools::workflows::diagnose_issues(
+        &state,
+        &json!({"file_path": "pkg", "symbol": "hello"}),
+    );
+    let error = directory_target.expect_err("directory symbol target should fail");
+    assert!(error.to_string().contains("requires a file target"));
 }
 
 #[test]

--- a/crates/codelens-mcp/src/tool_defs/build.rs
+++ b/crates/codelens-mcp/src/tool_defs/build.rs
@@ -124,12 +124,14 @@ fn build_tools() -> Vec<Tool> {
                 "task": {"type": "string", "description": "Description of the planned change"}
             }
         })).with_output_schema(workflow_alias_output_schema()).with_annotations(ro_w.clone()).with_max_response_tokens(3072),
-        Tool::new("diagnose_issues", "[CodeLens:Workflow] Diagnostics: file-level issues or unresolved reference check.", json!({
+        Tool::new("diagnose_issues", "[CodeLens:Workflow] Diagnostics: file, directory, or symbol-level issue triage.", json!({
             "type": "object",
             "properties": {
                 "file_path": {"type": "string", "description": "File to diagnose"},
                 "path": {"type": "string", "description": "Directory scope"},
-                "symbol": {"type": "string", "description": "Symbol to check references for"}
+                "symbol": {"type": "string", "description": "Symbol to check references for"},
+                "changed_files": {"type": "array", "items": {"type": "string"}, "description": "Optional changed files to narrow unresolved reference checks"},
+                "max_results": {"type": "integer", "description": "Optional per-file diagnostics cap"}
             }
         })).with_output_schema(workflow_alias_output_schema()).with_annotations(ro_w.clone()).with_max_response_tokens(3072),
         Tool::new("onboard_project", "[CodeLens:Session] One-shot onboarding: structure, key files, cycles, stats.", json!({"type":"object","properties":{}})).with_output_schema(onboard_output_schema()).with_annotations(ro_w.clone()),

--- a/crates/codelens-mcp/src/tools/lsp.rs
+++ b/crates/codelens-mcp/src/tools/lsp.rs
@@ -9,7 +9,7 @@ use codelens_engine::{
     LspDiagnosticRequest, LspRenamePlanRequest, LspRequest, LspTypeHierarchyRequest,
     LspWorkspaceSymbolRequest, check_lsp_status as core_check_lsp_status, extract_word_at_position,
     find_referencing_symbols_via_text, get_lsp_recipe as core_get_lsp_recipe,
-    get_type_hierarchy_native,
+    get_lsp_recipe_for_command as core_get_lsp_recipe_for_command, get_type_hierarchy_native,
 };
 use serde_json::json;
 
@@ -49,30 +49,9 @@ fn compact_text_references(
 }
 
 fn lsp_install_hint(command: &str) -> &'static str {
-    match command {
-        "pyright" => "  pip install pyright",
-        "typescript-language-server" => "  npm i -g typescript-language-server typescript",
-        "rust-analyzer" => "  rustup component add rust-analyzer",
-        "gopls" => "  go install golang.org/x/tools/gopls@latest",
-        "clangd" => "  brew install llvm  (or apt install clangd)",
-        "jdtls" => "  See https://github.com/eclipse-jdtls/eclipse.jdt.ls",
-        "solargraph" => "  gem install solargraph",
-        "intelephense" => "  npm i -g intelephense",
-        "kotlin-language-server" => "  See https://github.com/fwcd/kotlin-language-server",
-        "metals" => "  cs install metals  (via Coursier)",
-        "sourcekit-lsp" => "  Included with Xcode / Swift toolchain",
-        "csharp-ls" => "  dotnet tool install -g csharp-ls",
-        "dart" => "  dart pub global activate dart_language_server",
-        // Phase 6a languages
-        "lua-language-server" => "  brew install lua-language-server",
-        "zls" => "  brew install zls",
-        "nextls" => "  mix escript.install hex next_ls",
-        "haskell-language-server-wrapper" => "  ghcup install hls",
-        "ocamllsp" => "  opam install ocaml-lsp-server",
-        "erlang_ls" => "  brew install erlang_ls",
-        "bash-language-server" => "  npm i -g bash-language-server",
-        _ => "  Check your package manager for the LSP server binary",
-    }
+    core_get_lsp_recipe_for_command(command)
+        .map(|recipe| recipe.install_command)
+        .unwrap_or("Check your package manager for the LSP server binary")
 }
 
 fn enhance_lsp_error(err: anyhow::Error, command: &str) -> CodeLensError {

--- a/crates/codelens-mcp/src/tools/workflows.rs
+++ b/crates/codelens-mcp/src/tools/workflows.rs
@@ -1,13 +1,9 @@
 use crate::AppState;
 use crate::error::CodeLensError;
-use crate::tool_defs::deprecated_workflow_alias;
-use crate::tool_runtime::{ToolHandler, ToolResult};
-use serde_json::{Value, json};
-
-#[cfg(feature = "semantic")]
 use crate::protocol::BackendKind;
-#[cfg(feature = "semantic")]
-use crate::tool_runtime::success_meta;
+use crate::tool_defs::deprecated_workflow_alias;
+use crate::tool_runtime::{ToolHandler, ToolResult, success_meta};
+use serde_json::{Value, json};
 
 fn attach_workflow_metadata(workflow: &str, delegated_tool: &str, payload: Value) -> Value {
     let deprecation = deprecated_workflow_alias(workflow);
@@ -48,6 +44,100 @@ fn delegate_workflow(
     Ok((
         attach_workflow_metadata(workflow, delegated_tool, payload),
         meta,
+    ))
+}
+
+fn diagnose_path_scope(state: &AppState, path: &str, max_results: Option<u64>) -> ToolResult {
+    let project = state.project();
+    let resolved = project.resolve(path)?;
+    if resolved.is_file() {
+        return delegate_workflow(
+            state,
+            "diagnose_issues",
+            "get_file_diagnostics",
+            json!({
+                "file_path": path,
+                "max_results": max_results,
+            }),
+            crate::tools::lsp::get_file_diagnostics,
+        );
+    }
+    if !resolved.is_dir() {
+        return Err(CodeLensError::NotFound(format!(
+            "path does not exist in project scope: {path}"
+        )));
+    }
+
+    let candidate_files = codelens_engine::find_files(&project, "*", Some(path))?;
+    let max_files = 8usize;
+    let mut files = Vec::new();
+    let mut skipped_files = Vec::new();
+    let mut diagnosable_files = 0usize;
+    let mut diagnostic_count = 0usize;
+
+    for file_path in candidate_files.into_iter().map(|entry| entry.path) {
+        if crate::tools::default_lsp_command_for_path(&file_path).is_none() {
+            skipped_files.push(json!({
+                "file_path": file_path,
+                "reason": "no_default_lsp_mapping",
+            }));
+            continue;
+        }
+
+        diagnosable_files += 1;
+        if files.len() >= max_files {
+            skipped_files.push(json!({
+                "file_path": file_path,
+                "reason": "file_limit_reached",
+            }));
+            continue;
+        }
+
+        match crate::tools::lsp::get_file_diagnostics(
+            state,
+            &json!({
+                "file_path": &file_path,
+                "max_results": max_results,
+            }),
+        ) {
+            Ok((payload, _meta)) => {
+                let count = payload
+                    .get("count")
+                    .and_then(|value| value.as_u64())
+                    .unwrap_or_default() as usize;
+                diagnostic_count += count;
+                files.push(json!({
+                    "file_path": file_path,
+                    "count": count,
+                    "diagnostics": payload.get("diagnostics").cloned().unwrap_or_else(|| json!([])),
+                }));
+            }
+            Err(error) => {
+                skipped_files.push(json!({
+                    "file_path": file_path,
+                    "reason": "diagnostics_error",
+                    "error": error.to_string(),
+                }));
+            }
+        }
+    }
+
+    Ok((
+        attach_workflow_metadata(
+            "diagnose_issues",
+            "directory_diagnostics",
+            json!({
+                "path": path,
+                "scope": "directory",
+                "files": files,
+                "returned_file_count": files.len(),
+                "diagnosable_file_count": diagnosable_files,
+                "diagnostic_count": diagnostic_count,
+                "skipped_files": skipped_files,
+                "count": diagnostic_count,
+            }),
+        ),
+        success_meta(BackendKind::Lsp, 0.82),
     ))
 }
 
@@ -236,36 +326,54 @@ pub fn assess_change_readiness(state: &AppState, arguments: &Value) -> ToolResul
 }
 
 pub fn diagnose_issues(state: &AppState, arguments: &Value) -> ToolResult {
-    if arguments
-        .get("path")
-        .or_else(|| arguments.get("file_path"))
-        .and_then(|v| v.as_str())
-        .is_some()
-    {
+    let max_results = arguments
+        .get("max_results")
+        .and_then(|value| value.as_u64());
+
+    if let Some(symbol) = arguments.get("symbol").and_then(|v| v.as_str()) {
+        let file_path = arguments
+            .get("file_path")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| CodeLensError::MissingParam("file_path".to_owned()))?;
+        let resolved = state.project().resolve(file_path)?;
+        if !resolved.is_file() {
+            return Err(CodeLensError::Validation(
+                "diagnose_issues with `symbol` requires a file target, not a directory".to_owned(),
+            ));
+        }
+        return delegate_workflow(
+            state,
+            "diagnose_issues",
+            "unresolved_reference_check",
+            json!({
+                "file_path": file_path,
+                "symbol": symbol,
+                "changed_files": arguments.get("changed_files"),
+            }),
+            crate::tools::reports::unresolved_reference_check,
+        );
+    }
+
+    if let Some(file_path) = arguments.get("file_path").and_then(|v| v.as_str()) {
         return delegate_workflow(
             state,
             "diagnose_issues",
             "get_file_diagnostics",
             json!({
-                "file_path": arguments.get("file_path")
-                    .or_else(|| arguments.get("path"))
-                    .and_then(|v| v.as_str()),
+                "file_path": file_path,
+                "max_results": max_results,
             }),
             crate::tools::lsp::get_file_diagnostics,
         );
     }
 
-    delegate_workflow(
-        state,
-        "diagnose_issues",
-        "unresolved_reference_check",
-        json!({
-            "file_path": arguments.get("file_path").and_then(|v| v.as_str()),
-            "symbol": arguments.get("symbol").and_then(|v| v.as_str()),
-            "changed_files": arguments.get("changed_files"),
-        }),
-        crate::tools::reports::unresolved_reference_check,
-    )
+    if let Some(path) = arguments.get("path").and_then(|v| v.as_str()) {
+        return diagnose_path_scope(state, path, max_results);
+    }
+
+    Err(CodeLensError::MissingParam(
+        "file_path, path, or symbol".to_owned(),
+    ))
 }
 
 pub fn cleanup_duplicate_logic(state: &AppState, arguments: &Value) -> ToolResult {


### PR DESCRIPTION
## Summary
- tighten `diagnose_issues` so symbol checks require a file target and directory paths return bounded directory diagnostics
- normalize LSP recipe lookup by command path so absolute binary paths still resolve default args and install hints
- add regression coverage for directory diagnostics and absolute command-path LSP lookups

## Verification
- cargo check
- cargo test -p codelens-engine
- cargo test -p codelens-mcp
- cargo test -p codelens-mcp diagnose_issues
