### PR TITLE
feat(mcp): P1-C — file_path ↔ path bidirectional alias

### DIFF
--- a/crates/codelens-mcp/src/dispatch/envelope.rs
+++ b/crates/codelens-mcp/src/dispatch/envelope.rs
@@ -1,7 +1,7 @@
 //! Tool call envelope — normalized JSON-RPC params with profile/compact/harness routing.
 
+use crate::tool_defs::{default_budget_for_profile, ToolProfile};
 use crate::AppState;
-use crate::tool_defs::{ToolProfile, default_budget_for_profile};
 use serde_json::json;
 
 /// Normalized tool call request — extracted from raw JSON-RPC params.
@@ -25,10 +25,23 @@ impl ToolCallEnvelope {
             .and_then(|v| v.as_str())
             .ok_or(("Missing tool name", -32602i64))?
             .to_owned();
-        let arguments = params
+        let mut arguments = params
             .get("arguments")
             .cloned()
             .unwrap_or_else(|| json!({}));
+        // P1-C: tool parameter naming consistency. Different tools have
+        // historically expected `file_path` (capabilities, diagnostics,
+        // refactor) or `path` (impact reports, workflows) for the same
+        // semantic input. Onboarding clients hit -32602 when they
+        // guess wrong. We normalise here so callers may use either
+        // name; the canonical key required by the handler is
+        // populated alongside whatever the client sent.
+        //
+        // `relative_path` is *not* aliased — mutation primitives use
+        // it as a deliberate "rooted at project, no escape" marker
+        // distinct from arbitrary paths. Preserving the divergence
+        // keeps that contract honest.
+        apply_path_alias_normalisation(&mut arguments);
         let session = crate::session_context::SessionRequestContext::from_json(&arguments);
         let default_budget = state.execution_token_budget(&session);
         let budget = arguments
@@ -61,5 +74,97 @@ impl ToolCallEnvelope {
             compact,
             harness_phase,
         })
