### PR TITLE
chore(release): bump workspace to v1.9.58

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-engine"
-version = "1.9.50"
+version = "1.9.58"
 dependencies = [
  "anyhow",
  "criterion",
@@ -486,7 +486,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-mcp"
-version = "1.9.50"
+version = "1.9.58"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-tui"
-version = "1.9.50"
+version = "1.9.58"
 dependencies = [
  "anyhow",
  "codelens-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "Apache-2.0"
-version = "1.9.50"
+version = "1.9.58"
 description = "Harness-native Rust MCP server for code intelligence with generated surface governance, hybrid retrieval, and mutation-gated workflows"
 repository = "https://github.com/mupozg823/codelens-mcp-plugin"
 homepage = "https://github.com/mupozg823/codelens-mcp-plugin"

--- a/crates/codelens-mcp/Cargo.toml
+++ b/crates/codelens-mcp/Cargo.toml
@@ -28,7 +28,7 @@ url.workspace = true
 rusqlite.workspace = true
 toml = "0.8"
 rustls = { workspace = true, optional = true }
-codelens-engine = { path = "../codelens-engine", version = "=1.9.50" }
+codelens-engine = { path = "../codelens-engine", version = "=1.9.58" }
 thiserror.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/codelens-tui/Cargo.toml
+++ b/crates/codelens-tui/Cargo.toml
@@ -14,7 +14,7 @@ name = "codelens-tui"
 path = "src/main.rs"
 
 [dependencies]
-codelens-engine = { path = "../codelens-engine", version = "=1.9.50" }
+codelens-engine = { path = "../codelens-engine", version = "=1.9.58" }
 ratatui = "0.29"
 crossterm = "0.28"
 anyhow.workspace = true


### PR DESCRIPTION
## Summary

Reconcile `Cargo.toml` after the Apr 24 `codex/latest-mcp-remote-productization` merge brought `workspace.version` back from 1.9.57 to 1.9.50, and ship the Phase 2 close + Phase 3 production-ready stack on a single marketable version.

## Changes since v1.9.57

- Phase 1 G4 / G7 mutation substrate (#83 / #84)
- Phase 2-A/B/C/D foundation + role gate + lifecycle (#85 / #86 / #87)
- Phase 2 close part 1–4 ADR-0009 self-consistency (#91–#94)
- L4 internal-API docs / L6 per-project audit cache (#95 / #96)
- G7b `move_symbol` atomic 2-file substrate (#98)

## Verification

- `cargo build --release --features http`: pass
- `cargo test -p codelens-engine` (lib + doctest): pass
- `cargo test -p codelens-mcp`: 518 passed
- `cargo test -p codelens-mcp --features http`: 600 passed
- `cargo test -p codelens-mcp --no-default-features`: 486 passed
- `cargo clippy --release --all-targets`: 0 errors

## Real-test (CLI one-shot)

- `prepare_harness_session`, `find_symbol`, `verify_change_readiness` — happy path
- `replace_lines` via G7 substrate — full evidence (`apply_status:applied`, `evidence_hash`, `transaction_id`, `invalidated_paths`, hashes-before/after, `modified_files`, `edit_count`)
- `audit_log_query` — Refactor denied / Admin allowed; denied call itself audited
- Lifecycle states `Audited` / `Failed` / `Denied` recorded in audit log
- L6 per-project isolation — separate audit DB + Principals cache verified across two project paths
- Tree-sitter `rename_symbol` — preview-only block intact

## stdio MCP protocol

- `initialize` negotiates `2025-11-25` (latest), `2025-06-18`, `2025-03-26`; falls back to latest for unsupported clients
- `serverInfo`: codelens-mcp v1.9.58
- `tools/list`: 12 tools visible in `reviewer-graph` (37 total)

## Test plan

- [ ] CI matrix passes (ubuntu / macos / windows)
- [ ] After merge: tag `v1.9.58` on the merge commit and cut GitHub Release with these notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)