### PR TITLE
docs: add ADR index and docs README (v2)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,33 @@
+# CodeLens Documentation
+
+## Directory Structure
+
+| Directory | Contents | Audience |
+|-----------|----------|----------|
+| [`adr/`](adr/) | Architecture Decision Records (ADRs) | Contributors, maintainers |
+| [`design/`](design/) | Design specs and policy documents | Contributors, reviewers |
+| [`generated/`](generated/) | Auto-generated artifacts (surface manifest, schemas) | CI, tooling |
+| [`release-notes/`](release-notes/) | Per-version release notes | Users, operators |
+| [`schemas/`](schemas/) | JSON schemas for tool I/O and protocols | Client integrators |
+| [`superpowers/`](superpowers/) | Agent skill definitions and implementation plans | Agent orchestrators |
+| [`archive/`](archive/) | Superseded or historical documents | Archaeologists |
+
+## Quick Links
+
+- **ADR Index**: [`adr/README.md`](adr/README.md)
+- **Surface Manifest**: [`generated/surface-manifest.json`](generated/surface-manifest.json)
+- **Migration Guide**: [`migrate-from-codelens.md`](migrate-from-codelens.md)
+- **Install Matrix**: See top-level [`README.md`](../README.md)
+
+## Generated Artifacts
+
+The following files are auto-generated and should not be edited manually:
+
+- `generated/surface-manifest.json` — Built from `tool_defs.rs` via `cargo run -- --print-surface-manifest`
+- `generated/tool-schemas/` — JSON schemas derived from Rust types
+
+## Contributing
+
+- ADRs: Follow the established format; update the index.
+- Design docs: Place in `design/` with a clear scope and target version.
+- Release notes: Use `release-plz` + `git-cliff`; do not edit `CHANGELOG.md` directly.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,33 @@
+# Architecture Decision Records (ADR)
+
+This directory contains all Architecture Decision Records for the CodeLens project.
+
+## Index
+
+| ADR | Title | Status | Date | Supersedes |
+|-----|-------|--------|------|------------|
+| [ADR-0001](ADR-0001-runtime-boundaries-and-single-source-registries.md) | Runtime Boundaries and Single-Source Registries | Proposed | 2026-04-12 | — |
+| [ADR-0002](ADR-0002-enterprise-productization-evaluation-and-release-gates.md) | Enterprise Productization, Evaluation, and Release Gates | Proposed | 2026-04-13 | — |
+| [ADR-0004](ADR-0004-multi-agent-concurrency-primitives.md) | Multi-Agent Concurrency Primitives (Bounded-Evidence Only) | **Accepted** | 2026-04-15 | — |
+| [ADR-0005](ADR-0005-harness-v2.md) | Harness v2 — CodeLens as shared substrate for role-specialized agent hosts | **Accepted** | 2026-04-18 | — |
+| [ADR-0006](ADR-0006-agent-routing-enforcement.md) | Agent Routing Enforcement (server-side `preferred_executor` metadata) | **Accepted** | 2026-04-18 | — |
+| [ADR-0007](ADR-0007-symbiote-rebrand.md) | Symbiote as the v2 product metaphor and candidate rename | **Accepted** (pending trademark) | 2026-04-18 | — |
+| [ADR-0008](ADR-0008-serena-upper-compatible-absorption.md) | Serena Upper-Compatible Absorption (P1-P4, passive first) | **Accepted** | 2026-04-19 | — |
+| [ADR-0009](ADR-0009-mutation-trust-substrate.md) | Mutation Trust Substrate | Proposed | 2026-04-26 | Internal G4/G7 notes |
+| [ADR-0010](0010-telemetry-driven-tool-diet.md) | Telemetry-Driven Tool Surface Diet | Proposed | 2026-04-30 | — |
+
+## Status Legend
+
+- **Proposed** — Under discussion; not yet committed to implementation.
+- **Accepted** — Decision made and implementation in progress or complete.
+- **Deprecated** — No longer applicable; superseded by a newer ADR.
+- **Rejected** — Explicitly decided against.
+
+## Contributing
+
+When adding a new ADR:
+
+1. Use the next sequential number (e.g., `ADR-0011-...`).
+2. Copy the template from [design/adr-template.md](../design/adr-template.md) if available, or follow the structure of existing ADRs.
+3. Update this index.
+4. Link the ADR from relevant code comments where the decision is enforced.


### PR DESCRIPTION
Adds a structured index for all 9 ADRs and a top-level docs README explaining the directory layout.