### PR TITLE
feat(scip): surface scip_status + setup hint on startup probe (L1 slice 3)

### DIFF
--- a/crates/codelens-mcp/src/tools/session/metrics_config/capabilities.rs
+++ b/crates/codelens-mcp/src/tools/session/metrics_config/capabilities.rs
@@ -715,15 +715,27 @@ pub fn get_capabilities(state: &AppState, arguments: &serde_json::Value) -> Tool
     let mut scip_file_count: Option<usize> = None;
     #[allow(unused_mut)]
     let mut scip_symbol_count: Option<usize> = None;
+    // intelligence_sources reports backends the binary can ACTUALLY use.
+    // A stray index.scip on disk does not count when the binary lacks
+    // the scip-backend feature — claiming "scip" in that case would
+    // mislead agents into routing through type-aware tools that fall
+    // back to tree-sitter anyway.
+    #[cfg(feature = "scip-backend")]
     if scip_available {
         intelligence_sources.push("scip");
-        // Report SCIP index stats if the backend is loaded.
-        #[cfg(feature = "scip-backend")]
         if let Some(backend) = state.scip() {
             scip_file_count = Some(backend.file_count());
             scip_symbol_count = Some(backend.symbol_count());
         }
     }
+
+    // Tri-state SCIP discovery signal so an agent on the compact startup
+    // probe knows whether type-aware get_callers/get_callees are wired,
+    // available-but-uninitialized, or not compiled. Pre-slice-3 the
+    // compact probe was silent on SCIP entirely — the get_callers SCIP
+    // boost shipped in #105 was invisible to agents that didn't drill
+    // into `detail=full`.
+    let (scip_status, scip_setup_hint) = scip_status_for_response(scip_available);
 
     let embedding_indexed_bool = embedding_index_info
         .as_ref()
@@ -736,11 +748,15 @@ pub fn get_capabilities(state: &AppState, arguments: &serde_json::Value) -> Tool
 
     let payload = match detail {
         CapabilitiesDetail::Compact => {
-            // 12 core fields LLMs consume on a startup probe. Nested
+            // Core fields LLMs consume on a startup probe. Nested
             // sub-objects (`diagnostics_guidance`, `health_summary`)
             // and runtime introspection (CoreML compute units, SCIP
-            // counts, embedding runtime preferences, build_info) are
-            // only emitted when `detail=full`.
+            // file/symbol counts, embedding runtime preferences,
+            // build_info) are only emitted when `detail=full`.
+            // L1 slice 3 added `scip_status` (and an optional
+            // `scip_setup_hint` when actionable) so an agent can route
+            // to type-aware get_callers/get_callees without first
+            // asking for the full payload.
             json!({
                 "language": language,
                 "lsp_attached": lsp_attached,
@@ -754,6 +770,8 @@ pub fn get_capabilities(state: &AppState, arguments: &serde_json::Value) -> Tool
                 "unavailable": unavailable,
                 "binary_version": crate::build_info::BUILD_VERSION,
                 "binary_git_sha": crate::build_info::BUILD_GIT_SHA,
+                "scip_status": scip_status,
+                "scip_setup_hint": scip_setup_hint,
                 "detail_available": ["full"],
             })
         }
@@ -798,10 +816,43 @@ pub fn get_capabilities(state: &AppState, arguments: &serde_json::Value) -> Tool
             "scip_available": scip_available,
             "scip_file_count": scip_file_count,
             "scip_symbol_count": scip_symbol_count,
+            "scip_status": scip_status,
+            "scip_setup_hint": scip_setup_hint,
         }),
     };
 
     Ok((payload, success_meta(BackendKind::Config, 0.95)))
