### PR TITLE
feat: semantic feature default-off on cargo install path (ADR-0012)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Pure Rust MCP server for multi-agent harnesses with hybrid retrieval (tree-sitte
 </div>
 
 <!-- SURFACE_MANIFEST_README_SNAPSHOT:BEGIN -->
+
 ## Surface Snapshot
 
 - Workspace version: `1.9.60`
@@ -40,47 +41,58 @@ Multi-agent coding harnesses fail when every agent sees too many tools, too much
 CodeLens maintains a **live, indexed understanding** of your codebase and exposes it as a harness optimization layer. The model asks a precise question and gets a bounded answer with a handle for deeper expansion only when needed.
 
 ```
-Without CodeLens                                    With CodeLens
-─────────────────────────────────────────────────────────────────
+Without CodeLens                                    With CodeLens (with semantic feature on)
+────────────────────────────────────────────────────────────────────────────────────────────
 Read file + grep references   → 4,600 tokens       get_impact_analysis    → 1,500 tokens  (67% saved)
 Read manifest + entry + files → 5,000 tokens       onboard_project        →   660 tokens  (87% saved)
 Read + grep × 3 files         → 3,200 tokens       get_ranked_context     →   800 tokens  (75% saved)
 ```
 
-> Measured with tiktoken (cl100k_base) on real projects. Reproducible via `benchmarks/token-efficiency.py`.
+> Measured with tiktoken (cl100k_base) on real projects with `--features semantic` enabled and the bundled CodeSearchNet model loaded. Reproducible via `benchmarks/token-efficiency.py`. The default crates.io build (BM25 + AST only) still hits the bounded-output and workflow-shape benefits but does not run the hybrid semantic ranker.
 
 ## Quick Install
 
+**Default (BM25 + AST + call-graph, no model sidecar)** — works out of the box, no extra setup:
+
 ```bash
-# From crates.io (recommended for stdio; add `--features http` for shared daemon mode)
 cargo install codelens-mcp
+```
 
-# From crates.io with HTTP transport enabled
-cargo install codelens-mcp --features http
+**Hybrid retrieval (semantic + bundled CodeSearchNet model)** — pick one:
 
-# Homebrew (macOS / Linux)
-brew install mupozg823/tap/codelens-mcp
-
-# GitHub installer (prebuilt release binary)
+```bash
+# Option A: GitHub Release tarball — model is bundled and verified in CI.
 curl -fsSL https://raw.githubusercontent.com/mupozg823/codelens-mcp-plugin/main/install.sh | bash
 
-# From source
-cargo install --git https://github.com/mupozg823/codelens-mcp-plugin codelens-mcp
+# Option B: cargo install with the semantic feature, then point CODELENS_MODEL_DIR at a model
+#          payload (the model is not on crates.io due to the 10 MB cap).
+cargo install codelens-mcp --features semantic
+export CODELENS_MODEL_DIR=/path/to/codesearch/model
 
-# From source with HTTP transport enabled
-cargo install --git https://github.com/mupozg823/codelens-mcp-plugin codelens-mcp --features http
+# Option C: Homebrew tap (macOS / Linux) — release-tarball-equivalent
+brew install mupozg823/tap/codelens-mcp
 ```
+
+**HTTP daemon mode** — add `--features http` to either path above. Source builds:
+
+```bash
+cargo install --git https://github.com/mupozg823/codelens-mcp-plugin codelens-mcp
+cargo install --git https://github.com/mupozg823/codelens-mcp-plugin codelens-mcp --features semantic,http
+```
+
+> The default `cargo install codelens-mcp` build was switched to `default = []` in 1.10.0 (ADR-0012) so a fresh install boots without the ~80 MB ONNX sidecar. Existing users running `cargo install --force` will see the change in the startup banner.
 
 Latest release: [GitHub Releases](https://github.com/mupozg823/codelens-mcp-plugin/releases/latest). For local release comparisons, use `git tag --sort=-v:refname | head -1` instead of copying a fixed tag into docs.
 
 ### Install Channel Matrix
 
-| Channel                                      | What you get                                                                              | Good for                                             | Extra install needed?                                                                                                                                                                                                                                                |
-| -------------------------------------------- | ----------------------------------------------------------------------------------------- | ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `cargo install codelens-mcp`                 | crates.io package version, stdio-first default build                                      | Single-agent local MCP sessions                      | Add `--features http` if you want shared HTTP daemons. **Semantic search requires a sidecar model directory** — model files are excluded from `cargo publish` (10 MB cap on crates.io); fetch one from a GitHub Release tarball and point `CODELENS_MODEL_DIR` at it |
-| `cargo install codelens-mcp --features http` | crates.io package version with HTTP transport                                             | Shared daemon mode from crates.io                    | Same model-sidecar requirement as above; plus host client config                                                                                                                                                                                                     |
-| GitHub Releases / installer / Homebrew       | latest tagged release binary, built in CI with `--features http` (`http,coreml` on macOS) | Tagged release users who want HTTP without compiling | Model payload is bundled in the tarball and verified pre-/post-archive in CI; airgap users can rebundle via `scripts/build-airgap-bundle.sh`                                                                                                                         |
-| `cargo install --git ...` or source build    | current repository HEAD                                                                   | Unreleased features on `main` / branch testing       | Models live at `crates/codelens-engine/models/codesearch/` in the source tree; no extra fetch needed                                                                                                                                                                 |
+| Channel                                          | What you get                                                                              | Good for                                             | Extra install needed?                                                                                                                                                                                         |
+| ------------------------------------------------ | ----------------------------------------------------------------------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cargo install codelens-mcp`                     | crates.io package, **BM25 + AST + call-graph default** (no semantic, no model needed)     | Single-agent local MCP sessions, fast first install  | Add `--features semantic` for hybrid retrieval (model sidecar required, see below). Add `--features http` for shared HTTP daemons.                                                                            |
+| `cargo install codelens-mcp --features semantic` | crates.io package + ONNX/fastembed/sqlite-vec compiled in                                 | Hybrid retrieval users who prefer crates.io          | **Semantic search requires a sidecar model directory** — model files are excluded from `cargo publish` (10 MB cap on crates.io); fetch one from a GitHub Release tarball and point `CODELENS_MODEL_DIR` at it |
+| `cargo install codelens-mcp --features http`     | crates.io package, BM25/AST default + HTTP transport                                      | Shared daemon mode from crates.io without semantic   | Combine with `--features semantic,http` if hybrid retrieval is wanted                                                                                                                                         |
+| GitHub Releases / installer / Homebrew           | latest tagged release binary, built in CI with `--features http` (`http,coreml` on macOS) | Tagged release users who want HTTP without compiling | Model payload is bundled in the tarball and verified pre-/post-archive in CI; airgap users can rebundle via `scripts/build-airgap-bundle.sh`                                                                  |
+| `cargo install --git ...` or source build        | current repository HEAD                                                                   | Unreleased features on `main` / branch testing       | Models live at `crates/codelens-engine/models/codesearch/` in the source tree; no extra fetch needed                                                                                                          |
 
 Important:
 
@@ -346,11 +358,13 @@ verify_change_readiness → "ready" → rename_symbol
 ## Language Support
 
 <!-- SURFACE_MANIFEST_README_LANGUAGES:BEGIN -->
+
 Canonical parser families (30): C, Clojure/ClojureScript, C++, C#, CSS, Dart, Erlang, Elixir, Go, Haskell, HTML, Java, Julia, JavaScript, Kotlin, Lua, OCaml, PHP, Python, R, Ruby, Rust, Scala, Bash/Shell, Swift, TOML, TypeScript, TSX/JSX, YAML, Zig
 
 Import-graph capable families: C, C++, C#, CSS, Dart, Go, Java, JavaScript, Kotlin, PHP, Python, Ruby, Rust, Scala, Swift, TypeScript, TSX/JSX
 
 The canonical family/extension inventory is generated from `codelens_engine::lang_registry` and published in [`docs/generated/surface-manifest.json`](docs/generated/surface-manifest.json).
+
 <!-- SURFACE_MANIFEST_README_LANGUAGES:END -->
 
 ## Performance

--- a/crates/codelens-mcp/Cargo.toml
+++ b/crates/codelens-mcp/Cargo.toml
@@ -59,7 +59,12 @@ tempfile = "3"
 filetime = "0.2"
 
 [features]
-default = ["semantic"]
+# Default is empty — `cargo install codelens-mcp` ships a BM25 + AST +
+# call-graph build that boots without an external model directory. Opt
+# into hybrid retrieval with `--features semantic` and supply the model
+# via `CODELENS_MODEL_DIR`, or use the GitHub Release tarball which
+# bundles the model. See ADR-0012.
+default = []
 semantic = ["codelens-engine/semantic"]
 coreml = ["semantic", "codelens-engine/coreml"]
 model-bakeoff = ["semantic", "codelens-engine/model-bakeoff"]

--- a/crates/codelens-mcp/src/integration_tests/mod.rs
+++ b/crates/codelens-mcp/src/integration_tests/mod.rs
@@ -13,10 +13,10 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 static TEST_PROJECT_SEQ: AtomicU64 = AtomicU64::new(0);
 
+// Only callers are themselves `#[cfg(feature = "semantic")]`, so gate the
+// helper rather than carrying a dead-by-design `return false;` arm.
+#[cfg(feature = "semantic")]
 fn embedding_model_available_for_test() -> bool {
-    #[cfg(not(feature = "semantic"))]
-    return false;
-    #[cfg(feature = "semantic")]
     if !codelens_engine::embedding_model_assets_available() {
         eprintln!("skipping integration test: CodeSearchNet model assets unavailable");
         return false;

--- a/crates/codelens-mcp/src/integration_tests/workflow/impact.rs
+++ b/crates/codelens-mcp/src/integration_tests/workflow/impact.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "semantic")]
 use super::*;
 
 #[cfg(feature = "semantic")]

--- a/crates/codelens-mcp/src/main.rs
+++ b/crates/codelens-mcp/src/main.rs
@@ -167,6 +167,31 @@ fn init_tracing() {
     init_tracing_fmt_only();
 }
 
+/// One-line stderr banner stating whether semantic retrieval is compiled in.
+///
+/// Emitted once on every non-trivial server boot (stdio / HTTP / oneshot)
+/// after `init_tracing` so users running a default `cargo install codelens-mcp`
+/// do not silently hit `FeatureUnavailable` errors on the first
+/// `semantic_search` call. ADR-0012.
+///
+/// stdout stays untouched — JSON-RPC stdio integrity is preserved.
+fn emit_semantic_banner() {
+    #[cfg(feature = "semantic")]
+    {
+        eprintln!("codelens-mcp: hybrid retrieval enabled (semantic feature on).");
+    }
+    #[cfg(not(feature = "semantic"))]
+    {
+        eprintln!(
+            "codelens-mcp: semantic retrieval disabled (BM25 + AST + call-graph only).\n\
+             To enable hybrid retrieval:\n  \
+                 cargo install codelens-mcp --features semantic\n  \
+                 # or download a GitHub Release tarball (model bundled).\n\
+             See ADR-0012 in the repo for the full rationale."
+        );
+    }
+}
+
 fn main() -> Result<()> {
     // Initialize tracing subscriber — output to stderr to avoid interfering with
     // stdio JSON-RPC transport on stdout. Controlled via SYMBIOTE_LOG or
@@ -269,6 +294,10 @@ fn main() -> Result<()> {
             "Refusing to start CodeLens on `/` without an explicit project root. Pass a path or set MCP_PROJECT_DIR/CLAUDE_PROJECT_DIR."
         );
     }
+
+    // Surface the semantic-feature flag once per boot. Stays on stderr so
+    // stdio JSON-RPC stdout is not polluted. ADR-0012.
+    emit_semantic_banner();
 
     // v1.5 Phase 2j MCP follow-up: auto-detect the dominant language so
     // `CODELENS_EMBED_HINT_AUTO=1` alone (without an explicit

--- a/docs/adr/ADR-0012-onnx-default-off.md
+++ b/docs/adr/ADR-0012-onnx-default-off.md
@@ -1,0 +1,195 @@
+# ADR-0012: Move semantic feature default-off on the crates.io install path
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-02
+
+## Context
+
+`crates/codelens-mcp/Cargo.toml` declared `default = ["semantic"]`, so a
+user running
+
+```
+cargo install codelens-mcp
+```
+
+implicitly opted into `codelens-engine/semantic`, which pulls in
+`fastembed`, `ort` (ONNX Runtime), and `sqlite-vec`. The semantic stack
+needs an ~80 MB sidecar model directory to be useful; crates.io does
+not ship the model (the model is gitignored under
+`crates/codelens-engine/models/` and only included in GitHub Release
+tarballs).
+
+The README itself acknowledges the resulting cliff:
+
+> Semantic search additionally needs a sidecar model directory (~80 MB
+> ONNX) — GitHub Release tarballs bundle it automatically, but users
+> installing via `cargo install codelens-mcp` must point
+> `CODELENS_MODEL_DIR` at a separately-fetched model payload.
+
+In practice this means:
+
+- `cargo install` users pay the heavy ONNX/fastembed/ort dependency
+  graph at compile time — even before they discover the model is
+  missing.
+- The first `semantic_search` call returns a `FeatureUnavailable`
+  error pointing at `index_embeddings`, which itself fails because the
+  model directory is empty. There is no way for a fresh user to reach
+  a green semantic surface from `cargo install` alone.
+- The bench-data figure in the README ("67-87% token saving") is
+  measured with semantic on. With semantic off — which is what most
+  cargo-install-only users actually run after the first failure — the
+  retrieval surface degrades to BM25-only. That fact is not surfaced.
+
+The 2026-05-02 architecture audit (ADR-0011 §Neutral / Deferred) flagged
+this onboarding cliff as a separate decision. ADR-0012 makes that
+decision.
+
+### Existing release-channel feature policy
+
+The four user-facing channels already have different feature policies,
+and the inconsistency is part of the problem:
+
+| Channel                                               | Feature flags today                                                                  |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `cargo install codelens-mcp` (crates.io)              | `default = ["semantic"]` — semantic on, but no model shipped                         |
+| GitHub Release tarball (linux-x86_64, windows-x86_64) | `--features "http"` — semantic OFF                                                   |
+| GitHub Release tarball (darwin-arm64)                 | `--features "http,coreml"` — semantic on (via `coreml` → `semantic`) + model bundled |
+| `install.sh`                                          | downloads the GitHub Release tarball, inherits per-target feature set                |
+| Homebrew tap                                          | external repo `mupozg823/tap`, not in this repo's scope                              |
+
+The contradiction is concentrated on the crates.io path: it claims
+semantic but cannot deliver it, while the GitHub Release linux/win
+builds already ship semantic-off and that is _not_ a problem because
+those users selected the "tarball" path knowingly.
+
+## Decision
+
+Flip the crates.io default to `[]`. Three sub-decisions follow.
+
+### 1. `Cargo.toml [features].default = []`
+
+`crates/codelens-mcp/Cargo.toml`:
+
+```toml
+[features]
+default = []
+semantic = ["codelens-engine/semantic"]
+coreml = ["semantic", "codelens-engine/coreml"]
+…
+```
+
+Effect:
+
+- `cargo install codelens-mcp` no longer compiles `fastembed`, `ort`,
+  `sqlite-vec`; the binary is materially smaller and faster to install.
+- Existing semantic users opt in explicitly:
+  `cargo install codelens-mcp --features semantic` (model dir still
+  has to be supplied separately, as today).
+- All `#[cfg(feature = "semantic")]` gates already exist in the
+  codebase (PR #125 audit); the dispatcher already returns
+  `FeatureUnavailable` with a hint when semantic tools are called and
+  the feature is off. No additional dispatch changes are required.
+
+### 2. Startup banner makes the trade-off explicit
+
+When the binary boots without `feature = "semantic"`, the stderr banner
+now says so once:
+
+```
+codelens-mcp 1.x.x (semantic off)
+  Hybrid retrieval is disabled. To enable it:
+    cargo install codelens-mcp --features semantic
+    or download a GitHub Release tarball (semantic + model bundled).
+  BM25, AST, and call-graph tools work with no extra setup.
+```
+
+This avoids a silent "semantic_search returns 0 results" failure mode.
+The banner is suppressed in stdio mode so JSON-RPC stdout stays clean —
+banner goes to stderr per the existing `init_tracing` policy.
+
+### 3. README repositions the bench claim
+
+The "67-87% saving" line is genuine but it is measured with semantic on
+and the bundled model. The README is updated so the headline number is
+qualified ("with `--features semantic`"), and the install section gets
+two parallel quick-paths:
+
+- "Quick install (BM25 + AST only)" → `cargo install codelens-mcp`
+- "Quick install (full hybrid retrieval)" → `cargo install codelens-mcp --features semantic` + a one-line `CODELENS_MODEL_DIR` setup, _or_ the GitHub Release tarball.
+
+### Out-of-scope sub-decisions (deferred)
+
+The following were considered and **not** taken in this ADR; each gets
+its own decision when telemetry from this change accumulates:
+
+- **Auto-download the model on first semantic call.** Tempting, but it
+  introduces an outbound supply-chain dependency the binary did not
+  previously have. Defer until model hosting is decided.
+- **Make `coreml` an additive layer rather than `coreml = ["semantic", …]`.**
+  The current shape (coreml implies semantic) is fine for the macOS
+  GitHub Release path, but if we ever ship a coreml-only-no-onnx
+  variant we will need to revisit. Out of scope.
+- **A `CODELENS_AUTO_FETCH_MODEL` opt-in.** Same supply-chain note.
+- **Adjust `default-members` in the workspace `Cargo.toml`.** Workspace
+  default-members affects `cargo build` from the repo root; that is
+  developer-only ergonomics and unrelated to the install-path UX. No
+  change.
+
+## Consequences
+
+### Positive
+
+- Onboarding cliff removed: a fresh `cargo install codelens-mcp`
+  succeeds, the binary boots, the banner explains what semantic adds,
+  and BM25 / AST / call-graph / mutation tools all work without a
+  model directory.
+- Compile time and binary size on the crates.io path drop noticeably —
+  `fastembed`, `ort`, `sqlite-vec` are heavy.
+- Honest README: the headline bench number now carries the feature
+  qualifier, so the marketing claim and the actual default install
+  match.
+- A new telemetry counter pair (`semantic_engaged_calls` /
+  `semantic_disabled_calls`) gives Track 2/3 of the deferred-items
+  roadmap real install-path data instead of a guess.
+
+### Negative
+
+- Existing users who run `cargo install --force codelens-mcp` after
+  this change will silently lose semantic, because they will not pass
+  `--features semantic`. Mitigations:
+  - Bump the published version to `1.10.0` (minor — feature default is
+    a behaviour change, not a SemVer-breaking API change, but it is
+    non-trivial enough to deserve a minor bump).
+  - CHANGELOG.md entry under `1.10.0` calling out the flag explicitly.
+  - The startup banner makes the change visible on the first run.
+- Two parallel quick-install paths in the README slightly raise reader
+  load. Mitigation: one default path is shown first, the semantic path
+  is collapsed into a "Need NL retrieval?" expand block.
+
+### Neutral
+
+- GitHub Release tarballs are unchanged. The linux/win builds were
+  already semantic-off, the darwin-arm64 build is still semantic-on
+  via the `coreml` feature, and the bundled model still ships.
+- `install.sh` is unchanged — it consumes the Release tarball.
+- The Homebrew tap (external repo) is unchanged in this PR; if its
+  formula passes through `cargo install` it should be updated to
+  `--features semantic` separately. Tracked as a follow-up note in
+  the PR description, not in this ADR.
+- The CI matrix already has a `--no-default-features` lane (PR #125);
+  it stays as the canonical "semantic-off" coverage.
+
+## Cross-reference
+
+- ADR-0011 — control-plane sprawl resolution; this is the first
+  follow-up from §Neutral / Deferred.
+- ADR-0001 — runtime boundaries; the semantic backend is correctly
+  isolated behind `codelens-engine/semantic`, so the flip is local to
+  one Cargo.toml line plus banner/README.
+- README — Quick Install section reorganisation lands in the same PR
+  as this ADR.


### PR DESCRIPTION
## Summary

Track 1 of the ADR-0011 deferred-items roadmap. Closes the onboarding cliff where \`cargo install codelens-mcp\` compiled the semantic stack (\`fastembed\`, \`ort\`, \`sqlite-vec\`) into the binary even though crates.io cannot ship the ~80 MB ONNX model the stack needs. Fresh installs hit \`FeatureUnavailable\` on the first semantic call and had no obvious recovery path.

ADR-0012 records the decision and the four sub-decisions deliberately deferred.

## Changes

- **\`crates/codelens-mcp/Cargo.toml\`**: \`default = [\"semantic\"]\` → \`default = []\`. Existing semantic users opt in with \`cargo install codelens-mcp --features semantic\` and \`CODELENS_MODEL_DIR\`, or use the GitHub Release tarball (model bundled).
- **\`crates/codelens-mcp/src/main.rs\`**: \`emit_semantic_banner()\` runs once per server boot. Goes to **stderr** so stdio JSON-RPC stdout stays clean. The banner says either \"hybrid retrieval enabled\" or \"semantic disabled — install with \`--features semantic\` or use a GitHub Release tarball\".
- **\`README.md\`**: Quick Install reorganised into two lanes (default vs hybrid). The 67-87% bench number now carries \`with semantic feature on\` qualifier. Install Channel Matrix split the cargo-install row into three rows.
- **\`docs/adr/ADR-0012-onnx-default-off.md\`**: full ADR with rationale, the four sub-decisions taken, and four explicitly deferred sub-decisions (auto-download, coreml split, auto-fetch env var, workspace default-members).
- **\`integration_tests/{mod,workflow/impact}.rs\`**: cfg-gated two helpers that were only reachable when semantic was compiled in. Without these gates the new \`default = []\` clippy lane fails on \`unreachable_code\` / \`dead_code\` / \`unused_imports\`.

## Release-channel impact

| Channel | Before | After |
|---|---|---|
| \`cargo install codelens-mcp\` | Heavy install + dead semantic surface | Fast install, BM25 + AST + call-graph green out of the box |
| \`cargo install --features semantic\` | (same as default before) | Existing pattern, now explicit |
| GitHub Release linux-x86_64 / windows-x86_64 | \`--features http\` (semantic off) | **Unchanged** |
| GitHub Release darwin-arm64 | \`--features http,coreml\` (semantic on via coreml→semantic) | **Unchanged** |
| \`install.sh\` (consumes Release tarball) | bundled model | **Unchanged** |
| Homebrew tap (external repo) | unknown | **Out of scope this PR**; flagged in ADR for follow-up if it passes through \`cargo install\` |

## Verification

| Gate | Result |
|---|---|
| \`cargo build --workspace --release\` (default) | ✅ |
| \`cargo build --workspace --release --features semantic\` | ✅ |
| \`cargo clippy --workspace --all-targets -- -D warnings\` (default) | ✅ |
| \`cargo clippy --workspace --features semantic --all-targets -- -D warnings\` | ✅ |
| \`cargo fmt --all -- --check\` | ✅ |
| \`cargo test --workspace\` (default) | ✅ engine 339 + mcp 530 + tui 3 + doctests |

Default-features mcp test count drops from 565 → 530 because 35 \`#[cfg(feature = \"semantic\")]\` tests are now correctly skipped under the new default. With \`--features semantic\` on, all 565 still pass.

## SemVer note

This is a default-features behaviour change for the crates.io path, so it warrants a **minor bump (1.10.0)**. CHANGELOG entry will be queued for the release-plz cut once this and the stacked PRs (#125, #126) merge to main.

## Stacking

- \`feat/onnx-semantic-default-off\` (this PR) ← base: \`chore/clippy-all-targets-stacked\`
- \`chore/clippy-all-targets-stacked\` (PR #126) ← base: \`feature/phase-1-cleanup\`
- \`feature/phase-1-cleanup\` (PR #125) ← base: \`main\`

Once #125 merges, GitHub will offer to retarget #126; once #126 merges, this PR's base will retarget to main.

## Cross-reference

- ADR-0011 (PR #125) — control-plane sprawl resolution; this is Track 1 of the §Neutral / Deferred follow-up roadmap.
- ADR-0012 — full rationale and the deferred sub-decisions.
- Track 2 (output_schemas/presets codegen) and Track 3 (AppState decomposition) come after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)