### PR TITLE
feat(mcp): Phase 2-D — lifecycle state machine + Err audit (ADR-0009 §3)

### DIFF
--- a/crates/codelens-mcp/src/dispatch/mod.rs
+++ b/crates/codelens-mcp/src/dispatch/mod.rs
@@ -174,9 +174,16 @@ pub(crate) fn dispatch_tool(
     let (result, gate_allowance, gate_failure) =
         engine.submit_message(name, arguments, session, ctx.surface);
 
-    // 7. Post-mutation side effects (graph invalidation, audit, incremental reindex).
-    if result.is_ok() && is_content_mutation_tool(name) {
-        apply_post_mutation(state, name, arguments, session, &ctx.active_surface);
+    // 7. Post-mutation side effects (graph invalidation, audit,
+    //    incremental reindex). The Ok-branch audit row is written
+    //    here with the full payload so evidence_hash captures the
+    //    structured response. The Err-branch row is written below
+    //    in the response match arm because we need to consume the
+    //    error.
+    if let Ok((payload, _)) = &result
+        && is_content_mutation_tool(name)
+    {
+        apply_post_mutation(state, name, arguments, session, &ctx.active_surface, payload);
     }
 
     let elapsed_ms = start.elapsed().as_millis();
@@ -215,18 +222,27 @@ pub(crate) fn dispatch_tool(
             start,
             id,
         }),
-        Err(error) => build_error_response(
-            name,
-            error,
-            gate_failure,
-            arguments,
-            &ctx.active_surface,
-            &session.session_id,
-            state,
-            start,
-            id,
-            ctx.doom_count,
-            ctx.doom_rapid,
-        ),
+        Err(error) => {
+            // ADR-0009 §3 Err-branch audit row: when a mutation tool
+            // returns Err (pre-substrate validation, substrate failure
+            // beyond rollback, etc.) write a Failed-state row so the
+            // audit trail mirrors the success path.
+            if is_content_mutation_tool(name) {
+                session::record_audit_failure(state, name, arguments, session, &error);
+            }
+            build_error_response(
+                name,
+                error,
+                gate_failure,
+                arguments,
+                &ctx.active_surface,
+                &session.session_id,
+                state,
+                start,
+                id,
+                ctx.doom_count,
+                ctx.doom_rapid,
+            )
+        }
     }
 }