+}
+
+/// Tri-state SCIP discovery signal:
+/// - `"enabled"` — feature compiled AND `index.scip` present at one of
+///   the standard locations
+/// - `"available_no_index"` — feature compiled but no index detected;
+///   pair with the actionable `scip_setup_hint` so agents can guide
+///   users to generate one
+/// - `"not_compiled"` — feature disabled in this binary; no hint is
+///   emitted because the binary cannot benefit from an index even if
+///   one were generated
+fn scip_status_for_response(scip_available: bool) -> (&'static str, Option<String>) {
+    #[cfg(feature = "scip-backend")]
+    {
+        if scip_available {
+            ("enabled", None)
+        } else {
+            (
+                "available_no_index",
+                Some(
+                    "Run `scripts/generate-scip-index.sh` (wraps `rust-analyzer scip .`) at the project root to enable type-aware get_callers/get_callees."
+                        .to_owned(),
+                ),
+            )
+        }
+    }
+    #[cfg(not(feature = "scip-backend"))]
+    {
+        let _ = scip_available;
+        ("not_compiled", None)
+    }
 }
 
 #[cfg(test)]
@@ -835,6 +886,56 @@ mod tests {
             CapabilitiesDetail::from_value(&json!({"detail": "full"})),
             CapabilitiesDetail::Full
         );
+    }
+
+    #[cfg(feature = "scip-backend")]
+    #[test]
+    fn scip_status_when_compiled_with_index_present() {
+        // L1 slice 3 — `index.scip` was just generated → status flips
+        // from `available_no_index` to `enabled` and the actionable
+        // setup hint disappears (no work left to do).
+        let (status, hint) = scip_status_for_response(true);
+        assert_eq!(status, "enabled");
+        assert!(
+            hint.is_none(),
+            "no setup hint needed once the index is present"
+        );
+    }
+
+    #[cfg(feature = "scip-backend")]
+    #[test]
+    fn scip_status_when_compiled_without_index_emits_setup_hint() {
+        // The reverse case: agent on a fresh checkout sees `enabled` is
+        // not yet reachable, so we surface a one-line shell command
+        // pointing at the helper script. This must mention the script
+        // by name so an agent can copy-paste it without further lookup.
+        let (status, hint) = scip_status_for_response(false);
+        assert_eq!(status, "available_no_index");
+        let hint = hint.expect("setup hint required when index missing");
+        assert!(
+            hint.contains("scripts/generate-scip-index.sh"),
+            "hint must point at the helper script (got: {hint})"
+        );
+        assert!(
+            hint.contains("rust-analyzer scip"),
+            "hint must reference the underlying tool (got: {hint})"
+        );
+    }
+
+    #[cfg(not(feature = "scip-backend"))]
+    #[test]
+    fn scip_status_when_feature_disabled_is_not_compiled() {
+        // Binary built without `--features scip-backend` cannot ever
+        // benefit from an index file. We report `not_compiled` and emit
+        // no hint to avoid sending agents on a wild goose chase that
+        // would not change behavior. Whether `scip_available` is true
+        // (stray index file in project root) doesn't matter — the
+        // binary cannot read it.
+        for scip_available in [false, true] {
+            let (status, hint) = scip_status_for_response(scip_available);
+            assert_eq!(status, "not_compiled");
+            assert!(hint.is_none());
+        }
     }
 
     #[test]

