### PR TITLE
chore: remove *.md from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,4 +75,3 @@ index.scip
 .scip/
 
 .bench-baselines/
-*.md


### PR DESCRIPTION
Fixes release-plz failure caused by 171 tracked+ignored markdown files.