### PR TITLE
chore(clippy): clear remaining --all-targets warnings (stacked on PR #125)

### DIFF
--- a/crates/codelens-engine/src/edit_transaction.rs
+++ b/crates/codelens-engine/src/edit_transaction.rs
@@ -366,20 +366,21 @@ fn sha256_hex(bytes: &[u8]) -> String {
 }
 
 #[cfg(test)]
+type FullWriteInjectHook = std::cell::RefCell<Option<Box<dyn FnOnce(&std::path::Path)>>>;
+
+#[cfg(test)]
 thread_local! {
     /// Test-only hook: when set, called once between Phase 1 capture and
     /// Phase 2 verify with the resolved path so a test can mutate the file
     /// to simulate TOCTOU drift. Cleared after one call.
-    pub(crate) static FULL_WRITE_INJECT_BETWEEN_CAPTURE_AND_VERIFY:
-        std::cell::RefCell<Option<Box<dyn FnOnce(&std::path::Path)>>> =
+    pub(crate) static FULL_WRITE_INJECT_BETWEEN_CAPTURE_AND_VERIFY: FullWriteInjectHook =
         std::cell::RefCell::new(None);
 
     /// Test-only hook: when set, called once immediately before the Phase 3
     /// rollback restore write, with the resolved path. Allows a test to
     /// reverse any permission changes that caused the initial write to fail,
     /// so the rollback `fs::write` can succeed. Cleared after one call.
-    pub(crate) static FULL_WRITE_INJECT_BEFORE_ROLLBACK:
-        std::cell::RefCell<Option<Box<dyn FnOnce(&std::path::Path)>>> =
+    pub(crate) static FULL_WRITE_INJECT_BEFORE_ROLLBACK: FullWriteInjectHook =
         std::cell::RefCell::new(None);
 }
 

--- a/crates/codelens-engine/src/symbols/types.rs
+++ b/crates/codelens-engine/src/symbols/types.rs
@@ -269,7 +269,13 @@ pub(crate) enum ReadDb<'a> {
     Writer(std::sync::MutexGuard<'a, IndexDb>),
 }
 
+// `tests` is intentionally placed mid-file: it exercises the
+// `SymbolProvenance` enum that is defined above, while the
+// `AnalyzedFile`/`Deref` items below predate the test module and are
+// unrelated to it. Reordering would force a noisy `git blame` rewrite,
+// so we keep the layout and silence the lint.
 #[cfg(test)]
+#[allow(clippy::items_after_test_module)]
 mod tests {
     use super::SymbolProvenance;
 

--- a/crates/codelens-mcp/src/dispatch/session.rs
+++ b/crates/codelens-mcp/src/dispatch/session.rs
@@ -388,7 +388,11 @@ pub(super) fn record_audit_failure(
     }
 }
 
+// `tests` precedes `record_span_fields` because both reach into the
+// `transaction_id_for` family this file owns; reordering the file would
+// rewrite a long `git blame` history. Silence the lint instead.
 #[cfg(test)]
+#[allow(clippy::items_after_test_module)]
 mod tests {
     use super::*;
     use crate::session_context::SessionRequestContext;

--- a/crates/codelens-mcp/src/error.rs
+++ b/crates/codelens-mcp/src/error.rs
@@ -227,7 +227,7 @@ mod tests {
             -32008
         );
         assert_eq!(
-            CodeLensError::Io(std::io::Error::new(std::io::ErrorKind::Other, "x")).jsonrpc_code(),
+            CodeLensError::Io(std::io::Error::other("x")).jsonrpc_code(),
             -32603
         );
         assert_eq!(

--- a/crates/codelens-mcp/src/integration_tests/workflow/change.rs
+++ b/crates/codelens-mcp/src/integration_tests/workflow/change.rs
@@ -122,7 +122,7 @@ fn refactor_safety_report_keeps_preview_payload_lean() {
         &state,
         crate::protocol::JsonRpcRequest {
             jsonrpc: "2.0".to_owned(),
-            id: Some(json!(3102_3)),
+            id: Some(json!(31023)),
             method: "resources/read".to_owned(),
             params: Some(json!({"uri": format!("codelens://analysis/{analysis_id}/summary")})),
         },

--- a/crates/codelens-mcp/src/integration_tests/workflow/ci_audit.rs
+++ b/crates/codelens-mcp/src/integration_tests/workflow/ci_audit.rs
@@ -256,7 +256,7 @@ fn resources_include_profile_guides_and_analysis_summaries() {
         &state,
         crate::protocol::JsonRpcRequest {
             jsonrpc: "2.0".to_owned(),
-            id: Some(json!(22_1)),
+            id: Some(json!(221)),
             method: "resources/read".to_owned(),
             params: Some(json!({"uri": "codelens://analysis/recent"})),
         },
@@ -270,7 +270,7 @@ fn resources_include_profile_guides_and_analysis_summaries() {
         &state,
         crate::protocol::JsonRpcRequest {
             jsonrpc: "2.0".to_owned(),
-            id: Some(json!(22_2)),
+            id: Some(json!(222)),
             method: "resources/read".to_owned(),
             params: Some(json!({"uri": "codelens://analysis/jobs"})),
         },
@@ -367,7 +367,7 @@ fn resources_include_profile_guides_and_analysis_summaries() {
         &state,
         crate::protocol::JsonRpcRequest {
             jsonrpc: "2.0".to_owned(),
-            id: Some(json!(242_1)),
+            id: Some(json!(2421)),
             method: "resources/read".to_owned(),
             params: Some(json!({"uri": "codelens://harness/modes"})),
         },
@@ -383,7 +383,7 @@ fn resources_include_profile_guides_and_analysis_summaries() {
         &state,
         crate::protocol::JsonRpcRequest {
             jsonrpc: "2.0".to_owned(),
-            id: Some(json!(242_2)),
+            id: Some(json!(2422)),
             method: "resources/read".to_owned(),
             params: Some(json!({"uri": "codelens://harness/spec"})),
         },
@@ -400,7 +400,7 @@ fn resources_include_profile_guides_and_analysis_summaries() {
         &state,
         crate::protocol::JsonRpcRequest {
             jsonrpc: "2.0".to_owned(),
-            id: Some(json!(242_21)),
+            id: Some(json!(24221)),
             method: "resources/read".to_owned(),
             params: Some(json!({"uri": "codelens://harness/host-adapters"})),
         },
@@ -424,7 +424,7 @@ fn resources_include_profile_guides_and_analysis_summaries() {
         &state,
         crate::protocol::JsonRpcRequest {
             jsonrpc: "2.0".to_owned(),
-            id: Some(json!(242_215)),
+            id: Some(json!(242215)),
             method: "resources/read".to_owned(),
             params: Some(json!({"uri": "codelens://harness/host", "host": "claude-code"})),
         },
@@ -472,7 +472,7 @@ fn resources_include_profile_guides_and_analysis_summaries() {
         &state,
         crate::protocol::JsonRpcRequest {
             jsonrpc: "2.0".to_owned(),
-            id: Some(json!(242_211)),
+            id: Some(json!(242211)),
             method: "resources/read".to_owned(),
             params: Some(json!({"uri": "codelens://design/agent-experience"})),
         },
@@ -488,7 +488,7 @@ fn resources_include_profile_guides_and_analysis_summaries() {
         &state,
         crate::protocol::JsonRpcRequest {
             jsonrpc: "2.0".to_owned(),
-            id: Some(json!(242_22)),
+            id: Some(json!(24222)),
             method: "resources/read".to_owned(),
             params: Some(json!({"uri": "codelens://host-adapters/codex"})),
         },
@@ -510,7 +510,7 @@ fn resources_include_profile_guides_and_analysis_summaries() {
         &state,
         crate::protocol::JsonRpcRequest {
             jsonrpc: "2.0".to_owned(),
-            id: Some(json!(242_23)),
+            id: Some(json!(24223)),
             method: "resources/read".to_owned(),
             params: Some(json!({"uri": "codelens://host-adapters/cursor"})),
         },
@@ -528,7 +528,7 @@ fn resources_include_profile_guides_and_analysis_summaries() {
         &state,
         crate::protocol::JsonRpcRequest {
             jsonrpc: "2.0".to_owned(),
-            id: Some(json!(242_24)),
+            id: Some(json!(24224)),
             method: "resources/read".to_owned(),
             params: Some(json!({"uri": "codelens://host-adapters/windsurf"})),
         },
@@ -542,7 +542,7 @@ fn resources_include_profile_guides_and_analysis_summaries() {
         &state,
         crate::protocol::JsonRpcRequest {
             jsonrpc: "2.0".to_owned(),
-            id: Some(json!(242_3)),
+            id: Some(json!(2423)),
             method: "resources/read".to_owned(),
             params: Some(json!({"uri": "codelens://schemas/handoff-artifact/v1"})),
         },

--- a/crates/codelens-mcp/src/integration_tests/workflow/mod.rs
+++ b/crates/codelens-mcp/src/integration_tests/workflow/mod.rs
@@ -54,4 +54,7 @@ mod resources;
 mod schema;
 mod session;
 mod symbol;
+// `workflow/workflow.rs` keeps end-to-end fixtures grouped under their
+// parent feature name; renaming would churn external test paths.
+#[allow(clippy::module_inception)]
 mod workflow;

--- a/crates/codelens-mcp/src/principals.rs
+++ b/crates/codelens-mcp/src/principals.rs
@@ -430,9 +430,8 @@ role = "Admin"
         // Empty string must NOT shadow the env fallback. We assert the
         // function does not return Some("") — env may still produce
         // None depending on test runner state, which is allowed.
-        match resolve_principal_id(&session) {
-            Some(s) => assert!(!s.is_empty(), "empty session id must not surface"),
-            None => {}
+        if let Some(s) = resolve_principal_id(&session) {
+            assert!(!s.is_empty(), "empty session id must not surface");
         }
     }
 

--- a/crates/codelens-mcp/src/symbol_retrieval.rs
+++ b/crates/codelens-mcp/src/symbol_retrieval.rs
@@ -295,6 +295,7 @@ fn emit_compound_and_parts(compound: &str, out: &mut Vec<String>) {
 mod tests {
     use super::*;
 
+    #[allow(clippy::too_many_arguments)]
     fn doc(
         name: &str,
         name_path: &str,

--- a/crates/codelens-mcp/src/tools/query_analysis/tests.rs
+++ b/crates/codelens-mcp/src/tools/query_analysis/tests.rs
@@ -308,6 +308,7 @@ fn short_entrypoint_semantic_prior_prefers_rename_function_over_edit_type() {
                 line: 1,
                 signature: "pub struct RenameEdit".to_owned(),
                 name_path: "RenameEdit".to_owned(),
+                #[allow(clippy::approx_constant)]
                 score: 0.318,
             },
             SemanticMatch {


### PR DESCRIPTION
## Summary

Stacked on top of [PR #125](https://github.com/mupozg823/codelens-mcp-plugin/pull/125). Closes the deferred follow-up listed in ADR-0011 §Neutral / Deferred — \`cargo clippy --workspace --all-targets -- -D warnings\`.

CI runs the workspace-only lint, so 11 \`--all-targets\` warnings in test fixtures and two engine helpers had been silent on main. PR #125 happens to fix 5 of them as a side effect of its test-hygiene commit; this PR clears the remaining 11.

## Changes

- **digits-grouping (×10)** in \`integration_tests/workflow/{change,ci_audit}.rs\`: JSON-RPC ids like \`22_1\`, \`242_22\`, \`3102_3\` regrouped to bare integers (no semantic change).
- **very-complex-type (×2)** in \`engine/edit_transaction.rs\`: thread-local hooks now share a \`FullWriteInjectHook\` type alias.
- **items-after-test-module (×2)** in \`engine/symbols/types.rs\` and \`mcp/dispatch/session.rs\`: \`mod tests\` stays mid-file because trailing helpers are unrelated and reordering would churn \`git blame\`. Annotated \`#[allow(clippy::items_after_test_module)]\` with a comment.
- **Error::other (×1)** in \`mcp/error.rs\`: idiomatic constructor.
- **match-single-pattern (×1)** in \`mcp/principals.rs\`: \`match\` → \`if let Some\`.
- **too-many-arguments (×1)** in \`mcp/symbol_retrieval.rs\`: 9-arg test helper tagged \`#[allow(clippy::too_many_arguments)]\`.
- **approx-constant (×1)** in \`mcp/tools/query_analysis/tests.rs\`: \`0.318\` is a deliberate score literal, tagged \`#[allow(clippy::approx_constant)]\` at the field site.
- **module-inception (×1)** in \`mcp/integration_tests/workflow/mod.rs\`: fixture grouping convention, tagged \`#[allow(clippy::module_inception)]\` with a comment.

## Verification

| Gate | Result |
|---|---|
| \`cargo clippy --workspace --all-targets -- -D warnings\` | ✅ clean |
| \`cargo fmt --all -- --check\` | ✅ clean |
| \`cargo test --workspace\` | ✅ 565 + 339 + 3 tui + 5 + 1 + 1 + 1 |

## Stacking notes

- **Base = \`feature/phase-1-cleanup\`** (PR #125), not \`main\`. The other 5 warnings are cleared in PR #125's P1-E commits, so attempting to merge this branch directly to main first would leave the lint failing.
- After PR #125 merges, GitHub will offer to retarget this PR to \`main\` automatically; it should rebase cleanly because the file lists do not overlap.

## Suggestion: harden CI

Consider promoting the existing \`cargo clippy --workspace -- -D warnings\` step in \`.github/workflows/ci.yml\` to \`--workspace --all-targets -- -D warnings\` once this lands, so future test-fixture lint regressions fail in CI rather than accumulating silently. Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)