### PR TITLE
feat(tools): fan out unknown_args + limit/top_k aliases to 5 read-only tools (P1-B)

### DIFF
--- a/crates/codelens-mcp/src/integration_tests/readonly.rs
+++ b/crates/codelens-mcp/src/integration_tests/readonly.rs
@@ -28,6 +28,122 @@ fn returns_symbols_via_tool_call() {
     assert_eq!(payload["success"], json!(true));
 }
 
+// P1-B contract: every read-only tool in the second wave must
+// 1) honor `limit` / `top_k` aliases for whatever its canonical
+//    limit field is (or skip the alias if it has no limit field),
+// 2) surface unknown top-level keys in `unknown_args: [...]` so
+//    silent drops of agent input become observable.
+//
+// Doc: docs/design/arg-validation-policy.md
+#[test]
+fn p1_b_arg_validation_contract_across_five_tools() {
+    let project = project_root();
+    fs::write(
+        project.as_path().join("contract.py"),
+        "def alpha():\n    pass\n\
+         def beta():\n    alpha()\n    print('x')\n\
+         def gamma():\n    beta()\n",
+    )
+    .unwrap();
+    let state = make_state(&project);
+
+    // get_callers — limit alias narrows result set; banana surfaced
+    let p = call_tool(
+        &state,
+        "get_callers",
+        json!({"function_name": "alpha", "limit": 1, "banana": 1}),
+    );
+    assert_eq!(p["success"], json!(true));
+    assert_eq!(
+        p["data"]["unknown_args"],
+        json!(["banana"]),
+        "get_callers must surface unknown banana key"
+    );
+
+    // get_callees — top_k alias works as well
+    let p = call_tool(
+        &state,
+        "get_callees",
+        json!({"function_name": "beta", "top_k": 5, "threshold": 0.5}),
+    );
+    assert_eq!(p["success"], json!(true));
+    assert_eq!(
+        p["data"]["unknown_args"],
+        json!(["threshold"]),
+        "get_callees must surface unknown threshold key"
+    );
+
+    // find_symbol — canonical is `max_matches`, but `limit` should still alias to it
+    let p = call_tool(
+        &state,
+        "find_symbol",
+        json!({"name": "alpha", "limit": 3, "carrot": "c"}),
+    );
+    assert_eq!(p["success"], json!(true));
+    assert_eq!(
+        p["data"]["unknown_args"],
+        json!(["carrot"]),
+        "find_symbol must surface unknown carrot key"
+    );
+
+    // find_referencing_symbols — limit alias on tree-sitter fallback path
+    let p = call_tool(
+        &state,
+        "find_referencing_symbols",
+        json!({"file_path": "contract.py", "symbol_name": "alpha", "limit": 5, "fizz": true}),
+    );
+    assert_eq!(p["success"], json!(true));
+    assert_eq!(
+        p["data"]["unknown_args"],
+        json!(["fizz"]),
+        "find_referencing_symbols must surface unknown fizz key"
+    );
+
+    // get_ranked_context — no limit alias (depth is the relevant control),
+    // but unknown args still surface
+    let p = call_tool(
+        &state,
+        "get_ranked_context",
+        json!({"query": "alpha", "buzz": 9}),
+    );
+    assert_eq!(p["success"], json!(true));
+    assert_eq!(
+        p["data"]["unknown_args"],
+        json!(["buzz"]),
+        "get_ranked_context must surface unknown buzz key"
+    );
+
+    // Negative case: clean args produce no `unknown_args` key on any
+    // of the five tools (backward compatibility for happy-path agents).
+    for (tool, args) in [
+        (
+            "get_callers",
+            json!({"function_name": "alpha", "max_results": 5}),
+        ),
+        (
+            "get_callees",
+            json!({"function_name": "beta", "max_results": 5}),
+        ),
+        ("find_symbol", json!({"name": "alpha", "max_matches": 3})),
+        (
+            "find_referencing_symbols",
+            json!({"file_path": "contract.py", "symbol_name": "alpha", "max_results": 5}),
+        ),
+        ("get_ranked_context", json!({"query": "alpha", "depth": 2})),
+    ] {
+        let p = call_tool(&state, tool, args);
+        assert_eq!(
+            p["success"],
+            json!(true),
+            "{tool} clean call should succeed"
+        );
+        assert!(
+            p["data"].get("unknown_args").is_none(),
+            "{tool} clean args must not include unknown_args key (backward compat)"
+        );
+    }
+}
+
 #[test]
 fn find_symbol_surfaces_tree_sitter_precision_evidence() {
     let project = project_root();

--- a/crates/codelens-mcp/src/tool_runtime.rs
+++ b/crates/codelens-mcp/src/tool_runtime.rs
@@ -89,6 +89,13 @@ pub fn optional_usize_with_aliases(
 /// not honor `threshold` sees the field was ignored, instead of
 /// receiving silent default behavior.
 ///
+/// Keys whose name begins with `_` are treated as harness-internal
+/// metadata (e.g. the `_session_id` that `call_tool` auto-injects in
+/// integration tests, the `_meta` envelope MCP clients sometimes
+/// attach) and are NEVER reported as unknown — they are not user
+/// input. Without this exception every `unknown_args` array on every
+/// tool would noisily include `_session_id`.
+///
 /// Returns an empty Vec for non-object values so non-object inputs
 /// fall through to the handler's existing argument parsing without
 /// spurious "unknown" claims.
@@ -98,6 +105,7 @@ pub fn collect_unknown_args(value: &serde_json::Value, known: &[&str]) -> Vec<St
     };
     let mut unknown: Vec<String> = map
         .keys()
+        .filter(|k| !k.starts_with('_'))
         .filter(|k| !known.iter().any(|allowed| allowed == k))
         .cloned()
         .collect();
@@ -151,6 +159,23 @@ mod tests {
         let args = json!({"query": "x", "limit": 5});
         let unknown = collect_unknown_args(&args, &["query", "limit"]);
         assert!(unknown.is_empty());
+    }
+
+    #[test]
+    fn collect_unknown_args_skips_underscore_prefixed_harness_keys() {
+        // Harness-internal keys like `_session_id` (auto-injected by
+        // the integration-test `call_tool` helper) and `_meta` (some
+        // MCP clients attach this to every tool call) are not user
+        // input. They must never surface as "unknown" or every tool
+        // response would carry noisy `unknown_args: ["_session_id"]`.
+        let args = json!({
+            "query": "x",
+            "_session_id": "abc",
+            "_meta": {"trace": "..."},
+            "real_unknown": 1,
+        });
+        let unknown = collect_unknown_args(&args, &["query"]);
+        assert_eq!(unknown, vec!["real_unknown".to_owned()]);
     }
 
     #[test]

--- a/crates/codelens-mcp/src/tools/graph.rs
+++ b/crates/codelens-mcp/src/tools/graph.rs
@@ -232,9 +232,27 @@ pub fn find_scoped_references_tool(state: &AppState, arguments: &serde_json::Val
 }
 
 pub fn get_callers_tool(state: &AppState, arguments: &serde_json::Value) -> ToolResult {
+    // P1-B — accept `limit`/`top_k` aliases for `max_results` and surface
+    // unknown top-level keys so an agent that passes (e.g.) `threshold:
+    // 0.5` to a tool that does not honor it sees the field was ignored.
+    // See docs/design/arg-validation-policy.md.
+    const KNOWN_ARGS: &[&str] = &[
+        "function_name",
+        "file_path",
+        "path",
+        "max_results",
+        "limit",
+        "top_k",
+    ];
     let function_name = required_string(arguments, "function_name")?;
     let file_path = optional_string(arguments, "file_path");
-    let max_results = optional_usize(arguments, "max_results", 50);
+    let max_results = crate::tool_runtime::optional_usize_with_aliases(
+        arguments,
+        "max_results",
+        &["limit", "top_k"],
+        50,
+    );
+    let unknown_args = crate::tool_runtime::collect_unknown_args(arguments, KNOWN_ARGS);
     let graph_cache = state.graph_cache();
     Ok(get_callers(
         &state.project(),
@@ -280,24 +298,41 @@ pub fn get_callers_tool(state: &AppState, arguments: &serde_json::Value) -> Tool
             confidence_basis,
             call_graph_evidence_signals(&resolution_summary),
         );
-        (
-            json!({
-                "function": function_name,
-                "callers": value,
-                "count": value.len(),
-                "confidence_basis": confidence_basis,
-                "resolution_summary": resolution_summary,
-                "evidence": evidence,
-            }),
-            meta,
-        )
+        let mut payload = json!({
+            "function": function_name,
+            "callers": value,
+            "count": value.len(),
+            "confidence_basis": confidence_basis,
+            "resolution_summary": resolution_summary,
+            "evidence": evidence,
+        });
+        if !unknown_args.is_empty()
+            && let Some(map) = payload.as_object_mut()
+        {
+            map.insert("unknown_args".to_owned(), json!(unknown_args));
+        }
+        (payload, meta)
     })?)
 }
 
 pub fn get_callees_tool(state: &AppState, arguments: &serde_json::Value) -> ToolResult {
+    const KNOWN_ARGS: &[&str] = &[
+        "function_name",
+        "file_path",
+        "path",
+        "max_results",
+        "limit",
+        "top_k",
+    ];
     let function_name = required_string(arguments, "function_name")?;
     let file_path = optional_string(arguments, "file_path");
-    let max_results = optional_usize(arguments, "max_results", 50);
+    let max_results = crate::tool_runtime::optional_usize_with_aliases(
+        arguments,
+        "max_results",
+        &["limit", "top_k"],
+        50,
+    );
+    let unknown_args = crate::tool_runtime::collect_unknown_args(arguments, KNOWN_ARGS);
     let graph_cache = state.graph_cache();
     Ok(get_callees(
         &state.project(),
@@ -346,17 +381,20 @@ pub fn get_callees_tool(state: &AppState, arguments: &serde_json::Value) -> Tool
             confidence_basis,
             call_graph_evidence_signals(&resolution_summary),
         );
-        (
-            json!({
-                "function": function_name,
-                "callees": value,
-                "count": value.len(),
-                "confidence_basis": confidence_basis,
-                "resolution_summary": resolution_summary,
-                "evidence": evidence,
-            }),
-            meta,
-        )
+        let mut payload = json!({
+            "function": function_name,
+            "callees": value,
+            "count": value.len(),
+            "confidence_basis": confidence_basis,
+            "resolution_summary": resolution_summary,
+            "evidence": evidence,
+        });
+        if !unknown_args.is_empty()
+            && let Some(map) = payload.as_object_mut()
+        {
+            map.insert("unknown_args".to_owned(), json!(unknown_args));
+        }
+        (payload, meta)
     })?)
 }
 

