### PR TITLE
feat(call-graph): recognize Rust macro invocations as caller→callee edges (C-1)

### DIFF
--- a/crates/codelens-engine/src/call_graph.rs
+++ b/crates/codelens-engine/src/call_graph.rs
@@ -837,6 +837,8 @@ const RUST_CALL_QUERY: &str = r#"
 (call_expression function: (identifier) @callee)
 (call_expression function: (field_expression field: (field_identifier) @callee))
 (call_expression function: (scoped_identifier name: (identifier) @callee))
+(macro_invocation macro: (identifier) @callee)
+(macro_invocation macro: (scoped_identifier name: (identifier) @callee))
 "#;
 
 #[cfg(test)]
@@ -948,6 +950,64 @@ mod tests {
                 .any(|e| e.caller_name == "main" && e.callee_name == "run"),
             "expected main->run edge, got {edges:?}"
         );
+    }
+
+    /// Rust macro invocations (`vec!`, `assert_eq!`, project-defined macros,
+    /// scoped macros like `mycrate::log!`) are extremely common — but before
+    /// 2026-04-26 they were silently dropped from the call graph because
+    /// `macro_invocation` is a distinct AST node from `call_expression`.
+    ///
+    /// `println!` / `eprintln!` / `format!` / `print!` are intentionally
+    /// filtered by `is_noise_callee` to keep std-debug lines out of the
+    /// graph; the query DOES discover them but the noise filter drops them.
+    /// Project-named macros and `vec!` / `assert_eq!` survive — those are
+    /// the meaningful edges this PR unlocks.
+    #[test]
+    fn extracts_rust_macro_invocations_as_callers() {
+        let dir = temp_dir("rs-macros");
+        let path = dir.join("macros.rs");
+        fs::write(
+            &path,
+            r#"macro_rules! my_log { ($($t:tt)*) => {} }
+fn run() {
+    let v = vec![1, 2, 3];
+    assert_eq!(v.len(), 3);
+    my_log!("hello");
+}
+"#,
+        )
+        .expect("write");
+        let edges = extract_calls(&path);
+        for expected in ["vec", "assert_eq", "my_log"] {
+            assert!(
+                edges
+                    .iter()
+                    .any(|e| e.caller_name == "run" && e.callee_name == expected),
+                "expected run->{expected} macro edge, got {edges:?}"
+            );
+        }
+    }
+
+    /// Scoped macro invocations (`mycrate::my_macro!`). Uses project-named
+    /// macros so they survive the std-noise filter.
+    #[test]
+    fn extracts_rust_scoped_macro_invocations() {
+        let dir = temp_dir("rs-scoped-macros");
+        let path = dir.join("scoped.rs");
+        fs::write(
+            &path,
+            "fn run() {\n    mycrate::trace_event!(\"hi\");\n    helpers::record_metric!(42);\n}\n",
+        )
+        .expect("write");
+        let edges = extract_calls(&path);
+        for expected in ["trace_event", "record_metric"] {
+            assert!(
+                edges
+                    .iter()
+                    .any(|e| e.caller_name == "run" && e.callee_name == expected),
+                "expected run->{expected} scoped macro edge, got {edges:?}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Cross-language recall measurement (2026-04-26) found that \`RUST_CALL_QUERY\` matched **zero** \`macro_invocation\` nodes — \`vec!\`, \`assert_eq!\`, project-defined macros, and scoped macros (\`mycrate::my_macro!\`) were silently dropped from the call graph because tree-sitter-rust models \`macro_invocation\` as a distinct AST node from \`call_expression\`.

This is the C-1 slice of the cross-lang recall pass-2 plan (memory: \`project_cross_lang_recall_probe_2026_04_26\`).

## Change
Two new query patterns:
\`\`\`text
(macro_invocation macro: (identifier) @callee)
(macro_invocation macro: (scoped_identifier name: (identifier) @callee))
\`\`\`

Standard noise (\`println!\`/\`eprintln!\`/\`format!\`/\`print!\`/\`log!\`/\`info!\`/\`warn!\`/\`error!\`/\`debug!\`) continues to be dropped by \`is_noise_callee\` so debug-print lines don't pollute the graph; **project macros and meaningful asserts now survive**.

## Test plan
- [x] New: \`extracts_rust_macro_invocations_as_callers\` — covers \`vec!\`, \`assert_eq!\`, project-defined \`my_log!\`
- [x] New: \`extracts_rust_scoped_macro_invocations\` — covers \`mycrate::trace_event!\`, \`helpers::record_metric!\`
- [x] \`cargo test -p codelens-engine\` — 336/336
- [x] \`cargo test -p codelens-mcp\` — 535/535 (no regression)
- [x] \`cargo clippy -p codelens-engine\` — clean

## Next slices (per memory)
- C-2: Java \`new Foo()\` constructor (object_creation_expression)
- C-3: Java method reference (\`Foo::bar\`) + diagnose why basic method_invocation chains weren't found in probe

🤖 Generated with [Claude Code](https://claude.com/claude-code)