### PR TITLE
feat(engine+mcp): Phase 1 G4 — WorkspaceEditTransaction substrate

### DIFF
--- a/crates/codelens-engine/src/edit_transaction.rs
+++ b/crates/codelens-engine/src/edit_transaction.rs
@@ -10,7 +10,7 @@
 //! same-function two-read window; disk-snapshot/lock guarantees are
 //! deferred to Phase 2.
 
-#![allow(dead_code, unused_imports)]
+#![allow(dead_code)]
 
 use crate::lsp::types::LspResourceOp;
 use crate::project::ProjectRoot;
@@ -123,8 +123,21 @@ impl WorkspaceEditTransaction {
     /// Apply edits with hash-based evidence and rollback on failure.
     /// Implementation lands incrementally in T2~T6.
     pub fn apply_with_evidence(&self, project: &ProjectRoot) -> Result<ApplyEvidence, ApplyError> {
+        if !self.resource_ops.is_empty() {
+            return Err(ApplyError::ResourceOpsUnsupported);
+        }
+        if self.edits.is_empty() {
+            return Ok(ApplyEvidence {
+                status: ApplyStatus::NoOp,
+                file_hashes_before: BTreeMap::new(),
+                file_hashes_after: BTreeMap::new(),
+                rollback_report: Vec::new(),
+                modified_files: 0,
+                edit_count: 0,
+            });
+        }
         let _ = project;
-        unimplemented!("apply_with_evidence implemented in T2~T6")
+        unimplemented!("apply path implemented in T3~T6")
     }
 }
 
@@ -136,4 +149,51 @@ fn sha256_hex(bytes: &[u8]) -> String {
         let _ = write!(output, "{byte:02x}");
     }
     output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn empty_project() -> ProjectRoot {
+        let dir = std::env::temp_dir().join(format!(
+            "codelens-edit-tx-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        ProjectRoot::new(dir.to_str().unwrap()).unwrap()
+    }
+
+    #[test]
+    fn noop_returns_evidence_with_status_noop() {
+        let project = empty_project();
+        let tx = WorkspaceEditTransaction::new(vec![], vec![]);
+        let evidence = tx.apply_with_evidence(&project).expect("noop apply ok");
+        assert_eq!(evidence.status, ApplyStatus::NoOp);
+        assert!(evidence.file_hashes_before.is_empty());
+        assert!(evidence.file_hashes_after.is_empty());
+        assert!(evidence.rollback_report.is_empty());
+        assert_eq!(evidence.modified_files, 0);
+        assert_eq!(evidence.edit_count, 0);
+    }
+
+    #[test]
+    fn resource_ops_non_empty_returns_unsupported() {
+        let project = empty_project();
+        let tx = WorkspaceEditTransaction::new(
+            vec![],
+            vec![LspResourceOp {
+                kind: "create".to_owned(),
+                file_path: "new.txt".to_owned(),
+                old_file_path: None,
+                new_file_path: None,
+            }],
+        );
+        let result = tx.apply_with_evidence(&project);
+        assert!(matches!(result, Err(ApplyError::ResourceOpsUnsupported)));
+    }
 }

--- a/crates/codelens-engine/src/edit_transaction.rs
+++ b/crates/codelens-engine/src/edit_transaction.rs
@@ -173,10 +173,70 @@ impl WorkspaceEditTransaction {
             backups.insert(resolved, bytes);
         }
 
-        // T4~T6 fill in Phase 2 recheck, Phase 3 apply, Phase 4 post-hash
-        let _ = backups;
-        let _ = file_hashes_before;
-        unimplemented!("apply path T4~T6")
+        // Phase 3: apply via crate::rename::apply_edits
+        if let Err(source) = crate::rename::apply_edits(project, &self.edits) {
+            // T5 will replace this with full rollback logic; for now
+            // wrap in ApplyFailed with empty evidence so the type matches.
+            return Err(ApplyError::ApplyFailed {
+                source,
+                evidence: ApplyEvidence {
+                    status: ApplyStatus::RolledBack,
+                    file_hashes_before,
+                    file_hashes_after: BTreeMap::new(),
+                    rollback_report: Vec::new(),
+                    modified_files: 0,
+                    edit_count: 0,
+                },
+            });
+        }
+
+        // Phase 4: capture post-apply state
+        let mut file_hashes_after: BTreeMap<String, FileHash> = BTreeMap::new();
+        for file_path in self.unique_file_paths() {
+            let resolved = match project.resolve(&file_path) {
+                Ok(path) => path,
+                Err(_) => {
+                    file_hashes_after.insert(
+                        file_path.clone(),
+                        FileHash {
+                            sha256: String::new(),
+                            bytes: 0,
+                        },
+                    );
+                    continue;
+                }
+            };
+            match fs::read(&resolved) {
+                Ok(bytes) => {
+                    file_hashes_after.insert(
+                        file_path.clone(),
+                        FileHash {
+                            sha256: sha256_hex(&bytes),
+                            bytes: bytes.len(),
+                        },
+                    );
+                }
+                Err(_) => {
+                    file_hashes_after.insert(
+                        file_path.clone(),
+                        FileHash {
+                            sha256: String::new(),
+                            bytes: 0,
+                        },
+                    );
+                }
+            }
+        }
+
+        let _ = &backups;
+        Ok(ApplyEvidence {
+            status: ApplyStatus::Applied,
+            file_hashes_before,
+            file_hashes_after,
+            rollback_report: Vec::new(),
+            modified_files: self.modified_files,
+            edit_count: self.edit_count,
+        })
     }
 }
 
@@ -255,5 +315,84 @@ mod tests {
             "expected PreReadFailed for missing.txt, got {:?}",
             result.err()
         );
+    }
+
+    fn write_file(project: &ProjectRoot, name: &str, content: &str) -> PathBuf {
+        let resolved = project.resolve(name).unwrap();
+        std::fs::create_dir_all(resolved.parent().unwrap()).ok();
+        std::fs::write(&resolved, content).unwrap();
+        resolved
+    }
+
+    #[test]
+    fn happy_path_two_files_apply_succeeds_with_evidence() {
+        let project = empty_project();
+        write_file(&project, "a.txt", "alpha\n");
+        write_file(&project, "b.txt", "beta\n");
+        let tx = WorkspaceEditTransaction::new(
+            vec![
+                RenameEdit {
+                    file_path: "a.txt".to_owned(),
+                    line: 1,
+                    column: 1,
+                    old_text: "alpha".to_owned(),
+                    new_text: "ALPHA".to_owned(),
+                },
+                RenameEdit {
+                    file_path: "b.txt".to_owned(),
+                    line: 1,
+                    column: 1,
+                    old_text: "beta".to_owned(),
+                    new_text: "BETA".to_owned(),
+                },
+            ],
+            vec![],
+        );
+        let evidence = tx
+            .apply_with_evidence(&project)
+            .expect("happy path apply ok");
+        assert_eq!(evidence.status, ApplyStatus::Applied);
+        assert_eq!(evidence.file_hashes_before.len(), 2);
+        assert_eq!(evidence.file_hashes_after.len(), 2);
+        assert!(evidence.rollback_report.is_empty());
+        assert_eq!(evidence.modified_files, 2);
+        assert_eq!(evidence.edit_count, 2);
+        for (path, before) in &evidence.file_hashes_before {
+            let after = evidence
+                .file_hashes_after
+                .get(path)
+                .expect("after entry exists");
+            assert_ne!(before.sha256, after.sha256, "hash for {path} should differ");
+        }
+        assert_eq!(
+            std::fs::read_to_string(project.resolve("a.txt").unwrap()).unwrap(),
+            "ALPHA\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(project.resolve("b.txt").unwrap()).unwrap(),
+            "BETA\n"
+        );
+    }
+
+    #[test]
+    fn pre_apply_hash_is_deterministic_for_same_input() {
+        let project = empty_project();
+        write_file(&project, "x.txt", "stable\n");
+        let tx_a = WorkspaceEditTransaction::new(
+            vec![RenameEdit {
+                file_path: "x.txt".to_owned(),
+                line: 1,
+                column: 1,
+                old_text: "stable".to_owned(),
+                new_text: "stable".to_owned(),
+            }],
+            vec![],
+        );
+        let ev_a = tx_a.apply_with_evidence(&project).unwrap();
+        let tx_b = tx_a.clone();
+        let ev_b = tx_b.apply_with_evidence(&project).unwrap();
+        let hash_a = &ev_a.file_hashes_before["x.txt"].sha256;
+        let hash_b = &ev_b.file_hashes_before["x.txt"].sha256;
+        assert_eq!(hash_a, hash_b);
     }
 }

--- a/crates/codelens-engine/src/edit_transaction.rs
+++ b/crates/codelens-engine/src/edit_transaction.rs
@@ -132,24 +132,11 @@ impl WorkspaceEditTransaction {
         paths
     }
 
-    /// Apply edits with hash-based evidence and rollback on failure.
-    /// Implementation lands incrementally in T2~T6.
-    pub fn apply_with_evidence(&self, project: &ProjectRoot) -> Result<ApplyEvidence, ApplyError> {
-        if !self.resource_ops.is_empty() {
-            return Err(ApplyError::ResourceOpsUnsupported);
-        }
-        if self.edits.is_empty() {
-            return Ok(ApplyEvidence {
-                status: ApplyStatus::NoOp,
-                file_hashes_before: BTreeMap::new(),
-                file_hashes_after: BTreeMap::new(),
-                rollback_report: Vec::new(),
-                modified_files: 0,
-                edit_count: 0,
-            });
-        }
-
-        // Phase 1: capture pre-apply state (single read; backup + hash)
+    /// Phase 1: read each unique file once, capture sha256 + raw backup bytes.
+    pub(crate) fn capture_pre_apply(
+        &self,
+        project: &ProjectRoot,
+    ) -> Result<(HashMap<PathBuf, Vec<u8>>, BTreeMap<String, FileHash>), ApplyError> {
         let mut backups: HashMap<PathBuf, Vec<u8>> = HashMap::new();
         let mut file_hashes_before: BTreeMap<String, FileHash> = BTreeMap::new();
         for file_path in self.unique_file_paths() {
@@ -172,6 +159,67 @@ impl WorkspaceEditTransaction {
             );
             backups.insert(resolved, bytes);
         }
+        Ok((backups, file_hashes_before))
+    }
+
+    /// Phase 2: re-read each captured file and confirm sha256 still matches.
+    /// Light same-function TOCTOU window; strong guarantees deferred to Phase 2.
+    pub(crate) fn verify_pre_apply(
+        &self,
+        project: &ProjectRoot,
+        backups: &HashMap<PathBuf, Vec<u8>>,
+        hashes_before: &BTreeMap<String, FileHash>,
+    ) -> Result<(), ApplyError> {
+        for file_path in self.unique_file_paths() {
+            let resolved = project
+                .resolve(&file_path)
+                .map_err(|e| ApplyError::PreReadFailed {
+                    file_path: file_path.clone(),
+                    source: e,
+                })?;
+            let bytes_now = fs::read(&resolved).map_err(|e| ApplyError::PreReadFailed {
+                file_path: file_path.clone(),
+                source: anyhow::Error::from(e),
+            })?;
+            let hash_now = sha256_hex(&bytes_now);
+            let expected = hashes_before
+                .get(&file_path)
+                .map(|h| h.sha256.clone())
+                .unwrap_or_default();
+            if hash_now != expected {
+                return Err(ApplyError::PreApplyHashMismatch {
+                    file_path,
+                    expected,
+                    actual: hash_now,
+                });
+            }
+            let _ = backups; // referenced for invariant: same set of files captured
+        }
+        Ok(())
+    }
+
+    /// Apply edits with hash-based evidence and rollback on failure.
+    /// Implementation lands incrementally in T2~T6.
+    pub fn apply_with_evidence(&self, project: &ProjectRoot) -> Result<ApplyEvidence, ApplyError> {
+        if !self.resource_ops.is_empty() {
+            return Err(ApplyError::ResourceOpsUnsupported);
+        }
+        if self.edits.is_empty() {
+            return Ok(ApplyEvidence {
+                status: ApplyStatus::NoOp,
+                file_hashes_before: BTreeMap::new(),
+                file_hashes_after: BTreeMap::new(),
+                rollback_report: Vec::new(),
+                modified_files: 0,
+                edit_count: 0,
+            });
+        }
+
+        // Phase 1: capture pre-apply state
+        let (backups, file_hashes_before) = self.capture_pre_apply(project)?;
+
+        // Phase 2: light TOCTOU re-check (same-function window)
+        self.verify_pre_apply(project, &backups, &file_hashes_before)?;
 
         // Phase 3: apply via crate::rename::apply_edits
         if let Err(source) = crate::rename::apply_edits(project, &self.edits) {
@@ -517,5 +565,34 @@ mod tests {
         let mut restore = std::fs::metadata(&path_b).unwrap().permissions();
         restore.set_mode(0o644);
         let _ = std::fs::set_permissions(&path_b, restore);
+    }
+
+    #[test]
+    fn toctou_recheck_detects_external_mutation_between_phases() {
+        let project = empty_project();
+        let path = write_file(&project, "tt.txt", "before\n");
+        let tx = WorkspaceEditTransaction::new(
+            vec![RenameEdit {
+                file_path: "tt.txt".to_owned(),
+                line: 1,
+                column: 1,
+                old_text: "before".to_owned(),
+                new_text: "after".to_owned(),
+            }],
+            vec![],
+        );
+
+        let (backups, hashes_before) = tx.capture_pre_apply(&project).expect("phase 1 capture ok");
+        // External writer mutates the file between phases.
+        std::fs::write(&path, "TAMPERED\n").unwrap();
+
+        let result = tx.verify_pre_apply(&project, &backups, &hashes_before);
+        assert!(
+            matches!(result, Err(ApplyError::PreApplyHashMismatch { ref file_path, .. }) if file_path == "tt.txt"),
+            "expected PreApplyHashMismatch for tt.txt, got {:?}",
+            result.err()
+        );
+        // Disk contains the external mutation; substrate did not apply edits.
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "TAMPERED\n");
     }
 }

--- a/crates/codelens-engine/src/edit_transaction.rs
+++ b/crates/codelens-engine/src/edit_transaction.rs
@@ -1,0 +1,139 @@
+//! Workspace edit transaction substrate.
+//!
+//! Provides a reusable domain object for multi-file mutations with
+//! pre-apply hash capture, post-apply hash verification, and rollback
+//! evidence. Used by LSP rename, safe_delete_apply, and future engine
+//! mutation primitives.
+//!
+//! Rollback model: transactional best-effort with rollback evidence.
+//! In-memory backups + restore-on-error. TOCTOU re-check is a light
+//! same-function two-read window; disk-snapshot/lock guarantees are
+//! deferred to Phase 2.
+
+#![allow(dead_code, unused_imports)]
+
+use crate::lsp::types::LspResourceOp;
+use crate::project::ProjectRoot;
+use crate::rename::RenameEdit;
+use anyhow::{Context, Result};
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, HashMap};
+use std::fs;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone)]
+pub struct WorkspaceEditTransaction {
+    pub edits: Vec<RenameEdit>,
+    pub resource_ops: Vec<LspResourceOp>,
+    pub modified_files: usize,
+    pub edit_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ApplyEvidence {
+    pub status: ApplyStatus,
+    pub file_hashes_before: BTreeMap<String, FileHash>,
+    pub file_hashes_after: BTreeMap<String, FileHash>,
+    pub rollback_report: Vec<RollbackEntry>,
+    pub modified_files: usize,
+    pub edit_count: usize,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ApplyStatus {
+    Applied,
+    RolledBack,
+    NoOp,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RollbackEntry {
+    pub file_path: String,
+    pub restored: bool,
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FileHash {
+    pub sha256: String,
+    pub bytes: usize,
+}
+
+#[derive(Debug)]
+pub enum ApplyError {
+    ResourceOpsUnsupported,
+    PreReadFailed {
+        file_path: String,
+        source: anyhow::Error,
+    },
+    PreApplyHashMismatch {
+        file_path: String,
+        expected: String,
+        actual: String,
+    },
+    ApplyFailed {
+        source: anyhow::Error,
+        evidence: ApplyEvidence,
+    },
+}
+
+impl std::fmt::Display for ApplyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ResourceOpsUnsupported => write!(
+                f,
+                "unsupported_semantic_refactor: resource operations are preview-only in this release"
+            ),
+            Self::PreReadFailed { file_path, source } => {
+                write!(f, "pre-apply read failed for `{file_path}`: {source}")
+            }
+            Self::PreApplyHashMismatch {
+                file_path,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "pre-apply hash mismatch for `{file_path}`: expected {expected}, got {actual}"
+            ),
+            Self::ApplyFailed { source, .. } => write!(f, "apply failed: {source}"),
+        }
+    }
+}
+
+impl std::error::Error for ApplyError {}
+
+impl WorkspaceEditTransaction {
+    pub fn new(edits: Vec<RenameEdit>, resource_ops: Vec<LspResourceOp>) -> Self {
+        let modified_files = edits
+            .iter()
+            .map(|edit| &edit.file_path)
+            .collect::<std::collections::HashSet<_>>()
+            .len();
+        let edit_count = edits.len();
+        Self {
+            edits,
+            resource_ops,
+            modified_files,
+            edit_count,
+        }
+    }
+
+    /// Apply edits with hash-based evidence and rollback on failure.
+    /// Implementation lands incrementally in T2~T6.
+    pub fn apply_with_evidence(&self, project: &ProjectRoot) -> Result<ApplyEvidence, ApplyError> {
+        let _ = project;
+        unimplemented!("apply_with_evidence implemented in T2~T6")
+    }
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    let mut output = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        use std::fmt::Write as _;
+        let _ = write!(output, "{byte:02x}");
+    }
+    output
+}

--- a/crates/codelens-engine/src/edit_transaction.rs
+++ b/crates/codelens-engine/src/edit_transaction.rs
@@ -133,6 +133,7 @@ impl WorkspaceEditTransaction {
     }
 
     /// Phase 1: read each unique file once, capture sha256 + raw backup bytes.
+    #[allow(clippy::type_complexity)]
     pub(crate) fn capture_pre_apply(
         &self,
         project: &ProjectRoot,

--- a/crates/codelens-engine/src/edit_transaction.rs
+++ b/crates/codelens-engine/src/edit_transaction.rs
@@ -15,7 +15,7 @@
 use crate::lsp::types::LspResourceOp;
 use crate::project::ProjectRoot;
 use crate::rename::RenameEdit;
-use anyhow::{Context, Result};
+use anyhow::Result;
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, HashMap};
@@ -120,6 +120,18 @@ impl WorkspaceEditTransaction {
         }
     }
 
+    fn unique_file_paths(&self) -> Vec<String> {
+        let mut paths: Vec<String> = self
+            .edits
+            .iter()
+            .map(|edit| edit.file_path.clone())
+            .collect::<std::collections::BTreeSet<_>>()
+            .into_iter()
+            .collect();
+        paths.sort();
+        paths
+    }
+
     /// Apply edits with hash-based evidence and rollback on failure.
     /// Implementation lands incrementally in T2~T6.
     pub fn apply_with_evidence(&self, project: &ProjectRoot) -> Result<ApplyEvidence, ApplyError> {
@@ -136,8 +148,35 @@ impl WorkspaceEditTransaction {
                 edit_count: 0,
             });
         }
-        let _ = project;
-        unimplemented!("apply path implemented in T3~T6")
+
+        // Phase 1: capture pre-apply state (single read; backup + hash)
+        let mut backups: HashMap<PathBuf, Vec<u8>> = HashMap::new();
+        let mut file_hashes_before: BTreeMap<String, FileHash> = BTreeMap::new();
+        for file_path in self.unique_file_paths() {
+            let resolved = project
+                .resolve(&file_path)
+                .map_err(|e| ApplyError::PreReadFailed {
+                    file_path: file_path.clone(),
+                    source: e,
+                })?;
+            let bytes = fs::read(&resolved).map_err(|e| ApplyError::PreReadFailed {
+                file_path: file_path.clone(),
+                source: anyhow::Error::from(e),
+            })?;
+            file_hashes_before.insert(
+                file_path.clone(),
+                FileHash {
+                    sha256: sha256_hex(&bytes),
+                    bytes: bytes.len(),
+                },
+            );
+            backups.insert(resolved, bytes);
+        }
+
+        // T4~T6 fill in Phase 2 recheck, Phase 3 apply, Phase 4 post-hash
+        let _ = backups;
+        let _ = file_hashes_before;
+        unimplemented!("apply path T4~T6")
     }
 }
 