--- a/scripts/generate-scip-index.sh
+++ b/scripts/generate-scip-index.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Generate a SCIP index for the current Rust workspace so CodeLens can
+# wire its `scip-backend` feature into get_callers / get_callees and any
+# follow-up type-aware tooling.
+#
+# Output: ./index.scip (auto-detected by ScipBackend::detect at session
+# startup; gitignored as of L1 slice 1).
+#
+# Requires: rust-analyzer (>= 2024-08, supports `scip` subcommand).
+#   brew install rust-analyzer       # macOS
+#   rustup component add rust-analyzer
+#
+# Re-run this whenever Cargo.toml dependencies change or major refactors
+# move/rename function symbols. The MCP server picks up the new index on
+# its next restart (or first scip() access if not previously cached).
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUTPUT="${ROOT}/index.scip"
+
+if ! command -v rust-analyzer >/dev/null 2>&1; then
+	echo "error: rust-analyzer not found in PATH" >&2
+	echo "       install with: brew install rust-analyzer" >&2
+	echo "       or:           rustup component add rust-analyzer" >&2
+	exit 1
+fi
+
+if ! rust-analyzer --help 2>&1 | grep -q "^[[:space:]]*scip"; then
+	echo "error: rust-analyzer is too old; missing the \`scip\` subcommand" >&2
+	echo "       upgrade rust-analyzer (>= 2024-08 required)" >&2
+	exit 1
+fi
+
+cd "${ROOT}"
+echo "==> generating SCIP index at ${OUTPUT}"
+echo "    (this can take 15-60s on a medium-sized workspace)"
+
+start=$(date +%s)
+rust-analyzer scip . --output "${OUTPUT}"
+elapsed=$(($(date +%s) - start))
+
+bytes=$(stat -f%z "${OUTPUT}" 2>/dev/null || stat -c%s "${OUTPUT}")
+mb=$((bytes / 1024 / 1024))
+
+echo
+echo "==> done in ${elapsed}s — ${mb}MB at ${OUTPUT}"
+echo
+echo "next steps:"
+echo "  1. Build the MCP server with the scip-backend feature:"
+echo "       cargo build --release --features scip-backend --bin codelens-mcp"
+echo "  2. Restart any running daemons (launchctl kickstart -k gui/\$(id -u)/dev.codelens.mcp-readonly etc.)."
+echo "  3. The next call to get_callers / get_callees will surface SCIP-resolved entries"
+echo "     (resolution: \"scip\") alongside the tree-sitter call graph."


### PR DESCRIPTION
## Summary
- New tri-state \`scip_status\` field (\"enabled\" / \"available_no_index\" / \"not_compiled\") on both compact and full \`get_capabilities\` responses.
- Optional \`scip_setup_hint\` only when actionable — names \`scripts/generate-scip-index.sh\` + \`rust-analyzer scip\` so an agent can copy-paste the next step.
- Fixes related dishonesty: \`intelligence_sources\` no longer claims \`\"scip\"\` on binaries built without the feature flag.
- New \`scripts/generate-scip-index.sh\` wraps \`rust-analyzer scip .\` with dep check + post-run guidance.

## Why
Slice 3 closes the discovery gap left by #104 + #105. The compact startup probe was silent on SCIP entirely, so agents didn't know whether type-aware \`get_callers\`/\`get_callees\` were wired or how to enable them.

## Live verification (all three states)
| Build | index.scip present? | scip_status | scip_setup_hint | intelligence_sources |
|---|---|---|---|---|
| default | n/a (binary can't read) | \`not_compiled\` | \`null\` | \`[tree_sitter, semantic]\` |
| scip-backend | yes | \`enabled\` | \`null\` | \`[tree_sitter, semantic, scip]\` |
| scip-backend | no | \`available_no_index\` | actionable string | \`[tree_sitter, semantic]\` |

## Out of scope (deferred)
- Wiring SCIP into rename_symbol / get_impact_analysis
- CI gate that enforces an index exists for releases
- Auto-regeneration when Cargo.toml changes

## Test plan
- [x] \`cargo test -p codelens-mcp --bin codelens-mcp\` — 525 passed (+1)
- [x] \`cargo test -p codelens-mcp --features scip-backend --bin codelens-mcp\` — 526 passed (+2)
- [x] \`cargo test -p codelens-mcp --features http --bin codelens-mcp\` — 607 passed (+1)
- [x] \`cargo test -p codelens-mcp --no-default-features --bin codelens-mcp\` — 493 passed (+1)
- [x] \`cargo clippy -p codelens-mcp --features scip-backend -- -W clippy::all\` — no new warnings
- [x] \`bash -n scripts/generate-scip-index.sh\` — syntax OK
- [x] \`embedding-quality.py --check --min-hybrid-mrr 0.65\` passes (0.679)
- [x] All 3 live states verified end-to-end on the release binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)