### PR TITLE
feat(scip): wire SCIP backend into get_callers (L1 slice 2)

### DIFF
--- a/crates/codelens-engine/src/scip_backend.rs
+++ b/crates/codelens-engine/src/scip_backend.rs
@@ -13,7 +13,7 @@ use std::path::Path;
 use protobuf::Message;
 use scip::types::{self as scip_types, Index};
 
-use crate::call_graph::{is_noise_callee, CalleeEntry};
+use crate::call_graph::{is_noise_callee, CalleeEntry, CallerEntry};
 use crate::ir::{
     CodeDiagnostic, DiagnosticSeverity, IntelligenceSource, PreciseBackend, SearchCandidate,
 };
@@ -202,6 +202,122 @@ impl ScipBackend {
             });
         }
         callees
+    }
+
+    /// Find callers of `function_name` across the indexed corpus using
+    /// reference occurrences plus a next-definition enclosing-scope walk.
+    ///
+    /// SCIP does not directly model "X calls Y"; it records occurrences
+    /// (symbol, role, range) per document. To answer "who calls foo?":
+    ///
+    ///   1. Resolve foo to one or more SCIP symbols (function-like only,
+    ///      filtered by `is_function_like_symbol`).
+    ///   2. For every reference (non-definition) occurrence of those
+    ///      symbols across all documents, locate the nearest preceding
+    ///      function-like definition in the same document — that is the
+    ///      enclosing caller. The caller's body extent is approximated by
+    ///      "from this def to the next function-like def" (mirrors the
+    ///      heuristic used in `find_callees`).
+    ///
+    /// Returns an empty Vec when no function-like symbol matches the
+    /// requested name; callers fall through to tree-sitter cleanly.
+    pub fn find_callers(&self, function_name: &str) -> Vec<CallerEntry> {
+        // Step 1 — resolve target symbols (must be function-like; we don't
+        // want to surface struct/type defs as "callees of themselves").
+        let target_symbols: std::collections::HashSet<String> = self
+            .symbol_info
+            .keys()
+            .filter(|s| Self::short_name(s) == function_name && Self::is_function_like_symbol(s))
+            .cloned()
+            .chain(self.documents.values().flat_map(|doc| {
+                doc.occurrences
+                    .iter()
+                    .filter(|occ| Self::is_definition(occ))
+                    .filter(|occ| {
+                        Self::short_name(&occ.symbol) == function_name
+                            && Self::is_function_like_symbol(&occ.symbol)
+                    })
+                    .map(|occ| occ.symbol.clone())
+            }))
+            .collect();
+        if target_symbols.is_empty() {
+            return Vec::new();
+        }
+
+        let mut callers: Vec<CallerEntry> = Vec::new();
+        let mut seen: std::collections::HashSet<(String, String, usize)> =
+            std::collections::HashSet::new();
+
+        for (path, doc) in &self.documents {
+            // Per-document sorted list of function-like definitions for
+            // enclosing-scope lookup. Building this once amortizes the
+            // O(occ * fn_def) work over each candidate occurrence.
+            let mut fn_defs: Vec<(usize, &str)> = doc
+                .occurrences
+                .iter()
+                .filter(|occ| {
+                    Self::is_definition(occ) && Self::is_function_like_symbol(&occ.symbol)
+                })
+                .map(|occ| (Self::parse_range(occ).0, occ.symbol.as_str()))
+                .collect();
+            fn_defs.sort_by_key(|(line, _)| *line);
+
+            for occ in &doc.occurrences {
+                if Self::is_definition(occ) {
+                    continue;
+                }
+                if !target_symbols.contains(&occ.symbol) {
+                    continue;
+                }
+                let (line, _, _, _) = Self::parse_range(occ);
+
+                // Find the nearest fn def at or before `line` whose body
+                // extends past `line` (i.e. the next fn def is strictly
+                // greater). Skip references that fall outside any
+                // function body — they're top-level/static-init refs.
+                let Some(enc_idx) = fn_defs.iter().rposition(|(def_line, _)| *def_line <= line)
+                else {
+                    continue;
+                };
+                let next_def_line = fn_defs
+                    .get(enc_idx + 1)
+                    .map(|(l, _)| *l)
+                    .unwrap_or(usize::MAX);
+                if line >= next_def_line {
+                    continue;
+                }
+
+                let enc_symbol = fn_defs[enc_idx].1;
+                let caller_name = Self::short_name(enc_symbol).to_owned();
+                // Self-reference within own body (recursion) — skip to
+                // mirror tree-sitter behavior so the call graph harness
+                // treats the two backends consistently.
+                if caller_name == function_name {
+                    continue;
+                }
+                if !seen.insert((path.clone(), caller_name.clone(), line)) {
+                    continue;
+                }
+
+                callers.push(CallerEntry {
+                    file: path.clone(),
+                    function: caller_name,
+                    line,
+                    confidence: 0.95,
+                    resolution: Some("scip"),
+                });
+            }
+        }
+        callers
+    }
+
+    /// SCIP descriptor heuristic: function/method symbols include `()` in
+    /// their descriptor string (e.g. `pkg/mod/foo().` or
+    /// `pkg/mod/impl#[`Bar`]baz().`). Types end with `#`, fields with `.`,
+    /// neither carries `()`. Cheaper and more portable than reading the
+    /// optional SymbolInformation.kind field.
+    fn is_function_like_symbol(scip_symbol: &str) -> bool {
+        scip_symbol.contains("()")
     }
 }
 