--- a/crates/codelens-mcp/src/tools/lsp.rs
+++ b/crates/codelens-mcp/src/tools/lsp.rs
@@ -104,13 +104,35 @@ fn enhance_lsp_error(err: anyhow::Error, command: &str) -> CodeLensError {
 /// over IDE-grade type precision. LSP adds latency (cold start 2-30s),
 /// requires external server installation, and fails on incomplete code.
 pub fn find_referencing_symbols(state: &AppState, arguments: &serde_json::Value) -> ToolResult {
+    // P1-B — limit/top_k aliases + unknown_args.
+    // See docs/design/arg-validation-policy.md.
+    const KNOWN_ARGS: &[&str] = &[
+        "file_path",
+        "path",
+        "symbol_name",
+        "max_results",
+        "limit",
+        "top_k",
+        "use_lsp",
+        "include_context",
+        "full_results",
+        "sample_limit",
+        "line",
+        "column",
+    ];
     let file_path = required_string(arguments, "file_path")?.to_owned();
     let symbol_name_param = optional_string(arguments, "symbol_name");
-    let max_results = optional_usize(arguments, "max_results", 20);
+    let max_results = crate::tool_runtime::optional_usize_with_aliases(
+        arguments,
+        "max_results",
+        &["limit", "top_k"],
+        20,
+    );
     let use_lsp = optional_bool(arguments, "use_lsp", false);
     let include_context = optional_bool(arguments, "include_context", false);
     let full_results = optional_bool(arguments, "full_results", false);
     let sample_limit = optional_usize(arguments, "sample_limit", 8);
+    let unknown_args = crate::tool_runtime::collect_unknown_args(arguments, KNOWN_ARGS);
 
     let has_position = arguments.get("line").is_some() && arguments.get("column").is_some();
 
@@ -148,17 +170,20 @@ pub fn find_referencing_symbols(state: &AppState, arguments: &serde_json::Value)
                         count,
                     ),
                 );
