### PR TITLE
docs(engine): mark mutation primitives as internal API (L4)

### DIFF
--- a/crates/codelens-engine/src/auto_import.rs
+++ b/crates/codelens-engine/src/auto_import.rs
@@ -2,6 +2,12 @@
 //!
 //! Detects unresolved symbols in a file and suggests imports from the project's symbol index.
 //! Generates language-appropriate import statements and inserts at the correct position.
+//!
+//! **Internal API.** `add_import` writes through
+//! `apply_full_write_with_evidence` and bypasses ADR-0009 role
+//! gates, audit sinks, and cache invalidation when called outside
+//! `codelens-mcp` dispatch. Route mutations through MCP — see the
+//! crate-level docs in `lib.rs`.
 
 use crate::import_graph::extract_imports_for_file;
 use crate::project::ProjectRoot;

--- a/crates/codelens-engine/src/edit_transaction.rs
+++ b/crates/codelens-engine/src/edit_transaction.rs
@@ -1,5 +1,14 @@
 //! Workspace edit transaction substrate.
 //!
+//! **Internal API.** `apply_full_write_with_evidence` and
+//! `WorkspaceEditTransaction::apply` are the lowest-level disk-write
+//! primitives in CodeLens. They produce `ApplyEvidence` and an
+//! optional rollback report but **do not** enforce ADR-0009 role
+//! gates, write audit rows, or invalidate engine caches — those
+//! guarantees are layered on top by `codelens-mcp` dispatch. Direct
+//! callers from outside the workspace silently bypass the trust
+//! substrate. See the crate-level docs in `lib.rs`.
+//!
 //! Provides a reusable domain object for multi-file mutations with
 //! pre-apply hash capture, post-apply hash verification, and rollback
 //! evidence. Used by LSP rename, safe_delete_apply, and future engine

--- a/crates/codelens-engine/src/file_ops/writer.rs
+++ b/crates/codelens-engine/src/file_ops/writer.rs
@@ -1,3 +1,18 @@
+//! Raw single-file write primitives.
+//!
+//! **Internal API — bypass-the-substrate warning.** Every function in
+//! this module performs an unconditional disk write through
+//! `apply_full_write_with_evidence`. None of them enforce
+//! ADR-0009 role gates, write audit rows, or invalidate engine
+//! caches. That contract lives in `codelens-mcp`'s
+//! `dispatch::session::apply_post_mutation`.
+//!
+//! Consumers must call these primitives only via `codelens-mcp`
+//! dispatch (HTTP / stdio MCP, or in-process `dispatch_tool`) —
+//! direct calls from third-party crates silently bypass the
+//! principals.toml configuration, the audit log, and downstream
+//! cache invalidation. See the crate-level docs in `lib.rs`.
+
 use crate::edit_transaction::{apply_full_write_with_evidence, ApplyEvidence};
 use crate::project::ProjectRoot;
 use anyhow::{bail, Context, Result};

--- a/crates/codelens-engine/src/lib.rs
+++ b/crates/codelens-engine/src/lib.rs
@@ -1,3 +1,32 @@
+//! # codelens-engine
+//!
+//! Read/mutate/index primitives for CodeLens. **Internal API.**
+//!
+//! Mutation primitives — every function that writes to the project
+//! tree (`file_ops::writer::*`, `auto_import::add_import`,
+//! `edit_transaction::apply_full_write_with_evidence`,
+//! `lsp::LspWorkspaceEditTransaction::apply`, `rename::apply_rename`) —
+//! **do NOT enforce ADR-0009 role gates, audit sinks, or cache
+//! invalidation contracts**. Those guarantees live exclusively in
+//! `codelens-mcp`'s dispatch pipeline (`dispatch::role_gate`,
+//! `dispatch::session::apply_post_mutation`).
+//!
+//! Consumers — including third-party crates that depend on
+//! `codelens-engine` — **MUST** route mutations through
+//! `codelens-mcp` (HTTP / stdio MCP protocol, or in-process
+//! `dispatch_tool`) so the trust substrate can audit, gate, and
+//! invalidate consistently. Calling mutation primitives directly is
+//! supported only inside the workspace (mcp + engine tests + benches);
+//! anything else is at the caller's own risk and will silently bypass
+//! the project's principals.toml configuration.
+//!
+//! Read primitives (`find_*`, `get_*`, `search_*`, `LspSessionPool`)
+//! are safe to call directly — they have no side effects on disk or
+//! audit state.
+//!
+//! See ADR-0009 (`docs/adr/ADR-0009-mutation-trust-substrate.md`)
+//! for the full contract this crate participates in.
+
 pub mod auto_import;
 pub mod call_graph;
 pub mod circular;


### PR DESCRIPTION
## Summary
Doc-only mitigation for the L4 gap. ADR-0009's trust contract (role gate + audit + cache invalidation) lives in `codelens-mcp` dispatch; the engine's mutation primitives don't enforce it themselves. Direct engine callers from outside the workspace silently bypass the substrate.

**Why doc-only:** today there are no out-of-workspace consumers (codelens-tui is read-only; the only mutation caller is codelens-mcp). Refactoring every primitive's signature to thread a `PrincipalContext` would be ~700 LOC across 9 raw_fs primitives + auto_import + edit_transaction, and would buy nothing concrete until a third-party consumer actually appears. We make the contract honest in documentation now and reserve a future `unstable-mutation-api` cargo feature for the day a real consumer needs explicit opt-in.

## Changes
- `lib.rs` crate-level doc: spell out what mutation primitives do **not** enforce, point readers at codelens-mcp's dispatch as the only supported entry point for mutations, link to ADR-0009.
- `file_ops/writer.rs` module doc: inline "bypass-the-substrate" warning beside the actual disk-write functions.
- `auto_import.rs` + `edit_transaction.rs` module docs: matching warnings on the other two mutation surfaces.

## Test plan
- [x] cargo test -p codelens-engine — 1 doctest pass
- [x] cargo test -p codelens-mcp — 516 pass
- [x] cargo clippy -p codelens-engine -p codelens-mcp -- -W clippy::all — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)