### PR TITLE
fix(scripts): correct zero-call tool bucket count

### DIFF
--- a/scripts/analyze-tool-usage.py
+++ b/scripts/analyze-tool-usage.py
@@ -57,11 +57,11 @@ def analyze(data: dict) -> None:
 
         # Distribution buckets
         buckets = Counter()
+        # Zero-call tools come from a separate field, not from per_tool list
+        buckets["zero"] = len(zero_call)
         for t in tools:
             c = t.get("calls", 0)
-            if c == 0:
-                buckets["zero"] += 1
-            elif c <= 5:
+            if c <= 5:
                 buckets["1-5"] += 1
             elif c <= 20:
                 buckets["6-20"] += 1


### PR DESCRIPTION
Fixes dead code in CALL DISTRIBUTION where the zero bucket was never populated. per_tool only contains tools with call_count > 0; zero-call tools come from a separate field.\n\nReported by @chatgpt-codex-connector.