### PR TITLE
docs: production operating guide + principals.toml sample (#5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 <div align="center">
 
-# CodeLens MCP 
+# CodeLens MCP
 
 **Agent-native code intelligence server with bounded workflows, precise fallback, and auditable releases.**
-
 
 If you are preparing automation or host configs for the eventual cutover, use the host-by-host migration guide: [`docs/migrate-from-codelens.md`](docs/migrate-from-codelens.md).
 
@@ -18,6 +17,7 @@ Pure Rust MCP server for multi-agent harnesses with hybrid retrieval (tree-sitte
 </div>
 
 <!-- SURFACE_MANIFEST_README_SNAPSHOT:BEGIN -->
+
 ## Surface Snapshot
 
 - Workspace version: `1.9.50`
@@ -76,12 +76,12 @@ Latest release: [GitHub Releases](https://github.com/mupozg823/codelens-mcp-plug
 
 ### Install Channel Matrix
 
-| Channel                                      | What you get                                                     | Good for                                             | Extra install needed?                                                          |
-| -------------------------------------------- | ---------------------------------------------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------ |
-| `cargo install codelens-mcp`                 | crates.io package version, stdio-first default build             | Single-agent local MCP sessions                      | Add `--features http` if you want shared HTTP daemons                          |
-| `cargo install codelens-mcp --features http` | crates.io package version with HTTP transport                    | Shared daemon mode from crates.io                    | No extra CodeLens package, but you still need the host client config           |
+| Channel                                      | What you get                                                                              | Good for                                             | Extra install needed?                                                          |
+| -------------------------------------------- | ----------------------------------------------------------------------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `cargo install codelens-mcp`                 | crates.io package version, stdio-first default build                                      | Single-agent local MCP sessions                      | Add `--features http` if you want shared HTTP daemons                          |
+| `cargo install codelens-mcp --features http` | crates.io package version with HTTP transport                                             | Shared daemon mode from crates.io                    | No extra CodeLens package, but you still need the host client config           |
 | GitHub Releases / installer / Homebrew       | latest tagged release binary, built in CI with `--features http` (`http,coreml` on macOS) | Tagged release users who want HTTP without compiling | No extra CodeLens build; semantic still needs a model sidecar or airgap bundle |
-| `cargo install --git ...` or source build    | current repository HEAD                                          | Unreleased features on `main` / branch testing       | No extra package, but you compile locally                                      |
+| `cargo install --git ...` or source build    | current repository HEAD                                                                   | Unreleased features on `main` / branch testing       | No extra package, but you compile locally                                      |
 
 Important:
 
@@ -335,14 +335,53 @@ verify_change_readiness → "ready" → rename_symbol
                         → "blocked" → fix blockers first
 ```
 
+### Operating in Production (ADR-0009)
+
+CodeLens enforces a four-part trust contract on every mutation tool — role gate, durable audit log, lifecycle state machine, cache invalidation. The defaults are friendly to local single-user installs; flip the env / drop a config file when you need stricter posture.
+
+**Roles & principals.** Mutation tools require `Refactor` (codebase) or `Admin` (`audit_log_query`); everything else is `ReadOnly`. Bind a principal id with one of:
+
+- HTTP `Authorization: Bearer <jwt>` — `sub` claim is the principal id
+- HTTP `X-Codelens-Principal` header (dev mode, no JWT)
+- stdio: `CODELENS_PRINCIPAL=<id>` env
+
+Resolve `(principal → role)` with a `principals.toml` at `<project>/.codelens/principals.toml` (project-local; takes precedence) or `~/.codelens/principals.toml` (user-global):
+
+```toml
+[default]
+role = "ReadOnly"
+
+[principal."alice@example.com"]
+role = "Refactor"
+
+[principal."ops-bot"]
+role = "Admin"
+```
+
+When no `principals.toml` exists, the loader falls back to **permissive** (every id maps to `Refactor`) — preserves existing single-user behaviour. Set `CODELENS_AUTH_MODE=strict` to flip the fallback to `ReadOnly` (every mutation denied until you author the file). Strict mode is loud about missing config — startup logs a warning so you notice immediately.
+
+**Audit log.** Every successful, failed, rolled-back, and denied mutation writes one row to `<project>/.codelens/audit/audit_log.sqlite`. Query it back through MCP with the `audit_log_query` tool (Admin role) — filter by `transaction_id` (returned in every mutation response under `data.transaction_id`), `since_ms`, or `limit`. Each row carries `principal`, `tool`, `args_hash`, `apply_status`, `state_from`/`state_to`, `evidence_hash`, `rollback_restored`, `error_message`, and a `session_metadata` JSON blob with the request's project_scope/surface/client_name/etc.
+
+**Retention.** Audit rows are pruned + the SQLite file `VACUUM`-ed once per daemon lifetime (first audit access). Window controlled by:
+
+- unset → 90 days (default)
+- `CODELENS_AUDIT_RETENTION_DAYS=0` (or negative) → retention disabled, rows kept forever
+- any positive integer → rows older than that many days deleted
+
+Operators who need cold-archive shipping should rsync / S3-sync the SQLite file before the sweep — gzip rotation is intentionally out of scope.
+
+**LSP / embedding capability.** Tools that need an LSP server or an embedding index degrade gracefully: missing-server errors include the install command (e.g. `npm i -g pyright`), `find_referencing_symbols` falls back to tree-sitter when LSP is unavailable, and `semantic_search` returns a structured "feature unavailable" hint pointing at `bm25_symbol_search`. Probe runtime state with `get_capabilities` — it reports LSP attach status, embedding index info, and project-level health in one call.
+
 ## Language Support
 
 <!-- SURFACE_MANIFEST_README_LANGUAGES:BEGIN -->
+
 Canonical parser families (30): C, Clojure/ClojureScript, C++, C#, CSS, Dart, Erlang, Elixir, Go, Haskell, HTML, Java, Julia, JavaScript, Kotlin, Lua, OCaml, PHP, Python, R, Ruby, Rust, Scala, Bash/Shell, Swift, TOML, TypeScript, TSX/JSX, YAML, Zig
 
 Import-graph capable families: C, C++, C#, CSS, Dart, Go, Java, JavaScript, Kotlin, PHP, Python, Ruby, Rust, Scala, Swift, TypeScript, TSX/JSX
 
 The canonical family/extension inventory is generated from `codelens_engine::lang_registry` and published in [`docs/generated/surface-manifest.json`](docs/generated/surface-manifest.json).
+
 <!-- SURFACE_MANIFEST_README_LANGUAGES:END -->
 
 ## Performance
@@ -408,16 +447,16 @@ python3 benchmarks/embedding-quality.py . --isolated-copy
 
 ## vs Serena
 
-| Axis             | CodeLens                                    | Serena                    |
-| ---------------- | ------------------------------------------- | ------------------------- |
-| Runtime          | Single Rust binary, <12ms cold start        | Python + uv               |
-| Intelligence     | tree-sitter + SQLite + optional LSP/SCIP    | LSP by default            |
-| Token efficiency | Bounded workflows, 50-87% savings           | Standard tool responses   |
-| Workflow layer   | Composite reports + analysis handles        | Symbolic tools            |
-| Semantic search  | Sidecar ONNX + hybrid ranking + NL bridging | No bundled model          |
+| Axis             | CodeLens                                                  | Serena                          |
+| ---------------- | --------------------------------------------------------- | ------------------------------- |
+| Runtime          | Single Rust binary, <12ms cold start                      | Python + uv                     |
+| Intelligence     | tree-sitter + SQLite + optional LSP/SCIP                  | LSP by default                  |
+| Token efficiency | Bounded workflows, 50-87% savings                         | Standard tool responses         |
+| Workflow layer   | Composite reports + analysis handles                      | Symbolic tools                  |
+| Semantic search  | Sidecar ONNX + hybrid ranking + NL bridging               | No bundled model                |
 | Refactoring      | Gated mutations + LSP rename/navigation/safe-delete apply | Stronger broad IDE-backed edits |
-| Enterprise       | Config policy, rate limit, OTel, SBOM       | None                      |
-| Offline          | Works offline with a staged sidecar model   | Depends on backend        |
+| Enterprise       | Config policy, rate limit, OTel, SBOM                     | None                            |
+| Offline          | Works offline with a staged sidecar model                 | Depends on backend              |
 
 See [docs/serena-comparison.md](docs/serena-comparison.md) for detailed gap analysis.
 
@@ -441,13 +480,13 @@ cargo test -p codelens-mcp --no-default-features   # semantic=off path
 
 ### Feature Flags
 
-| Feature        | Description                               | Binary Size Impact |
-| -------------- | ----------------------------------------- | ------------------ |
-| `semantic`     | Semantic pipeline with sidecar ONNX model | +53MB              |
+| Feature        | Description                                             | Binary Size Impact |
+| -------------- | ------------------------------------------------------- | ------------------ |
+| `semantic`     | Semantic pipeline with sidecar ONNX model               | +53MB              |
 | `coreml`       | macOS CoreML execution provider for semantic embeddings | platform-dependent |
-| `http`         | Streamable HTTP + SSE transport           | +2MB               |
-| `otel`         | OpenTelemetry OTLP gRPC exporter          | +4MB               |
-| `scip-backend` | SCIP index precise navigation             | +1MB               |
+| `http`         | Streamable HTTP + SSE transport                         | +2MB               |
+| `otel`         | OpenTelemetry OTLP gRPC exporter                        | +4MB               |
+| `scip-backend` | SCIP index precise navigation                           | +1MB               |
 
 ## Harness Architecture
 
@@ -497,31 +536,31 @@ CodeLens is designed as a **harness coprocessor** — it doesn't replace your ag
 
 ## MCP Spec Compliance
 
-| Feature                                 | Status                                 |
-| --------------------------------------- | -------------------------------------- |
-| Streamable HTTP + SSE                   | Supported                              |
-| Role-based capability negotiation       | `--profile` flag                       |
-| Tool Annotations (readOnly/destructive) | Supported                              |
-| Tool Output Schemas                     | Generated from the surface manifest    |
-| `.well-known/mcp.json` Server Card      | HTTP transport                         |
-| HTTPS transport                         | Built-in rustls PEM cert/key support   |
-| Bearer/JWKS auth                        | Protected resource server mode         |
-| Anthropic remote connector              | Tool-only compatibility profile        |
-| Analysis handles + section expansion    | Supported                              |
-| Durable analysis jobs                   | Supported                              |
-| Mutation audit log                      | `.codelens/audit/mutation-audit.jsonl` |
-| Multi-project queries                   | `query_project`                        |
-| Contextual tool chaining                | `suggested_next_tools`                 |
+| Feature                                 | Status                                  |
+| --------------------------------------- | --------------------------------------- |
+| Streamable HTTP + SSE                   | Supported                               |
+| Role-based capability negotiation       | `--profile` flag                        |
+| Tool Annotations (readOnly/destructive) | Supported                               |
+| Tool Output Schemas                     | Generated from the surface manifest     |
+| `.well-known/mcp.json` Server Card      | HTTP transport                          |
+| HTTPS transport                         | Built-in rustls PEM cert/key support    |
+| Bearer/JWKS auth                        | Protected resource server mode          |
+| Anthropic remote connector              | Tool-only compatibility profile         |
+| Analysis handles + section expansion    | Supported                               |
+| Durable analysis jobs                   | Supported                               |
+| Mutation audit log                      | `.codelens/audit/mutation-audit.jsonl`  |
+| Multi-project queries                   | `query_project`                         |
+| Contextual tool chaining                | `suggested_next_tools`                  |
 | MCP 2025-11-25 spec                     | Latest + 2025-06-18/03-26 compatibility |
 
 ## Quality Assurance
 
-| Suite                      | Gate                                  | Scope                                      |
-| -------------------------- | ------------------------------------- | ------------------------------------------ |
-| codelens-engine            | `cargo test -p codelens-engine`       | Parsing, ranking, embedding, IR            |
-| codelens-mcp               | `cargo test -p codelens-mcp`          | Dispatch, workflows, profiles, schemas     |
-| codelens-mcp (no semantic) | `cargo test -p codelens-mcp --no-default-features` | Feature-off path verification              |
-| Dataset lint               | `python3 benchmarks/lint-datasets.py --project .` | file_exists, negative!=positive, duplicates |
+| Suite                      | Gate                                               | Scope                                       |
+| -------------------------- | -------------------------------------------------- | ------------------------------------------- |
+| codelens-engine            | `cargo test -p codelens-engine`                    | Parsing, ranking, embedding, IR             |
+| codelens-mcp               | `cargo test -p codelens-mcp`                       | Dispatch, workflows, profiles, schemas      |
+| codelens-mcp (no semantic) | `cargo test -p codelens-mcp --no-default-features` | Feature-off path verification               |
+| Dataset lint               | `python3 benchmarks/lint-datasets.py --project .`  | file_exists, negative!=positive, duplicates |
 
 ```bash
 # Full verification

--- a/docs/principals.toml.sample
+++ b/docs/principals.toml.sample
@@ -1,0 +1,38 @@
+# CodeLens MCP — sample principals.toml
+#
+# Copy to one of:
+#   <project>/.codelens/principals.toml   (project-local, wins)
+#   ~/.codelens/principals.toml           (user-global default)
+#
+# When no file is present, the loader falls back to:
+#   - CODELENS_AUTH_MODE unset / =permissive → every id is Refactor
+#   - CODELENS_AUTH_MODE=strict              → every id is ReadOnly
+#                                              (mutations denied until
+#                                               you list the principal
+#                                               here)
+#
+# Roles (most → least privileged):
+#   Admin     — audit_log_query, future job-control tools
+#   Refactor  — code-mutation tools (raw_fs primitives, rename_symbol, ...)
+#   ReadOnly  — analyze_*, find_*, get_*, semantic_search, memory_*, ...
+#
+# Higher roles inherit lower roles' tools (Admin can call Refactor and
+# ReadOnly tools; Refactor can call ReadOnly tools).
+
+# Default role applied to any principal id not listed below.
+# `ReadOnly` is the sensible production default — opt principals in to
+# mutation explicitly.
+[default]
+role = "ReadOnly"
+
+# Human operators with full mutation rights but not audit access.
+[principal."alice@example.com"]
+role = "Refactor"
+
+# CI bot scoped to read-only checks (PR review, capability probes).
+[principal."ci-bot"]
+role = "ReadOnly"
+
+# On-call operator who needs audit_log_query for incident response.
+[principal."ops-admin@example.com"]
+role = "Admin"


### PR DESCRIPTION
## Summary
README's Setup section already covers install + transport choice. Production deployment also needs to know how to bind principals, read the audit trail, tune retention, and recover when an LSP server isn't installed. None of that was documented; ADR-0009 contracts were invisible to users following the README. **No code change** — every contract this doc describes already ships in `feat/phase3-l6-multiproject-audit` and earlier PRs.

## Changes
- **README "Operating in Production (ADR-0009)"** — new subsection under Mutation Safety:
  - principal binding sources (JWT sub, `X-Codelens-Principal`, `CODELENS_PRINCIPAL` env)
  - `principals.toml` lookup order (project-local > user-global)
  - permissive vs strict default + `CODELENS_AUTH_MODE` flag
  - `audit_log_query` tool surface, `transaction_id` round-trip, `session_metadata` column
  - retention window + `CODELENS_AUDIT_RETENTION_DAYS`
  - graceful degradation contract for LSP / embedding / `semantic_search` (install hints, tree-sitter fallback, `get_capabilities` probe)
- **docs/principals.toml.sample** — annotated reference file with the three role tiers, hierarchy notes, and four typical principal shapes (default `ReadOnly`, human operator `Refactor`, CI bot `ReadOnly`, on-call ops `Admin`).

## Stack
Based on `feat/phase3-l6-multiproject-audit` (PR #96). Once #96 merges this PR will retarget to `main` automatically.

## Test plan
- [x] cargo test -p codelens-mcp — 518 pass
- [x] cargo clippy -p codelens-mcp -- -W clippy::all — clean
- [x] no functional change — README + sample TOML only

🤖 Generated with [Claude Code](https://claude.com/claude-code)