+    }
+}
+
+/// P1-C: bidirectional alias between `file_path` and `path`. When the
+/// caller sets one, populate the other with the same value so handler
+/// `arguments.get("...")` lookups succeed regardless of which name
+/// the schema actually requires. If both are present and differ, the
+/// caller's choice wins (we do not overwrite either side); if both are
+/// present and equal, this is a no-op.
+///
+/// `relative_path` is intentionally NOT aliased — see envelope::parse
+/// for the rationale.
+fn apply_path_alias_normalisation(arguments: &mut serde_json::Value) {
+    let Some(obj) = arguments.as_object_mut() else {
+        return;
+    };
+    let has_file_path = obj.contains_key("file_path");
+    let has_path = obj.contains_key("path");
+    match (has_file_path, has_path) {
+        (true, false) => {
+            if let Some(value) = obj.get("file_path").cloned() {
+                obj.insert("path".to_owned(), value);
+            }
+        }
+        (false, true) => {
+            if let Some(value) = obj.get("path").cloned() {
+                obj.insert("file_path".to_owned(), value);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn run_alias(value: serde_json::Value) -> serde_json::Value {
+        let mut v = value;
+        apply_path_alias_normalisation(&mut v);
+        v
+    }
+
+    #[test]
+    fn file_path_alone_is_aliased_to_path() {
+        let out = run_alias(json!({ "file_path": "src/foo.rs" }));
+        assert_eq!(out["file_path"], "src/foo.rs");
+        assert_eq!(out["path"], "src/foo.rs");
+    }
+
+    #[test]
+    fn path_alone_is_aliased_to_file_path() {
+        let out = run_alias(json!({ "path": "src/bar.rs" }));
+        assert_eq!(out["path"], "src/bar.rs");
+        assert_eq!(out["file_path"], "src/bar.rs");
+    }
+
+    #[test]
+    fn both_keys_present_left_intact() {
+        let out = run_alias(json!({
+            "file_path": "src/foo.rs",
+            "path": "src/bar.rs",
+        }));
+        assert_eq!(out["file_path"], "src/foo.rs");
+        assert_eq!(out["path"], "src/bar.rs");
+    }
+
+    #[test]
+    fn neither_key_present_no_op() {
+        let out = run_alias(json!({ "name": "MyType" }));
+        assert!(out.get("file_path").is_none());
+        assert!(out.get("path").is_none());
+    }
+
+    #[test]
+    fn relative_path_not_aliased() {
+        // Mutation primitives keep `relative_path` distinct from
+        // both `file_path` and `path` to mark the rooted-no-escape
+        // contract.
+        let out = run_alias(json!({ "relative_path": "src/foo.rs" }));
+        assert_eq!(out["relative_path"], "src/foo.rs");
+        assert!(out.get("file_path").is_none());
+        assert!(out.get("path").is_none());
+    }
+
+    #[test]
+    fn non_object_argument_no_op() {
+        let out = run_alias(json!("scalar string"));
+        assert_eq!(out, json!("scalar string"));
+        let out = run_alias(json!([1, 2, 3]));
+        assert_eq!(out, json!([1, 2, 3]));
     }
 }

--- a/crates/codelens-mcp/src/integration_tests/workflow.rs
+++ b/crates/codelens-mcp/src/integration_tests/workflow.rs
@@ -154,6 +154,51 @@ fn impact_report_uses_existing_embedding_index_for_semantic_status() {
     );
 }
 
+/// P1-C: dispatch envelope aliases `file_path` ↔ `path` so callers
+/// may use either name. Verified end-to-end through `tools/call`:
+/// the same tool accepts both and produces an equivalent response.
+#[test]
+fn dispatch_aliases_file_path_and_path_arguments() {
+    let project = project_root();
+    fs::write(project.as_path().join("alias_check.py"), "x = 1\n").unwrap();
+    let state = make_state(&project);
+
+    // Caller sends `file_path` — handler reads it normally.
+    let with_file_path = call_tool(
+        &state,
+        "get_capabilities",
+        json!({ "file_path": "alias_check.py", "detail": "compact" }),
+    );
+    assert_eq!(with_file_path["success"], json!(true));
+    assert_eq!(
+        with_file_path["data"]["language"],
+        json!("py"),
+        "file_path should resolve language"
+    );
+
+    // Caller sends `path` instead — alias lifts it into `file_path`
+    // before dispatch, handler reads it equally well.
+    let with_path = call_tool(
+        &state,
+        "get_capabilities",
+        json!({ "path": "alias_check.py", "detail": "compact" }),
+    );
+    assert_eq!(with_path["success"], json!(true));
+    assert_eq!(
+        with_path["data"]["language"],
+        json!("py"),
+        "path alias should resolve language identically"
+    );
+
+    // The two responses should be equivalent on the language field;
+    // we do not pin every byte because runtime introspection (binary
+    // build sha, daemon start time) is identical here too.
+    assert_eq!(
+        with_file_path["data"]["language"],
+        with_path["data"]["language"]
+    );
+}
+
 /// P1-A: `detail=compact` returns the 12 core fields only and trims
 /// response size meaningfully. Backward-compat: `detail=full` (and
 /// the unset default) keeps the historical 38-field shape — covered by


### PR DESCRIPTION
## Summary

Bidirectional alias at the dispatch envelope layer between \`file_path\` and \`path\`. When the caller sets one, the other is populated with the same value before the schema check / handler runs. Both keys present + different values are left intact (caller's choice wins).

\`relative_path\` is intentionally NOT aliased — mutation primitives use it as a deliberate \"rooted at project, no escape\" marker.

## Why

Diagnostic fork (post-PR #87) found that calling \`get_symbols_overview\` with \`file_path\` and \`get_capabilities\` with \`path\` both yielded -32602. Onboarding clients hit this regularly across the ~25 tools that take a path-like input.

## Test plan

- [x] 6 unit tests in \`dispatch::envelope\`: file_path-only / path-only / both / neither / relative_path / non-object
- [x] 1 integration test: same \`get_capabilities\` call works with both names; responses agree on language
- [x] cargo test -p codelens-mcp — 494 (was 487 + 7) pass
- [x] cargo test -p codelens-mcp --features http — 573 pass
- [x] cargo clippy -p codelens-mcp --features http — 0 warnings

## Note on P1-B (sibling task)

\`get_file_diagnostics\` was triaged as **no real code gap**. The tool is registered in dispatch table, tool_defs/build.rs, 7 presets, and integration tests. The fork's \"missing from ToolSearch index\" diagnostic was a fork-environment external-client issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)