@@ -716,5 +832,75 @@ mod tests {
 
         let callees_wrong_file = backend.find_callees("handle_request", "src/unknown.rs");
         assert!(callees_wrong_file.is_empty());
+    }
+
+    #[test]
+    fn find_callers_resolves_enclosing_function_via_next_def() {
+        // L1 slice 2 acceptance — `find_callers(dispatch_tool)` must
+        // attribute the call site at router.rs:12 to handle_request (the
+        // function whose body contains line 12) and the call at line 27
+        // to other_fn. Top-level references (outside any fn body) are
+        // skipped. The fixture covers both happy paths and the
+        // "outside-body" rejection case.
+        let idx = build_callees_fixture();
+        let file = write_index_to_file(&idx);
+        let backend = ScipBackend::load(file.path()).unwrap();
+
+        let callers = backend.find_callers("read_resource");
+        // read_resource is referenced at router.rs:14 (in handle_request)
+        // AND at router.rs:27 (in other_fn). Both are valid callers.
+        let mut caller_pairs: Vec<(String, usize)> = callers
+            .iter()
+            .map(|c| (c.function.clone(), c.line))
+            .collect();
+        caller_pairs.sort();
+        assert_eq!(
+            caller_pairs,
+            vec![
+                ("handle_request".to_owned(), 14),
+                ("other_fn".to_owned(), 27),
+            ],
+            "callers should attribute occurrences to their enclosing fn"
+        );
+
+        for c in &callers {
+            assert_eq!(c.resolution, Some("scip"));
+            assert!(c.confidence >= 0.9);
+            assert_eq!(c.file, "crates/codelens-mcp/src/server/router.rs");
+        }
+    }
+
+    #[test]
+    fn find_callers_returns_empty_for_unknown_or_non_function() {
+        // Negative cases:
+        //   1. Unknown name → empty (caller falls through to tree-sitter).
+        //   2. A symbol that exists but is not function-like (no `()` in
+        //      its descriptor — a struct or field) must not be reported
+        //      as having callers; otherwise `get_callers("MyStruct")`
+        //      would return everywhere the type is mentioned, which is
+        //      not the call-graph contract.
+        let mut idx = build_callees_fixture();
+        // Append a struct-like symbol "Config#" referenced from inside
+        // handle_request body. find_callers("Config") must NOT pick it up.
+        let struct_sym = "scip-rust cargo codelens-mcp 1.9 server/router/Config#".to_owned();
+        let mut struct_def = scip_types::Occurrence::new();
+        struct_def.range = vec![18, 4, 10];
+        struct_def.symbol = struct_sym.clone();
+        struct_def.symbol_roles = 1; // definition (struct)
+        idx.documents[0].occurrences.push(struct_def);
+        let mut struct_ref = scip_types::Occurrence::new();
+        struct_ref.range = vec![13, 8, 14];
+        struct_ref.symbol = struct_sym.clone();
+        struct_ref.symbol_roles = 0;
+        idx.documents[0].occurrences.push(struct_ref);
+
+        let file = write_index_to_file(&idx);
+        let backend = ScipBackend::load(file.path()).unwrap();
+
+        assert!(backend.find_callers("no_such_function").is_empty());
+        assert!(
+            backend.find_callers("Config").is_empty(),
+            "non-function symbols must be filtered by is_function_like_symbol"
+        );
     }
 }

