### PR TITLE
chore(docs): refresh surface manifest snapshot to workspace v1.9.59 (P0-1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ Pure Rust MCP server for multi-agent harnesses with hybrid retrieval (tree-sitte
 <!-- SURFACE_MANIFEST_README_SNAPSHOT:BEGIN -->
 ## Surface Snapshot
 
-- Workspace version: `1.9.50`
+- Workspace version: `1.9.59`
 - Workspace members: `3` (`crates/codelens-engine`, `crates/codelens-mcp`, `crates/codelens-tui`)
-- Registered tool definitions: `114`
-- Tool output schemas: `85 / 114`
+- Registered tool definitions: `117`
+- Tool output schemas: `86 / 117`
 - Supported language families: `30` across `49` extensions
 - Profiles: `planner-readonly` (35), `builder-minimal` (38), `reviewer-graph` (37), `evaluator-compact` (14), `refactor-full` (51), `ci-audit` (45), `workflow-first` (19)
-- Presets: `minimal` (27), `balanced` (81), `full` (114)
+- Presets: `minimal` (27), `balanced` (84), `full` (117)
 - Canonical manifest: [`docs/generated/surface-manifest.json`](docs/generated/surface-manifest.json)
 <!-- SURFACE_MANIFEST_README_SNAPSHOT:END -->
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,10 +6,10 @@
 ## Current Snapshot (2026-04-25)
 
 <!-- SURFACE_MANIFEST_ARCHITECTURE_SNAPSHOT:BEGIN -->
-- Workspace version: `1.9.50`
+- Workspace version: `1.9.59`
 - Workspace members: `3` (`crates/codelens-engine`, `crates/codelens-mcp`, `crates/codelens-tui`)
-- Registered tool definitions in source: `114`
-- Tool output schemas in source: `85 / 114`
+- Registered tool definitions in source: `117`
+- Tool output schemas in source: `86 / 117`
 - Supported language families: `30` across `49` extensions
 - Canonical manifest: [`docs/generated/surface-manifest.json`](generated/surface-manifest.json)
 <!-- SURFACE_MANIFEST_ARCHITECTURE_SNAPSHOT:END -->

--- a/docs/generated/surface-manifest.json
+++ b/docs/generated/surface-manifest.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "codelens-surface-manifest-v1",
   "workspace": {
-    "version": "1.9.50",
+    "version": "1.9.59",
     "description": "Harness-native Rust MCP server for code intelligence with generated surface governance, hybrid retrieval, and mutation-gated workflows",
     "members": [
       "crates/codelens-engine",
@@ -11,8 +11,8 @@
     "member_count": 3
   },
   "tool_registry": {
-    "definition_count": 114,
-    "output_schema_count": 85,
+    "definition_count": 117,
+    "output_schema_count": 86,
     "namespaces": {
       "filesystem": 6,
       "graph": 14,
@@ -20,23 +20,23 @@
       "memory": 5,
       "mutation": 16,
       "reports": 28,
-      "session": 31,
+      "session": 34,
       "symbols": 11
     },
     "tiers": {
-      "analysis": 26,
+      "analysis": 28,
       "primitive": 56,
-      "workflow": 32
+      "workflow": 33
     },
     "phases": {
-      "agnostic": 38,
+      "agnostic": 41,
       "build": 18,
       "eval": 8,
       "plan": 29,
       "review": 21
     },
     "preferred_executors": {
-      "any": 88,
+      "any": 91,
       "claude": 9,
       "codex-builder": 17
     },
@@ -510,6 +510,15 @@
         "estimated_tokens": 186
       },
       {
+        "name": "explain_code_flow",
+        "namespace": "session",
+        "tier": "analysis",
+        "phase": null,
+        "preferred_executor": null,
+        "has_output_schema": false,
+        "estimated_tokens": 131
+      },
+      {
         "name": "review_architecture",
         "namespace": "reports",
         "tier": "workflow",
@@ -733,6 +742,15 @@
         "preferred_executor": null,
         "has_output_schema": true,
         "estimated_tokens": 257
+      },
+      {
+        "name": "retry_analysis_job",
+        "namespace": "session",
+        "tier": "workflow",
+        "phase": null,
+        "preferred_executor": null,
+        "has_output_schema": true,
+        "estimated_tokens": 267
       },
       {
         "name": "list_analysis_jobs",
@@ -966,7 +984,7 @@
         "phase": null,
         "preferred_executor": null,
         "has_output_schema": true,
-        "estimated_tokens": 1023
+        "estimated_tokens": 1080
       },
       {
         "name": "get_tool_metrics",
@@ -1003,6 +1021,15 @@
         "preferred_executor": null,
         "has_output_schema": true,
         "estimated_tokens": 227
+      },
+      {
+        "name": "audit_log_query",
+        "namespace": "session",
+        "tier": "analysis",
+        "phase": null,
+        "preferred_executor": null,
+        "has_output_schema": false,
+        "estimated_tokens": 191
       },
       {
         "name": "summarize_file",
@@ -1483,7 +1510,7 @@
       },
       {
         "name": "balanced",
-        "tool_count": 81,
+        "tool_count": 84,
         "preferred_namespaces": [
           "reports",
           "symbols",
@@ -1522,6 +1549,7 @@
           "refresh_symbol_index",
           "propagate_deletions",
           "semantic_code_review",
+          "retry_analysis_job",
           "replace_symbol_body",
           "find_relevant_rules",
           "get_ranked_context",
@@ -1536,8 +1564,10 @@
           "find_code_duplicates",
           "classify_symbol",
           "resolve_symbol_target",
+          "explain_code_flow",
           "query_project",
           "get_capabilities",
+          "audit_log_query",
           "rename_symbol",
           "get_analysis_job",
           "get_analysis_section",
@@ -1581,7 +1611,7 @@
       },
       {
         "name": "full",
-        "tool_count": 114,
+        "tool_count": 117,
         "preferred_namespaces": [
           "filesystem",
           "graph",
@@ -1630,6 +1660,7 @@
           "refresh_symbol_index",
           "propagate_deletions",
           "semantic_code_review",
+          "retry_analysis_job",
           "summarize_file",
           "get_complexity",
           "get_impact_analysis",
@@ -1648,10 +1679,12 @@
           "refactor_change_signature",
           "find_relevant_rules",
           "resolve_symbol_target",
+          "explain_code_flow",
           "query_project",
           "get_capabilities",
           "audit_builder_session",
           "audit_planner_session",
+          "audit_log_query",
           "get_ranked_context",
           "bm25_symbol_search",
           "search_symbols_fuzzy",
@@ -3226,13 +3259,13 @@
   },
   "runtime": {
     "server_name": "codelens-mcp",
-    "version": "1.9.50",
+    "version": "1.9.59",
     "transport": [
       "stdio",
       "streamable-http"
     ],
     "active_surface": "preset:balanced",
-    "visible_tool_count": 81,
+    "visible_tool_count": 84,
     "daemon_mode": "standard",
     "supports_http": true,
     "supports_semantic": true,
@@ -3262,12 +3295,12 @@
     ]
   },
   "summary": {
-    "workspace_version": "1.9.50",
+    "workspace_version": "1.9.59",
     "workspace_member_count": 3,
-    "registered_tool_definitions": 114,
+    "registered_tool_definitions": 117,
     "tool_output_schemas": {
-      "declared": 85,
-      "total": 114
+      "declared": 86,
+      "total": 117
     },
     "harness_mode_count": 4,
     "harness_contract_count": 3,

--- a/docs/platform-setup.md
+++ b/docs/platform-setup.md
@@ -587,8 +587,8 @@ agent = client.agents.create(
 ## Preset Comparison
 
 <!-- SURFACE_MANIFEST_PLATFORM_SURFACES:BEGIN -->
-- Workspace version: `1.9.50`
-- Presets: `minimal` (27), `balanced` (81), `full` (114)
+- Workspace version: `1.9.59`
+- Presets: `minimal` (27), `balanced` (84), `full` (117)
 - Profiles: `planner-readonly` (35), `builder-minimal` (38), `reviewer-graph` (37), `evaluator-compact` (14), `refactor-full` (51), `ci-audit` (45), `workflow-first` (19)
 - Canonical manifest: [`docs/generated/surface-manifest.json`](generated/surface-manifest.json)
 <!-- SURFACE_MANIFEST_PLATFORM_SURFACES:END -->


### PR DESCRIPTION
## Summary
External assessment flagged stale canonical-truth artifacts:
- README.md / docs/architecture.md / docs/platform-setup.md / docs/generated/surface-manifest.json all still claimed workspace 1.9.50 and 114 registered tools.
- Workspace has been at 1.9.59 since #99 and three tools have been added since last manifest run: \`explain_code_flow\` (#100), \`retry_analysis_job\` (#100), \`audit_log_query\` (#93).

\`python3 scripts/surface-manifest.py --write\` reconciles every generated block. No source file (Cargo.toml, src/**) is modified — purely a snapshot refresh.

## Diff scope
| File | Change |
|---|---|
| README.md | version 1.9.50→1.9.59, tool counts 114→117, schemas 85→86, presets balanced 81→84 / full 114→117 |
| docs/architecture.md | mirror of README snapshot block |
| docs/platform-setup.md | preset comparison block updated |
| docs/generated/surface-manifest.json | full canonical artifact (3 new tool entries) |

## Verification
- \`python3 scripts/surface-manifest.py --check\` → exit 0
- \`python3 scripts/surface-manifest.py --check-operation-matrix /tmp/operation-matrix.json\` → exit 0
- \`python3 scripts/test/test-surface-manifest-contracts.py\` → all PASS
- \`cargo test -p codelens-mcp --bin codelens-mcp\` → 525 passed
- \`cargo test -p codelens-mcp --features http\` → 607 passed

## Why P0
External judgment: \"Cargo workspace는 1.9.59인데 README/docs/generated는 1.9.50을 말합니다. 이건 제품 신뢰도 문제입니다.\" The CI step \`surface manifest drift check\` was already in place to catch this — it just hadn't been re-run after #93/#99/#100. This PR closes the gap and makes the next drift visible immediately on PR.

## Out of scope (other P0 items, separate PRs)
- P0-2: release artifact model verification gap
- P0-3: tool input unknown-field handling (e.g., \`semantic_search\` silently ignoring \`limit\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)