### PR TITLE
refactor(mcp): Phase 2 close part 1 — ADR-0009 self-consistency (M1+M4+M6+M2+L3+L1)

### DIFF
--- a/crates/codelens-mcp/src/dispatch/mod.rs
+++ b/crates/codelens-mcp/src/dispatch/mod.rs
@@ -171,16 +171,16 @@ pub(crate) fn dispatch_tool(
 
     // 6. Execute via mutation gate (if applicable) or directly via dispatch table.
     let engine = QueryEngine::new(state);
-    let (result, gate_allowance, gate_failure) =
+    let (mut result, gate_allowance, gate_failure) =
         engine.submit_message(name, arguments, session, ctx.surface);
 
     // 7. Post-mutation side effects (graph invalidation, audit,
-    //    incremental reindex). The Ok-branch audit row is written
-    //    here with the full payload so evidence_hash captures the
-    //    structured response. The Err-branch row is written below
-    //    in the response match arm because we need to consume the
-    //    error.
-    if let Ok((payload, _)) = &result
+    //    incremental reindex, transaction_id injection). The Ok-branch
+    //    audit row is written here with the full payload so
+    //    evidence_hash captures the structured response. The Err-branch
+    //    row is written below in the response match arm because we
+    //    need to consume the error.
+    if let Ok((payload, _)) = &mut result
         && is_content_mutation_tool(name)
     {
         apply_post_mutation(state, name, arguments, session, &ctx.active_surface, payload);

--- a/crates/codelens-mcp/src/dispatch/role_gate.rs
+++ b/crates/codelens-mcp/src/dispatch/role_gate.rs
@@ -12,7 +12,7 @@
 
 use crate::audit_sink::{canonical_sha256_hex, AuditRecord};
 use crate::error::CodeLensError;
-use crate::principals::{current_principal_id, required_role_for, Role};
+use crate::principals::{required_role_for, resolve_principal_id, Role};
 use crate::session_context::SessionRequestContext;
 use crate::AppState;
 use serde_json::Value;
@@ -30,7 +30,7 @@ pub(super) fn enforce_role_gate(
     session: &SessionRequestContext,
 ) -> Result<(), CodeLensError> {
     let required = required_role_for(name);
-    let principal_id = current_principal_id();
+    let principal_id = resolve_principal_id(session);
     let principal_role = state.principals().resolve(principal_id.as_deref());
     if principal_role.satisfies(required) {
         return Ok(());

--- a/crates/codelens-mcp/src/dispatch/session.rs
+++ b/crates/codelens-mcp/src/dispatch/session.rs
@@ -50,15 +50,48 @@ pub(super) fn collect_session_context(
     }
 }
 
-/// Apply graph invalidation, symbol reindex, embedding reindex, and audit
-/// after a successful content-mutation tool call.
+/// Compute the canonical `transaction_id` shared by audit rows and
+/// the response envelope. Format: `{session_id}-{tool}-{args_hash[..16]}`.
+/// Stable for a given (session, tool, args) triple — that means the
+/// agent can recompute it independently and `audit_log_query` joins
+/// across the session/outcome rows for one call.
+pub(super) fn transaction_id_for(
+    session: &crate::session_context::SessionRequestContext,
+    tool: &str,
+    arguments: &serde_json::Value,
+) -> String {
+    let args_hash = crate::audit_sink::canonical_sha256_hex(arguments);
+    format!("{}-{}-{}", session.session_id, tool, &args_hash[..16])
+}
+
+/// L3: inject `transaction_id` into the response payload so the agent
+/// can use it as the lookup key for `audit_log_query` (P2-F). The id
+/// is added to `payload.data.transaction_id` when `data` is an object;
+/// otherwise to `payload.transaction_id` directly. An existing key is
+/// not overwritten — the handler may have its own (e.g. workflows
+/// composing multiple primitives).
+fn inject_transaction_id(payload: &mut serde_json::Value, transaction_id: &str) {
+    if let Some(data) = payload.get_mut("data").and_then(|v| v.as_object_mut()) {
+        data.entry("transaction_id".to_owned())
+            .or_insert_with(|| serde_json::Value::String(transaction_id.to_owned()));
+        return;
+    }
+    if let Some(obj) = payload.as_object_mut() {
+        obj.entry("transaction_id".to_owned())
+            .or_insert_with(|| serde_json::Value::String(transaction_id.to_owned()));
+    }
+}
+
+/// Apply graph invalidation, symbol reindex, embedding reindex, audit,
+/// and transaction_id surfacing after a successful content-mutation
+/// tool call.
 pub(super) fn apply_post_mutation(
     state: &AppState,
     name: &str,
     arguments: &serde_json::Value,
     session: &crate::session_context::SessionRequestContext,
     active_surface: &str,
-    payload: &serde_json::Value,
+    payload: &mut serde_json::Value,
 ) {
     state.graph_cache().invalidate();
     state.clear_recent_preflights();
@@ -111,6 +144,8 @@ pub(super) fn apply_post_mutation(
         warn!(tool = name, error = %error, "failed to write mutation audit event");
     }
     record_audit_outcome(state, name, arguments, session, payload);
+    let transaction_id = transaction_id_for(session, name, arguments);
+    inject_transaction_id(payload, &transaction_id);
     if !session.is_local() {
         tracing::info!(
             tool = name,
@@ -215,7 +250,7 @@ fn record_audit_outcome(
         transaction_id,
         timestamp_ms: now_ms,
         // P2-C resolves the principal id from CODELENS_PRINCIPAL.
-        principal: crate::principals::current_principal_id(),
+        principal: crate::principals::resolve_principal_id(session),
         tool: name.to_owned(),
         args_hash,
         apply_status: payload_apply_status,
@@ -263,7 +298,7 @@ pub(super) fn record_audit_failure(
     let record = crate::audit_sink::AuditRecord {
         transaction_id,
         timestamp_ms: now_ms,
-        principal: crate::principals::current_principal_id(),
+        principal: crate::principals::resolve_principal_id(session),
         tool: name.to_owned(),
         args_hash,
         apply_status: "failed".to_owned(),
@@ -287,6 +322,65 @@ pub(super) fn record_audit_failure(
             error = %io_err,
             "failed to write audit_sink failure row"
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session_context::SessionRequestContext;
+    use serde_json::json;
+
+    fn fake_session() -> SessionRequestContext {
+        SessionRequestContext::from_json(&json!({
+            "_session_id": "sess-T",
+        }))
+    }
+
+    #[test]
+    fn transaction_id_is_stable_for_same_inputs() {
+        let session = fake_session();
+        let args = json!({"file_path": "src/foo.rs", "lines": [1, 2]});
+        let a = transaction_id_for(&session, "delete_lines", &args);
+        let b = transaction_id_for(&session, "delete_lines", &args);
+        assert_eq!(a, b, "same (session, tool, args) must produce same id");
+    }
+
+    #[test]
+    fn transaction_id_changes_when_args_change() {
+        let session = fake_session();
+        let a = transaction_id_for(&session, "delete_lines", &json!({"k": 1}));
+        let b = transaction_id_for(&session, "delete_lines", &json!({"k": 2}));
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn inject_transaction_id_into_data_subobject() {
+        let mut payload = json!({ "data": { "apply_status": "applied" } });
+        inject_transaction_id(&mut payload, "tx-123");
+        assert_eq!(payload["data"]["transaction_id"], "tx-123");
+        assert_eq!(payload["data"]["apply_status"], "applied");
+    }
+
+    #[test]
+    fn inject_transaction_id_into_root_when_no_data() {
+        let mut payload = json!({ "apply_status": "applied" });
+        inject_transaction_id(&mut payload, "tx-123");
+        assert_eq!(payload["transaction_id"], "tx-123");
+    }
+
+    #[test]
+    fn inject_transaction_id_does_not_overwrite_existing() {
+        let mut payload = json!({ "data": { "transaction_id": "handler-tx" } });
+        inject_transaction_id(&mut payload, "dispatch-tx");
+        assert_eq!(payload["data"]["transaction_id"], "handler-tx");
+    }
+
+    #[test]
+    fn inject_transaction_id_no_op_on_non_object_payload() {
+        let mut scalar = json!("just a string");
+        inject_transaction_id(&mut scalar, "tx-123");
+        assert_eq!(scalar, json!("just a string"));
     }
 }
 

--- a/crates/codelens-mcp/src/lifecycle.rs
+++ b/crates/codelens-mcp/src/lifecycle.rs
@@ -11,36 +11,26 @@
 //! - `Failed`: handler returned `Err`, no on-disk mutation happened
 //!   (or it happened but rollback failed). Caller should treat as
 //!   partial-state and consult the rollback_report.
-//! - `Denied`: ADR-0009 §1 deviation — pre-handler rejection by the
-//!   role gate; the handler never ran. ADR §3 did not include this
-//!   terminal explicitly, but P2-C surfaced it as a discrete audit
-//!   value. Documented here as a recognised state value rather than
-//!   forcing it through `Failed`.
+//! - `Denied`: pre-handler rejection by the role gate; the handler
+//!   never ran.
 //!
-//! The intermediate states (`Drafted`, `Previewed`, `Verifying`,
-//! `Applying`, `Committed`) are reserved for the multi-row trail
-//! that P2-F's `audit_log_query` will surface; today the audit sink
-//! writes one row per call directly to the terminal value with
-//! `state_from` populated to indicate which intermediate the call
-//! traversed.
-
-#![allow(dead_code)]
+//! The intermediate states (`Verifying`, `Applying`) are written into
+//! the audit `state_from` column to identify which dispatch phase the
+//! call traversed before reaching its terminal state.
 
 use serde::{Deserialize, Serialize};
 
-/// 8-state mutation lifecycle (plus the `Denied` deviation from §1).
+/// 6-state mutation lifecycle: 2 intermediate (`Verifying`, `Applying`)
+/// + 4 terminal (`Audited`, `RolledBack`, `Failed`, `Denied`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum LifecycleState {
-    /// Mutation request constructed but not yet previewed.
-    Drafted,
-    /// Preview produced; no apply attempted.
-    Previewed,
     /// Pre-apply hash capture happening (G4/G7 substrate Phase 1+2).
+    /// Recorded as `state_from` for failures rejected before the
+    /// substrate runs (e.g. line out of range, validation Err).
     Verifying,
     /// Verify passed; substrate is performing fs::write (Phase 3).
+    /// Recorded as `state_from` for the success/rollback outcome path.
     Applying,
-    /// Apply succeeded; substrate has post-hash evidence ready.
-    Committed,
     /// Apply succeeded AND audit row written. Terminal success state.
     Audited,
     /// Apply failed; substrate restored backup. Terminal partial state.
@@ -56,11 +46,8 @@ pub enum LifecycleState {
 impl LifecycleState {
     pub fn as_str(self) -> &'static str {
         match self {
-            LifecycleState::Drafted => "Drafted",
-            LifecycleState::Previewed => "Previewed",
             LifecycleState::Verifying => "Verifying",
             LifecycleState::Applying => "Applying",
-            LifecycleState::Committed => "Committed",
             LifecycleState::Audited => "Audited",
             LifecycleState::RolledBack => "RolledBack",
             LifecycleState::Failed => "Failed",
@@ -82,16 +69,6 @@ impl LifecycleState {
             _ => None,
         }
     }
-
-    pub fn is_terminal(self) -> bool {
-        matches!(
-            self,
-            LifecycleState::Audited
-                | LifecycleState::RolledBack
-                | LifecycleState::Failed
-                | LifecycleState::Denied
-        )
-    }
 }
 
 #[cfg(test)]
@@ -100,8 +77,6 @@ mod tests {
 
     #[test]
     fn as_str_round_trips_through_terminal_for_apply_status() {
-        // Every state that has a corresponding apply_status string must
-        // round-trip back to itself.
         let cases = [
             ("applied", LifecycleState::Audited),
             ("rolled_back", LifecycleState::RolledBack),
@@ -134,32 +109,12 @@ mod tests {
     }
 
     #[test]
-    fn is_terminal_covers_terminals_only() {
-        for s in [
-            LifecycleState::Audited,
-            LifecycleState::RolledBack,
-            LifecycleState::Failed,
-            LifecycleState::Denied,
-        ] {
-            assert!(s.is_terminal(), "{s:?} should be terminal");
-        }
-        for s in [
-            LifecycleState::Drafted,
-            LifecycleState::Previewed,
-            LifecycleState::Verifying,
-            LifecycleState::Applying,
-            LifecycleState::Committed,
-        ] {
-            assert!(!s.is_terminal(), "{s:?} should NOT be terminal");
-        }
-    }
-
-    #[test]
     fn as_str_and_known_strings_match() {
         // Audit log column values written elsewhere in the codebase
         // depend on these exact strings.
         assert_eq!(LifecycleState::Audited.as_str(), "Audited");
         assert_eq!(LifecycleState::Applying.as_str(), "Applying");
+        assert_eq!(LifecycleState::Verifying.as_str(), "Verifying");
         assert_eq!(LifecycleState::RolledBack.as_str(), "RolledBack");
         assert_eq!(LifecycleState::Failed.as_str(), "Failed");
         assert_eq!(LifecycleState::Denied.as_str(), "Denied");

--- a/crates/codelens-mcp/src/principals.rs
+++ b/crates/codelens-mcp/src/principals.rs
@@ -98,6 +98,20 @@ impl Principals {
         }
     }
 
+    /// Strict fallback used when `CODELENS_AUTH_MODE=strict` is set
+    /// and no `principals.toml` is present. Every principal —
+    /// including the unknown ones — gets `ReadOnly`, so any
+    /// mutation tool is denied until the operator places an explicit
+    /// principals.toml. This makes "secure by default" opt-in
+    /// rather than the global default (which would break existing
+    /// stdio installations).
+    pub fn strict_default() -> Self {
+        Self {
+            default_role: Role::ReadOnly,
+            by_id: HashMap::new(),
+        }
+    }
+
     /// Resolve a principal id to its role. Unknown ids fall back to
     /// the default role.
     pub fn resolve(&self, principal_id: Option<&str>) -> Role {
@@ -122,9 +136,14 @@ impl Principals {
     /// 1. `<project>/.codelens/principals.toml`
     /// 2. `$HOME/.codelens/principals.toml`
     ///
-    /// Returns the permissive default when no file is found. Parse
-    /// errors propagate so misconfiguration is surfaced loudly at
-    /// startup instead of silently falling back to `Refactor`.
+    /// When no file is found, the fallback is chosen by
+    /// `CODELENS_AUTH_MODE`:
+    /// - unset / `permissive` → [`Self::permissive_default`]
+    /// - `strict` → [`Self::strict_default`] (every unknown id is
+    ///   `ReadOnly`, so mutation tools are denied)
+    ///
+    /// Parse errors propagate so misconfiguration is surfaced loudly
+    /// at startup instead of silently falling back.
     pub fn discover(project_audit_dir: &Path) -> Result<Self> {
         // project audit dir is `<project>/.codelens/audit/`; principals.toml
         // lives one directory up at `<project>/.codelens/principals.toml`.
@@ -140,7 +159,20 @@ impl Principals {
                 return Self::load_from(&user_path);
             }
         }
-        Ok(Self::permissive_default())
+        Ok(Self::default_for_env())
+    }
+
+    /// Choose between [`Self::permissive_default`] and
+    /// [`Self::strict_default`] based on `CODELENS_AUTH_MODE`.
+    fn default_for_env() -> Self {
+        match std::env::var("CODELENS_AUTH_MODE")
+            .ok()
+            .as_deref()
+            .map(str::trim)
+        {
+            Some("strict") => Self::strict_default(),
+            _ => Self::permissive_default(),
+        }
     }
 
     /// Parse a specific TOML file. Public for testability.
@@ -181,32 +213,45 @@ impl Principals {
     }
 }
 
-/// Required role to call `tool`. Maps every tool name to one of the
-/// three tiers; the rule is simple by design (mutation tools require
-/// Refactor; everything else is ReadOnly). New tools added in the
-/// future are ReadOnly by default unless they appear in
-/// [`crate::tool_defs::is_content_mutation_tool`].
+/// Required role to call `tool`. Code-mutation tools require
+/// `Refactor`; everything else is `ReadOnly`.
+///
+/// Memory tools (`write_memory`/`delete_memory`/`rename_memory`)
+/// are an explicit carve-out: they mutate agent-side context, not
+/// the project's source tree, so the role gate treats them as
+/// `ReadOnly`. They remain in `is_content_mutation_tool` so the
+/// audit sink still records each memory change.
 pub fn required_role_for(tool: &str) -> Role {
-    if crate::tool_defs::is_content_mutation_tool(tool) {
-        Role::Refactor
-    } else {
-        Role::ReadOnly
+    match tool {
+        "write_memory" | "delete_memory" | "rename_memory" => Role::ReadOnly,
+        other if crate::tool_defs::is_content_mutation_tool(other) => Role::Refactor,
+        _ => Role::ReadOnly,
     }
 }
 
 /// Resolve the principal id for the current request from the
-/// environment.
-///
-/// Priority order:
-/// 1. `CODELENS_PRINCIPAL` env var (stdio + dev mode)
-/// 2. None (caller-provided HTTP / JWT bindings come in P2-C-follow-up)
-///
-/// Phase 2-C limits the binding to env-only so the role gate can land
-/// without coupling to the HTTP feature flag. Header / JWT extraction
-/// is mechanical to add in a follow-up once the Authorization plumbing
-/// is in place.
+/// environment. Stdio-only fallback: the dispatch path prefers the
+/// session-bound id when available — see [`resolve_principal_id`].
 pub fn current_principal_id() -> Option<String> {
     std::env::var("CODELENS_PRINCIPAL").ok()
+}
+
+/// L1 (ADR-0009 §1): resolve the principal id for one dispatch call.
+///
+/// Priority order:
+/// 1. `session.principal_id` — populated from the HTTP JWT `sub`
+///    claim (or `X-Codelens-Principal` header in dev mode) by the
+///    HTTP transport before the request is dispatched.
+/// 2. `CODELENS_PRINCIPAL` env — stdio fallback.
+/// 3. `None` — falls through to the `default` role in
+///    `principals.toml`.
+pub fn resolve_principal_id(
+    session: &crate::session_context::SessionRequestContext,
+) -> Option<String> {
+    if let Some(id) = session.principal_id.as_deref().filter(|s| !s.is_empty()) {
+        return Some(id.to_owned());
+    }
+    current_principal_id()
 }
 
 #[cfg(test)]
@@ -229,6 +274,26 @@ mod tests {
         assert_eq!(p.resolve(None), Role::Refactor);
         assert_eq!(p.resolve(Some("alice")), Role::Refactor);
         assert_eq!(p.explicit_count(), 0);
+    }
+
+    #[test]
+    fn strict_default_denies_mutation_for_every_unknown_id() {
+        // CODELENS_AUTH_MODE=strict fallback: nobody is privileged
+        // until principals.toml lists them.
+        let p = Principals::strict_default();
+        assert_eq!(p.default_role(), Role::ReadOnly);
+        assert_eq!(p.resolve(None), Role::ReadOnly);
+        assert_eq!(p.resolve(Some("anyone")), Role::ReadOnly);
+        assert!(
+            !p.resolve(Some("anyone"))
+                .satisfies(required_role_for("create_text_file")),
+            "strict default must deny code-mutation tools"
+        );
+        assert!(
+            p.resolve(Some("anyone"))
+                .satisfies(required_role_for("write_memory")),
+            "strict default must still allow memory-tier tools (M6)"
+        );
     }
 
     #[test]
@@ -356,7 +421,24 @@ role = "Admin"
         assert_eq!(required_role_for("create_text_file"), Role::Refactor);
         assert_eq!(required_role_for("delete_lines"), Role::Refactor);
         assert_eq!(required_role_for("rename_symbol"), Role::Refactor);
-        assert_eq!(required_role_for("write_memory"), Role::Refactor);
+    }
+
+    #[test]
+    fn memory_tools_are_readonly_despite_being_mutation_tools() {
+        // Memory writes are agent-context, not codebase mutation.
+        // The role gate must let read-only principals call them, but
+        // the audit sink still tracks them via is_content_mutation_tool.
+        for tool in ["write_memory", "delete_memory", "rename_memory"] {
+            assert_eq!(
+                required_role_for(tool),
+                Role::ReadOnly,
+                "{tool} should be ReadOnly for the role gate"
+            );
+            assert!(
+                crate::tool_defs::is_content_mutation_tool(tool),
+                "{tool} should still appear in is_content_mutation_tool for audit"
+            );
+        }
     }
 
     #[test]
@@ -365,6 +447,33 @@ role = "Admin"
         assert_eq!(required_role_for("get_callers"), Role::ReadOnly);
         assert_eq!(required_role_for("analyze_change_request"), Role::ReadOnly);
         assert_eq!(required_role_for("semantic_search"), Role::ReadOnly);
+    }
+
+    #[test]
+    fn resolve_principal_id_prefers_session_over_env() {
+        // Build a session whose principal_id is set (e.g. JWT sub claim
+        // injected by the HTTP transport).
+        let session =
+            crate::session_context::SessionRequestContext::from_json(&serde_json::json!({
+                "_session_principal_id": "alice@example.com",
+            }));
+        let resolved = resolve_principal_id(&session);
+        assert_eq!(resolved.as_deref(), Some("alice@example.com"));
+    }
+
+    #[test]
+    fn resolve_principal_id_treats_empty_session_value_as_absent() {
+        let session =
+            crate::session_context::SessionRequestContext::from_json(&serde_json::json!({
+                "_session_principal_id": "",
+            }));
+        // Empty string must NOT shadow the env fallback. We assert the
+        // function does not return Some("") — env may still produce
+        // None depending on test runner state, which is allowed.
+        match resolve_principal_id(&session) {
+            Some(s) => assert!(!s.is_empty(), "empty session id must not surface"),
+            None => {}
+        }
     }
 
     #[test]

--- a/crates/codelens-mcp/src/server/auth.rs
+++ b/crates/codelens-mcp/src/server/auth.rs
@@ -139,6 +139,9 @@ pub(crate) enum AuthFailure {
 
 #[derive(Debug, Deserialize)]
 struct Claims {
+    /// JWT subject claim — used as the ADR-0009 §1 principal id when
+    /// the role gate consults the authorization context.
+    sub: Option<String>,
     scope: Option<String>,
     scp: Option<Vec<String>>,
 }
@@ -162,9 +165,17 @@ impl HttpAuthState {
             .clone()
     }
 
-    pub(crate) async fn authorize(&self, headers: &HeaderMap) -> Result<(), AuthFailure> {
+    /// Validate the request's `Authorization` header. On success
+    /// returns the principal id derived from the JWT `sub` claim
+    /// (or `None` when auth is `Off` / no `sub` was present —
+    /// e.g. an `X-Codelens-Principal` dev-mode header takes over in
+    /// that case, see [`Self::dev_principal_header`]).
+    pub(crate) async fn authorize(
+        &self,
+        headers: &HeaderMap,
+    ) -> Result<Option<String>, AuthFailure> {
         let config = match self.config() {
-            HttpAuthConfig::Off => return Ok(()),
+            HttpAuthConfig::Off => return Ok(Self::dev_principal_header(headers)),
             HttpAuthConfig::Jwks(config) => config,
         };
         let token = bearer_token(headers).ok_or(AuthFailure::Missing)?;
@@ -174,7 +185,20 @@ impl HttpAuthState {
         {
             return Err(AuthFailure::InsufficientScope);
         }
-        Ok(())
+        Ok(claims.sub)
+    }
+
+    /// L1 (ADR-0009 §1) dev-mode fallback: when JWT auth is disabled
+    /// the operator may still tag requests with `X-Codelens-Principal`
+    /// so the role gate can be exercised in tests / local proxies.
+    /// Production deployments should use JWT validation instead.
+    fn dev_principal_header(headers: &HeaderMap) -> Option<String> {
+        headers
+            .get("x-codelens-principal")
+            .and_then(|value| value.to_str().ok())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned)
     }
 
     async fn validate_jwt(

--- a/crates/codelens-mcp/src/server/transport_http.rs
+++ b/crates/codelens-mcp/src/server/transport_http.rs
@@ -188,33 +188,64 @@ fn protected_resource_path(request_path: &str) -> Option<String> {
         .map(|path| format!("/{path}"))
 }
 
-async fn auth_rejection_response(state: &AppState, headers: &HeaderMap) -> Option<Response> {
+/// L1 (ADR-0009 §1): authenticate the HTTP request and surface the
+/// resolved principal id. Returns `Ok(Some(sub))` when JWT auth is
+/// enabled and validation succeeds, `Ok(None)` when auth is `Off`
+/// and no `X-Codelens-Principal` dev header is present, and `Err`
+/// (with the rejection response) on auth failure.
+async fn authenticate_request(
+    state: &AppState,
+    headers: &HeaderMap,
+) -> Result<Option<String>, Response> {
     let auth = state.http_auth();
     match auth.authorize(headers).await {
-        Ok(()) => None,
+        Ok(principal) => Ok(principal),
         Err(crate::server::auth::AuthFailure::InsufficientScope) => {
             let mut challenge = auth.www_authenticate();
             if !challenge.contains("error=\"insufficient_scope\"") {
                 challenge.push_str(", error=\"insufficient_scope\"");
             }
-            Some(
-                (
-                    StatusCode::FORBIDDEN,
-                    [(header::WWW_AUTHENTICATE, challenge)],
-                    "Insufficient scope",
-                )
-                    .into_response(),
+            Err((
+                StatusCode::FORBIDDEN,
+                [(header::WWW_AUTHENTICATE, challenge)],
+                "Insufficient scope",
             )
+                .into_response())
         }
-        Err(_) => Some(
-            (
-                StatusCode::UNAUTHORIZED,
-                [(header::WWW_AUTHENTICATE, auth.www_authenticate())],
-                "Unauthorized",
-            )
-                .into_response(),
-        ),
+        Err(_) => Err((
+            StatusCode::UNAUTHORIZED,
+            [(header::WWW_AUTHENTICATE, auth.www_authenticate())],
+            "Unauthorized",
+        )
+            .into_response()),
     }
+}
+
+/// L1 (ADR-0009 §1): inject the authenticated principal id into the
+/// JSON-RPC request params under the `_session_principal_id` key.
+/// `SessionRequestContext::from_json` reads that key, and the role
+/// gate prefers it over `CODELENS_PRINCIPAL` env. No-op when no
+/// principal id is bound (stdio + auth=off) or when the request is
+/// not a `tools/call` (the only method whose params is a structured
+/// object the dispatch path reads `_session_*` from).
+fn inject_principal_id_into_params(request: &mut JsonRpcRequest, principal_id: &str) {
+    if request.method != "tools/call" {
+        return;
+    }
+    let Some(params) = request.params.as_mut() else {
+        return;
+    };
+    let Some(arguments) = params
+        .as_object_mut()
+        .and_then(|p| p.get_mut("arguments"))
+        .and_then(|a| a.as_object_mut())
+    else {
+        return;
+    };
+    arguments.insert(
+        "_session_principal_id".to_owned(),
+        serde_json::Value::String(principal_id.to_owned()),
+    );
 }
 
 /// Phase 4d (§single-instance guard): probe the target port before
@@ -374,9 +405,10 @@ async fn mcp_post_handler(
     if !protocol_version_header_ok(&headers) {
         return (StatusCode::BAD_REQUEST, "Unsupported MCP-Protocol-Version").into_response();
     }
-    if let Some(response) = auth_rejection_response(&state, &headers).await {
-        return response;
-    }
+    let principal_id = match authenticate_request(&state, &headers).await {
+        Ok(principal_id) => principal_id,
+        Err(response) => return response,
+    };
 
     let session_id = headers
         .get("mcp-session-id")
@@ -412,6 +444,15 @@ async fn mcp_post_handler(
         && store.get(sid).is_none()
     {
         return (StatusCode::NOT_FOUND, "Unknown session").into_response();
+    }
+
+    // L1: thread the authenticated principal id through to the
+    //     dispatch path. Done before session metadata injection so the
+    //     `_session_principal_id` key sits alongside the rest of the
+    //     `_session_*` block when SessionRequestContext::from_json
+    //     reads it back out.
+    if let Some(principal_id) = principal_id.as_deref() {
+        inject_principal_id_into_params(&mut request, principal_id);
     }
 
     // Inject session metadata into request params based on method
@@ -494,7 +535,7 @@ async fn mcp_get_handler(State(state): State<Arc<AppState>>, headers: HeaderMap)
     if !protocol_version_header_ok(&headers) {
         return (StatusCode::BAD_REQUEST, "Unsupported MCP-Protocol-Version").into_response();
     }
-    if let Some(response) = auth_rejection_response(&state, &headers).await {
+    if let Err(response) = authenticate_request(&state, &headers).await {
         return response;
     }
 
@@ -546,7 +587,7 @@ async fn mcp_delete_handler(State(state): State<Arc<AppState>>, headers: HeaderM
     if !protocol_version_header_ok(&headers) {
         return (StatusCode::BAD_REQUEST, "Unsupported MCP-Protocol-Version").into_response();
     }
-    if let Some(response) = auth_rejection_response(&state, &headers).await {
+    if let Err(response) = authenticate_request(&state, &headers).await {
         return response;
     }
     if let Some(id) = headers.get("mcp-session-id").and_then(|v| v.to_str().ok())
@@ -629,5 +670,65 @@ mod single_instance_guard_tests {
         // Port 0 is reserved and unbindable via TcpStream::connect.
         // Should return false (not-occupied) without panicking.
         let _ = port_is_occupied(0).await;
+    }
+}
+
+#[cfg(test)]
+mod principal_injection_tests {
+    use super::*;
+    use crate::protocol::JsonRpcRequest;
+
+    fn parse(body: &str) -> JsonRpcRequest {
+        serde_json::from_str(body).expect("test request body must be valid json-rpc")
+    }
+
+    #[test]
+    fn injects_principal_id_into_tools_call_arguments() {
+        let mut request = parse(
+            r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"create_text_file","arguments":{"relative_path":"x"}}}"#,
+        );
+        inject_principal_id_into_params(&mut request, "alice@example.com");
+        let arguments = request
+            .params
+            .as_ref()
+            .and_then(|p| p.get("arguments"))
+            .expect("arguments must remain present");
+        assert_eq!(arguments["_session_principal_id"], "alice@example.com");
+        // Existing fields untouched.
+        assert_eq!(arguments["relative_path"], "x");
+    }
+
+    #[test]
+    fn does_not_inject_when_method_is_not_tools_call() {
+        let mut request = parse(
+            r#"{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}"#,
+        );
+        inject_principal_id_into_params(&mut request, "alice@example.com");
+        assert!(
+            request
+                .params
+                .as_ref()
+                .and_then(|p| p.get("_session_principal_id"))
+                .is_none(),
+            "non tools/call methods must not be mutated"
+        );
+    }
+
+    #[test]
+    fn does_not_inject_when_arguments_missing() {
+        // Notification-style tools/call without arguments object — the
+        // injector must be a no-op rather than panic.
+        let mut request = parse(
+            r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"create_text_file"}}"#,
+        );
+        inject_principal_id_into_params(&mut request, "alice@example.com");
+        assert!(
+            request
+                .params
+                .as_ref()
+                .and_then(|p| p.get("arguments"))
+                .is_none(),
+            "missing arguments must remain missing"
+        );
     }
 }

--- a/crates/codelens-mcp/src/session_context.rs
+++ b/crates/codelens-mcp/src/session_context.rs
@@ -16,6 +16,12 @@ pub(crate) struct SessionRequestContext {
     pub requested_profile: Option<String>,
     pub client_name: Option<String>,
     pub client_version: Option<String>,
+    /// L1 (ADR-0009 §1): principal id derived from the request channel
+    /// (HTTP JWT `sub` claim or `X-Codelens-Principal` header). When
+    /// present, the role gate uses this in preference to
+    /// `CODELENS_PRINCIPAL` env. None for stdio + dev mode where no
+    /// channel binding is available — env fallback applies.
+    pub principal_id: Option<String>,
 }
 
 impl SessionRequestContext {
@@ -32,6 +38,7 @@ impl SessionRequestContext {
             requested_profile: str_field(value, "_session_requested_profile"),
             client_name: str_field(value, "_session_client_name"),
             client_version: str_field(value, "_session_client_version"),
+            principal_id: str_field(value, "_session_principal_id"),
         }
     }
 
@@ -63,4 +70,25 @@ fn string_array_field(value: &serde_json::Value, key: &str) -> Vec<String> {
                 .collect()
         })
         .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn from_json_reads_principal_id_when_present() {
+        // L1: HTTP transport injects _session_principal_id from JWT sub.
+        let ctx = SessionRequestContext::from_json(&json!({
+            "_session_principal_id": "alice@example.com",
+        }));
+        assert_eq!(ctx.principal_id.as_deref(), Some("alice@example.com"));
+    }
+
+    #[test]
+    fn from_json_returns_none_principal_when_absent() {
+        let ctx = SessionRequestContext::from_json(&json!({"_session_id": "sess-1"}));
+        assert!(ctx.principal_id.is_none());
+    }
 }

--- a/crates/codelens-mcp/src/state.rs
+++ b/crates/codelens-mcp/src/state.rs
@@ -290,6 +290,19 @@ impl AppState {
                 crate::principals::Principals::permissive_default()
             }
         };
+        // Strict fallback (CODELENS_AUTH_MODE=strict + no principals.toml)
+        // produces an empty mapping with default_role=ReadOnly. Surface
+        // that loudly so the operator knows mutation tools are denied
+        // until they author the file.
+        if resolved.default_role() == crate::principals::Role::ReadOnly
+            && resolved.explicit_count() == 0
+        {
+            tracing::warn!(
+                audit_dir = %dir.display(),
+                "CODELENS_AUTH_MODE=strict in effect with no principals.toml — \
+                 every principal is ReadOnly and code-mutation tools will be denied"
+            );
+        }
         let arc = Arc::new(resolved);
         let _ = self.principals.set(Arc::clone(&arc));
         self.principals.get().cloned().unwrap_or(arc)

--- a/docs/adr/ADR-0009-mutation-trust-substrate.md
+++ b/docs/adr/ADR-0009-mutation-trust-substrate.md
@@ -8,8 +8,8 @@
 ## Context
 
 Phase 0 + Phase 1 G4 + Phase 1 G7 made _what_ an apply does honest:
-authority, can_apply, edit_authority, hash-based ApplyEvidence, rollback
-report. But _who is allowed to call_ and _what actually happened
+authority, can*apply, edit_authority, hash-based ApplyEvidence, rollback
+report. But \_who is allowed to call* and _what actually happened
 durably_ are still implicit:
 
 - MCP stdio = anyone-with-process-access calls every mutation tool.
@@ -87,7 +87,8 @@ Principal binding source (priority order):
 Enforcement is in `dispatch.rs`: one call to
 `enforce_role(tool_name, principal_role)?` before handler invocation.
 On reject: `Err(CodeLensError::PermissionDenied)`, JSON-RPC error code
-`-32004`, audit row written with `apply_status="denied"`.
+`-32008` (deviation: `-32004` was already used by `IndexNotReady`),
+audit row written with `apply_status="denied"`.
 
 ### 2. Durable Audit Sink
 
@@ -137,47 +138,67 @@ impl AuditSink {
 
 ### 3. Mutation Lifecycle State Machine
 
+The dispatch entry decides between two intermediate states based on
+where the call exits the pipeline. Pre-handler rejections (role gate)
+short-circuit to `Denied` without ever entering the substrate.
+
 ```
-         preview_requested
-Drafted ───────────────────► Previewed
-                                │
-                                │ apply_requested
-                                ▼
-                            Verifying
-                       ┌────────┴───────┐
-        verify_failed │                │ verify_passed
-                      ▼                ▼
-                  Failed            Applying
-                                ┌─────┴─────┐
-                  apply_failed_ │           │ apply_succeeded
-                  restored      │           │
-                                ▼           ▼
-                          RolledBack   Committed
-                              │             │
-                              │             │ audit_recorded
-                  apply_failed│             ▼
-                  _lost       │         Audited
-                              ▼
-                          Failed
+                     role_gate_denied
+         (request) ─────────────────────► Denied   (terminal)
+
+         (request)
+            │ role_gate_passed
+            ▼
+        Verifying
+       ┌────┴─────┐
+verify │          │ verify_passed
+failed │          ▼
+       │       Applying
+       │      ┌────┴────┐
+       │      │         │ apply_succeeded
+       │      │         ▼
+       │      │      Audited      (terminal — Hybrid "applied" or "no_op")
+       │      │
+       │      │ apply_failed_restored
+       │      ▼
+       │   RolledBack    (terminal — Hybrid "rolled_back")
+       ▼
+     Failed              (terminal — handler Err, no on-disk mutation
+                          OR apply_failed_lost)
 ```
 
 ```rust
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
 pub enum LifecycleState {
-    Drafted,
-    Previewed,
+    // Intermediate (recorded as `state_from` in audit rows)
     Verifying,
     Applying,
-    Committed,
+    // Terminal (recorded as `state_to` in audit rows)
     Audited,
     RolledBack,
     Failed,
+    Denied,
 }
 ```
 
-Each transition is a single audit-log row. Terminal states:
-`Audited`, `RolledBack`, `Failed`. The agent reads back via
-`audit_log_query(transaction_id)` to recover the trail.
+Each call writes one audit-log row whose `state_from`/`state_to` pair
+identifies which path through the machine the call traversed.
+Terminal states: `Audited`, `RolledBack`, `Failed`, `Denied`. The
+agent reads back via `audit_log_query(transaction_id)` to recover the
+outcome.
+
+**Deviation from earlier draft.** Prior versions of this ADR enumerated
+9 states (`Drafted`, `Previewed`, `Committed`, plus the 6 above). Those
+3 intermediates were never wired into a transition; the substrate
+collapses preview/draft into the apply-time `Verifying` capture and
+treats `Committed` as the same row as `Audited` (one row per call,
+written after substrate write succeeds). They were removed for
+self-consistency with the architecture rule "no dead variants".
+
+**JSON-RPC code deviation.** §1 specified `-32004` for
+`PermissionDenied`; that code is already used by `IndexNotReady`. The
+shipped error returns `-32008` instead. The semantics (pre-handler
+denial, no on-disk effect, `Denied` row written) are unchanged.
 
 ### 4. Cache Invalidation Contract
 
@@ -213,7 +234,7 @@ _before_ the response is returned to the agent. The agent's next
 | 초기 버전은 모놀리식 우선                    | ✅ AuditSink + role gate live in mcp crate, no new service                                                         |
 | 역할 기반 권한은 화면/액션/API 모두 명시     | ✅ Role enum gates dispatch entry; principals.toml is the config surface                                           |
 | 감사 로그가 필요한 액션은 반드시 기록        | ✅ all 11 mutation tools + LSP rename apply + safe_delete_apply write rows                                         |
-| 상태 전이는 enum과 이벤트 기준으로 문서화    | ✅ LifecycleState enum + 9 named transitions in §3                                                                 |
+| 상태 전이는 enum과 이벤트 기준으로 문서화    | ✅ LifecycleState enum (6 states: 2 intermediate + 4 terminal) + transitions in §3                                 |
 | 새 추상화는 중복 제거가 입증된 경우에만 추가 | ✅ AuditSink replaces ad-hoc response-only evidence; CacheInvalidator trait replaces missing implicit invalidation |
 | 다이어그램은 C4 + dynamic flow 2종 유지      | ✅ updated in `docs/architecture.md` (separate PR)                                                                 |
 
@@ -263,7 +284,7 @@ Agent       dispatch                AppState         engine          audit_log  
   │─tools/call►│                       │                │                │           │
   │            │── principal_resolve ──┤                │                │           │
   │            │── role_gate ──────────┤                │                │           │
-  │            │   (deny? → audit row "denied", return -32004)            │           │
+  │            │   (deny? → audit row state_to=Denied, return -32008)     │           │
   │            │                                                                     │
   │            │── tool dispatch ──────────────────────►│                │           │
   │            │                                        │── apply ──►(disk)          │
@@ -273,9 +294,9 @@ Agent       dispatch                AppState         engine          audit_log  
   │            │── cache_invalidate(paths) ─────────────────────────────────────────►│
   │            │   (Embedding/Bm25/Lsp/SymbolDb self-clear for those paths)          │
   │            │                                                                     │
-  │            │── audit_record(transition: Applying→Committed) ──────────►│         │
-  │            │                                                            │        │
-  │            │── audit_record(transition: Committed→Audited) ────────────►│         │
+  │            │── audit_record(state_from=Applying, state_to=Audited)──►│         │
+  │            │   (Hybrid "applied"/"no_op" → Audited; "rolled_back" → RolledBack;  │
+  │            │    handler Err → state_from=Verifying, state_to=Failed)             │
   │            │                                                                     │
   │◄─response──│  (apply_status, transaction_id, evidence, invalidated_paths)        │
 ```
@@ -289,7 +310,7 @@ Agent       dispatch                AppState         engine          audit_log  
 | **P2-C** | Role gate + principals.toml loader + dispatch enforcement + denied-row audit                    | ~400     |
 | **P2-D** | LifecycleState enum + state-transition events + audit_record per transition                     | ~300     |
 | **P2-E** | CacheInvalidator trait + engine implementations (Embedding/Bm25/Lsp/SymbolDb) + dispatch wiring | ~600     |
-| **P2-F** | `audit_log_query` tool + JSON-RPC error code -32004 docs + retention/rotation                   | ~300     |
+| **P2-F** | `audit_log_query` tool + JSON-RPC error code -32008 docs + retention/rotation                   | ~300     |
 
 Each PR stands alone, cargo green, has a single observable contract. Stacked
 on each other in this order.


### PR DESCRIPTION
## Summary
- **M1** LifecycleState 9→6: drop 3 dead variants (Drafted/Previewed/Committed); keep Verifying/Applying as `state_from` and Audited/RolledBack/Failed/Denied as terminals.
- **M4** ADR-0009 §3 diagram + code block now match the 6-state enum, with explicit Denied transition and -32004→-32008 deviation note.
- **M6** memory tools (write_memory/delete_memory/rename_memory) are ReadOnly for the role gate; still tracked by the audit sink.
- **M2** `CODELENS_AUTH_MODE=strict` env flag — strict_default (every principal ReadOnly) instead of permissive_default when no principals.toml.
- **L3** transaction_id surfaced in `payload.data.transaction_id` for future `audit_log_query` follow-up. Stable: same `(session, tool, args)` triple → same id.
- **L1** HTTP/JWT principal binding — JWT `sub` claim threads to dispatch as `_session_principal_id`; role gate prefers session id over `CODELENS_PRINCIPAL` env. `X-Codelens-Principal` dev-mode header for `auth=off`.

Six small fixes that move ADR-0009's promise into ADR-0009's shipped code. Heavier follow-ups (P2-E cache invalidation, P2-F audit_log_query, M3 dual-sink consolidation) are intentionally deferred to keep this PR reviewable.

## Test plan
- [x] cargo test -p codelens-engine — 1 doctest pass
- [x] cargo test -p codelens-mcp — 505 pass
- [x] cargo test -p codelens-mcp --features http — 587 pass
- [x] cargo test -p codelens-mcp --no-default-features — 473 pass
- [x] cargo clippy -p codelens-mcp -- -W clippy::all — clean
- [x] cargo clippy -p codelens-mcp --features http -- -W clippy::all — clean
- [x] new unit tests: principals (resolve_principal_id env↔session priority, strict_default, memory carve-out), session_context (principal_id round-trip), dispatch::session (transaction_id stability + inject), transport_http (principal injection method gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)