-                return Ok((
-                    json!({
-                        "references": refs_limited,
-                        "count": count,
-                        "returned_count": count,
-                        "sampled": false,
-                        "backend": "oxc_semantic",
-                        "evidence": evidence,
-                    }),
-                    meta,
-                ));
+                let mut payload = json!({
+                    "references": refs_limited,
+                    "count": count,
+                    "returned_count": count,
+                    "sampled": false,
+                    "backend": "oxc_semantic",
+                    "evidence": evidence,
+                });
+                if !unknown_args.is_empty()
+                    && let Some(map) = payload.as_object_mut()
+                {
+                    map.insert("unknown_args".to_owned(), json!(unknown_args));
+                }
+                return Ok((payload, meta));
             }
         }
         // oxc failed or empty — try SCIP if available, then fall through to tree-sitter
@@ -198,17 +223,20 @@ pub fn find_referencing_symbols(state: &AppState, arguments: &serde_json::Value)
                                 })
                             })
                             .collect();
-                        return Ok((
-                            json!({
-                                "references": refs_json,
-                                "count": count,
-                                "returned_count": count,
-                                "sampled": false,
-                                "backend": "scip",
-                                "evidence": evidence,
-                            }),
-                            meta,
-                        ));
+                        let mut payload = json!({
+                            "references": refs_json,
+                            "count": count,
+                            "returned_count": count,
+                            "sampled": false,
+                            "backend": "scip",
+                            "evidence": evidence,
+                        });
+                        if !unknown_args.is_empty()
+                            && let Some(map) = payload.as_object_mut()
+                        {
+                            map.insert("unknown_args".to_owned(), json!(unknown_args));
+                        }
+                        return Ok((payload, meta));
                     }
                 }
             }
