### PR TITLE
feat(dispatch): accept limit/top_k aliases + surface unknown args (P0-3)

### DIFF
--- a/crates/codelens-mcp/src/dispatch/table.rs
+++ b/crates/codelens-mcp/src/dispatch/table.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::sync::LazyLock;
 
 #[cfg(feature = "semantic")]
-use crate::{AppState, error::CodeLensError, protocol::BackendKind, tools::ToolResult};
+use crate::{error::CodeLensError, protocol::BackendKind, tools::ToolResult, AppState};
 #[cfg(feature = "semantic")]
 use serde_json::json;
 
@@ -51,10 +51,18 @@ pub(crate) static DISPATCH_TABLE: LazyLock<
 #[cfg(feature = "semantic")]
 fn semantic_search_handler(state: &AppState, arguments: &serde_json::Value) -> ToolResult {
     let query = tools::required_string(arguments, "query")?;
-    let max_results = arguments
-        .get("max_results")
-        .and_then(|v| v.as_u64())
-        .unwrap_or(20) as usize;
+    // P0-3 — accept `limit`/`top_k` as aliases for `max_results` so an
+    // agent that sends the common alias is not silently dropped to the
+    // default of 20. The canonical name still wins when both are
+    // present.
+    const KNOWN_ARGS: &[&str] = &["query", "max_results", "limit", "top_k"];
+    let max_results = crate::tool_runtime::optional_usize_with_aliases(
+        arguments,
+        "max_results",
+        &["limit", "top_k"],
+        20,
+    );
+    let unknown_args = crate::tool_runtime::collect_unknown_args(arguments, KNOWN_ARGS);
 
     let project = state.project();
     let guard = state.embedding_engine();
@@ -165,6 +173,15 @@ fn semantic_search_handler(state: &AppState, arguments: &serde_json::Value) -> T
                 );
             }
         }
+    }
+    // Surface unknown top-level argument keys so an agent that passed
+    // (e.g.) `threshold: 0.5` to a tool that does not honor it sees
+    // the field was ignored. Only emitted when non-empty so the
+    // existing happy-path response shape is unchanged.
+    if !unknown_args.is_empty()
+        && let Some(map) = payload.as_object_mut()
+    {
+        map.insert("unknown_args".to_owned(), json!(unknown_args));
     }
     Ok((payload, tools::success_meta(BackendKind::Semantic, 0.85)))
 }

--- a/crates/codelens-mcp/src/tool_runtime.rs
+++ b/crates/codelens-mcp/src/tool_runtime.rs
@@ -1,6 +1,6 @@
-use crate::AppState;
 use crate::error::CodeLensError;
 use crate::protocol::{BackendKind, ToolResponseMeta};
+use crate::AppState;
 
 /// Tool handler result type — every handler returns this.
 pub type ToolResult = Result<(serde_json::Value, ToolResponseMeta), CodeLensError>;
