### PR TITLE
fix(mcp): release-readiness bundle — test race + clippy 4

### DIFF
--- a/crates/codelens-mcp/src/integration_tests/mutation_evidence.rs
+++ b/crates/codelens-mcp/src/integration_tests/mutation_evidence.rs
@@ -11,6 +11,19 @@
 
 use super::*;
 
+/// Tests that mutate the `CODELENS_PRINCIPAL` env var must hold this
+/// guard. `unsafe { env::set_var(...) }` is process-global, so two
+/// such tests running in parallel race on the snapshot the role gate /
+/// audit_sink read. The mutex serialises only the env-mutating
+/// section; tests that do not touch the env are unaffected.
+fn principal_env_guard() -> std::sync::MutexGuard<'static, ()> {
+    use std::sync::{Mutex, OnceLock};
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
 #[test]
 fn replace_lines_tool_response_includes_evidence() {
     let project = project_root();
@@ -135,6 +148,7 @@ fn add_import_tool_response_includes_evidence() {
 /// the new fields.
 #[test]
 fn audit_outcome_row_carries_evidence_hash_and_correct_terminal_state() {
+    let _guard = principal_env_guard();
     let project = project_root();
     let saved_principal = std::env::var("CODELENS_PRINCIPAL").ok();
     unsafe {
@@ -249,6 +263,7 @@ fn audit_failure_row_recorded_for_error_response() {
 /// if the gate ever defaulted to `ReadOnly`.
 #[test]
 fn role_gate_denies_mutation_for_read_only_principal() {
+    let _guard = principal_env_guard();
     use crate::audit_sink::AuditSink;
     use crate::principals::Principals;
 

--- a/crates/codelens-mcp/src/server/auth.rs
+++ b/crates/codelens-mcp/src/server/auth.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "http")]
-
 use axum::http::HeaderMap;
 use jsonwebtoken::jwk::{Jwk, JwkSet, KeyAlgorithm};
 use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode, decode_header};
@@ -22,16 +20,17 @@ impl StaticJwks {
     }
 }
 
-#[derive(Debug, Clone)]
+/// Box<JwksAuthConfig> would equalise variant size, but the enum is
+/// constructed once at server startup and stored in Arc<HttpAuthState>;
+/// the Off variant is rarely chosen in production and the per-request
+/// match cost is dwarfed by jsonwebtoken validation. `#[allow]` instead
+/// of boxing keeps construction code straightforward.
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug, Clone, Default)]
 pub(crate) enum HttpAuthConfig {
+    #[default]
     Off,
     Jwks(JwksAuthConfig),
-}
-
-impl Default for HttpAuthConfig {
-    fn default() -> Self {
-        Self::Off
-    }
 }
 
 impl HttpAuthConfig {

--- a/crates/codelens-mcp/src/server/http_config.rs
+++ b/crates/codelens-mcp/src/server/http_config.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "http")]
-
 use super::auth::HttpAuthConfig;
 use super::transport_http::{HttpServerConfig, TlsConfig};
 use crate::cli::cli_option_value;


### PR DESCRIPTION
## Summary

Diagnostic fork against the freshly-merged Phase 0/1/2 stack (PR #82–#87) found 5 immediate gaps. This PR addresses the two release-blocking ones; the remaining three are queued as separate PRs.

### 1. Test race on \`CODELENS_PRINCIPAL\` (P0)

\`audit_outcome_row_carries_evidence_hash_and_correct_terminal_state\` and \`role_gate_denies_mutation_for_read_only_principal\` both mutate the process-global env var via \`unsafe { env::set_var }\`. Parallel test execution caused intermittent failures where one test read the snapshot mid-mutation by the other (audit row \`principal=None\` when \"p2d-test-user\" was expected).

Fix: module-local \`OnceLock<Mutex<()>>\` guard taken at the start of every env-mutating test. No new dependency. Tests that do not touch the env are unaffected. **4× repeat run: 4/4 PASS, 0 flakes**.

### 2. Clippy warnings under \`--features http\` (P0 release gate)

- \`server/auth.rs\` and \`server/http_config.rs\`: removed duplicated \`#![cfg(feature = \"http\")]\` (server/mod.rs already gates the whole subtree).
- \`HttpAuthConfig\`: \`impl Default\` → \`#[derive(Default)]\` + \`#[default]\` on \`Off\`.
- \`HttpAuthConfig\`: explicit \`#[allow(clippy::large_enum_variant)]\` with rationale (constructed once at startup, per-request match cost dwarfed by jsonwebtoken validation; box adds indirection without measurement justification per the memory rule \"측정 없는 최적화 금지\").

## Test plan

- [x] \`cargo test -p codelens-mcp\` — 483 PASS, 0 fail
- [x] \`cargo test -p codelens-mcp --features http\` — 562 PASS, 0 fail
- [x] \`cargo clippy -p codelens-mcp --features http -- -W clippy::all\` — 0 warning
- [x] 4 consecutive \`mutation_evidence\` runs — all 8/8 PASS

## Out of scope (queued as next PRs)

- get_file_diagnostics tool surface gap (~50 LOC)
- get_capabilities response slim (~80 LOC; currently 19 % token budget)
- tool parameter naming consistency (~150 LOC: name vs name_path, path vs file_path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)