@@ -236,17 +264,20 @@ pub fn find_referencing_symbols(state: &AppState, arguments: &serde_json::Value)
                     0,
                 ),
             );
-            (
-                json!({
-                    "references": references,
-                    "count": total_count,
-                    "returned_count": references.len(),
-                    "sampled": sampled,
-                    "include_context": include_context,
-                    "evidence": evidence,
-                }),
-                meta,
-            )
+            let mut payload = json!({
+                "references": references,
+                "count": total_count,
+                "returned_count": references.len(),
+                "sampled": sampled,
+                "include_context": include_context,
+                "evidence": evidence,
+            });
+            if !unknown_args.is_empty()
+                && let Some(map) = payload.as_object_mut()
+            {
+                map.insert("unknown_args".to_owned(), json!(unknown_args));
+            }
+            (payload, meta)
         })?);
     }
 
@@ -301,16 +332,19 @@ pub fn find_referencing_symbols(state: &AppState, arguments: &serde_json::Value)
                         value.len(),
                     ),
                 );
-                return Ok((
-                    json!({
-                        "references": value,
-                        "count": value.len(),
-                        "returned_count": value.len(),
-                        "sampled": false,
-                        "evidence": evidence,
-                    }),
-                    meta,
-                ));
+                let mut payload = json!({
+                    "references": value,
+                    "count": value.len(),
+                    "returned_count": value.len(),
+                    "sampled": false,
+                    "evidence": evidence,
+                });
+                if !unknown_args.is_empty()
+                    && let Some(map) = payload.as_object_mut()
+                {
+                    map.insert("unknown_args".to_owned(), json!(unknown_args));
+                }
+                return Ok((payload, meta));
             }
             Err(_) => {
                 // LSP failed — fall through to tree-sitter

--- a/crates/codelens-mcp/src/tools/symbols/handlers.rs
+++ b/crates/codelens-mcp/src/tools/symbols/handlers.rs
@@ -64,6 +64,23 @@ pub fn get_symbols_overview(state: &AppState, arguments: &Value) -> ToolResult {
 }
 
 pub fn find_symbol(state: &AppState, arguments: &Value) -> ToolResult {
+    // P1-B — `find_symbol`'s canonical limit field is `max_matches`,
+    // not `max_results`, but agents typing `limit`/`top_k` mean the
+    // same thing. See docs/design/arg-validation-policy.md.
+    const KNOWN_ARGS: &[&str] = &[
+        "symbol_id",
+        "name",
+        "file_path",
+        "path",
+        "include_body",
+        "exact_match",
+        "max_matches",
+        "limit",
+        "top_k",
+        "body_full",
+        "body_line_limit",
+        "body_char_limit",
+    ];
     let symbol_id = optional_string(arguments, "symbol_id");
     let name = symbol_id
         .or_else(|| optional_string(arguments, "name"))
@@ -71,7 +88,13 @@ pub fn find_symbol(state: &AppState, arguments: &Value) -> ToolResult {
     let file_path = optional_string(arguments, "file_path");
     let include_body = optional_bool(arguments, "include_body", false);
     let exact_match = optional_bool(arguments, "exact_match", false);
-    let max_matches = optional_usize(arguments, "max_matches", 50);
+    let max_matches = crate::tool_runtime::optional_usize_with_aliases(
+        arguments,
+        "max_matches",
+        &["limit", "top_k"],
+        50,
+    );
+    let unknown_args = crate::tool_runtime::collect_unknown_args(arguments, KNOWN_ARGS);
     let body_full = optional_bool(arguments, "body_full", false);
     let body_line_limit = optional_usize(arguments, "body_line_limit", 12);
     let body_char_limit = optional_usize(arguments, "body_char_limit", 600);
@@ -125,17 +148,20 @@ pub fn find_symbol(state: &AppState, arguments: &Value) -> ToolResult {
                         sym
                     })
                     .collect();
-                return Ok((
-                    json!({
-                        "symbols": syms,
-                        "count": count,
-                        "body_truncated_count": 0,
-                        "body_preview": false,
-                        "backend": "scip",
-                        "evidence": evidence,
-                    }),
-                    meta,
-                ));
+                let mut payload = json!({
+                    "symbols": syms,
+                    "count": count,
+                    "body_truncated_count": 0,
+                    "body_preview": false,
+                    "backend": "scip",
+                    "evidence": evidence,
+                });
+                if !unknown_args.is_empty()
+                    && let Some(map) = payload.as_object_mut()
+                {
+                    map.insert("unknown_args".to_owned(), json!(unknown_args));
+                }
+                return Ok((payload, meta));
             }
         }
     }