--- a/crates/codelens-mcp/src/dispatch/session.rs
+++ b/crates/codelens-mcp/src/dispatch/session.rs
@@ -58,6 +58,7 @@ pub(super) fn apply_post_mutation(
     arguments: &serde_json::Value,
     session: &crate::session_context::SessionRequestContext,
     active_surface: &str,
+    payload: &serde_json::Value,
 ) {
     state.graph_cache().invalidate();
     state.clear_recent_preflights();
@@ -109,7 +110,7 @@ pub(super) fn apply_post_mutation(
     if let Err(error) = state.record_mutation_audit(name, active_surface, arguments, session) {
         warn!(tool = name, error = %error, "failed to write mutation audit event");
     }
-    record_audit_outcome(state, name, arguments, session);
+    record_audit_outcome(state, name, arguments, session, payload);
     if !session.is_local() {
         tracing::info!(
             tool = name,
@@ -120,11 +121,18 @@ pub(super) fn apply_post_mutation(
 }
 
 /// ADR-0009 §2 + §3: write a single row to the durable audit_sink
-/// describing the outcome of a successful mutation. For Phase 2-B this
-/// uses placeholder state values (`Applying` → `Audited` and apply
-/// status `applied`); the lifecycle state machine and rolled_back /
-/// failed branches land in P2-D once handlers expose evidence to
-/// dispatch.
+/// describing the outcome of a successful mutation.
+///
+/// `state_from` is `Applying` (substrate Phase 3) and `state_to` is
+/// determined from the response payload's `apply_status` field
+/// (Hybrid contract from G7) — `applied` → `Audited`, `rolled_back` →
+/// `RolledBack`, `no_op` → `Audited`. Unknown / missing apply_status
+/// defaults to `Audited` since the handler succeeded.
+///
+/// `evidence_hash` is the canonical sha256 of the response payload's
+/// `data` subobject if present (the structured evidence-bearing
+/// section); else of the entire payload. This lets the audit log
+/// verify replay equivalence without storing user content.
 ///
 /// Failures here are logged at warn but never propagated — losing one
 /// audit row must not break the call. The legacy jsonl sink in
@@ -134,6 +142,7 @@ fn record_audit_outcome(
     name: &str,
     arguments: &serde_json::Value,
     session: &crate::session_context::SessionRequestContext,
+    payload: &serde_json::Value,
 ) {
     let Some(sink) = state.audit_sink() else {
         return;
@@ -143,34 +152,140 @@ fn record_audit_outcome(
         .map(|d| d.as_millis() as i64)
         .unwrap_or(0);
     let args_hash = crate::audit_sink::canonical_sha256_hex(arguments);
-    // Transaction id derives from session + tool + args_hash + ts so
-    // distinct calls of the same tool+args yield distinct ids while
-    // a future state-machine transition for the same call can reuse
-    // it (P2-D wires this through dispatch context).
     let transaction_id = format!("{}-{}-{}", session.session_id, name, &args_hash[..16]);
+
+    // ADR-0009 §3: derive terminal state from the Hybrid apply_status.
+    // The handler returned Ok, so the call definitely traversed
+    // Verifying → Applying. The payload's apply_status (set by G7
+    // Hybrid contract on raw_fs primitives) determines whether we
+    // reached Committed→Audited (applied/no_op) or RolledBack.
+    let payload_apply_status = payload
+        .get("data")
+        .and_then(|d| d.get("apply_status"))
+        .or_else(|| payload.get("apply_status"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("applied")
+        .to_owned();
+    let state_to =
+        crate::lifecycle::LifecycleState::terminal_for_apply_status(&payload_apply_status)
+            .unwrap_or(crate::lifecycle::LifecycleState::Audited);
+
+    // ADR-0009 §3 rollback_restored: when Hybrid returned RolledBack,
+    // probe the rollback_report to summarise restore success. This is
+    // a single-file aggregate ("did *every* restore succeed?"); the
+    // detailed rollback_report stays in the response, not the audit
+    // column.
+    let rollback_restored = if state_to == crate::lifecycle::LifecycleState::RolledBack {
+        payload
+            .get("data")
+            .and_then(|d| d.get("rollback_report"))
+            .or_else(|| payload.get("rollback_report"))
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                !arr.is_empty()
+                    && arr.iter().all(|entry| {
+                        entry
+                            .get("restored")
+                            .and_then(|r| r.as_bool())
+                            .unwrap_or(false)
+                    })
+            })
+    } else {
+        None
+    };
+
+    // ADR-0009 §3 evidence_hash: hash the structured `data` subobject
+    // when the response uses the standard envelope; fall back to the
+    // whole payload otherwise.
+    let evidence_value = payload.get("data").unwrap_or(payload);
+    let evidence_hash = Some(crate::audit_sink::canonical_sha256_hex(evidence_value));
+
+    let error_message = if state_to == crate::lifecycle::LifecycleState::RolledBack {
+        payload
+            .get("data")
+            .and_then(|d| d.get("error_message"))
+            .or_else(|| payload.get("error_message"))
+            .and_then(|v| v.as_str())
+            .map(str::to_owned)
+    } else {
+        None
+    };
+
     let record = crate::audit_sink::AuditRecord {
         transaction_id,
         timestamp_ms: now_ms,
-        // Phase 2-C populates this from the resolved principal binding.
-        principal: None,
+        // P2-C resolves the principal id from CODELENS_PRINCIPAL.
+        principal: crate::principals::current_principal_id(),
         tool: name.to_owned(),
         args_hash,
-        apply_status: "applied".to_owned(),
-        // Phase 2-D will set the actual previous state by querying the
-        // sink for the same transaction_id.
-        state_from: Some("Applying".to_owned()),
-        state_to: "Audited".to_owned(),
-        // Phase 2-D + handler-level evidence threading lands the real
-        // hash; for P2-B this stays None as a deliberate marker.
-        evidence_hash: None,
-        rollback_restored: None,
-        error_message: None,
+        apply_status: payload_apply_status,
+        state_from: Some(
+            crate::lifecycle::LifecycleState::Applying
+                .as_str()
+                .to_owned(),
+        ),
+        state_to: state_to.as_str().to_owned(),
+        evidence_hash,
+        rollback_restored,
+        error_message,
     };
     if let Err(error) = sink.write(&record) {
         warn!(
             tool = name,
             error = %error,
             "failed to write audit_sink outcome row"
+        );
+    }
+}
+
+/// ADR-0009 §3: write one row for a mutation that returned `Err`.
+/// Terminal state is `Failed`; `apply_status` is `failed`. Used when
+/// the handler reports an error before the substrate runs (e.g. line
+/// out of range) or after a substrate write that could not even
+/// roll back. Hybrid `RolledBack` is *not* an Err — that case is
+/// handled by `record_audit_outcome` because the handler returns Ok.
+pub(super) fn record_audit_failure(
+    state: &AppState,
+    name: &str,
+    arguments: &serde_json::Value,
+    session: &crate::session_context::SessionRequestContext,
+    error: &crate::error::CodeLensError,
+) {
+    let Some(sink) = state.audit_sink() else {
+        return;
+    };
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0);
+    let args_hash = crate::audit_sink::canonical_sha256_hex(arguments);
+    let transaction_id = format!("{}-{}-{}", session.session_id, name, &args_hash[..16]);
+    let record = crate::audit_sink::AuditRecord {
+        transaction_id,
+        timestamp_ms: now_ms,
+        principal: crate::principals::current_principal_id(),
+        tool: name.to_owned(),
+        args_hash,
+        apply_status: "failed".to_owned(),
+        // Pre-substrate validation rejection happens before Applying;
+        // we use Verifying as the most informative `state_from`
+        // marker for "got past the role gate but the substrate did
+        // not commit".
+        state_from: Some(
+            crate::lifecycle::LifecycleState::Verifying
+                .as_str()
+                .to_owned(),
+        ),
+        state_to: crate::lifecycle::LifecycleState::Failed.as_str().to_owned(),
+        evidence_hash: None,
+        rollback_restored: None,
+        error_message: Some(error.to_string()),
+    };
+    if let Err(io_err) = sink.write(&record) {
+        warn!(
+            tool = name,
+            error = %io_err,
+            "failed to write audit_sink failure row"
         );
     }
 }

--- a/crates/codelens-mcp/src/integration_tests/mutation_evidence.rs
+++ b/crates/codelens-mcp/src/integration_tests/mutation_evidence.rs
@@ -127,6 +127,117 @@ fn add_import_tool_response_includes_evidence() {
     );
 }
 
+/// ADR-0009 §3 (P2-D lifecycle): a successful mutation now writes
+/// `state_to=Audited`, `evidence_hash` populated (canonical sha256 of
+/// the response payload's data subobject), `principal` set when
+/// CODELENS_PRINCIPAL is bound. This builds on the
+/// create_text_file_writes_audit_sink_row test from P2-B by checking
+/// the new fields.
+#[test]
+fn audit_outcome_row_carries_evidence_hash_and_correct_terminal_state() {
+    let project = project_root();
+    let saved_principal = std::env::var("CODELENS_PRINCIPAL").ok();
+    unsafe {
+        std::env::set_var("CODELENS_PRINCIPAL", "p2d-test-user");
+    }
+    let state = make_state(&project);
+    let _ = call_tool(
+        &state,
+        "create_text_file",
+        json!({
+            "relative_path": "p2d_audit_target.txt",
+            "content": "p2d\n",
+            "overwrite": false,
+        }),
+    );
+    let sink = state.audit_sink().expect("audit_sink available");
+    let rows = sink.query(None, None, 100).expect("query");
+    let row = rows
+        .iter()
+        .find(|r| r.tool == "create_text_file" && r.apply_status == "applied")
+        .expect("applied audit row");
+
+    assert_eq!(row.state_to, "Audited", "Ok mutation reaches Audited");
+    assert_eq!(row.state_from.as_deref(), Some("Applying"));
+    assert!(
+        row.evidence_hash.is_some(),
+        "P2-D must populate evidence_hash on Ok branch"
+    );
+    let hash = row.evidence_hash.as_deref().unwrap();
+    assert_eq!(
+        hash.len(),
+        64,
+        "evidence_hash must be 64-char sha256 hex, got {hash:?}"
+    );
+    assert_eq!(
+        row.principal.as_deref(),
+        Some("p2d-test-user"),
+        "principal must reflect CODELENS_PRINCIPAL env"
+    );
+
+    unsafe {
+        match saved_principal {
+            Some(v) => std::env::set_var("CODELENS_PRINCIPAL", v),
+            None => std::env::remove_var("CODELENS_PRINCIPAL"),
+        }
+    }
+}
+
+/// ADR-0009 §3 (P2-D lifecycle): when a mutation tool returns Err
+/// (pre-substrate validation rejected the call, e.g. line out of
+/// range), the audit log gets a `state_to=Failed`, `apply_status=failed`
+/// row carrying the error message. Mirrors the success-path audit row
+/// shape so `audit_log_query` (P2-F) can reconstruct full lifecycle.
+#[test]
+fn audit_failure_row_recorded_for_error_response() {
+    let project = project_root();
+    let state = make_state(&project);
+
+    // delete_lines with start_line=99 in a 1-line file forces the
+    // engine primitive to bail with `start_line out of range`. The
+    // Err propagates back to dispatch's match arm.
+    fs::write(project.as_path().join("p2d_failure_target.txt"), "only\n").unwrap();
+    let err_response = call_tool(
+        &state,
+        "delete_lines",
+        json!({
+            "relative_path": "p2d_failure_target.txt",
+            "start_line": 99,
+            "end_line": 100,
+        }),
+    );
+    assert_eq!(
+        err_response.get("success").and_then(|v| v.as_bool()),
+        Some(false),
+        "out-of-range delete_lines must surface success=false, got {err_response}"
+    );
+
+    let sink = state.audit_sink().expect("audit_sink available");
+    let rows = sink.query(None, None, 100).expect("query");
+    let failure_row = rows
+        .iter()
+        .find(|r| r.tool == "delete_lines" && r.apply_status == "failed")
+        .expect("failed audit row must exist");
+
+    assert_eq!(
+        failure_row.state_to, "Failed",
+        "Err response writes terminal Failed"
+    );
+    assert_eq!(failure_row.state_from.as_deref(), Some("Verifying"));
+    assert!(
+        failure_row.evidence_hash.is_none(),
+        "no evidence on Err branch"
+    );
+    let msg = failure_row
+        .error_message
+        .as_deref()
+        .expect("error_message populated on Err");
+    assert!(
+        msg.contains("out of range") || msg.contains("start_line"),
+        "error_message must reflect the error cause, got {msg:?}"
+    );
+}
+
 /// ADR-0009 §1 (P2-C role gate): when `CODELENS_PRINCIPAL` env var is
 /// set and `principals.toml` maps that principal to `ReadOnly`, every
 /// mutation tool call is denied with a JSON-RPC -32008 error AND an

--- a/crates/codelens-mcp/src/lifecycle.rs
+++ b/crates/codelens-mcp/src/lifecycle.rs
@@ -1,0 +1,167 @@
+//! ADR-0009 §3: mutation lifecycle state machine.
+//!
+//! Each terminal state corresponds to a specific path through the
+//! dispatch pipeline:
+//!
+//! - `Audited`: handler returned `Ok`, response includes evidence,
+//!   apply_post_mutation completed, audit row written.
+//! - `RolledBack`: handler returned `Ok` with apply_status="rolled_back"
+//!   (Hybrid contract — substrate restored the backup after a Phase 3
+//!   write failure).
+//! - `Failed`: handler returned `Err`, no on-disk mutation happened
+//!   (or it happened but rollback failed). Caller should treat as
+//!   partial-state and consult the rollback_report.
+//! - `Denied`: ADR-0009 §1 deviation — pre-handler rejection by the
+//!   role gate; the handler never ran. ADR §3 did not include this
+//!   terminal explicitly, but P2-C surfaced it as a discrete audit
+//!   value. Documented here as a recognised state value rather than
+//!   forcing it through `Failed`.
+//!
+//! The intermediate states (`Drafted`, `Previewed`, `Verifying`,
+//! `Applying`, `Committed`) are reserved for the multi-row trail
+//! that P2-F's `audit_log_query` will surface; today the audit sink
+//! writes one row per call directly to the terminal value with
+//! `state_from` populated to indicate which intermediate the call
+//! traversed.
+
+#![allow(dead_code)]
+
+use serde::{Deserialize, Serialize};
+
+/// 8-state mutation lifecycle (plus the `Denied` deviation from §1).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum LifecycleState {
+    /// Mutation request constructed but not yet previewed.
+    Drafted,
+    /// Preview produced; no apply attempted.
+    Previewed,
+    /// Pre-apply hash capture happening (G4/G7 substrate Phase 1+2).
+    Verifying,
+    /// Verify passed; substrate is performing fs::write (Phase 3).
+    Applying,
+    /// Apply succeeded; substrate has post-hash evidence ready.
+    Committed,
+    /// Apply succeeded AND audit row written. Terminal success state.
+    Audited,
+    /// Apply failed; substrate restored backup. Terminal partial state.
+    RolledBack,
+    /// Apply failed and rollback failed, OR pre-substrate validation
+    /// rejected the call (handler returned Err before substrate ran).
+    /// Terminal failure state — caller may need manual remediation.
+    Failed,
+    /// Pre-handler rejection by the role gate. Terminal state.
+    Denied,
+}
+
+impl LifecycleState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            LifecycleState::Drafted => "Drafted",
+            LifecycleState::Previewed => "Previewed",
+            LifecycleState::Verifying => "Verifying",
+            LifecycleState::Applying => "Applying",
+            LifecycleState::Committed => "Committed",
+            LifecycleState::Audited => "Audited",
+            LifecycleState::RolledBack => "RolledBack",
+            LifecycleState::Failed => "Failed",
+            LifecycleState::Denied => "Denied",
+        }
+    }
+
+    /// Map an `apply_status` field value (as written to the audit_log
+    /// `apply_status` column) back to the terminal lifecycle state it
+    /// implies. Returns `None` for unrecognised statuses so callers
+    /// can treat them as opaque.
+    pub fn terminal_for_apply_status(status: &str) -> Option<Self> {
+        match status {
+            "applied" => Some(LifecycleState::Audited),
+            "rolled_back" => Some(LifecycleState::RolledBack),
+            "failed" => Some(LifecycleState::Failed),
+            "denied" => Some(LifecycleState::Denied),
+            "no_op" => Some(LifecycleState::Audited),
+            _ => None,
+        }
+    }
+
+    pub fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            LifecycleState::Audited
+                | LifecycleState::RolledBack
+                | LifecycleState::Failed
+                | LifecycleState::Denied
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn as_str_round_trips_through_terminal_for_apply_status() {
+        // Every state that has a corresponding apply_status string must
+        // round-trip back to itself.
+        let cases = [
+            ("applied", LifecycleState::Audited),
+            ("rolled_back", LifecycleState::RolledBack),
+            ("failed", LifecycleState::Failed),
+            ("denied", LifecycleState::Denied),
+        ];
+        for (status, state) in cases {
+            assert_eq!(
+                LifecycleState::terminal_for_apply_status(status),
+                Some(state),
+                "status {status} should map to {state:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_apply_status_returns_none() {
+        assert_eq!(LifecycleState::terminal_for_apply_status("explosion"), None);
+        assert_eq!(LifecycleState::terminal_for_apply_status(""), None);
+    }
+
+    #[test]
+    fn no_op_maps_to_audited() {
+        // no_op is a successful mutation that did no disk write;
+        // semantically still an audit-success terminal.
+        assert_eq!(
+            LifecycleState::terminal_for_apply_status("no_op"),
+            Some(LifecycleState::Audited)
+        );
+    }
+
+    #[test]
+    fn is_terminal_covers_terminals_only() {
+        for s in [
+            LifecycleState::Audited,
+            LifecycleState::RolledBack,
+            LifecycleState::Failed,
+            LifecycleState::Denied,
+        ] {
+            assert!(s.is_terminal(), "{s:?} should be terminal");
+        }
+        for s in [
+            LifecycleState::Drafted,
+            LifecycleState::Previewed,
+            LifecycleState::Verifying,
+            LifecycleState::Applying,
+            LifecycleState::Committed,
+        ] {
+            assert!(!s.is_terminal(), "{s:?} should NOT be terminal");
+        }
+    }
+
+    #[test]
+    fn as_str_and_known_strings_match() {
+        // Audit log column values written elsewhere in the codebase
+        // depend on these exact strings.
+        assert_eq!(LifecycleState::Audited.as_str(), "Audited");
+        assert_eq!(LifecycleState::Applying.as_str(), "Applying");
+        assert_eq!(LifecycleState::RolledBack.as_str(), "RolledBack");
+        assert_eq!(LifecycleState::Failed.as_str(), "Failed");
+        assert_eq!(LifecycleState::Denied.as_str(), "Denied");
+    }
+}

--- a/crates/codelens-mcp/src/main.rs
+++ b/crates/codelens-mcp/src/main.rs
@@ -15,6 +15,7 @@ mod dispatch;
 mod env_compat;
 mod error;
 mod job_store;
+mod lifecycle;
 mod mutation_audit;
 mod mutation_gate;
 mod operator;


### PR DESCRIPTION
## Summary

Lands ADR-0009 §3 — the mutation lifecycle state machine plus
Err-branch audit row writing and evidence_hash population.

- New `lifecycle.rs` with `LifecycleState` enum (9 variants), terminal-state mapping for Hybrid \`apply_status\`, is_terminal helper. 5 unit tests.
- `record_audit_outcome` now derives `state_to` from the payload's apply_status, populates `evidence_hash` (canonical sha256 of structured response), captures `rollback_restored` aggregate from `rollback_report`, and reflects the principal from CODELENS_PRINCIPAL.
- New `record_audit_failure` writes one row per Err response (state_to=Failed, apply_status=failed, error_message captured).
- `dispatch/mod.rs` Ok branch threads payload into apply_post_mutation; Err branch invokes record_audit_failure before build_error_response.

## Architecture rules compliance

| Rule | Status |
|---|---|
| 모놀리식 우선 | ✅ |
| 상태 전이는 enum과 이벤트 기준으로 문서화 | ✅ LifecycleState enum + terminal_for_apply_status + ADR-0009 §3 transition table |
| 감사 로그가 필요한 액션은 반드시 기록 | ✅ Ok / Err / Denied (P2-C) / RolledBack all written |
| 새 추상화는 중복 제거가 입증된 경우에만 추가 | ✅ enum replaces 4 string-literal sites |

## Test plan

- [x] 5 unit tests in lifecycle.rs
- [x] 2 new integration tests in mutation_evidence.rs (Ok evidence_hash + Err Failed-state row)
- [x] cargo test -p codelens-mcp — 483 (was 476 + 7) pass, 0 fail
- [x] cargo test -p codelens-mcp --features http — 562 pass, 0 fail
- [x] cargo clippy -p codelens-mcp -- -W clippy::all — 0 warnings

## Out of scope (deferred)

- P2-E CacheInvalidator trait (engine cache layers)
- P2-F audit_log_query MCP tool + retention rotation + multi-row state-machine reconstruction

🤖 Generated with [Claude Code](https://claude.com/claude-code)