@@ -195,5 +234,26 @@ mod tests {
         );
         let result = tx.apply_with_evidence(&project);
         assert!(matches!(result, Err(ApplyError::ResourceOpsUnsupported)));
+    }
+
+    #[test]
+    fn pre_read_fails_when_file_missing() {
+        let project = empty_project();
+        let tx = WorkspaceEditTransaction::new(
+            vec![RenameEdit {
+                file_path: "missing.txt".to_owned(),
+                line: 1,
+                column: 1,
+                old_text: "x".to_owned(),
+                new_text: "y".to_owned(),
+            }],
+            vec![],
+        );
+        let result = tx.apply_with_evidence(&project);
+        assert!(
+            matches!(result, Err(ApplyError::PreReadFailed { ref file_path, .. }) if file_path == "missing.txt"),
+            "expected PreReadFailed for missing.txt, got {:?}",
+            result.err()
+        );
     }
 }

--- a/crates/codelens-engine/src/edit_transaction.rs
+++ b/crates/codelens-engine/src/edit_transaction.rs
@@ -175,15 +175,73 @@ impl WorkspaceEditTransaction {
 
         // Phase 3: apply via crate::rename::apply_edits
         if let Err(source) = crate::rename::apply_edits(project, &self.edits) {
-            // T5 will replace this with full rollback logic; for now
-            // wrap in ApplyFailed with empty evidence so the type matches.
+            let mut rollback_report: Vec<RollbackEntry> = Vec::new();
+            let mut file_hashes_after_rb: BTreeMap<String, FileHash> = BTreeMap::new();
+
+            // Restore each backup; record per-file success/failure.
+            // Iterate sorted file paths for deterministic ordering.
+            let sorted_paths = self.unique_file_paths();
+            for file_path in &sorted_paths {
+                let resolved = match project.resolve(file_path) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        rollback_report.push(RollbackEntry {
+                            file_path: file_path.clone(),
+                            restored: false,
+                            reason: Some(format!("resolve failed: {e}")),
+                        });
+                        continue;
+                    }
+                };
+                let backup_bytes = match backups.get(&resolved) {
+                    Some(bytes) => bytes,
+                    None => {
+                        rollback_report.push(RollbackEntry {
+                            file_path: file_path.clone(),
+                            restored: false,
+                            reason: Some("no backup captured".to_owned()),
+                        });
+                        continue;
+                    }
+                };
+                match fs::write(&resolved, backup_bytes) {
+                    Ok(()) => rollback_report.push(RollbackEntry {
+                        file_path: file_path.clone(),
+                        restored: true,
+                        reason: None,
+                    }),
+                    Err(e) => rollback_report.push(RollbackEntry {
+                        file_path: file_path.clone(),
+                        restored: false,
+                        reason: Some(format!("write failed: {e}")),
+                    }),
+                }
+            }
+
+            // Capture post-rollback hashes (truth check).
+            for file_path in &sorted_paths {
+                let resolved = match project.resolve(file_path) {
+                    Ok(p) => p,
+                    Err(_) => continue,
+                };
+                if let Ok(bytes) = fs::read(&resolved) {
+                    file_hashes_after_rb.insert(
+                        file_path.clone(),
+                        FileHash {
+                            sha256: sha256_hex(&bytes),
+                            bytes: bytes.len(),
+                        },
+                    );
+                }
+            }
+
             return Err(ApplyError::ApplyFailed {
                 source,
                 evidence: ApplyEvidence {
                     status: ApplyStatus::RolledBack,
                     file_hashes_before,
-                    file_hashes_after: BTreeMap::new(),
-                    rollback_report: Vec::new(),
+                    file_hashes_after: file_hashes_after_rb,
+                    rollback_report,
                     modified_files: 0,
                     edit_count: 0,
                 },
@@ -228,7 +286,6 @@ impl WorkspaceEditTransaction {
             }
         }
 
-        let _ = &backups;
         Ok(ApplyEvidence {
             status: ApplyStatus::Applied,
             file_hashes_before,
@@ -394,5 +451,71 @@ mod tests {
         let hash_a = &ev_a.file_hashes_before["x.txt"].sha256;
         let hash_b = &ev_b.file_hashes_before["x.txt"].sha256;
         assert_eq!(hash_a, hash_b);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rollback_restores_first_file_when_second_apply_fails() {
+        use std::os::unix::fs::PermissionsExt;
+        let project = empty_project();
+        let path_a = write_file(&project, "ra.txt", "alpha\n");
+        let path_b = write_file(&project, "rb.txt", "beta\n");
+        let mut perms = std::fs::metadata(&path_b).unwrap().permissions();
+        perms.set_mode(0o444);
+        std::fs::set_permissions(&path_b, perms).unwrap();
+
+        let tx = WorkspaceEditTransaction::new(
+            vec![
+                RenameEdit {
+                    file_path: "ra.txt".to_owned(),
+                    line: 1,
+                    column: 1,
+                    old_text: "alpha".to_owned(),
+                    new_text: "ALPHA".to_owned(),
+                },
+                RenameEdit {
+                    file_path: "rb.txt".to_owned(),
+                    line: 1,
+                    column: 1,
+                    old_text: "beta".to_owned(),
+                    new_text: "BETA".to_owned(),
+                },
+            ],
+            vec![],
+        );
+
+        let result = tx.apply_with_evidence(&project);
+        let evidence = match result {
+            Err(ApplyError::ApplyFailed { evidence, .. }) => evidence,
+            other => panic!("expected ApplyFailed, got {other:?}"),
+        };
+        assert_eq!(evidence.status, ApplyStatus::RolledBack);
+        assert_eq!(evidence.modified_files, 0);
+        assert_eq!(evidence.edit_count, 0);
+        let ra_now = std::fs::read_to_string(&path_a).unwrap();
+        assert_eq!(ra_now, "alpha\n", "ra.txt should be restored to alpha");
+        let before = evidence.file_hashes_before.get("ra.txt").unwrap();
+        let after = evidence.file_hashes_after.get("ra.txt").unwrap();
+        assert_eq!(
+            before.sha256, after.sha256,
+            "ra.txt hash should match pre-apply after rollback"
+        );
+        let entry_a = evidence
+            .rollback_report
+            .iter()
+            .find(|e| e.file_path == "ra.txt")
+            .expect("rollback entry for ra.txt");
+        assert!(entry_a.restored, "ra.txt restore should succeed");
+        assert!(entry_a.reason.is_none());
+        let entry_b = evidence
+            .rollback_report
+            .iter()
+            .find(|e| e.file_path == "rb.txt");
+        assert!(entry_b.is_some(), "rb.txt rollback entry should exist");
+
+        // restore perms so tempdir cleanup works
+        let mut restore = std::fs::metadata(&path_b).unwrap().permissions();
+        restore.set_mode(0o644);
+        let _ = std::fs::set_permissions(&path_b, restore);
     }
 }

--- a/crates/codelens-engine/src/lib.rs
+++ b/crates/codelens-engine/src/lib.rs
@@ -4,6 +4,7 @@ pub mod circular;
 pub mod community;
 pub mod coupling;
 pub mod db;
+pub mod edit_transaction;
 #[cfg(feature = "semantic")]
 pub mod embedding;
 pub mod embedding_store;
@@ -31,6 +32,9 @@ pub use circular::{CircularDependency, find_circular_dependencies};
 pub use coupling::{CouplingEntry, get_change_coupling};
 pub use db::{
     DirStats, IndexDb, NewCall, NewImport, NewSymbol, SymbolWithFile, content_hash, index_db_path,
+};
+pub use edit_transaction::{
+    ApplyError, ApplyEvidence, ApplyStatus, FileHash, RollbackEntry, WorkspaceEditTransaction,
 };
 pub use file_ops::{
     DirectoryEntry, EnclosingSymbol, FileMatch, FileReadResult, PatternMatch, SmartPatternMatch,

--- a/crates/codelens-engine/src/lsp/mod.rs
+++ b/crates/codelens-engine/src/lsp/mod.rs
@@ -110,7 +110,8 @@ pub fn apply_workspace_edit_value(
 ) -> Result<LspWorkspaceEditTransaction> {
     let transaction = workspace_edit_transaction_from_value(project, edit)?;
     if !dry_run {
-        apply_workspace_edit_transaction(project, &transaction)?;
+        let _ = apply_workspace_edit_transaction(project, &transaction)
+            .map_err(|e| anyhow::Error::msg(e.to_string()))?;
     }
     Ok(transaction)
 }
@@ -118,7 +119,7 @@ pub fn apply_workspace_edit_value(
 pub fn apply_workspace_edit_transaction(
     project: &ProjectRoot,
     transaction: &LspWorkspaceEditTransaction,
-) -> Result<()> {
+) -> Result<crate::edit_transaction::ApplyEvidence, crate::edit_transaction::ApplyError> {
     workspace_edit::apply_workspace_edit_transaction(project, transaction)
 }
 

--- a/crates/codelens-engine/src/lsp/parser_tests.rs
+++ b/crates/codelens-engine/src/lsp/parser_tests.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use super::parsers::{rename_edits_from_workspace_edit_response, rename_plan_from_response};
 use super::workspace_edit::workspace_edit_transaction_from_response;
 use crate::ProjectRoot;

--- a/crates/codelens-engine/src/lsp/types.rs
+++ b/crates/codelens-engine/src/lsp/types.rs
@@ -170,7 +170,14 @@ pub struct LspWorkspaceEditTransaction {
     pub resource_ops: Vec<LspResourceOp>,
     pub modified_files: usize,
     pub edit_count: usize,
+    #[deprecated(note = "use ApplyEvidence::status from substrate apply_with_evidence instead")]
     pub rollback_available: bool,
+}
+
+impl From<LspWorkspaceEditTransaction> for crate::edit_transaction::WorkspaceEditTransaction {
+    fn from(value: LspWorkspaceEditTransaction) -> Self {
+        crate::edit_transaction::WorkspaceEditTransaction::new(value.edits, value.resource_ops)
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/crates/codelens-engine/src/lsp/workspace_edit.rs
+++ b/crates/codelens-engine/src/lsp/workspace_edit.rs
@@ -3,12 +3,12 @@ use super::position::{byte_column_for_utf16_position, extract_text_for_range};
 use super::types::{LspResourceOp, LspWorkspaceEditTransaction};
 use crate::project::ProjectRoot;
 use crate::rename::RenameEdit;
-use anyhow::{Context, Result, bail};
-use serde_json::{Map, Value, json};
-use std::collections::HashMap;
+use anyhow::{bail, Context, Result};
+use serde_json::{json, Map, Value};
 use std::fs;
 use url::Url;
 
+#[allow(deprecated)]
 pub(super) fn workspace_edit_transaction_from_response(
     project: &ProjectRoot,
     response: Value,
@@ -67,26 +67,10 @@ pub(super) fn workspace_edit_transaction_from_edit(
 pub(super) fn apply_workspace_edit_transaction(
     project: &ProjectRoot,
     transaction: &LspWorkspaceEditTransaction,
-) -> Result<()> {
-    if !transaction.resource_ops.is_empty() {
-        bail!("LSP resource operations are preview-only in this release");
-    }
-    let mut backups = HashMap::new();
-    for edit in &transaction.edits {
-        let resolved = project.resolve(&edit.file_path)?;
-        backups
-            .entry(resolved.clone())
-            .or_insert_with(|| fs::read_to_string(&resolved));
-    }
-    if let Err(error) = crate::rename::apply_edits(project, &transaction.edits) {
-        for (path, backup) in backups {
-            if let Ok(content) = backup {
-                let _ = fs::write(path, content);
-            }
-        }
-        return Err(error);
-    }
-    Ok(())
+) -> Result<crate::edit_transaction::ApplyEvidence, crate::edit_transaction::ApplyError> {
+    let workspace_tx: crate::edit_transaction::WorkspaceEditTransaction =
+        transaction.clone().into();
+    workspace_tx.apply_with_evidence(project)
 }
 
 fn collect_changes(

--- a/crates/codelens-mcp/src/integration_tests/semantic_refactor.rs
+++ b/crates/codelens-mcp/src/integration_tests/semantic_refactor.rs
@@ -552,6 +552,216 @@ fn lsp_rename_evidence_is_fact_based_not_placeholder() {
     assert!(updated.contains("renamed_fn()"), "{updated}");
 }
 
+// ── T9: safe_delete substrate migration tests ──────────────────────────────
+
+/// Returns a minimal LSP mock script (as a String) that reports only the
+/// declaration reference at (line=0, char=4..9) so `safe_to_delete == true`.
+fn safe_delete_lsp_mock_src() -> String {
+    concat!(
+        "#!/usr/bin/env python3\n",
+        "import sys, json\n",
+        "def read_msg():\n",
+        "    h = ''\n",
+        "    while True:\n",
+        "        c = sys.stdin.buffer.read(1)\n",
+        "        if not c: return None\n",
+        "        h += c.decode('ascii')\n",
+        "        if h.endswith('\\r\\n\\r\\n'): break\n",
+        "    length = int([l for l in h.split('\\r\\n') if l.startswith('Content-Length:')][0].split(': ')[1])\n",
+        "    return json.loads(sys.stdin.buffer.read(length).decode('utf-8'))\n",
+        "def send(r):\n",
+        "    out = json.dumps(r)\n",
+        "    b = out.encode('utf-8')\n",
+        "    sys.stdout.buffer.write(f'Content-Length: {len(b)}\\r\\n\\r\\n'.encode('ascii'))\n",
+        "    sys.stdout.buffer.write(b)\n",
+        "    sys.stdout.buffer.flush()\n",
+        "while True:\n",
+        "    msg = read_msg()\n",
+        "    if msg is None: break\n",
+        "    rid = msg.get('id')\n",
+        "    m = msg.get('method', '')\n",
+        "    if m == 'initialized': continue\n",
+        "    if rid is None: continue\n",
+        "    if m == 'initialize':\n",
+        "        send({'jsonrpc':'2.0','id':rid,'result':{'capabilities':{'referencesProvider':True}}})\n",
+        "    elif m == 'textDocument/references':\n",
+        "        uri = msg['params']['textDocument']['uri']\n",
+        "        send({'jsonrpc':'2.0','id':rid,'result':[{'uri':uri,'range':{'start':{'line':0,'character':4},'end':{'line':0,'character':9}}}]})\n",
+        "    elif m == 'shutdown':\n",
+        "        send({'jsonrpc':'2.0','id':rid,'result':None})\n",
+        "    else:\n",
+        "        send({'jsonrpc':'2.0','id':rid,'result':None})\n",
+    )
+    .to_owned()
+}
+
+fn write_safe_delete_mock(
+    project: &codelens_engine::ProjectRoot,
+    suffix: &str,
+) -> std::path::PathBuf {
+    let mock_path = project.as_path().join(format!("mock_lsp_sd_{suffix}.py"));
+    fs::write(&mock_path, safe_delete_lsp_mock_src()).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&mock_path, fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    mock_path
+}
+
+#[test]
+fn safe_delete_substrate_dry_run_advertises_preview_only() {
+    let project = project_root();
+    let path = project.as_path().join("sd_dry.py");
+    fs::write(&path, "def alpha():\n    pass\n").unwrap();
+    let mock = write_safe_delete_mock(&project, "dry");
+    let state = make_state(&project);
+
+    let payload = call_tool(
+        &state,
+        "propagate_deletions",
+        json!({
+            "file_path": "sd_dry.py",
+            "symbol_name": "alpha",
+            "semantic_edit_backend": "lsp",
+            "line": 1,
+            "column": 5,
+            "command": "python3",
+            "args": [mock.to_string_lossy()],
+            "dry_run": true
+        }),
+    );
+    let scope = payload.get("data").unwrap_or(&payload);
+    let tx = &scope["transaction"]["contract"];
+    assert_eq!(tx["apply_status"], json!("preview_only"), "{payload}");
+}
+
+#[test]
+fn safe_delete_substrate_real_apply_returns_evidence() {
+    let project = project_root();
+    let path = project.as_path().join("sd_apply.py");
+    fs::write(&path, "def alpha():\n    pass\n").unwrap();
+    let mock = write_safe_delete_mock(&project, "apply");
+    let state = make_state(&project);
+
+    let payload = call_tool(
+        &state,
+        "propagate_deletions",
+        json!({
+            "file_path": "sd_apply.py",
+            "symbol_name": "alpha",
+            "semantic_edit_backend": "lsp",
+            "line": 1,
+            "column": 5,
+            "command": "python3",
+            "args": [mock.to_string_lossy()],
+            "dry_run": false
+        }),
+    );
+    let scope = payload.get("data").unwrap_or(&payload);
+    let tx = &scope["transaction"]["contract"];
+    assert_eq!(tx["apply_status"], json!("applied"), "{payload}");
+    assert_eq!(tx["rollback_plan"]["available"], json!(true), "{payload}");
+    let hashes_after = tx["file_hashes_after"]
+        .as_object()
+        .expect("file_hashes_after must be an object");
+    assert!(
+        !hashes_after.is_empty(),
+        "file_hashes_after must be populated"
+    );
+    let report = tx["rollback_report"]
+        .as_array()
+        .expect("rollback_report must be an array");
+    assert!(
+        report.is_empty(),
+        "rollback_report should be empty on success"
+    );
+    let after = fs::read_to_string(&path).unwrap();
+    assert!(
+        !after.contains("def alpha"),
+        "alpha should be deleted: {after:?}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn safe_delete_substrate_rollback_when_write_blocked() {
+    use std::os::unix::fs::PermissionsExt;
+    let project = project_root();
+    let path = project.as_path().join("sd_rollback.py");
+    fs::write(&path, "def alpha():\n    pass\n").unwrap();
+    let mock = write_safe_delete_mock(&project, "rollback");
+    let state = make_state(&project);
+
+    let mut perms = fs::metadata(&path).unwrap().permissions();
+    perms.set_mode(0o444);
+    fs::set_permissions(&path, perms).unwrap();
+
+    let payload = call_tool(
+        &state,
+        "propagate_deletions",
+        json!({
+            "file_path": "sd_rollback.py",
+            "symbol_name": "alpha",
+            "semantic_edit_backend": "lsp",
+            "line": 1,
+            "column": 5,
+            "command": "python3",
+            "args": [mock.to_string_lossy()],
+            "dry_run": false
+        }),
+    );
+
+    // Restore permissions immediately so temp dir cleanup works.
+    let mut restore = fs::metadata(&path).unwrap().permissions();
+    restore.set_mode(0o644);
+    let _ = fs::set_permissions(&path, restore);
+
+    let scope = payload.get("data").unwrap_or(&payload);
+    let tx = &scope["transaction"]["contract"];
+    assert_eq!(tx["apply_status"], json!("rolled_back"), "{payload}");
+    let report = tx["rollback_report"]
+        .as_array()
+        .expect("rollback_report must be an array");
+    assert!(
+        !report.is_empty(),
+        "rollback_report should be populated on rollback: {payload}"
+    );
+}
+
+#[test]
+fn safe_delete_substrate_dry_run_preserves_outer_fields() {
+    let project = project_root();
+    let path = project.as_path().join("sd_dry2.py");
+    fs::write(&path, "def alpha():\n    pass\n").unwrap();
+    let mock = write_safe_delete_mock(&project, "dry2");
+    let state = make_state(&project);
+
+    let payload = call_tool(
+        &state,
+        "propagate_deletions",
+        json!({
+            "file_path": "sd_dry2.py",
+            "symbol_name": "alpha",
+            "semantic_edit_backend": "lsp",
+            "line": 1,
+            "column": 5,
+            "command": "python3",
+            "args": [mock.to_string_lossy()],
+            "dry_run": true
+        }),
+    );
+    let scope = payload.get("data").unwrap_or(&payload);
+    assert!(
+        scope.get("safe_to_delete").is_some(),
+        "safe_to_delete must be present: {payload}"
+    );
+    assert!(
+        scope.get("affected_references").is_some(),
+        "affected_references must be present: {payload}"
+    );
+}
+
 fn write_code_action_mock(
     project: &codelens_engine::ProjectRoot,
     kind: &str,

--- a/crates/codelens-mcp/src/integration_tests/semantic_refactor.rs
+++ b/crates/codelens-mcp/src/integration_tests/semantic_refactor.rs
@@ -430,6 +430,128 @@ fn roslyn_adapter_discovers_sidecar_from_adapters_dir() {
     );
 }
 
+/// T3-1: LSP rename evidence is fact-based (substrate-derived), not placeholder.
+/// Verifies that `file_hashes_before`, `file_hashes_after`, and `apply_status`
+/// are populated from ApplyEvidence when the substrate apply path is taken.
+#[test]
+fn lsp_rename_evidence_is_fact_based_not_placeholder() {
+    let project = project_root();
+    let original = "def target_fn():\n    pass\n\ntarget_fn()\n";
+    fs::write(project.as_path().join("evidence_target.py"), original).unwrap();
+    let original_hash = sha256_hex_text(original);
+    let mock_lsp = concat!(
+        "#!/usr/bin/env python3\n",
+        "import sys, json\n",
+        "def read_msg():\n",
+        "    h = ''\n",
+        "    while True:\n",
+        "        c = sys.stdin.buffer.read(1)\n",
+        "        if not c: return None\n",
+        "        h += c.decode('ascii')\n",
+        "        if h.endswith('\\r\\n\\r\\n'): break\n",
+        "    length = int([l for l in h.split('\\r\\n') if l.startswith('Content-Length:')][0].split(': ')[1])\n",
+        "    return json.loads(sys.stdin.buffer.read(length).decode('utf-8'))\n",
+        "def send(r):\n",
+        "    out = json.dumps(r)\n",
+        "    b = out.encode('utf-8')\n",
+        "    sys.stdout.buffer.write(f'Content-Length: {len(b)}\\r\\n\\r\\n'.encode('ascii'))\n",
+        "    sys.stdout.buffer.write(b)\n",
+        "    sys.stdout.buffer.flush()\n",
+        "while True:\n",
+        "    msg = read_msg()\n",
+        "    if msg is None: break\n",
+        "    rid = msg.get('id')\n",
+        "    m = msg.get('method', '')\n",
+        "    if m == 'initialized': continue\n",
+        "    if rid is None: continue\n",
+        "    if m == 'initialize':\n",
+        "        send({'jsonrpc':'2.0','id':rid,'result':{'capabilities':{'renameProvider':{'prepareProvider':True}}}})\n",
+        "    elif m == 'textDocument/prepareRename':\n",
+        "        send({'jsonrpc':'2.0','id':rid,'result':{'range':{'start':{'line':0,'character':4},'end':{'line':0,'character':13}},'placeholder':'target_fn'}})\n",
+        "    elif m == 'textDocument/rename':\n",
+        "        uri = msg['params']['textDocument']['uri']\n",
+        "        new_name = msg['params']['newName']\n",
+        "        send({'jsonrpc':'2.0','id':rid,'result':{'changes':{uri:[{'range':{'start':{'line':0,'character':4},'end':{'line':0,'character':13}},'newText':new_name},{'range':{'start':{'line':3,'character':0},'end':{'line':3,'character':9}},'newText':new_name}]}}})\n",
+        "    elif m == 'shutdown':\n",
+        "        send({'jsonrpc':'2.0','id':rid,'result':None})\n",
+        "    else:\n",
+        "        send({'jsonrpc':'2.0','id':rid,'result':None})\n",
+    );
+    let mock_path = project.as_path().join("mock_lsp_rename_evidence_t3_1.py");
+    fs::write(&mock_path, mock_lsp).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&mock_path, fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    let state = make_state(&project);
+    let payload = call_tool(
+        &state,
+        "rename_symbol",
+        json!({
+            "file_path": "evidence_target.py",
+            "symbol_name": "target_fn",
+            "new_name": "renamed_fn",
+            "semantic_edit_backend": "lsp",
+            "line": 1,
+            "column": 5,
+            "command": "python3",
+            "args": [mock_path.to_string_lossy()]
+        }),
+    );
+
+    assert_eq!(payload["success"], json!(true), "{payload}");
+    let tx = &payload["data"]["transaction"]["contract"];
+
+    // T3-1: file_hashes_before must be populated with the pre-apply sha256
+    let hashes_before = tx["file_hashes_before"]
+        .as_object()
+        .expect("file_hashes_before should be an object");
+    assert!(
+        !hashes_before.is_empty(),
+        "hashes_before should be populated, got: {tx}"
+    );
+    assert_eq!(
+        hashes_before["evidence_target.py"]["sha256"],
+        json!(original_hash),
+        "hashes_before sha256 should match pre-apply content"
+    );
+
+    // T3-1: file_hashes_after must also be populated (substrate-derived)
+    let hashes_after = tx["file_hashes_after"]
+        .as_object()
+        .expect("file_hashes_after should be an object");
+    assert_eq!(
+        hashes_before.len(),
+        hashes_after.len(),
+        "hashes_before and after should have same key set"
+    );
+    for (path, before) in hashes_before {
+        assert!(
+            before["sha256"]
+                .as_str()
+                .map(|s| !s.is_empty())
+                .unwrap_or(false),
+            "hashes_before[{path}].sha256 should be non-empty"
+        );
+    }
+
+    // T3-1: apply_status must be substrate-derived, not a placeholder
+    assert!(
+        matches!(
+            tx["apply_status"].as_str(),
+            Some("applied") | Some("rolled_back") | Some("no_op")
+        ),
+        "apply_status should be substrate-derived: {:?}",
+        tx["apply_status"]
+    );
+
+    // Sanity: file was actually modified
+    let updated = fs::read_to_string(project.as_path().join("evidence_target.py")).unwrap();
+    assert!(updated.contains("def renamed_fn():"), "{updated}");
+    assert!(updated.contains("renamed_fn()"), "{updated}");
+}
+
 fn write_code_action_mock(
     project: &codelens_engine::ProjectRoot,
     kind: &str,

--- a/crates/codelens-mcp/src/tools/semantic_adapter.rs
+++ b/crates/codelens-mcp/src/tools/semantic_adapter.rs
@@ -96,12 +96,13 @@ fn invoke_workspace_edit_adapter(
         modified_files: transaction.modified_files,
         edit_count: transaction.edit_count,
         resource_ops: json!(transaction.resource_ops),
-        rollback_available: transaction.rollback_available,
+        rollback_available: false,
         workspace_edit: serde_json::to_value(&transaction)
             .unwrap_or_else(|_| json!({"serialization_error": true})),
         apply_status: if dry_run { "preview_only" } else { "applied" },
         references_checked: false,
         conflicts: json!([]),
+        evidence: None,
     });
     if !dry_run {
         codelens_engine::lsp::apply_workspace_edit_transaction(&state.project(), &transaction)
@@ -133,7 +134,7 @@ fn invoke_workspace_edit_adapter(
                 "modified_files": transaction.modified_files,
                 "edit_count": transaction.edit_count,
                 "resource_ops": transaction.resource_ops,
-                "rollback_available": transaction.rollback_available,
+                "rollback_available": false,
                 "contract": transaction_contract
             },
             "workspace_edit": transaction,

--- a/crates/codelens-mcp/src/tools/semantic_edit.rs
+++ b/crates/codelens-mcp/src/tools/semantic_edit.rs
@@ -411,6 +411,10 @@ pub(crate) fn safe_delete_with_lsp_backend(
     let mut safe_delete_action = "check_only";
     let mut modified_files = 0usize;
     let mut edit_count = 0usize;
+    let mut apply_evidence: Option<codelens_engine::ApplyEvidence> = None;
+    let mut apply_status_for_contract: &str = if dry_run { "preview_only" } else { "applied" };
+    let mut apply_failure_message: Option<String> = None;
+
     if !dry_run {
         if !safe_to_delete {
             return Err(CodeLensError::Validation(format!(
@@ -429,7 +433,7 @@ pub(crate) fn safe_delete_with_lsp_backend(
             ))
         })?;
         let resolved = state.project().resolve(&file_path)?;
-        let mut source = std::fs::read_to_string(&resolved)?;
+        let source = std::fs::read_to_string(&resolved)?;
         if start_byte >= end_byte
             || end_byte > source.len()
             || !source.is_char_boundary(start_byte)
@@ -443,12 +447,55 @@ pub(crate) fn safe_delete_with_lsp_backend(
         if source.as_bytes().get(delete_end) == Some(&b'\n') {
             delete_end += 1;
         }
-        source.replace_range(start_byte..delete_end, "");
-        std::fs::write(&resolved, source)?;
-        safe_delete_action = "applied";
-        modified_files = 1;
-        edit_count = 1;
+        let delete_text = source[start_byte..delete_end].to_owned();
+
+        // Compute 1-based (line, column) from byte offset for RenameEdit.
+        let line_for_edit = source[..start_byte].matches('\n').count() + 1;
+        let last_newline = source[..start_byte].rfind('\n').map(|p| p + 1).unwrap_or(0);
+        let column_for_edit = start_byte - last_newline + 1;
+
+        let edits = vec![codelens_engine::RenameEdit {
+            file_path: file_path.clone(),
+            line: line_for_edit,
+            column: column_for_edit,
+            old_text: delete_text,
+            new_text: String::new(),
+        }];
+        let tx = codelens_engine::WorkspaceEditTransaction::new(edits, Vec::new());
+        match tx.apply_with_evidence(&state.project()) {
+            Ok(evidence) => {
+                modified_files = evidence.modified_files;
+                edit_count = evidence.edit_count;
+                safe_delete_action = "applied";
+                apply_status_for_contract = "applied";
+                apply_evidence = Some(evidence);
+            }
+            Err(codelens_engine::ApplyError::ApplyFailed { source, evidence }) => {
+                modified_files = 0;
+                edit_count = 0;
+                safe_delete_action = "rolled_back";
+                apply_status_for_contract = "rolled_back";
+                apply_failure_message = Some(source.to_string());
+                apply_evidence = Some(evidence);
+            }
+            Err(other) => {
+                return Err(CodeLensError::Validation(format!(
+                    "safe_delete_apply: substrate refused: {other}"
+                )));
+            }
+        }
     }
+
+    let rollback_available = apply_evidence
+        .as_ref()
+        .map(|ev| {
+            matches!(
+                ev.status,
+                codelens_engine::ApplyStatus::Applied | codelens_engine::ApplyStatus::RolledBack
+            )
+        })
+        .unwrap_or(false);
+
     let message = if safe_to_delete {
         format!(
             "LSP found no non-declaration references for `{symbol_name}` in `{file_path}`. Deletion can proceed through the mutation gate."
@@ -472,16 +519,16 @@ pub(crate) fn safe_delete_with_lsp_backend(
                     modified_files,
                     edit_count,
                     resource_ops: json!([]),
-                    rollback_available: false,
+                    rollback_available,
                     workspace_edit: json!({"edits": []}),
-                    apply_status: if dry_run { "preview_only" } else { "applied" },
+                    apply_status: apply_status_for_contract,
                     references_checked: true,
                     conflicts: if safe_to_delete {
                         json!([])
                     } else {
                         serde_json::Value::Array(affected_references.clone())
                     },
-                    evidence: None,
+                    evidence: apply_evidence.as_ref(),
                 });
             json!({
                 "success": true,
@@ -490,7 +537,7 @@ pub(crate) fn safe_delete_with_lsp_backend(
                 "authority": if dry_run {
                     "semantic_readonly"
                 } else {
-                    "syntax"
+                    "workspace_edit"
                 },
                 "authority_backend": format!("lsp:{command_ref}"),
                 "can_preview": true,
@@ -519,12 +566,13 @@ pub(crate) fn safe_delete_with_lsp_backend(
                 "dry_run": dry_run,
                 "message": message,
                 "safe_delete_action": safe_delete_action,
+                "error_message": apply_failure_message,
                 "transaction": {
                     "dry_run": dry_run,
                     "modified_files": modified_files,
                     "edit_count": edit_count,
                     "resource_ops": [],
-                    "rollback_available": false,
+                    "rollback_available": rollback_available,
                     "contract": transaction_contract
                 },
                 "verification": {

--- a/crates/codelens-mcp/src/tools/semantic_edit.rs
+++ b/crates/codelens-mcp/src/tools/semantic_edit.rs
@@ -2,13 +2,13 @@ use super::semantic_edit_args::{
     code_action_kinds, code_action_range, language_for_file, position_source, symbol_position,
 };
 use super::{
-    AppState, ToolResult, default_lsp_command_for_path, optional_string, parse_lsp_args,
-    required_string, success_meta,
+    default_lsp_command_for_path, optional_string, parse_lsp_args, required_string, success_meta,
+    AppState, ToolResult,
 };
 use crate::error::CodeLensError;
 use crate::protocol::BackendKind;
 use codelens_engine::lsp::{LspCodeActionRequest, LspRenameRequest, LspRequest};
-use serde_json::{Map, Value, json};
+use serde_json::{json, Map, Value};
 use sha2::{Digest, Sha256};
 use std::collections::BTreeSet;
 
@@ -113,6 +113,26 @@ pub(crate) fn code_action_refactor_with_lsp_backend(
         .map(|edit| edit.file_path.clone())
         .collect::<Vec<_>>();
     let backend_id = format!("lsp:{command_ref}");
+    let apply_evidence: Option<codelens_engine::ApplyEvidence> = if !dry_run {
+        Some(
+            codelens_engine::lsp::apply_workspace_edit_transaction(
+                &state.project(),
+                &plan.transaction,
+            )
+            .map_err(|error| CodeLensError::LspError(format!("LSP {command_ref}: {error}")))?,
+        )
+    } else {
+        None
+    };
+    let rollback_available_derived = apply_evidence
+        .as_ref()
+        .map(|ev| {
+            matches!(
+                ev.status,
+                codelens_engine::ApplyStatus::Applied | codelens_engine::ApplyStatus::RolledBack
+            )
+        })
+        .unwrap_or(false);
     let transaction_contract = semantic_transaction_contract(SemanticTransactionContractInput {
         state,
         backend_id: &backend_id,
@@ -123,16 +143,13 @@ pub(crate) fn code_action_refactor_with_lsp_backend(
         modified_files: plan.transaction.modified_files,
         edit_count: plan.transaction.edit_count,
         resource_ops: json!(plan.transaction.resource_ops),
-        rollback_available: plan.transaction.rollback_available,
+        rollback_available: rollback_available_derived,
         workspace_edit: transaction.clone(),
         apply_status: if dry_run { "preview_only" } else { "applied" },
         references_checked: false,
         conflicts: json!([]),
+        evidence: apply_evidence.as_ref(),
     });
-    if !dry_run {
-        codelens_engine::lsp::apply_workspace_edit_transaction(&state.project(), &plan.transaction)
-            .map_err(|error| CodeLensError::LspError(format!("LSP {command_ref}: {error}")))?;
-    }
     let message = format!(
         "{} {} LSP codeAction edit(s) in {} file(s)",
         if dry_run { "Would apply" } else { "Applied" },
@@ -179,7 +196,7 @@ pub(crate) fn code_action_refactor_with_lsp_backend(
                 "modified_files": plan.transaction.modified_files,
                 "edit_count": plan.transaction.edit_count,
                 "resource_ops": plan.transaction.resource_ops,
-                "rollback_available": plan.transaction.rollback_available,
+                "rollback_available": rollback_available_derived,
                 "contract": transaction_contract
             },
             "workspace_edit": transaction,
@@ -244,6 +261,23 @@ pub(crate) fn rename_symbol_with_lsp_backend(
     let transaction_value =
         serde_json::to_value(&transaction).unwrap_or_else(|_| json!({"serialization_error": true}));
     let backend_id = format!("lsp:{command_ref}");
+    let apply_evidence: Option<codelens_engine::ApplyEvidence> = if !dry_run {
+        Some(
+            codelens_engine::lsp::apply_workspace_edit_transaction(&state.project(), &transaction)
+                .map_err(|error| CodeLensError::LspError(format!("LSP {command_ref}: {error}")))?,
+        )
+    } else {
+        None
+    };
+    let rollback_available_derived = apply_evidence
+        .as_ref()
+        .map(|ev| {
+            matches!(
+                ev.status,
+                codelens_engine::ApplyStatus::Applied | codelens_engine::ApplyStatus::RolledBack
+            )
+        })
+        .unwrap_or(false);
     let transaction_contract = semantic_transaction_contract(SemanticTransactionContractInput {
         state,
         backend_id: &backend_id,
@@ -254,16 +288,13 @@ pub(crate) fn rename_symbol_with_lsp_backend(
         modified_files,
         edit_count: total_replacements,
         resource_ops: json!(transaction.resource_ops),
-        rollback_available: transaction.rollback_available,
+        rollback_available: rollback_available_derived,
         workspace_edit: transaction_value,
         apply_status: if dry_run { "preview_only" } else { "applied" },
         references_checked: false,
         conflicts: json!([]),
+        evidence: apply_evidence.as_ref(),
     });
-    if !dry_run {
-        codelens_engine::lsp::apply_workspace_edit_transaction(&state.project(), &transaction)
-            .map_err(|error| CodeLensError::LspError(format!("LSP {command_ref}: {error}")))?;
-    }
     let message = format!(
         "{} {} LSP replacement(s) in {} file(s)",
         if dry_run { "Would make" } else { "Made" },
@@ -307,7 +338,7 @@ pub(crate) fn rename_symbol_with_lsp_backend(
                 "modified_files": modified_files,
                 "edit_count": total_replacements,
                 "resource_ops": transaction.resource_ops,
-                "rollback_available": transaction.rollback_available,
+                "rollback_available": rollback_available_derived,
                 "contract": transaction_contract
             },
             "verification": {
@@ -450,6 +481,7 @@ pub(crate) fn safe_delete_with_lsp_backend(
                     } else {
                         serde_json::Value::Array(affected_references.clone())
                     },
+                    evidence: None,
                 });
             json!({
                 "success": true,
@@ -531,17 +563,70 @@ pub(crate) struct SemanticTransactionContractInput<'a> {
     pub(crate) apply_status: &'a str,
     pub(crate) references_checked: bool,
     pub(crate) conflicts: Value,
+    /// When `Some`, evidence is single source of truth for file_hashes_before/
+    /// file_hashes_after / rollback_report / apply_status / modified_files /
+    /// edit_count / rollback_available. When `None` (preview/dry_run), the
+    /// existing struct fields are used and file_hashes_after is empty.
+    pub(crate) evidence: Option<&'a codelens_engine::ApplyEvidence>,
 }
 
 pub(crate) fn semantic_transaction_contract(input: SemanticTransactionContractInput<'_>) -> Value {
-    let file_hashes_before = file_hashes_before(input.state, input.file_paths);
+    let (
+        file_hashes_before_value,
+        file_hashes_after_value,
+        rollback_report_value,
+        rollback_available,
+        modified_files,
+        edit_count,
+        apply_status_resolved,
+    ) = match input.evidence {
+        Some(ev) => {
+            let hashes_before = serde_json::to_value(&ev.file_hashes_before).unwrap_or(Value::Null);
+            let hashes_after = serde_json::to_value(&ev.file_hashes_after).unwrap_or(Value::Null);
+            let rollback =
+                serde_json::to_value(&ev.rollback_report).unwrap_or(Value::Array(Vec::new()));
+            let status_str = match ev.status {
+                codelens_engine::ApplyStatus::Applied => "applied",
+                codelens_engine::ApplyStatus::RolledBack => "rolled_back",
+                codelens_engine::ApplyStatus::NoOp => "no_op",
+            };
+            (
+                hashes_before,
+                hashes_after,
+                rollback,
+                matches!(
+                    ev.status,
+                    codelens_engine::ApplyStatus::Applied
+                        | codelens_engine::ApplyStatus::RolledBack
+                ),
+                ev.modified_files,
+                ev.edit_count,
+                status_str,
+            )
+        }
+        None => {
+            let hashes_before = file_hashes_before(input.state, input.file_paths);
+            (
+                hashes_before,
+                Value::Object(serde_json::Map::new()),
+                Value::Array(Vec::new()),
+                input.rollback_available,
+                input.modified_files,
+                input.edit_count,
+                input.apply_status,
+            )
+        }
+    };
+
+    let tx_id = transaction_id(
+        input.backend_id,
+        input.operation,
+        input.file_paths,
+        &file_hashes_before_value,
+    );
+
     json!({
-        "transaction_id": transaction_id(
-            input.backend_id,
-            input.operation,
-            input.file_paths,
-            &file_hashes_before
-        ),
+        "transaction_id": tx_id,
         "model": "transactional_best_effort_with_rollback_evidence",
         "workspace_id": input.state.project().as_path().display().to_string(),
         "backend_id": input.backend_id,
@@ -551,17 +636,19 @@ pub(crate) fn semantic_transaction_contract(input: SemanticTransactionContractIn
             "file_paths": unique_file_paths(input.file_paths),
             "dry_run": input.dry_run,
         },
-        "file_hashes_before": file_hashes_before,
+        "file_hashes_before": file_hashes_before_value,
+        "file_hashes_after": file_hashes_after_value,
+        "rollback_report": rollback_report_value,
         "workspace_edit": input.workspace_edit,
         "preview_diff": [],
-        "apply_status": input.apply_status,
-        "modified_files": input.modified_files,
-        "edit_count": input.edit_count,
+        "apply_status": apply_status_resolved,
+        "modified_files": modified_files,
+        "edit_count": edit_count,
         "resource_ops": input.resource_ops,
         "rollback_plan": {
-            "available": input.rollback_available,
-            "evidence": if input.rollback_available {
-                "pre-apply file snapshots are held during apply and restored on apply failure"
+            "available": rollback_available,
+            "evidence": if rollback_available {
+                "pre-apply file snapshots are held during apply; restored on apply failure"
             } else {
                 "rollback evidence is unavailable for this operation path"
             }

--- a/docs/superpowers/plans/2026-04-25-codelens-phase1-g4-workspace-edit-transaction.md
+++ b/docs/superpowers/plans/2026-04-25-codelens-phase1-g4-workspace-edit-transaction.md
@@ -1,0 +1,1882 @@
+# Phase 1 G4 — WorkspaceEditTransaction Substrate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Generalize the existing engine apply path into a `WorkspaceEditTransaction` domain object with hash-based `ApplyEvidence` and rollback report; migrate `safe_delete_apply` off its own `fs::write`.
+
+**Architecture:** New `crates/codelens-engine/src/edit_transaction.rs` module hosts the substrate (types + `apply_with_evidence` method). `lsp::workspace_edit::apply_workspace_edit_transaction` becomes a thin wrapper. mcp `semantic_transaction_contract` takes `evidence: Option<&ApplyEvidence>` and uses it as single source of truth when present.
+
+**Tech Stack:** Rust (engine + mcp), `serde_json::Value`, `sha2::Sha256`, `anyhow::Result`.
+
+**Spec reference:** `docs/superpowers/specs/2026-04-25-codelens-phase1-g4-workspace-edit-transaction-design.md` (commit `25a49523`).
+
+**Branch:** `feat/phase1-g4-workspace-edit-transaction` (stacked on `codex/ide-refactor-substrate` head `25a49523`).
+
+**Existing types (reused, do NOT redefine):**
+
+- `crates/codelens-engine/src/rename.rs:21` — `pub struct RenameEdit { file_path: String, line: usize, column: usize, old_text: String, new_text: String }`
+- `crates/codelens-engine/src/rename.rs:419` — `pub fn apply_edits(project: &ProjectRoot, edits: &[RenameEdit]) -> Result<()>`
+- `crates/codelens-engine/src/lsp/types.rs:160` — `pub struct LspResourceOp { kind, file_path, old_file_path, new_file_path }`
+- `crates/codelens-engine/src/lsp/types.rs:168` — `pub struct LspWorkspaceEditTransaction { edits, resource_ops, modified_files, edit_count, rollback_available }`
+
+---
+
+## File Structure
+
+| Role                                                        | Path                                                             | Change     |
+| ----------------------------------------------------------- | ---------------------------------------------------------------- | ---------- |
+| Substrate types + `apply_with_evidence`                     | `crates/codelens-engine/src/edit_transaction.rs`                 | 신규       |
+| Module registration + re-export                             | `crates/codelens-engine/src/lib.rs`                              | 1~3줄 추가 |
+| LSP integration (signature + `From` impl)                   | `crates/codelens-engine/src/lsp/workspace_edit.rs`               | 수정       |
+| `LspWorkspaceEditTransaction.rollback_available` deprecated | `crates/codelens-engine/src/lsp/types.rs`                        | 1~3줄      |
+| Contract serialization + safe_delete_apply migration        | `crates/codelens-mcp/src/tools/semantic_edit.rs`                 | 수정       |
+| Adapter caller (None marker)                                | `crates/codelens-mcp/src/tools/semantic_adapter.rs`              | 1줄        |
+| T2/T3 integration tests                                     | `crates/codelens-mcp/src/integration_tests/semantic_refactor.rs` | 수정       |
+
+총 7 파일 (3 신규 + 4 수정 미만, AC-6 ≤ 9 만족).
+
+---
+
+### Task 1: substrate skeleton — 타입 정의 + 모듈 등록
+
+**Files:**
+
+- Create: `crates/codelens-engine/src/edit_transaction.rs`
+- Modify: `crates/codelens-engine/src/lib.rs`
+
+**Why this batch:** 타입을 먼저 정의하면 후속 task가 `apply_with_evidence` 동작을 구현할 수 있는 슬롯을 갖게 됨. 컴파일만 확인 (functional behavior 없음).
+
+- [ ] **Step 1: 신규 모듈 작성 — 타입 + skeleton apply_with_evidence**
+
+`crates/codelens-engine/src/edit_transaction.rs`:
+
+```rust
+//! Workspace edit transaction substrate.
+//!
+//! Provides a reusable domain object for multi-file mutations with
+//! pre-apply hash capture, post-apply hash verification, and rollback
+//! evidence. Used by LSP rename, safe_delete_apply, and future engine
+//! mutation primitives.
+//!
+//! Rollback model: transactional best-effort with rollback evidence.
+//! In-memory backups + restore-on-error. TOCTOU re-check is a light
+//! same-function two-read window; disk-snapshot/lock guarantees are
+//! deferred to Phase 2.
+
+use crate::lsp::types::LspResourceOp;
+use crate::project::ProjectRoot;
+use crate::rename::RenameEdit;
+use anyhow::{Context, Result};
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, HashMap};
+use std::fs;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone)]
+pub struct WorkspaceEditTransaction {
+    pub edits: Vec<RenameEdit>,
+    pub resource_ops: Vec<LspResourceOp>,
+    pub modified_files: usize,
+    pub edit_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ApplyEvidence {
+    pub status: ApplyStatus,
+    pub file_hashes_before: BTreeMap<String, FileHash>,
+    pub file_hashes_after: BTreeMap<String, FileHash>,
+    pub rollback_report: Vec<RollbackEntry>,
+    pub modified_files: usize,
+    pub edit_count: usize,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ApplyStatus {
+    Applied,
+    RolledBack,
+    NoOp,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RollbackEntry {
+    pub file_path: String,
+    pub restored: bool,
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FileHash {
+    pub sha256: String,
+    pub bytes: usize,
+}
+
+#[derive(Debug)]
+pub enum ApplyError {
+    ResourceOpsUnsupported,
+    PreReadFailed {
+        file_path: String,
+        source: anyhow::Error,
+    },
+    PreApplyHashMismatch {
+        file_path: String,
+        expected: String,
+        actual: String,
+    },
+    ApplyFailed {
+        source: anyhow::Error,
+        evidence: ApplyEvidence,
+    },
+}
+
+impl std::fmt::Display for ApplyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ResourceOpsUnsupported => write!(
+                f,
+                "unsupported_semantic_refactor: resource operations are preview-only in this release"
+            ),
+            Self::PreReadFailed { file_path, source } => {
+                write!(f, "pre-apply read failed for `{file_path}`: {source}")
+            }
+            Self::PreApplyHashMismatch {
+                file_path,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "pre-apply hash mismatch for `{file_path}`: expected {expected}, got {actual}"
+            ),
+            Self::ApplyFailed { source, .. } => write!(f, "apply failed: {source}"),
+        }
+    }
+}
+
+impl std::error::Error for ApplyError {}
+
+impl WorkspaceEditTransaction {
+    pub fn new(edits: Vec<RenameEdit>, resource_ops: Vec<LspResourceOp>) -> Self {
+        let modified_files = edits
+            .iter()
+            .map(|edit| &edit.file_path)
+            .collect::<std::collections::HashSet<_>>()
+            .len();
+        let edit_count = edits.len();
+        Self {
+            edits,
+            resource_ops,
+            modified_files,
+            edit_count,
+        }
+    }
+
+    /// Apply edits with hash-based evidence and rollback on failure.
+    /// Returns `Ok(ApplyEvidence)` on success, `Err(ApplyError)` on
+    /// pre-apply failure or apply failure (apply failure carries
+    /// `ApplyEvidence` with `status: RolledBack`).
+    pub fn apply_with_evidence(
+        &self,
+        project: &ProjectRoot,
+    ) -> Result<ApplyEvidence, ApplyError> {
+        // skeleton: future tasks fill in
+        let _ = project;
+        unimplemented!("apply_with_evidence implemented in Task 2~6")
+    }
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    let mut output = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        use std::fmt::Write as _;
+        let _ = write!(output, "{byte:02x}");
+    }
+    output
+}
+```
+
+(`Context`, `HashMap`, `PathBuf`, `fs` 등은 후속 task에서 사용하므로 unused warning 회피 위해 `#[allow(unused_imports)]`를 모듈 선언에 잠시 추가하거나, 사용 시점에 import. Step 1에서는 `#[allow(dead_code, unused_imports)]`를 모듈 상단에 임시 추가.)
+
+```rust
+#![allow(dead_code, unused_imports)] // removed in Task 2 once the function body lands
+```
+
+- [ ] **Step 2: lib.rs에 모듈 등록 + 핵심 타입 re-export**
+
+`crates/codelens-engine/src/lib.rs`에서 모듈 선언 블록(다른 `pub mod` 옆)에 추가:
+
+```rust
+pub mod edit_transaction;
+```
+
+기존 re-export 블록 또는 `pub use` 모음 옆에 추가:
+
+```rust
+pub use edit_transaction::{
+    ApplyError, ApplyEvidence, ApplyStatus, FileHash, RollbackEntry, WorkspaceEditTransaction,
+};
+```
+
+(`crates/codelens-engine/src/lib.rs` 구조 확인: 기존 `pub mod xxx;` 줄과 `pub use xxx::*;` 줄을 모방. 필요 시 grep `pub mod` 후 알파벳 순 삽입.)
+
+- [ ] **Step 3: cargo check — 컴파일 확인**
+
+```bash
+cargo check -p codelens-engine 2>&1 | tail -10
+```
+
+Expected: clean. `unimplemented!()` 매크로 호출은 컴파일 시점에 문제 없음(런타임 panic).
+
+- [ ] **Step 4: 회귀 가드 — 다른 패키지 빌드 확인**
+
+```bash
+cargo check -p codelens-mcp 2>&1 | tail -5
+cargo check -p codelens-mcp --features http 2>&1 | tail -5
+```
+
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/codelens-engine/src/edit_transaction.rs crates/codelens-engine/src/lib.rs
+git commit -m "$(cat <<'EOF'
+feat(engine): add edit_transaction module skeleton
+
+WorkspaceEditTransaction / ApplyEvidence / ApplyStatus / RollbackEntry /
+FileHash / ApplyError types defined; apply_with_evidence stubbed with
+unimplemented!() pending Task 2~6 behavior.
+
+Phase 1 G4 substrate foundation.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: NoOp + ResourceOpsUnsupported (no I/O)
+
+**Files:**
+
+- Modify: `crates/codelens-engine/src/edit_transaction.rs`
+
+**Why this batch:** 가장 가벼운 두 분기를 먼저 구현하여 control-flow shape을 확정. I/O 0이라 fault-injection 불필요.
+
+- [ ] **Step 1: 두 fail test 작성 (`#[cfg(test)] mod tests`)**
+
+`edit_transaction.rs` 끝에 추가:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn empty_project() -> ProjectRoot {
+        let dir = std::env::temp_dir().join(format!(
+            "codelens-edit-tx-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        ProjectRoot::new(dir.to_str().unwrap()).unwrap()
+    }
+
+    #[test]
+    fn noop_returns_evidence_with_status_noop() {
+        let project = empty_project();
+        let tx = WorkspaceEditTransaction::new(vec![], vec![]);
+        let evidence = tx.apply_with_evidence(&project).expect("noop apply ok");
+        assert_eq!(evidence.status, ApplyStatus::NoOp);
+        assert!(evidence.file_hashes_before.is_empty());
+        assert!(evidence.file_hashes_after.is_empty());
+        assert!(evidence.rollback_report.is_empty());
+        assert_eq!(evidence.modified_files, 0);
+        assert_eq!(evidence.edit_count, 0);
+    }
+
+    #[test]
+    fn resource_ops_non_empty_returns_unsupported() {
+        let project = empty_project();
+        let tx = WorkspaceEditTransaction::new(
+            vec![],
+            vec![LspResourceOp {
+                kind: "create".to_owned(),
+                file_path: "new.txt".to_owned(),
+                old_file_path: None,
+                new_file_path: None,
+            }],
+        );
+        let result = tx.apply_with_evidence(&project);
+        assert!(matches!(result, Err(ApplyError::ResourceOpsUnsupported)));
+    }
+}
+```
+
+- [ ] **Step 2: 실행 — 두 test fail 확인 (unimplemented panic)**
+
+```bash
+cargo test -p codelens-engine --lib edit_transaction:: 2>&1 | tail -10
+```
+
+Expected: 두 test 모두 `panicked at 'not implemented'` (unimplemented! 매크로).
+
+- [ ] **Step 3: NoOp + ResourceOpsUnsupported 분기 구현 + skeleton 제거**
+
+`edit_transaction.rs` 상단의 `#![allow(dead_code, unused_imports)]` 제거. `apply_with_evidence` 본문 교체:
+
+```rust
+    pub fn apply_with_evidence(
+        &self,
+        project: &ProjectRoot,
+    ) -> Result<ApplyEvidence, ApplyError> {
+        if !self.resource_ops.is_empty() {
+            return Err(ApplyError::ResourceOpsUnsupported);
+        }
+        if self.edits.is_empty() {
+            return Ok(ApplyEvidence {
+                status: ApplyStatus::NoOp,
+                file_hashes_before: BTreeMap::new(),
+                file_hashes_after: BTreeMap::new(),
+                rollback_report: Vec::new(),
+                modified_files: 0,
+                edit_count: 0,
+            });
+        }
+        // future tasks (Task 3~6): pre-read, recheck, apply, post-hash
+        let _ = project;
+        unimplemented!("apply path implemented in Task 3~6")
+    }
+```
+
+(unused import 제거: `Context`, `HashMap`, `PathBuf`, `fs`, `sha256_hex`는 Task 3에서 사용. `dead_code` allow 일단 유지.)
+
+`#![allow(dead_code, unused_imports)]` → `#![allow(dead_code)]` (sha256_hex가 아직 unused).
+
+- [ ] **Step 4: 실행 — 두 test 통과 + 빌드 확인**
+
+```bash
+cargo test -p codelens-engine --lib edit_transaction:: 2>&1 | tail -5
+cargo check -p codelens-engine 2>&1 | tail -3
+```
+
+Expected: 2 PASS. 0 fail.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/codelens-engine/src/edit_transaction.rs
+git commit -m "$(cat <<'EOF'
+feat(engine): handle NoOp + ResourceOpsUnsupported in apply_with_evidence
+
+empty edits return ApplyEvidence{status: NoOp}. resource_ops non-empty
+returns Err(ResourceOpsUnsupported). 2 unit tests added.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: pre-read failure (Phase 1 read 실패)
+
+**Files:**
+
+- Modify: `crates/codelens-engine/src/edit_transaction.rs`
+
+- [ ] **Step 1: pre-read-failed fail test 추가**
+
+`edit_transaction.rs`의 `mod tests` 안에 추가:
+
+```rust
+    #[test]
+    fn pre_read_fails_when_file_missing() {
+        let project = empty_project();
+        let tx = WorkspaceEditTransaction::new(
+            vec![RenameEdit {
+                file_path: "missing.txt".to_owned(),
+                line: 1,
+                column: 1,
+                old_text: "x".to_owned(),
+                new_text: "y".to_owned(),
+            }],
+            vec![],
+        );
+        let result = tx.apply_with_evidence(&project);
+        assert!(
+            matches!(result, Err(ApplyError::PreReadFailed { ref file_path, .. }) if file_path == "missing.txt"),
+            "expected PreReadFailed for missing.txt, got {:?}",
+            result.err()
+        );
+    }
+```
+
+- [ ] **Step 2: 실행 — fail 확인**
+
+```bash
+cargo test -p codelens-engine --lib edit_transaction::tests::pre_read_fails 2>&1 | tail -10
+```
+
+Expected: `panicked at 'not implemented'`.
+
+- [ ] **Step 3: Phase 1 read 구현**
+
+`apply_with_evidence` 본문에서 `unimplemented!("apply path implemented in Task 3~6")` 부분을 교체:
+
+```rust
+        // Phase 1: capture pre-apply state (single read; backup + hash)
+        let mut backups: HashMap<PathBuf, Vec<u8>> = HashMap::new();
+        let mut file_hashes_before: BTreeMap<String, FileHash> = BTreeMap::new();
+        for file_path in self.unique_file_paths() {
+            let resolved = project
+                .resolve(&file_path)
+                .map_err(|e| ApplyError::PreReadFailed {
+                    file_path: file_path.clone(),
+                    source: e,
+                })?;
+            let bytes = fs::read(&resolved).map_err(|e| ApplyError::PreReadFailed {
+                file_path: file_path.clone(),
+                source: anyhow::Error::from(e),
+            })?;
+            file_hashes_before.insert(
+                file_path.clone(),
+                FileHash {
+                    sha256: sha256_hex(&bytes),
+                    bytes: bytes.len(),
+                },
+            );
+            backups.insert(resolved, bytes);
+        }
+        // future: Phase 2 recheck, Phase 3 apply, Phase 4 post-hash
+        let _ = backups;
+        let _ = file_hashes_before;
+        unimplemented!("apply path Task 4~6")
+```
+
+`unique_file_paths` 헬퍼를 `impl WorkspaceEditTransaction` 안에 추가:
+
+```rust
+    fn unique_file_paths(&self) -> Vec<String> {
+        let mut paths: Vec<String> = self
+            .edits
+            .iter()
+            .map(|edit| edit.file_path.clone())
+            .collect::<std::collections::BTreeSet<_>>()
+            .into_iter()
+            .collect();
+        paths.sort();
+        paths
+    }
+```
+
+- [ ] **Step 4: 실행 — pre-read-failed test 통과 + 회귀 0**
+
+```bash
+cargo test -p codelens-engine --lib edit_transaction:: 2>&1 | tail -5
+```
+
+Expected: 3 PASS (`noop`, `resource_ops_non_empty`, `pre_read_fails`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/codelens-engine/src/edit_transaction.rs
+git commit -m "$(cat <<'EOF'
+feat(engine): pre-read phase + PreReadFailed error in substrate
+
+Phase 1 reads each unique edit file once, captures sha256 + length
+into file_hashes_before, stores raw bytes as in-memory backup. Missing
+files surface as ApplyError::PreReadFailed with the file path. 1 test
+added.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: happy path — apply via `apply_edits` + Phase 4 hash + hash determinism
+
+**Files:**
+
+- Modify: `crates/codelens-engine/src/edit_transaction.rs`
+
+- [ ] **Step 1: happy + determinism fail tests 추가**
+
+`mod tests`에 추가:
+
+```rust
+    fn write_file(project: &ProjectRoot, name: &str, content: &str) -> PathBuf {
+        let resolved = project.resolve(name).unwrap();
+        std::fs::create_dir_all(resolved.parent().unwrap()).ok();
+        std::fs::write(&resolved, content).unwrap();
+        resolved
+    }
+
+    #[test]
+    fn happy_path_two_files_apply_succeeds_with_evidence() {
+        let project = empty_project();
+        write_file(&project, "a.txt", "alpha\n");
+        write_file(&project, "b.txt", "beta\n");
+        let tx = WorkspaceEditTransaction::new(
+            vec![
+                RenameEdit {
+                    file_path: "a.txt".to_owned(),
+                    line: 1,
+                    column: 1,
+                    old_text: "alpha".to_owned(),
+                    new_text: "ALPHA".to_owned(),
+                },
+                RenameEdit {
+                    file_path: "b.txt".to_owned(),
+                    line: 1,
+                    column: 1,
+                    old_text: "beta".to_owned(),
+                    new_text: "BETA".to_owned(),
+                },
+            ],
+            vec![],
+        );
+        let evidence = tx
+            .apply_with_evidence(&project)
+            .expect("happy path apply ok");
+        assert_eq!(evidence.status, ApplyStatus::Applied);
+        assert_eq!(evidence.file_hashes_before.len(), 2);
+        assert_eq!(evidence.file_hashes_after.len(), 2);
+        assert!(evidence.rollback_report.is_empty());
+        assert_eq!(evidence.modified_files, 2);
+        assert_eq!(evidence.edit_count, 2);
+        // before hashes != after hashes
+        for (path, before) in &evidence.file_hashes_before {
+            let after = evidence
+                .file_hashes_after
+                .get(path)
+                .expect("after entry exists");
+            assert_ne!(before.sha256, after.sha256, "hash for {path} should differ");
+        }
+        // disk shows new content
+        assert_eq!(
+            std::fs::read_to_string(project.resolve("a.txt").unwrap()).unwrap(),
+            "ALPHA\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(project.resolve("b.txt").unwrap()).unwrap(),
+            "BETA\n"
+        );
+    }
+
+    #[test]
+    fn pre_apply_hash_is_deterministic_for_same_input() {
+        let project = empty_project();
+        write_file(&project, "x.txt", "stable\n");
+        let tx_a = WorkspaceEditTransaction::new(
+            vec![RenameEdit {
+                file_path: "x.txt".to_owned(),
+                line: 1,
+                column: 1,
+                old_text: "stable".to_owned(),
+                new_text: "stable".to_owned(),
+            }],
+            vec![],
+        );
+        // capture pre-apply hash twice via separate apply_with_evidence calls;
+        // since apply leaves content identical, second call sees same bytes.
+        let ev_a = tx_a.apply_with_evidence(&project).unwrap();
+        let tx_b = tx_a.clone();
+        let ev_b = tx_b.apply_with_evidence(&project).unwrap();
+        let hash_a = &ev_a.file_hashes_before["x.txt"].sha256;
+        let hash_b = &ev_b.file_hashes_before["x.txt"].sha256;
+        assert_eq!(hash_a, hash_b);
+    }
+```
+
+- [ ] **Step 2: 실행 — happy + determinism fail 확인 (unimplemented)**
+
+```bash
+cargo test -p codelens-engine --lib edit_transaction:: 2>&1 | tail -10
+```
+
+Expected: 2 신규 fail (`happy_path_two_files_apply_succeeds_with_evidence`, `pre_apply_hash_is_deterministic_for_same_input`); 기존 3 PASS.
+
+- [ ] **Step 3: Phase 3 apply + Phase 4 hash 구현**
+
+`apply_with_evidence`의 끝부분(Phase 1 캡처 직후)을 다음으로 교체:
+
+```rust
+        // Phase 3: apply via crate::rename::apply_edits
+        if let Err(source) = crate::rename::apply_edits(project, &self.edits) {
+            // Rollback path implemented in Task 5; for now propagate the error
+            // wrapped in ApplyFailed with empty evidence.
+            return Err(ApplyError::ApplyFailed {
+                source,
+                evidence: ApplyEvidence {
+                    status: ApplyStatus::RolledBack,
+                    file_hashes_before,
+                    file_hashes_after: BTreeMap::new(),
+                    rollback_report: Vec::new(),
+                    modified_files: 0,
+                    edit_count: 0,
+                },
+            });
+        }
+
+        // Phase 4: capture post-apply state
+        let mut file_hashes_after: BTreeMap<String, FileHash> = BTreeMap::new();
+        for file_path in self.unique_file_paths() {
+            let resolved = match project.resolve(&file_path) {
+                Ok(path) => path,
+                Err(_) => {
+                    file_hashes_after.insert(
+                        file_path.clone(),
+                        FileHash {
+                            sha256: String::new(),
+                            bytes: 0,
+                        },
+                    );
+                    continue;
+                }
+            };
+            match fs::read(&resolved) {
+                Ok(bytes) => {
+                    file_hashes_after.insert(
+                        file_path.clone(),
+                        FileHash {
+                            sha256: sha256_hex(&bytes),
+                            bytes: bytes.len(),
+                        },
+                    );
+                }
+                Err(_) => {
+                    file_hashes_after.insert(
+                        file_path.clone(),
+                        FileHash {
+                            sha256: String::new(),
+                            bytes: 0,
+                        },
+                    );
+                }
+            }
+        }
+
+        Ok(ApplyEvidence {
+            status: ApplyStatus::Applied,
+            file_hashes_before,
+            file_hashes_after,
+            rollback_report: Vec::new(),
+            modified_files: self.modified_files,
+            edit_count: self.edit_count,
+        })
+```
+
+- [ ] **Step 4: 실행 — 5 test 모두 통과**
+
+```bash
+cargo test -p codelens-engine --lib edit_transaction:: 2>&1 | tail -5
+```
+
+Expected: 5 PASS.
+
+- [ ] **Step 5: 회귀 가드 — engine 전체**
+
+```bash
+cargo test -p codelens-engine 2>&1 | grep -E "^test result:" | tail -10
+```
+
+Expected: 0 fail (모든 binaries 합산).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/codelens-engine/src/edit_transaction.rs
+git commit -m "$(cat <<'EOF'
+feat(engine): happy-path apply with post-hash evidence
+
+Phase 3 calls crate::rename::apply_edits; Phase 4 reads each file
+post-apply for sha256/byte length. ApplyFailed temporarily carries
+empty rollback evidence (Task 5 fills in restore logic). 2 tests
+added (happy two-file + hash determinism).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5: rollback path — restore + RollbackReport (Phase 3 error)
+
+**Files:**
+
+- Modify: `crates/codelens-engine/src/edit_transaction.rs`
+
+**Why this batch:** Phase 3 apply 실패 시 backups에서 복원 + 각 파일별 결과 기록. Permission-based fault injection으로 test.
+
+- [ ] **Step 1: rollback-success fail test 추가**
+
+`mod tests`에 추가 (Unix permission 사용; Windows에서는 skip):
+
+```rust
+    #[cfg(unix)]
+    #[test]
+    fn rollback_restores_first_file_when_second_apply_fails() {
+        use std::os::unix::fs::PermissionsExt;
+        let project = empty_project();
+        let path_a = write_file(&project, "ra.txt", "alpha\n");
+        let path_b = write_file(&project, "rb.txt", "beta\n");
+        // make rb.txt read-only so apply_edits fails when writing it
+        let mut perms = std::fs::metadata(&path_b).unwrap().permissions();
+        perms.set_mode(0o444);
+        std::fs::set_permissions(&path_b, perms).unwrap();
+
+        let tx = WorkspaceEditTransaction::new(
+            vec![
+                RenameEdit {
+                    file_path: "ra.txt".to_owned(),
+                    line: 1,
+                    column: 1,
+                    old_text: "alpha".to_owned(),
+                    new_text: "ALPHA".to_owned(),
+                },
+                RenameEdit {
+                    file_path: "rb.txt".to_owned(),
+                    line: 1,
+                    column: 1,
+                    old_text: "beta".to_owned(),
+                    new_text: "BETA".to_owned(),
+                },
+            ],
+            vec![],
+        );
+
+        let result = tx.apply_with_evidence(&project);
+        let evidence = match result {
+            Err(ApplyError::ApplyFailed { evidence, .. }) => evidence,
+            other => panic!("expected ApplyFailed, got {other:?}"),
+        };
+        assert_eq!(evidence.status, ApplyStatus::RolledBack);
+        assert_eq!(evidence.modified_files, 0);
+        assert_eq!(evidence.edit_count, 0);
+        // ra.txt restored on disk
+        let ra_now = std::fs::read_to_string(&path_a).unwrap();
+        assert_eq!(ra_now, "alpha\n", "ra.txt should be restored to alpha");
+        // hashes_after for ra.txt matches hashes_before (truth check)
+        let before = evidence.file_hashes_before.get("ra.txt").unwrap();
+        let after = evidence.file_hashes_after.get("ra.txt").unwrap();
+        assert_eq!(
+            before.sha256, after.sha256,
+            "ra.txt hash should match pre-apply after rollback"
+        );
+        // rollback_report contains an entry for ra.txt with restored=true
+        let entry_a = evidence
+            .rollback_report
+            .iter()
+            .find(|e| e.file_path == "ra.txt")
+            .expect("rollback entry for ra.txt");
+        assert!(entry_a.restored, "ra.txt restore should succeed");
+        assert!(entry_a.reason.is_none());
+        // rb.txt write was blocked, so it's still original content
+        // restore _attempt_ tries to write the same original; permissions
+        // may still block. Acceptable: entry exists for rb.txt either way.
+        let entry_b = evidence
+            .rollback_report
+            .iter()
+            .find(|e| e.file_path == "rb.txt");
+        assert!(entry_b.is_some(), "rb.txt rollback entry should exist");
+
+        // restore perms so tempdir cleanup works
+        let mut restore = std::fs::metadata(&path_b).unwrap().permissions();
+        restore.set_mode(0o644);
+        let _ = std::fs::set_permissions(&path_b, restore);
+    }
+```
+
+- [ ] **Step 2: 실행 — fail 확인**
+
+```bash
+cargo test -p codelens-engine --lib edit_transaction::tests::rollback_restores 2>&1 | tail -15
+```
+
+Expected: fail. 현재 ApplyFailed가 빈 rollback_report와 빈 hashes_after를 들고 반환되므로 assert가 깨짐.
+
+- [ ] **Step 3: rollback 로직 구현**
+
+`apply_with_evidence`의 Phase 3 분기를 다음으로 교체:
+
+```rust
+        // Phase 3: apply via crate::rename::apply_edits
+        if let Err(source) = crate::rename::apply_edits(project, &self.edits) {
+            let mut rollback_report: Vec<RollbackEntry> = Vec::new();
+            let mut file_hashes_after_rb: BTreeMap<String, FileHash> = BTreeMap::new();
+
+            // Restore each backup; record per-file success/failure.
+            // Iterate sorted file paths for deterministic ordering.
+            let sorted_paths = self.unique_file_paths();
+            for file_path in &sorted_paths {
+                let resolved = match project.resolve(file_path) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        rollback_report.push(RollbackEntry {
+                            file_path: file_path.clone(),
+                            restored: false,
+                            reason: Some(format!("resolve failed: {e}")),
+                        });
+                        continue;
+                    }
+                };
+                let backup_bytes = match backups.get(&resolved) {
+                    Some(bytes) => bytes,
+                    None => {
+                        rollback_report.push(RollbackEntry {
+                            file_path: file_path.clone(),
+                            restored: false,
+                            reason: Some("no backup captured".to_owned()),
+                        });
+                        continue;
+                    }
+                };
+                match fs::write(&resolved, backup_bytes) {
+                    Ok(()) => rollback_report.push(RollbackEntry {
+                        file_path: file_path.clone(),
+                        restored: true,
+                        reason: None,
+                    }),
+                    Err(e) => rollback_report.push(RollbackEntry {
+                        file_path: file_path.clone(),
+                        restored: false,
+                        reason: Some(format!("write failed: {e}")),
+                    }),
+                }
+            }
+
+            // Capture post-rollback hashes (truth check).
+            for file_path in &sorted_paths {
+                let resolved = match project.resolve(file_path) {
+                    Ok(p) => p,
+                    Err(_) => continue,
+                };
+                if let Ok(bytes) = fs::read(&resolved) {
+                    file_hashes_after_rb.insert(
+                        file_path.clone(),
+                        FileHash {
+                            sha256: sha256_hex(&bytes),
+                            bytes: bytes.len(),
+                        },
+                    );
+                }
+            }
+
+            return Err(ApplyError::ApplyFailed {
+                source,
+                evidence: ApplyEvidence {
+                    status: ApplyStatus::RolledBack,
+                    file_hashes_before,
+                    file_hashes_after: file_hashes_after_rb,
+                    rollback_report,
+                    modified_files: 0,
+                    edit_count: 0,
+                },
+            });
+        }
+```
+
+- [ ] **Step 4: 실행 — rollback test 통과 + 회귀 0**
+
+```bash
+cargo test -p codelens-engine --lib edit_transaction:: 2>&1 | tail -5
+cargo test -p codelens-engine 2>&1 | grep -E "^test result:" | tail -5
+```
+
+Expected: 6 PASS in edit_transaction tests. Engine total 0 fail.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/codelens-engine/src/edit_transaction.rs
+git commit -m "$(cat <<'EOF'
+feat(engine): rollback report + post-rollback hashes on apply failure
+
+Phase 3 failure now restores each backup file in deterministic order,
+records RollbackEntry{restored, reason} per file, and re-reads the
+filesystem to populate file_hashes_after with the truth (matching
+pre-apply hashes when restore succeeded). Replaces the silent
+let _ = fs::write pattern. 1 unix-only test added.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 6: TOCTOU recheck (Phase 2)
+
+**Files:**
+
+- Modify: `crates/codelens-engine/src/edit_transaction.rs`
+
+**Why this batch:** Phase 1과 Phase 3 사이에 약한 hash 재검증. TOCTOU가 자연스럽게 트리거되지 않으므로 substrate를 두 메서드(`capture_pre_apply` + `verify_pre_apply`)로 분리하여 test가 각각 호출 가능하게 함.
+
+- [ ] **Step 1: TOCTOU fail test 작성**
+
+`mod tests`에 추가:
+
+```rust
+    #[test]
+    fn toctou_recheck_detects_external_mutation_between_phases() {
+        let project = empty_project();
+        let path = write_file(&project, "tt.txt", "before\n");
+        let tx = WorkspaceEditTransaction::new(
+            vec![RenameEdit {
+                file_path: "tt.txt".to_owned(),
+                line: 1,
+                column: 1,
+                old_text: "before".to_owned(),
+                new_text: "after".to_owned(),
+            }],
+            vec![],
+        );
+
+        let (backups, hashes_before) = tx
+            .capture_pre_apply(&project)
+            .expect("phase 1 capture ok");
+        // External writer mutates the file between phases.
+        std::fs::write(&path, "TAMPERED\n").unwrap();
+
+        let result = tx.verify_pre_apply(&project, &backups, &hashes_before);
+        assert!(
+            matches!(result, Err(ApplyError::PreApplyHashMismatch { ref file_path, .. }) if file_path == "tt.txt"),
+            "expected PreApplyHashMismatch for tt.txt, got {:?}",
+            result.err()
+        );
+        // Disk contains the external mutation; substrate did not apply edits.
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "TAMPERED\n");
+    }
+```
+
+- [ ] **Step 2: 실행 — fail 확인 (`capture_pre_apply` / `verify_pre_apply` 미정의)**
+
+```bash
+cargo test -p codelens-engine --lib edit_transaction::tests::toctou 2>&1 | tail -10
+```
+
+Expected: 컴파일 에러 (메서드 없음). 이 test는 컴파일 자체가 실패해야 함 — Step 3에서 메서드 신규.
+
+- [ ] **Step 3: Phase 1 → `capture_pre_apply`, Phase 2 → `verify_pre_apply`로 분리**
+
+`impl WorkspaceEditTransaction`에 두 메서드 추가:
+
+```rust
+    /// Phase 1: read each unique file once, capture sha256 + raw backup bytes.
+    pub(crate) fn capture_pre_apply(
+        &self,
+        project: &ProjectRoot,
+    ) -> Result<(HashMap<PathBuf, Vec<u8>>, BTreeMap<String, FileHash>), ApplyError> {
+        let mut backups: HashMap<PathBuf, Vec<u8>> = HashMap::new();
+        let mut file_hashes_before: BTreeMap<String, FileHash> = BTreeMap::new();
+        for file_path in self.unique_file_paths() {
+            let resolved = project
+                .resolve(&file_path)
+                .map_err(|e| ApplyError::PreReadFailed {
+                    file_path: file_path.clone(),
+                    source: e,
+                })?;
+            let bytes = fs::read(&resolved).map_err(|e| ApplyError::PreReadFailed {
+                file_path: file_path.clone(),
+                source: anyhow::Error::from(e),
+            })?;
+            file_hashes_before.insert(
+                file_path.clone(),
+                FileHash {
+                    sha256: sha256_hex(&bytes),
+                    bytes: bytes.len(),
+                },
+            );
+            backups.insert(resolved, bytes);
+        }
+        Ok((backups, file_hashes_before))
+    }
+
+    /// Phase 2: re-read each captured file and confirm sha256 still matches.
+    /// Light same-function TOCTOU window; strong guarantees deferred to Phase 2.
+    pub(crate) fn verify_pre_apply(
+        &self,
+        project: &ProjectRoot,
+        backups: &HashMap<PathBuf, Vec<u8>>,
+        hashes_before: &BTreeMap<String, FileHash>,
+    ) -> Result<(), ApplyError> {
+        for file_path in self.unique_file_paths() {
+            let resolved = project
+                .resolve(&file_path)
+                .map_err(|e| ApplyError::PreReadFailed {
+                    file_path: file_path.clone(),
+                    source: e,
+                })?;
+            let bytes_now = fs::read(&resolved).map_err(|e| ApplyError::PreReadFailed {
+                file_path: file_path.clone(),
+                source: anyhow::Error::from(e),
+            })?;
+            let hash_now = sha256_hex(&bytes_now);
+            let expected = hashes_before
+                .get(&file_path)
+                .map(|h| h.sha256.clone())
+                .unwrap_or_default();
+            if hash_now != expected {
+                return Err(ApplyError::PreApplyHashMismatch {
+                    file_path,
+                    expected,
+                    actual: hash_now,
+                });
+            }
+            let _ = backups; // referenced for invariant: same set of files captured
+        }
+        Ok(())
+    }
+```
+
+- [ ] **Step 4: `apply_with_evidence` 본문 — 두 메서드 호출로 교체**
+
+기존 Phase 1 inline 코드를 다음으로 대체:
+
+```rust
+        // Phase 1: capture pre-apply state
+        let (backups, file_hashes_before) = self.capture_pre_apply(project)?;
+
+        // Phase 2: light TOCTOU re-check (same-function window)
+        self.verify_pre_apply(project, &backups, &file_hashes_before)?;
+```
+
+이후 Phase 3, Phase 4 코드는 그대로.
+
+- [ ] **Step 5: 실행 — TOCTOU test 통과 + 회귀 0**
+
+```bash
+cargo test -p codelens-engine --lib edit_transaction:: 2>&1 | tail -5
+cargo test -p codelens-engine 2>&1 | grep -E "^test result:" | tail -5
+```
+
+Expected: 7 PASS in edit_transaction. Engine total 0 fail.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/codelens-engine/src/edit_transaction.rs
+git commit -m "$(cat <<'EOF'
+feat(engine): TOCTOU pre-apply hash re-check substrate phase
+
+split Phase 1 (capture) and Phase 2 (verify) into pub(crate) methods
+so apply_with_evidence calls them sequentially and tests can drive
+them independently. detects external file mutation between the two
+reads via sha256 comparison and returns PreApplyHashMismatch. Light
+same-function window; strong guarantees deferred to Phase 2.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 7: LSP integration — `apply_workspace_edit_transaction` signature
+
+**Files:**
+
+- Modify: `crates/codelens-engine/src/lsp/types.rs`
+- Modify: `crates/codelens-engine/src/lsp/workspace_edit.rs`
+- Modify: callers of `apply_workspace_edit_transaction` in mcp (semantic_edit.rs L116, L247 likely)
+
+**Why this batch:** engine-side signature change. callers temporarily discard ApplyEvidence beyond `?` propagation; Task 8 wires evidence into the contract.
+
+- [ ] **Step 1: `From<LspWorkspaceEditTransaction> for WorkspaceEditTransaction` impl 추가 + deprecated 마킹**
+
+`crates/codelens-engine/src/lsp/types.rs`:
+
+```rust
+#[derive(Debug, Clone, Serialize)]
+pub struct LspWorkspaceEditTransaction {
+    pub edits: Vec<crate::rename::RenameEdit>,
+    pub resource_ops: Vec<LspResourceOp>,
+    pub modified_files: usize,
+    pub edit_count: usize,
+    #[deprecated(
+        note = "use ApplyEvidence::status from substrate apply_with_evidence instead"
+    )]
+    pub rollback_available: bool,
+}
+
+impl From<LspWorkspaceEditTransaction> for crate::edit_transaction::WorkspaceEditTransaction {
+    fn from(value: LspWorkspaceEditTransaction) -> Self {
+        crate::edit_transaction::WorkspaceEditTransaction::new(value.edits, value.resource_ops)
+    }
+}
+```
+
+(`#[deprecated]` 추가 시 컴파일러가 self의 `rollback_available` 사용에서 warning을 낼 수 있음. `lsp/workspace_edit.rs`의 기존 `LspWorkspaceEditTransaction { ..., rollback_available: true }` 빌더 호출에 `#[allow(deprecated)]` 추가하여 무음 처리.)
+
+- [ ] **Step 2: `apply_workspace_edit_transaction` 시그니처 변경**
+
+`crates/codelens-engine/src/lsp/workspace_edit.rs`의 `apply_workspace_edit_transaction` 함수 본문을 다음으로 교체:
+
+```rust
+pub(super) fn apply_workspace_edit_transaction(
+    project: &ProjectRoot,
+    transaction: &LspWorkspaceEditTransaction,
+) -> Result<crate::edit_transaction::ApplyEvidence, crate::edit_transaction::ApplyError> {
+    let workspace_tx: crate::edit_transaction::WorkspaceEditTransaction =
+        transaction.clone().into();
+    workspace_tx.apply_with_evidence(project)
+}
+```
+
+(`pub(super)` 가시성 유지. mcp 측은 `lsp::workspace_edit_transaction_from_response` + `apply_workspace_edit_transaction`을 직접 import하지 않고 mcp re-export 또는 lsp module 내부에서만 호출. mcp 측 caller는 다른 helper를 통해 호출하므로 시그니처 변경이 필요한지 확인.)
+
+```bash
+grep -rn "apply_workspace_edit_transaction" crates/codelens-mcp/ 2>&1 | head
+```
+
+만약 mcp 측 caller가 있다면 caller signatures도 업데이트 (Result<()> → Result<ApplyEvidence, ApplyError>).
+
+- [ ] **Step 3: 컴파일 확인 — 에러 식별**
+
+```bash
+cargo check -p codelens-engine 2>&1 | tail -20
+cargo check -p codelens-mcp 2>&1 | tail -20
+cargo check -p codelens-mcp --features http 2>&1 | tail -20
+```
+
+caller 사이트에서 type mismatch 에러 발생 예상. 각 에러 메시지의 file:line 식별.
+
+- [ ] **Step 4: caller 업데이트 (mcp 측)**
+
+각 caller에서 `apply_workspace_edit_transaction(project, &lsp_tx)?`를 다음으로 변경:
+
+```rust
+let evidence = apply_workspace_edit_transaction(project, &lsp_tx)
+    .map_err(|e| /* 적절한 CodeLensError 변환; ApplyError → anyhow → CodeLensError */)?;
+```
+
+`ApplyError`는 `std::error::Error` impl이 있으므로 `anyhow::Error::from(e)` 또는 `e.to_string()`으로 변환 가능. 이 단계에서는 `evidence`를 받기만 하고 사용 안 함 (Task 8에서 contract에 전달).
+
+caller 위치 후보: `crates/codelens-mcp/src/tools/semantic_edit.rs::rename_symbol_with_lsp_backend` 본문 안. (line ~100~250 사이의 LSP rename 처리 분기).
+
+- [ ] **Step 5: 빌드 + 기존 회귀 가드**
+
+```bash
+cargo check -p codelens-mcp --features http 2>&1 | tail -5
+cargo test -p codelens-engine 2>&1 | grep -E "^test result:" | tail -5
+cargo test -p codelens-mcp --no-default-features 2>&1 | tail -3
+cargo test -p codelens-mcp --features http 2>&1 | tail -3
+```
+
+Expected: 모두 0 fail. (LSP rename test는 evidence를 사용하지 않더라도 schema 변화 0이므로 통과.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/codelens-engine/src/lsp/types.rs crates/codelens-engine/src/lsp/workspace_edit.rs crates/codelens-mcp/src/tools/semantic_edit.rs
+git commit -m "$(cat <<'EOF'
+feat(engine): integrate LSP apply path into substrate
+
+apply_workspace_edit_transaction now delegates to
+WorkspaceEditTransaction::apply_with_evidence and returns
+Result<ApplyEvidence, ApplyError>. LspWorkspaceEditTransaction gains
+From<> for the substrate type. rollback_available marked deprecated
+in favor of ApplyEvidence::status. mcp callers consume the new return
+type but discard evidence pending Task 8 contract wiring.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 8: Contract serialization — `evidence` parameter
+
+**Files:**
+
+- Modify: `crates/codelens-mcp/src/tools/semantic_edit.rs`
+- Modify: `crates/codelens-mcp/src/tools/semantic_adapter.rs`
+
+**Why this batch:** `semantic_transaction_contract`이 evidence를 single source of truth로 받게 함. LSP rename callers (L116, L247)는 Task 7의 evidence를 전달. adapter caller는 None으로 명시.
+
+- [ ] **Step 1: `SemanticTransactionContractInput` + `semantic_transaction_contract` 시그니처 확장**
+
+`crates/codelens-mcp/src/tools/semantic_edit.rs`의 struct에 새 필드 추가:
+
+```rust
+pub(crate) struct SemanticTransactionContractInput<'a> {
+    pub(crate) state: &'a AppState,
+    pub(crate) backend_id: &'a str,
+    pub(crate) operation: &'a str,
+    pub(crate) target_symbol: Option<&'a str>,
+    pub(crate) file_paths: &'a [String],
+    pub(crate) dry_run: bool,
+    pub(crate) modified_files: usize,
+    pub(crate) edit_count: usize,
+    pub(crate) resource_ops: Value,
+    pub(crate) rollback_available: bool,
+    pub(crate) workspace_edit: Value,
+    pub(crate) apply_status: &'a str,
+    pub(crate) references_checked: bool,
+    pub(crate) conflicts: Value,
+    /// When `Some`, evidence overrides `file_hashes_before`/`apply_status`/
+    /// `modified_files`/`edit_count`/`rollback_available` from this struct;
+    /// also adds `file_hashes_after` and `rollback_report` to the output.
+    pub(crate) evidence: Option<&'a codelens_engine::ApplyEvidence>,
+}
+```
+
+`semantic_transaction_contract` 함수 본문 교체:
+
+```rust
+pub(crate) fn semantic_transaction_contract(input: SemanticTransactionContractInput<'_>) -> Value {
+    let (
+        file_hashes_before,
+        file_hashes_after,
+        rollback_report,
+        rollback_available,
+        modified_files,
+        edit_count,
+        apply_status_resolved,
+    ) = match input.evidence {
+        Some(ev) => {
+            let hashes_before = serde_json::to_value(&ev.file_hashes_before)
+                .unwrap_or(Value::Null);
+            let hashes_after = serde_json::to_value(&ev.file_hashes_after)
+                .unwrap_or(Value::Null);
+            let rollback = serde_json::to_value(&ev.rollback_report)
+                .unwrap_or(Value::Array(Vec::new()));
+            let status_str = match ev.status {
+                codelens_engine::ApplyStatus::Applied => "applied",
+                codelens_engine::ApplyStatus::RolledBack => "rolled_back",
+                codelens_engine::ApplyStatus::NoOp => "no_op",
+            };
+            (
+                hashes_before,
+                hashes_after,
+                rollback,
+                matches!(
+                    ev.status,
+                    codelens_engine::ApplyStatus::Applied
+                        | codelens_engine::ApplyStatus::RolledBack
+                ),
+                ev.modified_files,
+                ev.edit_count,
+                status_str,
+            )
+        }
+        None => {
+            let hashes_before = file_hashes_before(input.state, input.file_paths);
+            (
+                hashes_before,
+                Value::Object(serde_json::Map::new()),
+                Value::Array(Vec::new()),
+                input.rollback_available,
+                input.modified_files,
+                input.edit_count,
+                input.apply_status,
+            )
+        }
+    };
+
+    let tx_id = transaction_id(
+        input.backend_id,
+        input.operation,
+        input.file_paths,
+        &file_hashes_before,
+    );
+
+    json!({
+        "transaction_id": tx_id,
+        "model": "transactional_best_effort_with_rollback_evidence",
+        "workspace_id": input.state.project().as_path().display().to_string(),
+        "backend_id": input.backend_id,
+        "operation": input.operation,
+        "target_symbol": input.target_symbol,
+        "input_snapshot": {
+            "file_paths": unique_file_paths(input.file_paths),
+            "dry_run": input.dry_run,
+        },
+        "file_hashes_before": file_hashes_before,
+        "file_hashes_after": file_hashes_after,
+        "rollback_report": rollback_report,
+        "workspace_edit": input.workspace_edit,
+        "preview_diff": [],
+        "apply_status": apply_status_resolved,
+        "modified_files": modified_files,
+        "edit_count": edit_count,
+        "resource_ops": input.resource_ops,
+        "rollback_plan": {
+            "available": rollback_available,
+            "evidence": if rollback_available {
+                "pre-apply file snapshots are held during apply; restored on apply failure"
+            } else {
+                "rollback evidence is unavailable for this operation path"
+            }
+        },
+        "diagnostics_before": [],
+        "diagnostics_after": [],
+        "verification_result": {
+            "references_checked": input.references_checked,
+            "conflicts": input.conflicts,
+        },
+        "audit_record": {
+            "recorded": false,
+            "reason": "inline tool response only; session audit remains the durable audit channel"
+        }
+    })
+}
+```
+
+- [ ] **Step 2: 4 callers 업데이트 — 새 필드 명시**
+
+각 caller에서 struct literal에 `evidence: ...` 필드 추가:
+
+- semantic_edit.rs:L116 (LSP rename apply 후): `evidence: Some(&apply_evidence_var)` (Task 7에서 받은 evidence)
+- semantic_edit.rs:L247 (LSP rename 다른 분기): 동일
+- semantic_edit.rs:L434 (safe_delete_apply): 일단 `evidence: None` (Task 9에서 substrate 호출로 변경)
+- crates/codelens-mcp/src/tools/semantic_adapter.rs:L86 (JetBrains/Roslyn adapter): `evidence: None` (preview-only, substrate 안 거침)
+
+(L116/L247의 정확한 변수 이름은 코드 읽고 확정. 본 plan에서는 `apply_evidence` 라고 가정.)
+
+- [ ] **Step 3: 빌드 + 테스트**
+
+```bash
+cargo check -p codelens-mcp --features http 2>&1 | tail -5
+cargo test -p codelens-mcp --no-default-features 2>&1 | tail -3
+cargo test -p codelens-mcp --features http 2>&1 | tail -3
+```
+
+Expected: 0 fail. 응답 schema에 새 필드 (`file_hashes_after`, `rollback_report`)가 등장하지만 기존 test가 그것들을 assert하지 않으므로 회귀 0.
+
+- [ ] **Step 4: T3-1 LSP rename evidence 회귀 test 추가**
+
+`crates/codelens-mcp/src/integration_tests/semantic_refactor.rs`의 LSP rename 케이스 한 개에 evidence 검증 assertion 추가 (기존 test의 끝부분):
+
+```rust
+        // T3-1: evidence is fact-based, not placeholder
+        let payload = parse_tool_response(&response);
+        let scope = payload.get("data").unwrap_or(&payload);
+        let tx = &scope["transaction"]["contract"];
+        // file_hashes_before/after must be non-empty objects with sha256 fields
+        let hashes_before = tx["file_hashes_before"]
+            .as_object()
+            .expect("file_hashes_before should be an object");
+        let hashes_after = tx["file_hashes_after"]
+            .as_object()
+            .expect("file_hashes_after should be an object");
+        assert!(!hashes_before.is_empty(), "hashes_before should be populated");
+        assert_eq!(
+            hashes_before.len(),
+            hashes_after.len(),
+            "hashes_before and after should have same key set"
+        );
+        for (path, before) in hashes_before {
+            assert!(
+                before["sha256"].as_str().map(|s| !s.is_empty()).unwrap_or(false),
+                "hashes_before[{path}].sha256 should be non-empty"
+            );
+        }
+        // apply_status reflects substrate status
+        assert!(
+            matches!(
+                tx["apply_status"].as_str(),
+                Some("applied") | Some("rolled_back") | Some("no_op")
+            ),
+            "apply_status should be substrate-derived: {:?}",
+            tx["apply_status"]
+        );
+```
+
+(정확한 LSP rename test 함수 이름은 grep으로 확인: `grep -n "fn.*rename.*lsp\|fn.*lsp.*rename\|workspace_edit_lsp" crates/codelens-mcp/src/integration_tests/semantic_refactor.rs`. assertion을 적합한 test 안에 삽입.)
+
+- [ ] **Step 5: 실행**
+
+```bash
+cargo test -p codelens-mcp --features http 2>&1 | tail -3
+```
+
+Expected: 0 fail. 신규 assertion이 evidence 사실성을 검증.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/codelens-mcp/src/tools/semantic_edit.rs crates/codelens-mcp/src/tools/semantic_adapter.rs crates/codelens-mcp/src/integration_tests/semantic_refactor.rs
+git commit -m "$(cat <<'EOF'
+feat(mcp): semantic_transaction_contract takes ApplyEvidence
+
+new optional `evidence` field on SemanticTransactionContractInput.
+when present, evidence is single source of truth for file_hashes_before/
+file_hashes_after / rollback_report / apply_status / modified_files /
+edit_count / rollback_available. four callers updated: LSP rename paths
+pass Some(&evidence); safe_delete_apply leaves None pending Task 9;
+JetBrains/Roslyn adapter passes None (preview-only). 1 LSP rename
+regression test asserts hashes are fact-based, not placeholder.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 9: `safe_delete_apply` 마이그레이션 (TDD)
+
+**Files:**
+
+- Modify: `crates/codelens-mcp/src/tools/semantic_edit.rs`
+- Modify: `crates/codelens-mcp/src/integration_tests/semantic_refactor.rs`
+
+**Why this batch:** 자체 `std::fs::write` 제거. substrate를 거쳐 evidence 받아 contract에 전달. 4 case T2 추가.
+
+- [ ] **Step 1: T2-1 ~ T2-4 fail tests 추가**
+
+`crates/codelens-mcp/src/integration_tests/semantic_refactor.rs` (또는 신규 파일 `safe_delete_apply_evidence.rs`)에 추가:
+
+```rust
+#[test]
+fn safe_delete_apply_dry_run_advertises_preview_only() {
+    let project = project_root();
+    let state = make_state(&project);
+    let path = project.as_path().join("sd_dry.py");
+    fs::write(&path, "def alpha():\n    pass\n").unwrap();
+    let response = call_tool(
+        &state,
+        "safe_delete_apply",
+        json!({
+            "file_path": "sd_dry.py",
+            "symbol_name": "alpha",
+            "line": 1,
+            "column": 1,
+            "dry_run": true
+        }),
+    );
+    let scope = response.get("data").unwrap_or(&response);
+    let tx = &scope["transaction"]["contract"];
+    assert_eq!(tx["apply_status"], "preview_only");
+}
+
+#[test]
+fn safe_delete_apply_real_apply_returns_evidence() {
+    let project = project_root();
+    let state = make_state(&project);
+    let path = project.as_path().join("sd_apply.py");
+    fs::write(&path, "def alpha():\n    pass\n").unwrap();
+    let response = call_tool(
+        &state,
+        "safe_delete_apply",
+        json!({
+            "file_path": "sd_apply.py",
+            "symbol_name": "alpha",
+            "line": 1,
+            "column": 1,
+            "dry_run": false
+        }),
+    );
+    let scope = response.get("data").unwrap_or(&response);
+    let tx = &scope["transaction"]["contract"];
+    assert_eq!(tx["apply_status"], "applied");
+    assert_eq!(tx["rollback_plan"]["available"], true);
+    let hashes_after = tx["file_hashes_after"]
+        .as_object()
+        .expect("file_hashes_after");
+    assert!(!hashes_after.is_empty());
+    let report = tx["rollback_report"]
+        .as_array()
+        .expect("rollback_report");
+    assert!(report.is_empty(), "rollback_report should be empty on success");
+    // disk shows deletion
+    let after = fs::read_to_string(&path).unwrap();
+    assert!(!after.contains("def alpha"), "alpha should be deleted: {after:?}");
+}
+
+#[cfg(unix)]
+#[test]
+fn safe_delete_apply_rollback_when_write_blocked() {
+    use std::os::unix::fs::PermissionsExt;
+    let project = project_root();
+    let state = make_state(&project);
+    let path = project.as_path().join("sd_rollback.py");
+    fs::write(&path, "def alpha():\n    pass\n").unwrap();
+    let mut perms = fs::metadata(&path).unwrap().permissions();
+    perms.set_mode(0o444);
+    fs::set_permissions(&path, perms).unwrap();
+
+    let response = call_tool(
+        &state,
+        "safe_delete_apply",
+        json!({
+            "file_path": "sd_rollback.py",
+            "symbol_name": "alpha",
+            "line": 1,
+            "column": 1,
+            "dry_run": false
+        }),
+    );
+    let scope = response.get("data").unwrap_or(&response);
+    let tx = &scope["transaction"]["contract"];
+    // Apply failed, but tool returned Ok with rolled_back status (E5).
+    assert_eq!(tx["apply_status"], "rolled_back");
+    let report = tx["rollback_report"]
+        .as_array()
+        .expect("rollback_report");
+    assert!(!report.is_empty(), "rollback_report should be populated");
+
+    // restore perms for cleanup
+    let mut restore = fs::metadata(&path).unwrap().permissions();
+    restore.set_mode(0o644);
+    let _ = fs::set_permissions(&path, restore);
+}
+
+#[test]
+fn safe_delete_apply_dry_run_other_fields_unchanged() {
+    let project = project_root();
+    let state = make_state(&project);
+    let path = project.as_path().join("sd_dry2.py");
+    fs::write(&path, "def alpha():\n    pass\n").unwrap();
+    let response = call_tool(
+        &state,
+        "safe_delete_apply",
+        json!({
+            "file_path": "sd_dry2.py",
+            "symbol_name": "alpha",
+            "line": 1,
+            "column": 1,
+            "dry_run": true
+        }),
+    );
+    let scope = response.get("data").unwrap_or(&response);
+    // pre-existing fields stay (safe_to_delete, etc.)
+    assert!(scope.get("safe_to_delete").is_some());
+    assert!(scope.get("affected_references").is_some());
+}
+```
+
+- [ ] **Step 2: 실행 — fail 확인**
+
+```bash
+cargo test -p codelens-mcp --features http safe_delete_apply 2>&1 | tail -15
+```
+
+Expected: 4 새 test 모두 fail (apply_status != "applied" 등).
+
+- [ ] **Step 3: `safe_delete_apply` 본문 마이그레이션**
+
+`crates/codelens-mcp/src/tools/semantic_edit.rs::safe_delete_apply` (line ~380~516)의 apply 분기 (`if !dry_run { ... }` 블록) 교체:
+
+기존:
+
+```rust
+if !dry_run {
+    // ... tree-sitter range computation ...
+    let resolved = state.project().resolve(&file_path)?;
+    let mut source = std::fs::read_to_string(&resolved)?;
+    // ... boundary checks ...
+    source.replace_range(start_byte..delete_end, "");
+    std::fs::write(&resolved, source)?;
+    safe_delete_action = "applied";
+    modified_files = 1;
+    edit_count = 1;
+}
+```
+
+신규:
+
+```rust
+let mut apply_evidence: Option<codelens_engine::ApplyEvidence> = None;
+let mut apply_status_for_contract = if dry_run { "preview_only" } else { "applied" };
+let mut apply_failure_message: Option<String> = None;
+
+if !dry_run {
+    // ... existing tree-sitter range computation (unchanged) ...
+    let resolved = state.project().resolve(&file_path)?;
+    let source_for_preview = std::fs::read_to_string(&resolved)?;
+    // ... boundary checks (unchanged) ...
+    let delete_text = source_for_preview[start_byte..delete_end].to_owned();
+
+    let line_for_edit = source_for_preview[..start_byte]
+        .matches('\n')
+        .count()
+        + 1;
+    let last_newline = source_for_preview[..start_byte].rfind('\n').map(|p| p + 1).unwrap_or(0);
+    let column_for_edit = start_byte - last_newline + 1;
+
+    let edits = vec![codelens_engine::RenameEdit {
+        file_path: file_path.clone(),
+        line: line_for_edit,
+        column: column_for_edit,
+        old_text: delete_text,
+        new_text: String::new(),
+    }];
+    let tx = codelens_engine::WorkspaceEditTransaction::new(edits, Vec::new());
+    match tx.apply_with_evidence(&state.project()) {
+        Ok(evidence) => {
+            modified_files = evidence.modified_files;
+            edit_count = evidence.edit_count;
+            safe_delete_action = "applied";
+            apply_status_for_contract = "applied";
+            apply_evidence = Some(evidence);
+        }
+        Err(codelens_engine::ApplyError::ApplyFailed { source, evidence }) => {
+            modified_files = 0;
+            edit_count = 0;
+            safe_delete_action = "rolled_back";
+            apply_status_for_contract = "rolled_back";
+            apply_failure_message = Some(source.to_string());
+            apply_evidence = Some(evidence);
+        }
+        Err(other) => {
+            return Err(CodeLensError::Validation(format!(
+                "safe_delete_apply: substrate refused: {other}"
+            )));
+        }
+    }
+}
+```
+
+기존 `std::fs::read_to_string` + `replace_range` + `std::fs::write` 호출 모두 제거.
+
+contract input 구성 시점에서 새 필드 추가:
+
+```rust
+let transaction_contract = semantic_transaction_contract(SemanticTransactionContractInput {
+    state,
+    backend_id: &format!("lsp:{command_ref}"),
+    operation: "safe_delete_check",
+    target_symbol: Some(&symbol_name),
+    file_paths: std::slice::from_ref(&file_path),
+    dry_run,
+    modified_files,
+    edit_count,
+    resource_ops: json!([]),
+    rollback_available: apply_evidence.is_some(),
+    workspace_edit: json!({"edits": []}),
+    apply_status: apply_status_for_contract,
+    references_checked: true,
+    conflicts: ...,
+    evidence: apply_evidence.as_ref(),
+});
+```
+
+응답 객체 구성 시 `apply_failure_message`가 있으면 별도 필드로 노출 (E5: tool returns Ok with error_message field):
+
+```rust
+"error_message": apply_failure_message,  // None이면 JSON null로 직렬화
+```
+
+- [ ] **Step 4: 실행 — T2 4개 통과**
+
+```bash
+cargo test -p codelens-mcp --features http safe_delete_apply 2>&1 | tail -10
+cargo test -p codelens-mcp --no-default-features safe_delete_apply 2>&1 | tail -5
+```
+
+Expected: 4 PASS.
+
+- [ ] **Step 5: 회귀 가드 — 전체 mcp**
+
+```bash
+cargo test -p codelens-mcp --features http 2>&1 | tail -3
+cargo test -p codelens-mcp --no-default-features 2>&1 | tail -3
+```
+
+Expected: 0 fail.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/codelens-mcp/src/tools/semantic_edit.rs crates/codelens-mcp/src/integration_tests/semantic_refactor.rs
+git commit -m "$(cat <<'EOF'
+feat(mcp): migrate safe_delete_apply onto WorkspaceEditTransaction
+
+self-managed std::fs::write replaced with single-edit
+WorkspaceEditTransaction::apply_with_evidence call. response now
+carries fact-based file_hashes_after, rollback_report, and
+apply_status (applied/rolled_back/preview_only/no_op). E5 contract:
+apply failure surfaces as Ok response with apply_status=rolled_back +
+error_message; agent reads apply_status to detect partial state.
+4 integration tests added.
+
+Closes Phase 1 G4 substrate migration target.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 10: Final verification + evaluator dispatch
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: 전체 cargo test + clippy**
+
+```bash
+cargo check --workspace 2>&1 | tail -5
+cargo test -p codelens-engine 2>&1 | grep -E "^test result:" | awk '{ sum += $4 } END { print "engine total:", sum }'
+cargo test -p codelens-mcp --no-default-features 2>&1 | tail -3
+cargo test -p codelens-mcp --features http 2>&1 | tail -3
+cargo clippy -p codelens-engine -- -W clippy::all 2>&1 | tail -10
+cargo clippy -p codelens-mcp --features http -- -W clippy::all 2>&1 | tail -10
+```
+
+Expected:
+
+- workspace check clean
+- engine ≥ 321 + 8 (T1) = ≥ 329 PASS
+- mcp no-default ≥ 411 + 4 (T2) = ≥ 415 PASS, 0 fail
+- mcp http ≥ 522 + 4 (T2) + 1 (T3) = ≥ 527 PASS
+- clippy: 0 NEW warnings (deprecated 사용 사이트만 expected new note)
+
+- [ ] **Step 2: surface-manifest + contract gate**
+
+```bash
+python3 scripts/surface-manifest.py 2>&1 | tail -3
+echo "drift-exit=$?"
+cargo run -q -p codelens-mcp --features http -- --print-operation-matrix > /tmp/operation-matrix.json
+python3 scripts/surface-manifest.py --check-operation-matrix /tmp/operation-matrix.json
+echo "matrix-exit=$?"
+python3 scripts/test/test-surface-manifest-contracts.py
+echo "fixtures-exit=$?"
+```
+
+Expected: 모두 exit 0.
+
+- [ ] **Step 3: lint-datasets + agent-contract-check**
+
+```bash
+python3 benchmarks/lint-datasets.py --project . 2>&1 | tail -3
+python3 scripts/agent-contract-check.py --project . --strict 2>&1 | tail -3
+```
+
+Expected: 0 errors / 0 warnings.
+
+- [ ] **Step 4: AC checklist self-check (grep)**
+
+```bash
+echo "=== AC-1: substrate types ==="
+grep -E "pub struct WorkspaceEditTransaction|pub struct ApplyEvidence|pub enum ApplyStatus|pub struct RollbackEntry|pub struct FileHash|pub enum ApplyError" crates/codelens-engine/src/edit_transaction.rs | wc -l
+echo "(expect: 6)"
+
+echo "=== AC-2: LSP path 통합 ==="
+grep -n "apply_workspace_edit_transaction" crates/codelens-engine/src/lsp/workspace_edit.rs
+grep -n "From<LspWorkspaceEditTransaction>" crates/codelens-engine/src/lsp/types.rs
+grep -n "deprecated" crates/codelens-engine/src/lsp/types.rs
+
+echo "=== AC-3: safe_delete_apply substrate use ==="
+grep -n "WorkspaceEditTransaction::new\|apply_with_evidence" crates/codelens-mcp/src/tools/semantic_edit.rs
+grep -c "std::fs::write" crates/codelens-mcp/src/tools/semantic_edit.rs
+echo "(expect: 0 std::fs::write in semantic_edit.rs)"
+
+echo "=== AC-4: contract evidence param ==="
+grep -n "evidence: Option" crates/codelens-mcp/src/tools/semantic_edit.rs
+
+echo "=== AC-6: range guard ==="
+git diff 25a49523..HEAD --name-only | wc -l
+git diff 25a49523..HEAD --name-only
+
+echo "=== AC-7: Phase 0 envelope preserved ==="
+git diff 25a49523..HEAD -- crates/codelens-mcp/src/tools/mutation.rs | wc -l
+echo "(expect: 0 — mutation.rs untouched)"
+```
+
+각 출력이 기대값과 일치하는지 확인.
+
+- [ ] **Step 5: evaluator(opus) dispatch**
+
+```text
+Agent dispatch:
+  subagent_type: evaluator
+  model: opus
+  prompt: |
+    Spec: docs/superpowers/specs/2026-04-25-codelens-phase1-g4-workspace-edit-transaction-design.md (§6)
+    Plan: docs/superpowers/plans/2026-04-25-codelens-phase1-g4-workspace-edit-transaction.md
+    Branch HEAD vs base 25a49523 diff와 test 결과를 종합해 AC-1~AC-8 각각 PASS/PARTIAL/FAIL 채점.
+    AC-1~AC-7 중 1개라도 FAIL이면 전체 FAIL — 머지 보류.
+    출력 형식: 각 AC별 1줄 판정 + 증거 + 전체 verdict.
+```
+
+- [ ] **Step 6: PR 본문 작성 (선택, 사용자 승인 후)**
+
+evaluator PASS 후 사용자 명시 승인 시:
+
+```bash
+gh pr create --base main --head feat/phase1-g4-workspace-edit-transaction \
+  --title "feat(engine+mcp): Phase 1 G4 — WorkspaceEditTransaction substrate" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- New `crates/codelens-engine/src/edit_transaction.rs` substrate: `WorkspaceEditTransaction` domain object with `apply_with_evidence` returning `ApplyEvidence{status, file_hashes_before/after, rollback_report}`.
+- LSP `apply_workspace_edit_transaction` thin wrapper delegating to substrate. `LspWorkspaceEditTransaction.rollback_available` deprecated.
+- `safe_delete_apply` migrated off self-managed `fs::write` onto substrate. Apply failure surfaces as Ok response with `apply_status=rolled_back`.
+- `semantic_transaction_contract` takes `evidence: Option<&ApplyEvidence>`; 4 callers updated.
+
+Spec: `docs/superpowers/specs/2026-04-25-codelens-phase1-g4-workspace-edit-transaction-design.md`
+Plan: `docs/superpowers/plans/2026-04-25-codelens-phase1-g4-workspace-edit-transaction.md`
+
+Closes Phase 1 G4. G7 (engine `fs::write` 11 sites) and G5 (runtime capability probing) deferred to separate PRs.
+
+## Test plan
+- [x] `cargo test -p codelens-engine` — 8 substrate tests
+- [x] `cargo test -p codelens-mcp --features http` — 4 safe_delete + 1 LSP regression
+- [x] `python3 scripts/surface-manifest.py` + contract A/B + fixtures
+- [x] evaluator(opus) AC-1~AC-8 PASS
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+
+| Spec 항목                                                                    | Plan task                 |
+| ---------------------------------------------------------------------------- | ------------------------- |
+| §1 사용자 변경 — safe_delete_apply rollback_available true                   | Task 9                    |
+| §1 사용자 변경 — LSP rename evidence 사실 기반                               | Task 8                    |
+| §1 사용자 변경 — rollback_report 노출                                        | Task 5 + 8 + 9            |
+| §2 A edit_transaction.rs 신규                                                | Task 1~6                  |
+| §2 B lsp/workspace_edit.rs 시그니처                                          | Task 7                    |
+| §2 C lib.rs 등록                                                             | Task 1 Step 2             |
+| §2 D semantic_transaction_contract 시그니처 + safe_delete_apply 마이그레이션 | Task 8 + 9                |
+| §2 E LspWorkspaceEditTransaction From + deprecated                           | Task 7 Step 1             |
+| §2 F edit_transaction tests                                                  | Task 2~6 (8 case)         |
+| §2 G integration tests T2/T3                                                 | Task 8 (T3) + Task 9 (T2) |
+| §6 AC-1~AC-8                                                                 | Task 10                   |
+
+전 항목 커버됨.
+
+**2. Placeholder scan:** TBD/TODO/"add appropriate" 0건. 모든 step에 실제 코드/명령/expected output.
+
+**3. Type consistency:**
+
+- `WorkspaceEditTransaction::new(edits, resource_ops)` 시그니처 Task 1·9 동일. ✅
+- `apply_with_evidence(&self, project) -> Result<ApplyEvidence, ApplyError>` Task 1·7·9 동일. ✅
+- `RollbackEntry { file_path, restored, reason }` Task 1·5 동일. ✅
+- `evidence: Option<&codelens_engine::ApplyEvidence>` Task 8·9 동일. ✅
+- `apply_status` 값 enum: `applied` / `rolled_back` / `preview_only` / `no_op` Task 8·9 동일. ✅
+
+**4. Plan refinements**: spec 100% 매칭. 추가 refinement 없음.
+
+---
+
+## Execution Handoff
+
+**Plan complete and saved to `docs/superpowers/plans/2026-04-25-codelens-phase1-g4-workspace-edit-transaction.md`. Two execution options:**
+
+**1. Subagent-Driven (recommended)** — Task별 builder agent dispatch + 두 단계 리뷰. 10 task = 약 10~12 dispatch.
+
+**2. Inline Execution** — 이 세션에서 executing-plans 스킬로 batch 실행, 중간 checkpoint.
+
+**Which approach?**

--- a/docs/superpowers/specs/2026-04-25-codelens-phase1-g4-workspace-edit-transaction-design.md
+++ b/docs/superpowers/specs/2026-04-25-codelens-phase1-g4-workspace-edit-transaction-design.md
@@ -1,0 +1,416 @@
+# Phase 1 G4 — WorkspaceEditTransaction Substrate
+
+- 작성일: 2026-04-25
+- 브랜치: `feat/phase1-g4-workspace-edit-transaction` (stacked on `codex/ide-refactor-substrate`)
+- 단계: Phase 1 첫 PR
+- 다음 단계: G7(engine `fs::write` 11곳 통합), G5(runtime capability probing) — 별도 PR
+
+## 0. 배경 — 왜 이 PR인가
+
+Phase 0가 끝난 시점의 갭(시니어 리뷰 + Phase 0 final review에서 식별):
+
+- `crates/codelens-mcp/src/tools/semantic_edit.rs:416` `safe_delete_apply`가 `transaction_contract` metadata는 첨부하지만 실제 apply는 자체 `std::fs::write` → engine의 백업/롤백 substrate 우회.
+- 결과: `rollback_available: false`로 마킹된 contract가 실제로는 backup 0인 상태.
+
+기존 자산:
+
+- `crates/codelens-engine/src/lsp/workspace_edit.rs:67-90` `apply_workspace_edit_transaction` — 이미 in-memory 백업 + apply 실패 시 rollback 구현. LSP rename이 이걸 사용 중.
+- `LspWorkspaceEditTransaction` (engine `lsp/types.rs`) — `edits` / `resource_ops` / `modified_files` / `edit_count` / `rollback_available: true` 필드 보유. 단 LSP-namespaced.
+- `semantic_transaction_contract` (mcp `semantic_edit.rs:519-580`) — JSON 직렬화 contract. 4 callers (semantic_edit.rs:116/247/434, semantic_adapter.rs:86).
+
+본 PR은 **이미 존재하는 substrate를 일반화하고 모든 mutation primitive가 거치도록 통합**한다. "도메인 객체 신규"가 아니라 "도메인 객체 격상 + safe_delete_apply 마이그레이션 + evidence 강화".
+
+기존 substrate의 약점 두 가지를 함께 해소:
+
+1. **TOCTOU 갭** — read와 apply 사이 외부 수정 감지 못함. 본 PR은 약한 형태(같은 함수 내 두 read)로 좁힘. 강한 검증(snapshot/lock)은 Phase 2.
+2. **Silent rollback failure** — 기존 `let _ = fs::write(path, content)`는 rollback 실패 무시. 본 PR은 `RollbackEntry{restored, reason}`로 명시.
+
+## 1. Scope & Goals
+
+### 사용자가 보는 변경
+
+- `safe_delete_apply` 응답이 `rollback_available: true` (기존 `false`)로 바뀌고, `rollback_plan.evidence`에 hash 기반 사실 기록(`file_hashes_after`, rollback 리포트)이 들어감.
+- LSP rename 경로(`semantic_edit::rename_symbol_with_lsp_backend` 등 4 callers)도 같은 substrate를 거치므로 evidence 형태 통일 — 기존 `rollback_available: true`였지만 evidence 내용이 사실에 기반하게 됨(현재는 placeholder 문자열).
+- 새 transaction 실패 시 응답에 `rollback_report: [{file, restored: bool, reason?: ...}]`가 노출돼 agent가 부분 적용 상태를 식별 가능.
+
+### 비범위 (Phase 1 후속 PR로 위임)
+
+- G7: engine `auto_import` / `inline` / `move_symbol` / `rename` (engine 측) / `memory` 등 다른 fs::write 호출 사이트의 substrate 마이그레이션.
+- G5: capability matrix runtime probing.
+- 디스크 기반 snapshot rollback (Phase 2 재료).
+- Resource operation (create/rename/delete file) 지원 — 현재 LSP path도 preview-only이므로 그대로 유지.
+- 강한 TOCTOU 검증 (apply 직전 lock 등) — Phase 2.
+
+### 성공 조건
+
+- `safe_delete_apply`가 substrate를 거쳐 apply 성공/실패 양쪽에서 evidence 정확.
+- LSP rename path 회귀 0 (응답 schema 유지, evidence 값만 사실 기반으로 채워짐).
+- 신규 fault-injection rollback test green.
+- 기존 cargo test (engine + mcp default + http) 0 fail.
+
+---
+
+## 2. Components
+
+### A. `crates/codelens-engine/src/edit_transaction.rs` (신규, ~250줄)
+
+```rust
+pub struct WorkspaceEditTransaction {
+    pub edits: Vec<RenameEdit>,
+    pub resource_ops: Vec<LspResourceOp>,
+    pub modified_files: usize,
+    pub edit_count: usize,
+}
+
+pub struct ApplyEvidence {
+    pub status: ApplyStatus,
+    pub file_hashes_before: BTreeMap<String, FileHash>,
+    pub file_hashes_after: BTreeMap<String, FileHash>,
+    pub rollback_report: Vec<RollbackEntry>,
+    pub modified_files: usize,
+    pub edit_count: usize,
+}
+
+pub struct RollbackEntry {
+    pub file_path: String,
+    pub restored: bool,
+    pub reason: Option<String>,
+}
+
+pub enum ApplyStatus { Applied, RolledBack, NoOp }
+pub struct FileHash { pub sha256: String, pub bytes: usize }
+
+impl WorkspaceEditTransaction {
+    pub fn new(edits: Vec<RenameEdit>, resource_ops: Vec<LspResourceOp>) -> Self;
+    pub fn apply_with_evidence(&self, project: &ProjectRoot) -> Result<ApplyEvidence, ApplyError>;
+}
+
+pub enum ApplyError {
+    ResourceOpsUnsupported,
+    PreReadFailed { file_path: String, source: anyhow::Error },
+    PreApplyHashMismatch { file_path: String, expected: String, actual: String },
+    ApplyFailed { source: anyhow::Error, evidence: ApplyEvidence },
+}
+```
+
+`RenameEdit`은 `crates/codelens-engine/src/rename.rs`의 기존 구조 재사용. `LspResourceOp`은 `crates/codelens-engine/src/lsp/types.rs`에서 가져오되, edit_transaction 모듈에서도 use.
+
+### B. `crates/codelens-engine/src/lsp/workspace_edit.rs` (수정, ~30줄 변경)
+
+- `apply_workspace_edit_transaction(project, &LspWorkspaceEditTransaction)` → 내부에서 `WorkspaceEditTransaction::from(lsp_transaction).apply_with_evidence(project)`로 위임.
+- 반환 타입 변경: `Result<()>` → `Result<ApplyEvidence, ApplyError>`. caller(LSP rename path)도 업데이트.
+- `LspWorkspaceEditTransaction::into_workspace_edit_transaction()` 또는 `From` impl 추가.
+
+### C. `crates/codelens-engine/src/lib.rs` (1~2줄)
+
+- `pub mod edit_transaction;` 등록 + 핵심 타입 re-export(`WorkspaceEditTransaction`, `ApplyEvidence`, `ApplyStatus`, `RollbackEntry`, `ApplyError`).
+
+### D. `crates/codelens-mcp/src/tools/semantic_edit.rs` (수정, ~80줄 변경)
+
+- `safe_delete_apply`(line ~380-516):
+  1. tree-sitter로 delete range 산출(기존 코드 유지).
+  2. `RenameEdit` 단일-element vec 구성(`file_path`, `line`, `column`, `old_text=잘라낼 문자열`, `new_text=""`).
+  3. `WorkspaceEditTransaction::new(edits, vec![]).apply_with_evidence(project)` 호출.
+  4. 반환된 `ApplyEvidence`로 `semantic_transaction_contract` 채움.
+  5. 자체 `fs::read_to_string` + `replace_range` + `fs::write` 블록 제거.
+- `SemanticTransactionContractInput` / `semantic_transaction_contract`(line 519-580):
+  - 새 필드 `evidence: Option<&ApplyEvidence>` 추가.
+  - `evidence.is_some()`이면 그것이 single source of truth(file_hashes_before/after, rollback_report, modified_files, edit_count, apply_status, rollback_available).
+  - `None`인 경우 기존 필드 사용(LSP rename 경로 호환 + dry_run/preview).
+  - JSON 출력에 `file_hashes_after`, `rollback_report` 신규 필드 추가.
+- 4 callers 업데이트:
+  - L116, L247(LSP rename path): `apply_workspace_edit_transaction` 반환값으로 evidence 채움.
+  - L434(safe_delete_apply): substrate apply 결과로 evidence 채움.
+  - `semantic_adapter.rs:86`(JetBrains/Roslyn adapter): preview-only이므로 `evidence: None` 유지.
+
+### E. `crates/codelens-engine/src/lsp/types.rs` (수정, ~10줄)
+
+- `LspWorkspaceEditTransaction`에 `From<LspWorkspaceEditTransaction> for WorkspaceEditTransaction` impl.
+- `rollback_available` 필드: `#[deprecated(note = "use ApplyEvidence::status from substrate apply_with_evidence")]` 마킹. 제거는 G7 머지 후 별도 정리 PR(공개 API 안정성).
+
+### F. `crates/codelens-engine/src/edit_transaction_tests.rs` 또는 `edit_transaction.rs` 안의 `#[cfg(test)] mod tests` (신규, ~250줄)
+
+T1 케이스 7~9개(섹션 5).
+
+### G. `crates/codelens-mcp/src/integration_tests/semantic_refactor.rs` (수정)
+
+T2(safe_delete_apply 마이그레이션 회귀) + T3(LSP rename evidence 회귀) 케이스.
+
+**예상 footprint**: 3 신규 + 4~5 수정 = 7~8 파일, +650/-100줄. 단일 PR.
+
+---
+
+## 3. Data Flow
+
+### 경로 1 — `apply_with_evidence()` 내부 (substrate 핵심)
+
+```
+WorkspaceEditTransaction::apply_with_evidence(project)
+  ├─ if !resource_ops.empty() → return Err(ResourceOpsUnsupported)
+  ├─ if edits.empty() → return Ok(ApplyEvidence{status: NoOp, ...})
+  │
+  ├─ Phase 1: capture pre-apply state
+  │   for each unique file_path in edits:
+  │     resolved = project.resolve(file_path)
+  │     bytes = fs::read(resolved)   ← single read; backup + hash
+  │     hash_before = sha256(bytes)
+  │     backups.insert(resolved, bytes.clone())
+  │     hashes_before.insert(file_path, FileHash{sha256, bytes: len})
+  │
+  ├─ Phase 2: TOCTOU re-check (light)
+  │   for each (resolved, _) in backups:
+  │     bytes_now = fs::read(resolved)
+  │     if sha256(bytes_now) != hash_before:
+  │       discard backups; return Err(PreApplyHashMismatch{...})
+  │
+  ├─ Phase 3: apply via crate::rename::apply_edits(project, &edits)
+  │   if Err:
+  │     ── rollback ──
+  │     for each (resolved, original_bytes) in backups (sorted):
+  │       match fs::write(resolved, &original_bytes):
+  │         Ok  → push RollbackEntry{file, restored: true, reason: None}
+  │         Err(e) → push RollbackEntry{file, restored: false, reason: Some(e)}
+  │     hashes_after = read each path post-rollback (truth)
+  │     return Err(ApplyFailed{source, evidence: ApplyEvidence{
+  │       status: RolledBack, hashes_before, hashes_after, rollback_report,
+  │       modified_files: 0, edit_count: 0
+  │     }})
+  │
+  ├─ Phase 4: capture post-apply state
+  │   for each file_path:
+  │     bytes_after = fs::read(resolved)
+  │     hashes_after.insert(file_path, FileHash{sha256, bytes: len})
+  │     (read 실패 시 file_hashes_after[file] = {error: "..."})
+  │
+  └─ return Ok(ApplyEvidence{
+       status: Applied, hashes_before, hashes_after, rollback_report: [],
+       modified_files, edit_count
+     })
+```
+
+### 경로 2 — `safe_delete_apply` (mcp)
+
+```
+safe_delete_apply(state, args)
+  ├─ tree-sitter로 (start_byte, end_byte) 산출
+  ├─ source = fs::read_to_string(resolved)  ← preview용 (substrate가 별도 read)
+  ├─ delete_text = source[start_byte..delete_end]
+  ├─ edits = vec![RenameEdit{file_path, line, column, old_text, new_text: ""}]
+  ├─ tx = WorkspaceEditTransaction::new(edits, vec![])
+  │
+  ├─ if dry_run:
+  │   evidence = None
+  │   apply_status = "preview_only"
+  │
+  ├─ else:
+  │   match tx.apply_with_evidence(state.project()):
+  │     Ok(evidence) → apply_status = "applied"
+  │     Err(ApplyFailed{evidence}) → apply_status = "rolled_back"
+  │       (도구는 Err로 던지지 않고 Ok 응답에 evidence 포함; agent가 apply_status로 판정)
+  │     Err(other) → 도구는 Err 반환
+  │
+  └─ build response with semantic_transaction_contract(contract_input)
+```
+
+### 경로 3 — LSP rename 통합 (semantic_edit.rs:116, 247)
+
+```
+... 기존 LSP rename 흐름 ...
+lsp_tx: LspWorkspaceEditTransaction = workspace_edit_transaction_from_response(...)
+let workspace_tx: WorkspaceEditTransaction = lsp_tx.into();
+match workspace_tx.apply_with_evidence(project):
+  Ok(evidence) → contract_input.evidence = Some(&evidence)
+  Err(ApplyFailed{evidence}) → 동일하게 evidence 포함
+```
+
+### 경로 4 — Contract serialization
+
+```
+semantic_transaction_contract(input)
+  ├─ if input.evidence.is_some():
+  │   contract 필드 모두 evidence에서 (single source of truth)
+  │   rollback_available = matches!(evidence.status, RolledBack | Applied)
+  │   apply_status = match evidence.status {
+  │     Applied → "applied", RolledBack → "rolled_back", NoOp → "no_op"
+  │   }
+  │
+  ├─ else (preview/dry_run):
+  │   file_hashes_before = file_hashes_before_helper(state, input.file_paths) [기존]
+  │   file_hashes_after = []
+  │   rollback_report = []
+  │   apply_status = input.apply_status (호출자 명시)
+  │
+  └─ return JSON contract
+```
+
+### 핵심 결정점
+
+1. **TOCTOU 재read 갭 인정** — Phase 2 hash 재확인은 같은 함수 안의 약한 형태. 외부 writer가 두 read 사이에 끼어들 갭은 잔존. design에 명시.
+2. **Apply 실패 응답 형식** — 도구는 `Err`이 아니라 `Ok` 응답에 `apply_status: "rolled_back"`과 evidence 포함. agent가 evidence를 잃지 않게 함.
+
+---
+
+## 4. Error Handling
+
+| ID     | 트리거                        | substrate 동작                                                                                  | 도구 응답 형식                                                                                                                    |
+| ------ | ----------------------------- | ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| **E1** | `resource_ops` non-empty      | `Err(ResourceOpsUnsupported)`. 백업 진입 안 함.                                                 | tool returns `Err(Validation("unsupported_semantic_refactor: resource operations are preview-only..."))`                          |
+| **E2** | `edits` empty                 | `Ok(ApplyEvidence{status: NoOp, ...})`                                                          | response: `apply_status: "no_op"`, modified=0, edit=0                                                                             |
+| **E3** | Phase 1 read 실패             | `Err(PreReadFailed{file_path, source})`. 부분 백업 폐기.                                        | tool returns `Err(...)`. evidence 없음.                                                                                           |
+| **E4** | Phase 2 hash mismatch         | `Err(PreApplyHashMismatch{...})`. 백업 폐기. 디스크 변경 0.                                     | tool returns `Err(...)`. evidence 없음.                                                                                           |
+| **E5** | Phase 3 `apply_edits` 실패    | rollback 시도 → `Err(ApplyFailed{source, evidence: status=RolledBack, rollback_report 채워짐})` | **tool returns Ok((response, meta))** with `apply_status: "rolled_back"`, `error_message`, `rollback_report`, `file_hashes_after` |
+| **E6** | Phase 4 hash 재계산 실패      | `Ok(ApplyEvidence{status: Applied, file_hashes_after[file] = error})`                           | response: `apply_status: "applied"`, `file_hashes_after[file]: {error}`                                                           |
+| **E7** | rollback 중 일부 restore 실패 | `RollbackEntry{restored: false, reason: Some(e)}` 기록. 나머지 파일 계속 시도.                  | response의 `rollback_report`에 노출. **위험 신호** — agent는 사용자 개입 권유.                                                    |
+
+### 핵심 설계 결정
+
+1. **E5는 `Err`이 아니라 `Ok`로 반환** — agent가 evidence를 잃지 않도록. `apply_status` 필드가 fail-closed signal.
+2. **E1/E3/E4는 `Err`** — 디스크 변경 없음이 보장된 케이스.
+3. **E7(부분 rollback)은 `Ok`** — 사용자가 진단할 수 있는 정보가 더 가치 있음.
+4. **rollback report ordered** — `BTreeMap` 또는 sorted Vec로 deterministic.
+5. **TOCTOU 재read 갭 인정** — design doc에 명시. Phase 2(snapshot 기반)에서 좁힘.
+
+### 명시적으로 다루지 않는 것
+
+- 파일 핸들 lock / advisory lock (Phase 2)
+- 디스크 기반 snapshot (Phase 2)
+- 프로세스 크래시 중 apply 부분 적용 → 재시작 시 자동 rollback (Phase 2)
+- 동시 transaction 상호 lock (Phase 2)
+- inotify/fsevents 기반 외부 변경 감지 (Phase 2+)
+
+---
+
+## 5. Testing
+
+### T1 — substrate unit/integration test (신규)
+
+파일: `crates/codelens-engine/src/edit_transaction_tests.rs` 또는 `edit_transaction.rs` 안의 `#[cfg(test)] mod tests`.
+
+- **T1-happy** (2-file): 두 파일 edit 성공. status=Applied. hashes_before/after 정확. rollback_report=[]. modified_files=2, edit_count=2.
+- **T1-noop**: empty edits. status=NoOp.
+- **T1-resource-ops**: resource_ops non-empty. `Err(ResourceOpsUnsupported)`. 디스크 변경 0.
+- **T1-toctou**: test-only hook(`#[cfg(test)] inject_pre_apply_corruption`)으로 두 read 사이 외부 mutate 시뮬레이션. `Err(PreApplyHashMismatch)`.
+- **T1-rollback-success**: 두 번째 파일 read-only 권한 → `Err(ApplyFailed{evidence})`. 첫 파일 restore 성공 verify. status=RolledBack.
+- **T1-partial-rollback**: T1-rollback-success 변형. 첫 파일 restore도 실패 시뮬 → `RollbackEntry{restored: false, reason: Some(...)}`.
+- **T1-hash-determinism**: 동일 입력 두 번 호출 시 hashes_before 동일.
+- **T1-pre-read-failed**: 존재하지 않는 file_path → `Err(PreReadFailed)`.
+
+총 8 case.
+
+### T2 — `safe_delete_apply` 마이그레이션 회귀
+
+파일: `crates/codelens-mcp/src/integration_tests/semantic_refactor.rs` (기존 case 강화).
+
+- **T2-1 dry_run**: 응답에 `apply_status: "preview_only"`, evidence 없는 contract.
+- **T2-2 apply success**: `dry_run=false` → `apply_status: "applied"`, `rollback_available: true` (기존 false에서 변경), `file_hashes_after` 존재, `rollback_report: []`.
+- **T2-3 apply rollback**: read-only 파일에 대해 → `apply_status: "rolled_back"`, `rollback_report` non-empty. **에러로 던지지 않고 Ok 응답**.
+- **T2-4 unchanged on success boundary**: 기존 dry_run preview 응답의 다른 필드 변화 0.
+
+총 4 case.
+
+### T3 — LSP rename evidence 회귀
+
+파일: 같은 파일(LSP rename 케이스 강화).
+
+- **T3-1**: 기존 LSP rename apply 성공 — 응답 schema 변경 0. `file_hashes_before/after`/`rollback_report`/`modified_files`/`edit_count` 값이 사실 기반(placeholder 아님) verify.
+
+### T4 — 기존 회귀 가드 (변경 없음, 통과만 확인)
+
+- `cargo test -p codelens-engine` (T1 추가분 포함)
+- `cargo test -p codelens-mcp --no-default-features` (T2/T3 추가분 포함)
+- `cargo test -p codelens-mcp --features http`
+- `python3 scripts/surface-manifest.py`
+- `python3 scripts/surface-manifest.py --check-operation-matrix /tmp/operation-matrix.json`
+- `python3 scripts/test/test-surface-manifest-contracts.py`
+- `python3 benchmarks/lint-datasets.py --project .`
+- `cargo clippy -- -W clippy::all`
+
+### TOCTOU test 가능성
+
+`#[cfg(test)] pub fn` hook 권장: substrate에 test-only 함수(`inject_pre_apply_corruption(&self, file_path: &str)`)로 두 read 사이 mutate 시뮬레이션. production code 영향 0.
+
+### Pre-merge 게이트 순서
+
+1. cargo check
+2. cargo test (T1 + T2 + T3 + 기존)
+3. cargo clippy
+4. surface-manifest.py + contract A+B + fixtures
+5. evaluator(opus) 채점 — §6 acceptance criteria 대비
+
+---
+
+## 6. Acceptance Criteria
+
+### AC-1 (substrate 도메인 객체 + apply_with_evidence 동작)
+
+- `crates/codelens-engine/src/edit_transaction.rs` 신규 파일에 정의: `WorkspaceEditTransaction`, `ApplyEvidence`, `ApplyStatus { Applied, RolledBack, NoOp }`, `RollbackEntry`, `FileHash`, `ApplyError { ResourceOpsUnsupported, PreReadFailed, PreApplyHashMismatch, ApplyFailed{source, evidence} }`.
+- `WorkspaceEditTransaction::apply_with_evidence(&self, project) -> Result<ApplyEvidence, ApplyError>` 메서드 존재.
+- `crates/codelens-engine/src/lib.rs`에 `pub mod edit_transaction;` 등록 + 핵심 타입 re-export.
+- 증거: T1 8 case green.
+
+### AC-2 (LSP path 통합)
+
+- `apply_workspace_edit_transaction` 시그니처 `Result<()> → Result<ApplyEvidence, ApplyError>`.
+- `LspWorkspaceEditTransaction::into_workspace_edit_transaction()` 또는 `From` impl 존재.
+- `LspWorkspaceEditTransaction.rollback_available`에 `#[deprecated]` 마킹.
+- LSP rename 호출 사이트 응답 schema 변경 0.
+- 증거: T3-1 green; 기존 `integration_tests/semantic_refactor.rs` LSP rename 0 fail.
+
+### AC-3 (`safe_delete_apply` 마이그레이션)
+
+- `semantic_edit.rs::safe_delete_apply`에서 `std::fs::write(&resolved, source)` 호출 0개.
+- 자체 read+modify+write 블록이 substrate 호출로 대체.
+- 응답에 `rollback_available: true`, `file_hashes_after`, `rollback_report` 신규 등장.
+- `apply_status` 값이 `applied` / `rolled_back` / `preview_only` / `no_op`.
+- 증거: T2-1, T2-2, T2-3, T2-4 green.
+
+### AC-4 (Contract serialization 일반화)
+
+- `semantic_transaction_contract` 시그니처에 `evidence: Option<&ApplyEvidence>` 추가.
+- `evidence.is_some()`이면 single source of truth.
+- 4 callers 업데이트(L116/247: `Some(&evidence)`, L434: `Some(&evidence)`, semantic_adapter.rs:86: `None`).
+- JSON 출력에 `file_hashes_after`, `rollback_report` 신규 필드.
+
+### AC-5 (회귀 0)
+
+- `cargo test -p codelens-engine`: T1 추가 ≥ 7, 신규 fail 0.
+- `cargo test -p codelens-mcp --no-default-features`: T2 추가 ≥ 3, 신규 fail 0.
+- `cargo test -p codelens-mcp --features http`: 통과.
+- `cargo clippy -- -W clippy::all`: 신규 warning 0.
+- `python3 scripts/surface-manifest.py` + contract A+B + fixtures: exit 0.
+- `python3 benchmarks/lint-datasets.py --project .`: 0/0.
+
+### AC-6 (범위 준수)
+
+- 변경 파일 수 ≤ 9: edit_transaction.rs(신규) / lsp/workspace_edit.rs / lsp/types.rs / lib.rs(engine) / semantic_edit.rs / semantic_adapter.rs / semantic_refactor.rs(test) / edit_transaction_tests.rs(신규 또는 inline) / +1.
+- engine 측 다른 `fs::write` 호출 사이트(`auto_import`/`inline`/`move_symbol`/`rename`/`memory`) 변경 0 (G7 위임).
+- capability matrix 변경 0.
+- 새 LSP backend / 새 operation / 새 mutation primitive 0.
+
+### AC-7 (Phase 0 evidence 보존)
+
+- `tools/mutation.rs` 변경 0 (Phase 0 envelope 유지).
+- `tools/semantic_edit.rs::rename_symbol_with_lsp_backend` 응답에 Phase 0 5필드(`authority`/`authority_backend`/`can_preview`/`can_apply`/`edit_authority`) 모두 그대로.
+- tree-sitter rename downgrade 동작 변화 0.
+
+### AC-8 (문서 정합)
+
+- design doc commit됨.
+- README, CLAUDE.md, architecture.md 변경 0 (substrate, 후속 PR).
+
+### Evaluator 판정 규칙
+
+- AC-1 ~ AC-7 중 1개라도 FAIL → 전체 FAIL.
+- AC-8 FAIL → 경고만, 머지 가능.
+
+---
+
+## 7. 다음 단계 (이 PR 머지 후)
+
+Phase 1 후속 PR 후보:
+
+- **G7**: engine `auto_import`/`inline`/`move_symbol`/`rename`/`memory` 등 fs::write 호출 사이트를 substrate로 마이그레이션. 별도 brainstorming.
+- **G5**: capability matrix runtime probing. 별도 brainstorming.
+- **Phase 2**: 디스크 기반 snapshot rollback / 파일 lock / 프로세스 크래시 회복. 본 PR이 깐 substrate 위에 빌드.
+
+각 항목 별도 PR + 별도 design doc.


### PR DESCRIPTION
## Summary

**Stacked on PR #82** (Phase 0). Base will become `main` once #82 merges.

Generalize the existing engine apply path into a reusable `WorkspaceEditTransaction` domain object with `ApplyEvidence`, then migrate `safe_delete_apply` off its self-managed `std::fs::write`.

- New `crates/codelens-engine/src/edit_transaction.rs` (598 lines): `WorkspaceEditTransaction` + `apply_with_evidence` returning `Result<ApplyEvidence, ApplyError>`. `ApplyEvidence` carries `status` (Applied/RolledBack/NoOp), `file_hashes_before`/`after`, `rollback_report`, `modified_files`, `edit_count`.
- LSP `apply_workspace_edit_transaction` thin wrapper delegating to substrate. `LspWorkspaceEditTransaction.rollback_available` `#[deprecated]` (use `ApplyEvidence::status` instead).
- `safe_delete_apply` migrated: own `fs::write` removed, single-edit `WorkspaceEditTransaction` constructed and applied. Apply failure surfaces as `Ok` response with `apply_status: "rolled_back"` + `error_message` (E5 contract — agent reads `apply_status` to detect partial state).
- `semantic_transaction_contract` accepts `evidence: Option<&ApplyEvidence>`; 4 callers updated. JSON output gains `file_hashes_after`, `rollback_report`. Hardcoded `transaction.rollback_available` reads removed.

Spec: `docs/superpowers/specs/2026-04-25-codelens-phase1-g4-workspace-edit-transaction-design.md`
Plan: `docs/superpowers/plans/2026-04-25-codelens-phase1-g4-workspace-edit-transaction.md`

Closes Phase 1 **G4**. Phase 1 **G5** (runtime capability probing) and **G7** (engine `fs::write` 11 sites) deferred to separate PRs.

## P2 rollback policy (per spec §3-4)

- pre-apply hash capture (sha256 + bytes per file)
- post-apply hash verification (truth check; matches pre-apply hash on rollback)
- per-file `RollbackEntry { restored: bool, reason: Option<String> }` — replaces silent `let _ = fs::write` pattern
- TOCTOU re-check: same-function two-read window. Strong guarantees (disk snapshot / lock / process-crash recovery) deferred to Phase 2.

## Test plan

- [x] `cargo test -p codelens-engine` — 328 passed (8 substrate unit tests added)
- [x] `cargo test -p codelens-mcp --no-default-features` — 416 passed
- [x] `cargo test -p codelens-mcp --features http` — 527 passed (4 new safe_delete substrate tests + 1 LSP rename evidence regression)
- [x] `cargo clippy -p codelens-engine -- -W clippy::all` — 0 NEW warnings
- [x] `cargo clippy -p codelens-mcp --features http -- -W clippy::all` — 0 NEW warnings
- [x] `python3 scripts/surface-manifest.py` + contract A/B + 5/5 fixtures — all exit 0
- [x] Phase 0 envelope (`tools/mutation.rs`) — diff 0 lines (AC-7)
- [x] AC-1~AC-7 PASS (orchestrator synthesis); AC-8 PARTIAL (intentional substrate, non-blocking per spec §6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)