@@ -202,6 +228,9 @@ pub fn find_symbol(state: &AppState, arguments: &Value) -> ToolResult {
                         ),
                     ),
                 );
+                if !unknown_args.is_empty() {
+                    map.insert("unknown_args".to_owned(), json!(unknown_args));
+                }
             }
             (payload, meta)
         })?)
@@ -354,6 +383,22 @@ pub fn bm25_symbol_search(state: &AppState, arguments: &Value) -> ToolResult {
 }
 
 pub fn get_ranked_context(state: &AppState, arguments: &Value) -> ToolResult {
+    // P1-B — surface unknown_args. No `limit`/`top_k` alias here:
+    // get_ranked_context's relevant control is `depth` (graph
+    // expansion), not a top-N. See docs/design/arg-validation-policy.md.
+    const KNOWN_ARGS: &[&str] = &[
+        "query",
+        "path",
+        "file_path",
+        "max_tokens",
+        "include_body",
+        "depth",
+        "disable_semantic",
+        "session_id",
+        "logical_session_id",
+        "harness_phase",
+        "lsp_boost",
+    ];
     let query = required_string(arguments, "query")?;
     let query_analysis = analyze_retrieval_query(query);
     let path = optional_string(arguments, "path");
@@ -366,6 +411,7 @@ pub fn get_ranked_context(state: &AppState, arguments: &Value) -> ToolResult {
     let include_body = optional_bool(arguments, "include_body", false);
     let depth = optional_usize(arguments, "depth", 2);
     let disable_semantic = optional_bool(arguments, "disable_semantic", false);
+    let unknown_args = crate::tool_runtime::collect_unknown_args(arguments, KNOWN_ARGS);
     let exact_identifier_projection = query_analysis.original_query
         != query_analysis.expanded_query
         && !query_analysis.expanded_query.contains(char::is_whitespace);
@@ -541,6 +587,9 @@ pub fn get_ranked_context(state: &AppState, arguments: &Value) -> ToolResult {
             map.insert("sparse_evidence".to_owned(), json!(sparse_evidence));
         }
         map.insert("evidence".to_owned(), evidence);
+        if !unknown_args.is_empty() {
+            map.insert("unknown_args".to_owned(), json!(unknown_args));
+        }
     }
 
     Ok((payload, meta))

--- a/docs/design/arg-validation-policy.md
+++ b/docs/design/arg-validation-policy.md
@@ -1,0 +1,112 @@
+# Tool argument validation policy
+
+CodeLens tools accept JSON input via MCP `tools/call`. This document
+codifies how handlers should treat argument keys that the input
+schema does not define, and how to absorb common agent typos like
+`limit` into a tool's canonical `max_results` / `max_matches` field.
+
+Status: shipped on read-only tools listed below; mutation-tool strict
+mode and `CODELENS_STRICT_ARGS=1` opt-in remain out of scope for now.
+
+## Tri-state policy
+
+Every tool handler picks one of three modes based on its risk profile:
+
+1. **Lenient + visible (default for read-only tools)**
+   - Accept canonical names AND registered aliases for limit-like
+     fields.
+   - Surface every other top-level key in a `unknown_args: ["foo",
+"bar"]` array on the response so an agent that passed (e.g.)
+     `threshold: 0.5` to a tool that does not honor it sees the
+     field was ignored.
+   - Never error out on unknown args; do not include the
+     `unknown_args` key when there are none (backward compat).
+
+2. **Strict (default for mutation tools)**
+   - Reject unknown args with a `MissingParam("unknown arg: <key>")`
+     error before any side effect runs.
+   - Reserved for `rename_symbol`, `replace_symbol_body`,
+     `apply_full_writes_with_evidence`, `add_import`,
+     `delete_lines`, `insert_at_line`, `replace_lines`,
+     `replace_content`, `move_symbol`, `refactor_*`, etc.
+   - Rationale: silently dropping an arg on a mutation can cause
+     incorrect edits; an explicit error is safer than a quiet
+     no-op.
+
+3. **Aliased**
+   - Applied uniformly to read-only tools whose canonical limit
+     field is `max_results` or `max_matches`. The two project-wide
+     aliases are `limit` and `top_k`.
+   - Canonical name wins on collision (`{"max_results": 10,
+"limit": 99}` returns 10 results — never 99).
+   - Alias resolution does **not** suppress `unknown_args`: if both
+     `limit` and `banana` are passed, the response honors `limit`
+     and lists `["banana"]` under `unknown_args`.
+
+## Helpers
+
+Both helpers live in `crates/codelens-mcp/src/tool_runtime.rs` so
+they are usable from any handler regardless of feature flags.
+
+- `optional_usize_with_aliases(args, canonical, aliases, default)`
+- `collect_unknown_args(args, &KNOWN_ARGS) -> Vec<String>`
+
+## Read-only tools currently aliased
+
+The first wave is `semantic_search` (#110, P0-3). The second wave
+(this slice) covers the highest-traffic structural tools:
+
+| Canonical         | Aliases          | Tools                                                                       |
+| ----------------- | ---------------- | --------------------------------------------------------------------------- |
+| `max_results`     | `limit`, `top_k` | `semantic_search`, `get_callers`, `get_callees`, `find_referencing_symbols` |
+| `max_matches`     | `limit`, `top_k` | `find_symbol`                                                               |
+| (none — see note) | —                | `get_ranked_context`                                                        |
+
+Note on `get_ranked_context`: the tool has no limit-style argument
+in its current shape — the relevant control is `depth` (graph
+expansion depth), not a top-N. We still emit `unknown_args` so an
+agent that passes `max_results: 10` learns the field is ignored,
+but no alias is registered.
+
+## Adding a new tool
+
+For a new **read-only** tool:
+
+```rust
+const KNOWN_ARGS: &[&str] = &["query", "max_results", "limit", "top_k", "file_path"];
+let max_results = optional_usize_with_aliases(arguments, "max_results", &["limit", "top_k"], 20);
+let unknown_args = collect_unknown_args(arguments, KNOWN_ARGS);
+
+// ...build response...
+
+if !unknown_args.is_empty()
+    && let Some(map) = payload.as_object_mut()
+{
+    map.insert("unknown_args".to_owned(), json!(unknown_args));
+}
+```
+
+For a new **mutation** tool:
+
+- Use `serde_json::Value::as_object()` and explicitly `insert` the
+  recognized keys into a typed struct via `serde_json::from_value`,
+  or hand-walk the map and reject unknown keys with `MissingParam`.
+- Do **not** apply the lenient pattern — a typoed key on a
+  mutation can cause undefined behavior.
+
+## Out-of-scope
+
+- Strict-mode opt-in env flag (`CODELENS_STRICT_ARGS=1`) that
+  promotes `unknown_args` to a JSON-RPC error for read-only tools
+- Schema-side documentation of aliases in tool `input_schema`
+  (would force every consumer to rebuild)
+- Auditing every existing mutation handler for strict-mode
+  conformance — track separately, large blast radius
+
+## History
+
+- 2026-04-26 — `semantic_search` pilot, helpers landed
+  ([#110](https://github.com/mupozg823/codelens-mcp-plugin/pull/110))
+- 2026-04-26 — Wave 2 fan-out: `get_callers`, `get_callees`,
+  `find_referencing_symbols`, `find_symbol`, `get_ranked_context`
+  - this policy doc


### PR DESCRIPTION
## Summary
- Extends the lenient-and-visible arg-validation pattern from PR #110 (`semantic_search`) to 5 high-traffic read-only tools: `get_callers`, `get_callees`, `find_referencing_symbols`, `find_symbol`, `get_ranked_context`.
- Each handler now accepts `limit` / `top_k` as aliases for the canonical `max_results` / `max_matches` field where a top-N control exists, and surfaces non-allowlisted top-level keys as `unknown_args` so silently-ignored fields become visible.
- `collect_unknown_args` now skips `_`-prefixed keys (`_session_id`, `_meta`) so harness internals don't leak into responses.
- `KNOWN_ARGS` lists include both `file_path` and `path` because the dispatch envelope (P1-C) aliases them bidirectionally before handlers run.
- Adds `docs/design/arg-validation-policy.md` documenting the tri-state policy (lenient+visible / strict / aliased) and the per-tool alias table.

## Why
Senior assessment flagged these tools as the next-biggest agent-fluency wins after `semantic_search`. Agents typing `limit: 5` against `max_results` or passing tool-specific args like `threshold` previously saw silent default behavior. After this PR they get either honored or visibly flagged.

## Test plan
- [x] `cargo test -p codelens-mcp` — 534/534 pass
- [x] `cargo test -p codelens-mcp --features http` — 616/616 pass
- [x] `cargo test -p codelens-mcp --features scip-backend` (P1-B test) — pass
- [x] `cargo test -p codelens-mcp --no-default-features` (P1-B test) — pass
- [x] `cargo clippy -p codelens-mcp` — clean
- [x] New integration test: `p1_b_arg_validation_contract_across_five_tools` covers alias + unknown surface + clean baseline for all 5 tools
- [x] New unit test: `collect_unknown_args_skips_underscore_prefixed_harness_keys`

🤖 Generated with [Claude Code](https://claude.com/claude-code)