--- a/crates/codelens-mcp/src/tools/graph.rs
+++ b/crates/codelens-mcp/src/tools/graph.rs
@@ -244,6 +244,34 @@ pub fn get_callers_tool(state: &AppState, arguments: &serde_json::Value) -> Tool
         Some(graph_cache.as_ref()),
     )
     .map(|value| {
+        // L1 slice 2: when a SCIP index is loaded, prepend type-aware
+        // caller entries (resolution: "scip"). SCIP enclosing-scope walk
+        // catches callers that tree-sitter's name-based cascade
+        // misclassifies — Rust dispatch tables and macro-generated
+        // wrappers are the canonical example. Dedup against tree-sitter
+        // by (file, function, line) so counts are not inflated.
+        #[cfg(feature = "scip-backend")]
+        let mut value = value;
+        #[cfg(feature = "scip-backend")]
+        if let Some(backend) = state.scip() {
+            let scip_entries = backend.find_callers(function_name);
+            if !scip_entries.is_empty() {
+                let existing: std::collections::HashSet<(String, String, usize)> = value
+                    .iter()
+                    .map(|c| (c.file.clone(), c.function.clone(), c.line))
+                    .collect();
+                let mut merged: Vec<_> = scip_entries
+                    .into_iter()
+                    .filter(|c| !existing.contains(&(c.file.clone(), c.function.clone(), c.line)))
+                    .collect();
+                merged.append(&mut value);
+                value = merged;
+                if value.len() > max_results {
+                    value.truncate(max_results);
+                }
+            }
+        }
+
         let (resolution_summary, confidence_basis, meta) =
             call_graph_analysis(value.iter().map(|entry| entry.resolution));
         let evidence = crate::tool_evidence::tool_evidence(


### PR DESCRIPTION
## Summary
- New \`ScipBackend::find_callers(name)\` mirrors the find_callees pattern but in reverse: walks reference occurrences and attributes each to its enclosing function-like definition.
- New \`is_function_like_symbol\` helper filters struct/field defs out of the enclosing-scope candidate list so types referenced inside a fn body don't pollute results as "callers".
- \`tools/graph.rs::get_callers_tool\` merges SCIP+tree-sitter; cfg(scip-backend) gate; dedup by (file, function, line).

## Why
Follow-up to #104. SCIP indexes are now exploited on both sides of the call graph for self-repo + any project that runs \`rust-analyzer scip .\`. Tree-sitter alone misses caller attribution for Rust dispatch-table patterns, macro-generated wrappers, and trait dispatch — exactly where SCIP type-aware analysis adds the most value.

## Live validation
Built with \`--features scip-backend\`, \`index.scip\` symlinked at project root:

\`./target/release/codelens-mcp . --cmd get_callers --args '{\"function_name\":\"dispatch_tool\",\"max_results\":50}'\`

| Metric | Result |
|---|---|
| count | 4 callers |
| \`resolution_summary.scip\` | **2** (was 0 pre-PR) |
| confidence_basis | import_evidence |
| SCIP-only callers | handle_request@router.rs:127, run_oneshot@oneshot.rs:17 |
| call-graph-quality gate | PASS (edge_recall 1.0, 0 failed rows) |
| Self hybrid MRR | 0.679 ≥ 0.65 floor |

## Out of scope (deferred)
- Auto-attach to existing \`index.scip\` at session start
- SCIP index generation script + CI gate
- Wiring SCIP into get_impact_analysis / rename_symbol

## Test plan
- [x] \`cargo test -p codelens-engine --features scip-backend find_callers\` — 2 new tests pass
- [x] \`cargo test -p codelens-mcp --bin codelens-mcp\` — 524 (regression-free)
- [x] \`cargo test -p codelens-mcp --features scip-backend --bin codelens-mcp\` — 524
- [x] \`cargo test -p codelens-mcp --features http --bin codelens-mcp\` — 606
- [x] \`cargo test -p codelens-mcp --no-default-features --bin codelens-mcp\` — 492
- [x] \`cargo clippy -p codelens-mcp --features scip-backend -- -W clippy::all\` — no new warnings
- [x] call-graph-quality gate stays PASS
- [x] embedding-quality \`--check --min-hybrid-mrr 0.65\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)