@@ -54,4 +54,111 @@ pub fn optional_usize(value: &serde_json::Value, key: &str, default: usize) -> u
 /// Extract an optional bool argument with a default value.
 pub fn optional_bool(value: &serde_json::Value, key: &str, default: bool) -> bool {
     value.get(key).and_then(|v| v.as_bool()).unwrap_or(default)
+}
+
+/// Extract an optional usize argument, accepting any of `aliases` as
+/// equivalent to `canonical`. Aliases are checked in order; the first
+/// match wins. Existing tools that pass a single canonical name are
+/// unaffected (pass an empty `aliases` slice). Used to absorb common
+/// agent typos like `limit`/`top_k` for `max_results` without
+/// silently dropping the value.
+///
+/// Returns `default` only when neither the canonical key nor any alias
+/// resolves to a u64 in the JSON envelope.
+pub fn optional_usize_with_aliases(
+    value: &serde_json::Value,
+    canonical: &str,
+    aliases: &[&str],
+    default: usize,
+) -> usize {
+    if let Some(v) = value.get(canonical).and_then(|v| v.as_u64()) {
+        return v as usize;
+    }
+    for alias in aliases {
+        if let Some(v) = value.get(*alias).and_then(|v| v.as_u64()) {
+            return v as usize;
+        }
+    }
+    default
+}
+
+/// Return the names of every top-level key in `value` that does not
+/// appear in `known` — both the canonical names AND any registered
+/// aliases. Tools surface this list in their response so an agent that
+/// passes (e.g.) `{"query":"x","threshold":0.5}` to a tool that does
+/// not honor `threshold` sees the field was ignored, instead of
+/// receiving silent default behavior.
+///
+/// Returns an empty Vec for non-object values so non-object inputs
+/// fall through to the handler's existing argument parsing without
+/// spurious "unknown" claims.
+pub fn collect_unknown_args(value: &serde_json::Value, known: &[&str]) -> Vec<String> {
+    let Some(map) = value.as_object() else {
+        return Vec::new();
+    };
+    let mut unknown: Vec<String> = map
+        .keys()
+        .filter(|k| !known.iter().any(|allowed| allowed == k))
+        .cloned()
+        .collect();
+    unknown.sort();
+    unknown
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn optional_usize_with_aliases_prefers_canonical() {
+        // Canonical name takes precedence even when an alias is also
+        // present — protects callers from accidental contradictory
+        // values silently flipping based on iteration order.
+        let args = json!({"max_results": 10, "limit": 99});
+        let n = optional_usize_with_aliases(&args, "max_results", &["limit", "top_k"], 20);
+        assert_eq!(n, 10);
+    }
+
+    #[test]
+    fn optional_usize_with_aliases_accepts_first_alias() {
+        // The motivating P0 case: agent sends `limit: 5` to a tool
+        // whose canonical name is `max_results`. Pre-fix, this
+        // silently fell back to default 20. Post-fix, the alias is
+        // honored.
+        let args = json!({"limit": 5});
+        let n = optional_usize_with_aliases(&args, "max_results", &["limit", "top_k"], 20);
+        assert_eq!(n, 5);
+    }
+
+    #[test]
+    fn optional_usize_with_aliases_falls_back_when_absent() {
+        let args = json!({"query": "x"});
+        let n = optional_usize_with_aliases(&args, "max_results", &["limit", "top_k"], 20);
+        assert_eq!(n, 20);
+    }
+
+    #[test]
+    fn collect_unknown_args_returns_keys_outside_allowlist() {
+        let args = json!({"query": "x", "limit": 5, "banana": 1, "carrot": "c"});
+        let known = ["query", "limit"];
+        let unknown = collect_unknown_args(&args, &known);
+        assert_eq!(unknown, vec!["banana".to_owned(), "carrot".to_owned()]);
+    }
+
+    #[test]
+    fn collect_unknown_args_empty_for_clean_input() {
+        let args = json!({"query": "x", "limit": 5});
+        let unknown = collect_unknown_args(&args, &["query", "limit"]);
+        assert!(unknown.is_empty());
+    }
+
+    #[test]
+    fn collect_unknown_args_empty_for_non_object() {
+        // Defensive: a tool that receives a positional/string-only
+        // argument shouldn't crash trying to compute "unknown keys".
+        // Return empty so the handler's existing parsing handles it.
+        assert!(collect_unknown_args(&json!("plain"), &["query"]).is_empty());
+        assert!(collect_unknown_args(&json!(null), &["query"]).is_empty());
+    }
 }


### PR DESCRIPTION
## Summary
\`semantic_search\` now accepts \`limit\` and \`top_k\` as aliases for \`max_results\` and surfaces a top-level \`unknown_args\` array when an agent passes a key the handler does not honor.

## Why
External assessment: \"\`semantic_search\`는 \`max_results\`만 받는데 \`limit\` 같은 흔한 인자를 조용히 무시합니다. UX/API 견고성 부족입니다.\" Two related failure modes were silent:
1. Common alias (\`limit\`, \`top_k\`) → falls back to default 20
2. Unknown field (\`threshold\`, custom key) → silently dropped, no signal to the agent

## Behavior delta
| Input | Before | After |
|---|---|---|
| \`{"query":"x","limit":5}\` | 20 results (silent) | **5 results** |
| \`{"query":"x","top_k":2}\` | 20 results (silent) | **2 results** |
| \`{"query":"x","max_results":3,"limit":99}\` | 3 results | 3 results (canonical wins) |
| \`{"query":"x","limit":3,"banana":1,"threshold":0.5}\` | 20 results, no signal | 3 results + \`unknown_args: ["banana","threshold"]\` |
| \`{"query":"x","max_results":3}\` | 3 results | 3 results, **no \`unknown_args\` key** (backward compat) |

## Implementation
Two new helpers in \`crates/codelens-mcp/src/tool_runtime.rs\`:
- \`optional_usize_with_aliases(args, canonical, aliases, default)\` — canonical wins on collision
- \`collect_unknown_args(args, &allowed_keys)\` — sorted Vec; empty for non-object input

\`semantic_search_handler\` is the pilot. Other tools can opt in by passing their own \`KNOWN_ARGS\` allowlist; this PR keeps scope tight to validate the contract before fanning out.

## Test plan
- [x] \`cargo test -p codelens-mcp --bin codelens-mcp\` — 531 passed (+6 helper tests)
- [x] \`cargo test -p codelens-mcp --features http --bin codelens-mcp\` — 613 passed
- [x] \`cargo test -p codelens-mcp --no-default-features --bin codelens-mcp\` — 499 passed
- [x] 4 live release-binary smoke tests on self repo (\`limit\`, \`top_k\`, unknown fields, clean args)
- [x] embedding-quality \`--check --min-hybrid-mrr 0.65\` passes (0.679)

## Out of scope (deferred)
- Fan out the same allowlist + alias treatment to the other ~116 tools (separate PR per high-traffic tool)
- Strict-mode env flag (\`CODELENS_STRICT_ARGS=1\`) that promotes \`unknown_args\` to a JSON-RPC error
- Documentation in tool input_schema describing accepted aliases

🤖 Generated with [Claude Code](https://claude.com/claude-code)