### PR TITLE
feat(mcp): Phase 2-C — role gate + principals.toml (ADR-0009 §1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,6 +508,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
+ "toml",
  "tower 0.5.3",
  "tracing",
  "tracing-opentelemetry",
@@ -3278,6 +3279,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3742,6 +3752,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
@@ -4776,6 +4827,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/crates/codelens-mcp/Cargo.toml
+++ b/crates/codelens-mcp/Cargo.toml
@@ -26,6 +26,7 @@ serde_json.workspace = true
 sha2.workspace = true
 url.workspace = true
 rusqlite.workspace = true
+toml = "0.8"
 rustls = { workspace = true, optional = true }
 codelens-engine = { path = "../codelens-engine", version = "=1.9.50" }
 thiserror.workspace = true

--- a/crates/codelens-mcp/src/dispatch/mod.rs
+++ b/crates/codelens-mcp/src/dispatch/mod.rs
@@ -15,6 +15,7 @@ mod query_engine;
 mod rate_limit;
 mod response;
 mod response_support;
+mod role_gate;
 mod session;
 mod table;
 mod validation;
@@ -115,7 +116,26 @@ pub(crate) fn dispatch_tool(
         }
     };
 
-    // 4. Validate tool access (surface, namespace, tier, daemon mode).
+    // 4a. Role gate (ADR-0009 §1): principal must hold required role
+    //     for this tool. On deny, an audit row is written and the
+    //     caller receives a JSON-RPC -32008 error.
+    if let Err(role_err) = role_gate::enforce_role_gate(state, name, arguments, session) {
+        return build_error_response(
+            name,
+            role_err,
+            None,
+            arguments,
+            &ctx.active_surface,
+            &session.session_id,
+            state,
+            start,
+            id,
+            ctx.doom_count,
+            ctx.doom_rapid,
+        );
+    }
+
+    // 4b. Validate tool access (surface, namespace, tier, daemon mode).
     if let Err(access_err) = validate_tool_access(name, session, ctx.surface, state) {
         return build_error_response(
             name,

--- a/crates/codelens-mcp/src/dispatch/role_gate.rs
+++ b/crates/codelens-mcp/src/dispatch/role_gate.rs
@@ -1,0 +1,101 @@
+//! ADR-0009 §1 enforcement: every dispatch call passes through
+//! [`enforce_role_gate`] before the handler runs. On deny, this module
+//! also writes a single `apply_status="denied"` row to the audit sink
+//! so operators can post-hoc reconstruct who was rejected, when, and
+//! for which tool.
+//!
+//! The gate consults [`crate::principals::Principals`] (lazily loaded
+//! on `AppState`) and [`crate::principals::required_role_for`]. By
+//! design the rule is simple: mutation tools require `Refactor`,
+//! everything else requires `ReadOnly`, and `Admin` is reserved for
+//! future audit / job-control tools (P2-F).
+
+use crate::audit_sink::{canonical_sha256_hex, AuditRecord};
+use crate::error::CodeLensError;
+use crate::principals::{current_principal_id, required_role_for, Role};
+use crate::session_context::SessionRequestContext;
+use crate::AppState;
+use serde_json::Value;
+
+/// Enforce the role gate for a single dispatch call.
+///
+/// Returns `Ok(())` when the resolved principal's role satisfies the
+/// tool's required role. Returns `Err(CodeLensError::PermissionDenied)`
+/// otherwise — and writes one `apply_status="denied"` row to the audit
+/// sink before returning so the rejection is durably recorded.
+pub(super) fn enforce_role_gate(
+    state: &AppState,
+    name: &str,
+    arguments: &Value,
+    session: &SessionRequestContext,
+) -> Result<(), CodeLensError> {
+    let required = required_role_for(name);
+    let principal_id = current_principal_id();
+    let principal_role = state.principals().resolve(principal_id.as_deref());
+    if principal_role.satisfies(required) {
+        return Ok(());
+    }
+    record_denied_audit_row(
+        state,
+        name,
+        arguments,
+        session,
+        principal_id.as_deref(),
+        principal_role,
+        required,
+    );
+    Err(CodeLensError::PermissionDenied {
+        principal: principal_id.unwrap_or_else(|| "<default>".to_owned()),
+        principal_role: principal_role.as_str().to_owned(),
+        tool: name.to_owned(),
+        required_role: required.as_str().to_owned(),
+    })
+}
+
+fn record_denied_audit_row(
+    state: &AppState,
+    name: &str,
+    arguments: &Value,
+    session: &SessionRequestContext,
+    principal_id: Option<&str>,
+    principal_role: Role,
+    required_role: Role,
+) {
+    let Some(sink) = state.audit_sink() else {
+        return;
+    };
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0);
+    let args_hash = canonical_sha256_hex(arguments);
+    // Same transaction id derivation as `record_audit_outcome` so a
+    // future Admin running `audit_log_query(transaction_id)` can join
+    // the denied attempt against later retry attempts of the same
+    // call.
+    let transaction_id = format!("{}-{}-{}", session.session_id, name, &args_hash[..16]);
+    let record = AuditRecord {
+        transaction_id,
+        timestamp_ms: now_ms,
+        principal: principal_id.map(str::to_owned),
+        tool: name.to_owned(),
+        args_hash,
+        apply_status: "denied".to_owned(),
+        state_from: None,
+        state_to: "Denied".to_owned(),
+        evidence_hash: None,
+        rollback_restored: None,
+        error_message: Some(format!(
+            "principal_role={} does not satisfy required_role={}",
+            principal_role.as_str(),
+            required_role.as_str()
+        )),
+    };
+    if let Err(error) = sink.write(&record) {
+        tracing::warn!(
+            tool = name,
+            error = %error,
+            "failed to write denied-row audit_sink entry"
+        );
+    }
+}

--- a/crates/codelens-mcp/src/error.rs
+++ b/crates/codelens-mcp/src/error.rs
@@ -60,6 +60,17 @@ pub enum CodeLensError {
     #[allow(dead_code)]
     ResourceExhausted(String),
 
+    /// ADR-0009 §1: principal does not hold the role required by the
+    /// tool. Surfaces as JSON-RPC -32008 (note: ADR named -32004 but
+    /// that code is already taken by `IndexNotReady`).
+    #[error("Permission denied: principal '{principal}' (role={principal_role}) cannot call tool '{tool}' which requires role={required_role}")]
+    PermissionDenied {
+        principal: String,
+        principal_role: String,
+        tool: String,
+        required_role: String,
+    },
+
     /// I/O error.
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
@@ -90,6 +101,7 @@ impl CodeLensError {
             Self::Timeout { .. } => -32005,
             Self::StaleSession(_) => -32006,
             Self::ResourceExhausted(_) => -32007,
+            Self::PermissionDenied { .. } => -32008,
             Self::Io(_) => -32603,
             Self::Internal(_) => -32603,
         }

--- a/crates/codelens-mcp/src/integration_tests/mutation_evidence.rs
+++ b/crates/codelens-mcp/src/integration_tests/mutation_evidence.rs
@@ -127,6 +127,128 @@ fn add_import_tool_response_includes_evidence() {
     );
 }
 
+/// ADR-0009 §1 (P2-C role gate): when `CODELENS_PRINCIPAL` env var is
+/// set and `principals.toml` maps that principal to `ReadOnly`, every
+/// mutation tool call is denied with a JSON-RPC -32008 error AND an
+/// `apply_status="denied"` row is appended to the audit log. Read-only
+/// tools (e.g. `find_symbol`) still succeed.
+///
+/// `permissive_default` (no `principals.toml`, no env var) is covered
+/// implicitly by every other test in this file — they would all fail
+/// if the gate ever defaulted to `ReadOnly`.
+#[test]
+fn role_gate_denies_mutation_for_read_only_principal() {
+    use crate::audit_sink::AuditSink;
+    use crate::principals::Principals;
+
+    let project = project_root();
+
+    // Drop a `principals.toml` in the project's `.codelens/` so
+    // `Principals::discover` finds it via the audit_dir parent.
+    let codelens_dir = project.as_path().join(".codelens");
+    std::fs::create_dir_all(&codelens_dir).unwrap();
+    std::fs::write(
+        codelens_dir.join("principals.toml"),
+        r#"
+[default]
+role = "Refactor"
+
+[principal."ci-bot"]
+role = "ReadOnly"
+"#,
+    )
+    .unwrap();
+
+    // Sanity-check the loader path before touching dispatch.
+    let parsed =
+        Principals::discover(&codelens_dir.join("audit")).expect("principals.toml must parse");
+    assert_eq!(parsed.resolve(Some("ci-bot")).as_str(), "ReadOnly");
+
+    // Bind the request principal to ci-bot via env so role_gate
+    // resolves it on the dispatch path.
+    let saved_principal = std::env::var("CODELENS_PRINCIPAL").ok();
+    unsafe {
+        std::env::set_var("CODELENS_PRINCIPAL", "ci-bot");
+    }
+
+    let state = make_state(&project);
+
+    // Mutation tool MUST be denied.
+    let denied = call_tool(
+        &state,
+        "create_text_file",
+        json!({
+            "relative_path": "role_gate_target.txt",
+            "content": "should-not-be-written\n",
+            "overwrite": false,
+        }),
+    );
+    assert_eq!(
+        denied.get("success").and_then(|v| v.as_bool()),
+        Some(false),
+        "denied response must have success=false, got {denied}"
+    );
+    let error_msg = denied
+        .get("error")
+        .and_then(|e| e.as_str())
+        .unwrap_or_default();
+    assert!(
+        error_msg.contains("Permission denied"),
+        "error message must mention Permission denied, got {error_msg:?}"
+    );
+    assert!(
+        error_msg.contains("ci-bot") && error_msg.contains("ReadOnly"),
+        "error message must include principal id and role, got {error_msg:?}"
+    );
+
+    // ReadOnly tool MUST still succeed (find_symbol exists and is
+    // gated to ReadOnly).
+    let allowed = call_tool(
+        &state,
+        "find_symbol",
+        json!({
+            "name": "anything",
+        }),
+    );
+    // We do not assert on shape — only that the call did not get a
+    // PermissionDenied error.
+    let allowed_err = allowed
+        .get("error")
+        .and_then(|e| e.as_str())
+        .unwrap_or_default();
+    assert!(
+        !allowed_err.contains("Permission denied"),
+        "ReadOnly tool must NOT be denied for ReadOnly principal, got error={allowed_err:?}"
+    );
+
+    // Audit row for the denial must exist.
+    let sink = AuditSink::open(&state.audit_dir()).expect("audit_sink open");
+    let rows = sink.query(None, None, 100).expect("query");
+    let denied_row = rows
+        .iter()
+        .find(|r| r.tool == "create_text_file" && r.apply_status == "denied")
+        .expect("denied audit row must exist");
+    assert_eq!(denied_row.state_to, "Denied");
+    assert_eq!(denied_row.principal.as_deref(), Some("ci-bot"));
+    assert!(
+        denied_row
+            .error_message
+            .as_deref()
+            .unwrap_or("")
+            .contains("ReadOnly"),
+        "denied row error_message must reference principal_role, got {:?}",
+        denied_row.error_message
+    );
+
+    // Restore env so other tests are unaffected.
+    unsafe {
+        match saved_principal {
+            Some(v) => std::env::set_var("CODELENS_PRINCIPAL", v),
+            None => std::env::remove_var("CODELENS_PRINCIPAL"),
+        }
+    }
+}
+
 /// ADR-0009 §2 (P2-B wiring): a successful mutation tool call writes
 /// exactly one row to the durable audit_sink (SQLite) with
 /// `apply_status="applied"`, transition `Applying → Audited`, and a

--- a/crates/codelens-mcp/src/main.rs
+++ b/crates/codelens-mcp/src/main.rs
@@ -19,6 +19,7 @@ mod mutation_audit;
 mod mutation_gate;
 mod operator;
 mod preflight_store;
+mod principals;
 mod prompts;
 mod protocol;
 mod recent_buffer;

--- a/crates/codelens-mcp/src/principals.rs
+++ b/crates/codelens-mcp/src/principals.rs
@@ -1,0 +1,377 @@
+//! ADR-0009 §1: 3-tier role model + `principals.toml` loader.
+//!
+//! The role gate enforces `(principal, role) → allowed_tools` at the
+//! dispatch entry. This module owns the data model and the file-based
+//! configuration; `dispatch::role_gate` owns the enforcement decision.
+//!
+//! ## Role hierarchy
+//!
+//! ```text
+//! Admin    > Refactor > ReadOnly
+//! ```
+//!
+//! A principal with `Refactor` may call all `ReadOnly` tools; an
+//! `Admin` principal may call all `Refactor` tools.
+//!
+//! ## Required role per tool
+//!
+//! - **ReadOnly**: every non-mutation tool — `analyze_*`, `find_*`,
+//!   `get_*`, `semantic_search`, etc.
+//! - **Refactor**: every tool listed in
+//!   [`crate::tool_defs::is_content_mutation_tool`] (the 9 raw_fs
+//!   primitives + LSP rename + safe_delete + memory writes + refactor
+//!   primitives).
+//! - **Admin**: reserved for the future `audit_log_query` and job
+//!   control tools (P2-F). For now no tool requires it; the variant
+//!   exists so the configuration file is forward-compatible.
+//!
+//! ## Backward compatibility
+//!
+//! When `principals.toml` is absent, the loader returns a permissive
+//! default: every principal id maps to `Refactor`. This preserves the
+//! current pre-Phase-2 behaviour. Operators opt in to strict access by
+//! placing the file at `<project>/.codelens/principals.toml` or
+//! `~/.codelens/principals.toml`.
+//!
+//! ## File format
+//!
+//! ```toml
+//! [default]
+//! role = "ReadOnly"
+//!
+//! [principal."alice@example.com"]
+//! role = "Admin"
+//!
+//! [principal."ci-bot"]
+//! role = "ReadOnly"
+//! ```
+
+#![allow(dead_code)]
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::path::Path;
+
+/// 3-tier role; ordering encodes the hierarchy
+/// (`Admin > Refactor > ReadOnly`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Deserialize)]
+pub enum Role {
+    ReadOnly,
+    Refactor,
+    Admin,
+}
+
+impl Role {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Role::ReadOnly => "ReadOnly",
+            Role::Refactor => "Refactor",
+            Role::Admin => "Admin",
+        }
+    }
+
+    /// True when `self` may call any tool that requires `required`.
+    /// Encodes the role hierarchy: `Admin >= Refactor >= ReadOnly`.
+    pub fn satisfies(self, required: Role) -> bool {
+        self >= required
+    }
+}
+
+/// Resolved role mapping. Built once at AppState init from a
+/// `principals.toml` (if any) and consulted by the role gate on every
+/// dispatch.
+#[derive(Debug, Clone)]
+pub struct Principals {
+    default_role: Role,
+    by_id: HashMap<String, Role>,
+}
+
+impl Principals {
+    /// Permissive fallback used when no `principals.toml` is present.
+    /// Every principal — including the unknown ones — gets `Refactor`,
+    /// preserving the pre-Phase-2 behaviour.
+    pub fn permissive_default() -> Self {
+        Self {
+            default_role: Role::Refactor,
+            by_id: HashMap::new(),
+        }
+    }
+
+    /// Resolve a principal id to its role. Unknown ids fall back to
+    /// the default role.
+    pub fn resolve(&self, principal_id: Option<&str>) -> Role {
+        principal_id
+            .and_then(|id| self.by_id.get(id).copied())
+            .unwrap_or(self.default_role)
+    }
+
+    /// Number of explicit principal entries (excludes default). Useful
+    /// for tests and observability.
+    pub fn explicit_count(&self) -> usize {
+        self.by_id.len()
+    }
+
+    pub fn default_role(&self) -> Role {
+        self.default_role
+    }
+
+    /// Discover a `principals.toml` and parse it.
+    ///
+    /// Search order (first existing wins):
+    /// 1. `<project>/.codelens/principals.toml`
+    /// 2. `$HOME/.codelens/principals.toml`
+    ///
+    /// Returns the permissive default when no file is found. Parse
+    /// errors propagate so misconfiguration is surfaced loudly at
+    /// startup instead of silently falling back to `Refactor`.
+    pub fn discover(project_audit_dir: &Path) -> Result<Self> {
+        // project audit dir is `<project>/.codelens/audit/`; principals.toml
+        // lives one directory up at `<project>/.codelens/principals.toml`.
+        if let Some(codelens_dir) = project_audit_dir.parent() {
+            let project_path = codelens_dir.join("principals.toml");
+            if project_path.exists() {
+                return Self::load_from(&project_path);
+            }
+        }
+        if let Some(home) = std::env::var_os("HOME") {
+            let user_path = Path::new(&home).join(".codelens").join("principals.toml");
+            if user_path.exists() {
+                return Self::load_from(&user_path);
+            }
+        }
+        Ok(Self::permissive_default())
+    }
+
+    /// Parse a specific TOML file. Public for testability.
+    pub fn load_from(path: &Path) -> Result<Self> {
+        let bytes = std::fs::read_to_string(path)
+            .with_context(|| format!("failed to read {}", path.display()))?;
+        Self::parse(&bytes)
+            .with_context(|| format!("failed to parse principals file {}", path.display()))
+    }
+
+    /// Parse from in-memory TOML text. Public for unit tests.
+    pub fn parse(text: &str) -> Result<Self> {
+        #[derive(Deserialize)]
+        struct DefaultEntry {
+            role: Role,
+        }
+        #[derive(Deserialize)]
+        struct PrincipalEntry {
+            role: Role,
+        }
+        #[derive(Deserialize)]
+        struct File {
+            default: Option<DefaultEntry>,
+            #[serde(default)]
+            principal: HashMap<String, PrincipalEntry>,
+        }
+        let parsed: File = toml::from_str(text).context("toml parse error")?;
+        let default_role = parsed.default.map(|d| d.role).unwrap_or(Role::Refactor);
+        let by_id = parsed
+            .principal
+            .into_iter()
+            .map(|(id, entry)| (id, entry.role))
+            .collect();
+        Ok(Self {
+            default_role,
+            by_id,
+        })
+    }
+}
+
+/// Required role to call `tool`. Maps every tool name to one of the
+/// three tiers; the rule is simple by design (mutation tools require
+/// Refactor; everything else is ReadOnly). New tools added in the
+/// future are ReadOnly by default unless they appear in
+/// [`crate::tool_defs::is_content_mutation_tool`].
+pub fn required_role_for(tool: &str) -> Role {
+    if crate::tool_defs::is_content_mutation_tool(tool) {
+        Role::Refactor
+    } else {
+        Role::ReadOnly
+    }
+}
+
+/// Resolve the principal id for the current request from the
+/// environment.
+///
+/// Priority order:
+/// 1. `CODELENS_PRINCIPAL` env var (stdio + dev mode)
+/// 2. None (caller-provided HTTP / JWT bindings come in P2-C-follow-up)
+///
+/// Phase 2-C limits the binding to env-only so the role gate can land
+/// without coupling to the HTTP feature flag. Header / JWT extraction
+/// is mechanical to add in a follow-up once the Authorization plumbing
+/// is in place.
+pub fn current_principal_id() -> Option<String> {
+    std::env::var("CODELENS_PRINCIPAL").ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn role_ordering_encodes_hierarchy() {
+        assert!(Role::Admin > Role::Refactor);
+        assert!(Role::Refactor > Role::ReadOnly);
+        assert!(Role::Admin.satisfies(Role::ReadOnly));
+        assert!(Role::Refactor.satisfies(Role::ReadOnly));
+        assert!(!Role::ReadOnly.satisfies(Role::Refactor));
+        assert!(!Role::Refactor.satisfies(Role::Admin));
+    }
+
+    #[test]
+    fn permissive_default_resolves_every_id_to_refactor() {
+        let p = Principals::permissive_default();
+        assert_eq!(p.resolve(None), Role::Refactor);
+        assert_eq!(p.resolve(Some("alice")), Role::Refactor);
+        assert_eq!(p.explicit_count(), 0);
+    }
+
+    #[test]
+    fn parse_minimal_default_only() {
+        let toml = r#"
+            [default]
+            role = "ReadOnly"
+        "#;
+        let p = Principals::parse(toml).expect("parse ok");
+        assert_eq!(p.default_role(), Role::ReadOnly);
+        assert_eq!(p.resolve(None), Role::ReadOnly);
+        assert_eq!(p.explicit_count(), 0);
+    }
+
+    #[test]
+    fn parse_full_principal_table() {
+        let toml = r#"
+            [default]
+            role = "ReadOnly"
+
+            [principal."alice@example.com"]
+            role = "Admin"
+
+            [principal."ci-bot"]
+            role = "Refactor"
+        "#;
+        let p = Principals::parse(toml).expect("parse ok");
+        assert_eq!(p.default_role(), Role::ReadOnly);
+        assert_eq!(p.resolve(Some("alice@example.com")), Role::Admin);
+        assert_eq!(p.resolve(Some("ci-bot")), Role::Refactor);
+        assert_eq!(
+            p.resolve(Some("unknown")),
+            Role::ReadOnly,
+            "unknown id falls back to default_role"
+        );
+        assert_eq!(p.explicit_count(), 2);
+    }
+
+    #[test]
+    fn parse_missing_default_uses_refactor() {
+        let toml = r#"
+            [principal."alice"]
+            role = "Admin"
+        "#;
+        let p = Principals::parse(toml).expect("parse ok");
+        assert_eq!(p.default_role(), Role::Refactor);
+        assert_eq!(p.resolve(None), Role::Refactor);
+        assert_eq!(p.resolve(Some("alice")), Role::Admin);
+    }
+
+    #[test]
+    fn parse_invalid_role_string_errors() {
+        let toml = r#"
+            [default]
+            role = "Superuser"
+        "#;
+        let result = Principals::parse(toml);
+        assert!(result.is_err(), "invalid role must surface as Err");
+    }
+
+    #[test]
+    fn discover_returns_permissive_when_nothing_present() {
+        // Empty tempdir whose parent is also empty — neither
+        // project nor user file exists.
+        let dir = std::env::temp_dir().join(format!(
+            "codelens-principals-empty-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        // Force HOME to an empty dir for this test so the
+        // user-level fallback also misses.
+        let original_home = std::env::var_os("HOME");
+        let fake_home = dir.join("fake_home");
+        std::fs::create_dir_all(&fake_home).unwrap();
+        unsafe {
+            std::env::set_var("HOME", &fake_home);
+        }
+        let p = Principals::discover(&dir).expect("discover ok");
+        // Restore HOME before assertions so a panic does not leak.
+        unsafe {
+            match original_home {
+                Some(h) => std::env::set_var("HOME", h),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+        assert_eq!(p.default_role(), Role::Refactor);
+        assert_eq!(p.explicit_count(), 0);
+    }
+
+    #[test]
+    fn discover_loads_project_local_file() {
+        let codelens_dir = std::env::temp_dir().join(format!(
+            "codelens-principals-loaded-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let audit_dir = codelens_dir.join("audit");
+        std::fs::create_dir_all(&audit_dir).unwrap();
+        let principals_path = codelens_dir.join("principals.toml");
+        std::fs::write(
+            &principals_path,
+            r#"
+[default]
+role = "ReadOnly"
+
+[principal."alice"]
+role = "Admin"
+"#,
+        )
+        .unwrap();
+        let p = Principals::discover(&audit_dir).expect("discover ok");
+        assert_eq!(p.default_role(), Role::ReadOnly);
+        assert_eq!(p.resolve(Some("alice")), Role::Admin);
+    }
+
+    #[test]
+    fn required_role_for_mutation_tool_is_refactor() {
+        assert_eq!(required_role_for("create_text_file"), Role::Refactor);
+        assert_eq!(required_role_for("delete_lines"), Role::Refactor);
+        assert_eq!(required_role_for("rename_symbol"), Role::Refactor);
+        assert_eq!(required_role_for("write_memory"), Role::Refactor);
+    }
+
+    #[test]
+    fn required_role_for_query_tool_is_readonly() {
+        assert_eq!(required_role_for("find_symbol"), Role::ReadOnly);
+        assert_eq!(required_role_for("get_callers"), Role::ReadOnly);
+        assert_eq!(required_role_for("analyze_change_request"), Role::ReadOnly);
+        assert_eq!(required_role_for("semantic_search"), Role::ReadOnly);
+    }
+
+    #[test]
+    fn required_role_for_unknown_tool_defaults_to_readonly() {
+        // Conservative default: any tool we have not catalogued is
+        // assumed read-only and gated minimally. (Mutation tools
+        // must be explicitly declared in is_content_mutation_tool.)
+        assert_eq!(required_role_for("nonexistent_tool"), Role::ReadOnly);
+    }
+}

--- a/crates/codelens-mcp/src/state.rs
+++ b/crates/codelens-mcp/src/state.rs
@@ -134,6 +134,10 @@ pub(crate) struct AppState {
     /// access via `audit_sink()` so test helpers without an audit_dir
     /// do not pay the open cost upfront.
     audit_sink: OnceLock<Arc<crate::audit_sink::AuditSink>>,
+    /// ADR-0009 §1: resolved principal-to-role mapping. Lazy-init on
+    /// first access via `principals()` so test helpers do not pay the
+    /// TOML discovery cost when they never invoke a gated path.
+    principals: OnceLock<Arc<crate::principals::Principals>>,
 }
 
 /// A read-only project registered for cross-project queries.
@@ -259,6 +263,36 @@ impl AppState {
         self.active_project_context()
             .map(|context| context.audit_dir.clone())
             .unwrap_or_else(|| self.default_audit_dir.clone())
+    }
+
+    /// ADR-0009 §1: lazy accessor for the resolved principal-to-role
+    /// mapping. The first caller pays the TOML discovery + parse cost
+    /// (one stat for the project file, one stat for the user-global
+    /// file, one parse if either is found); all subsequent calls share
+    /// the same `Arc`. Discovery failures fall back to the permissive
+    /// default (every id maps to `Refactor`) so a malformed file does
+    /// not block the dispatch path — but the parse error is logged at
+    /// warn so operators see it loudly.
+    pub(crate) fn principals(&self) -> Arc<crate::principals::Principals> {
+        if let Some(existing) = self.principals.get() {
+            return Arc::clone(existing);
+        }
+        let dir = self.audit_dir();
+        let resolved = match crate::principals::Principals::discover(&dir) {
+            Ok(p) => p,
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    audit_dir = %dir.display(),
+                    "failed to load principals.toml — falling back to permissive default \
+                     (every principal mapped to Refactor)"
+                );
+                crate::principals::Principals::permissive_default()
+            }
+        };
+        let arc = Arc::new(resolved);
+        let _ = self.principals.set(Arc::clone(&arc));
+        self.principals.get().cloned().unwrap_or(arc)
     }
 
     /// ADR-0009 §2: lazy accessor for the durable audit sink. The first
@@ -563,6 +597,7 @@ impl AppState {
             // Multiple processes opening the same SQLite is safe (WAL
             // serialises writes); the OnceLock just caches per-clone.
             audit_sink: OnceLock::new(),
+            principals: OnceLock::new(),
         }
     }
 
@@ -648,6 +683,7 @@ impl AppState {
             compat_mode: Mutex::new(crate::server::compat::ServerCompatMode::Default),
             daemon_started_at: now_rfc3339_utc(),
             audit_sink: OnceLock::new(),
+            principals: OnceLock::new(),
         }
     }
 


### PR DESCRIPTION
## Summary

Lands ADR-0009 §1 — the 3-tier role model enforced at dispatch entry.
Mutation tools require Refactor; query tools require ReadOnly; Admin
tier reserved for future audit_log_query / job-control (P2-F).

- New `principals.rs` module: Role enum, Principals loader, TOML
  discovery (project → user-global → permissive default), tool→role
  mapping (`required_role_for`).
- New `dispatch/role_gate.rs`: single \`enforce_role_gate\` step,
  invoked before \`validate_tool_access\`. On deny: writes one
  \`apply_status="denied"\` audit row and returns CodeLensError::PermissionDenied.
- New CodeLensError::PermissionDenied variant; JSON-RPC code -32008
  (ADR named -32004 but that code was already taken by
  IndexNotReady — deviation noted in commit body).
- AppState: \`principals: OnceLock<Arc<Principals>>\` + lazy accessor.
- Cargo.toml: \`toml = "0.8"\` dependency for principals.toml parsing.

Backward-compatible: when no \`principals.toml\` is present anywhere,
the loader returns the permissive default (every id maps to
Refactor), preserving the pre-Phase-2 behaviour exactly. Operators
opt in to strict access by placing the file at \`<project>/.codelens/principals.toml\`
or \`~/.codelens/principals.toml\`.

## Architecture rules compliance

| Rule | Status |
|---|---|
| 모놀리식 우선 | ✅ all logic in mcp crate |
| 역할 기반 권한은 화면/액션/API 모두 명시 | ✅ Role enum gates dispatch entry; principals.toml is the config surface; tool→role mapping is one source of truth |
| 감사 로그가 필요한 액션은 반드시 기록 | ✅ denied calls also write one audit row (apply_status="denied", state_to="Denied") |
| 새 추상화는 중복 제거가 입증된 경우에만 추가 | ✅ Principals loader replaces ad-hoc env-var checks; role_gate is the single dispatch enforcement point |

## Test plan

- [x] 11 unit tests in \`principals.rs\`: hierarchy ordering, TOML parse (minimal / full / missing default / invalid role), discover (empty / loaded), required_role_for (mutation / query / unknown)
- [x] 1 integration test \`role_gate_denies_mutation_for_read_only_principal\`: principals.toml + CODELENS_PRINCIPAL env causes create_text_file to be denied (response \`success=false\`, error contains \"Permission denied\" / \"ci-bot\" / \"ReadOnly\"), find_symbol still succeeds, denied audit_log row exists
- [x] \`cargo test -p codelens-mcp\` — 476 (was 464 + 12) pass, 0 fail
- [x] \`cargo test -p codelens-mcp --features http\` — 555 pass, 0 fail
- [x] \`cargo clippy -p codelens-mcp -- -W clippy::all\` — 0 NEW warnings

## Out of scope (deferred)

- HTTP / JWT principal binding (current binding is env-only; mechanical follow-up once HTTP auth plumbing is touched)
- P2-D 8-state lifecycle + Err branch + evidence threading
- P2-E CacheInvalidator trait + 4 engine impls
- P2-F audit_log_query MCP tool + retention rotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)