### PR TITLE
feat(tool_defs): migrate rule_corpus + memory + semantic, close ADR-0013 (PR-F)

### DIFF
--- a/crates/codelens-mcp/src/tool_defs/build.rs
+++ b/crates/codelens-mcp/src/tool_defs/build.rs
@@ -1,9 +1,13 @@
 //! Tool registry: static TOOLS vec, lookup functions, and the build_tools constructor.
+//!
+//! After ADR-0013 PR-A..PR-F, the per-tool `Tool::new(...)` rows live
+//! entirely in `tools.toml` and are emitted by `super::generated`.
+//! This file now only owns the annotation-binding locals consumed by
+//! the generated category functions and the post-build pass that
+//! attaches namespace/title/estimated_tokens.
 
-use super::output_schemas::*;
 use super::presets::tool_namespace;
 use crate::protocol::{Tool, ToolAnnotations, ToolTier};
-use serde_json::json;
 use std::sync::LazyLock;
 
 static TOOLS: LazyLock<Vec<Tool>> = LazyLock::new(build_tools);
@@ -125,29 +129,16 @@ fn build_tools() -> Vec<Tool> {
     tools.extend(super::generated::session_tools(
         &mut_coord, &mut_p, &mutating, &ro_a, &ro_p, &ro_w,
     ));
+    tools.extend(super::generated::rule_corpus_tools(&ro_a));
+    tools.extend(super::generated::memory_tools(
+        &destructive,
+        &mut_p,
+        &mutating,
+        &ro_p,
+    ));
 
-    tools.extend(vec![
-        // ── Rule corpus retrieval ───────────────────────────────────────
-        Tool::new("find_relevant_rules", "[CodeLens:Workflow] BM25 search over CLAUDE.md + project memory for policy snippets matching a query. Separate corpus from code retrieval — rule text never pollutes semantic_search results.", json!({"required":["query"],"type":"object","properties":{"query":{"type":"string","description":"Natural-language query; identifier tokens are preserved"},"top_k":{"type":"integer","description":"Top-K results (1-20, default 3)"}}})).with_annotations(ro_a.clone()).with_max_response_tokens(2048),
-
-        // ── Memory ──────────────────────────────────────────────────────
-        Tool::new("list_memories", "[CodeLens:Memory] List project memory files under .codelens/memories.", json!({"type":"object","properties":{"topic":{"type":"string","description":"Optional topic to filter"}}})).with_output_schema(memory_list_output_schema()).with_annotations(ro_p.clone()),
-        Tool::new("read_memory", "[CodeLens:Memory] Read a named project memory file.", json!({"required":["memory_name"],"type":"object","properties":{"memory_name":{"type":"string"}}})).with_annotations(ro_p.clone()),
-        Tool::new("write_memory", "[CodeLens:Memory] Create or overwrite a project memory file.", json!({"required":["memory_name","content"],"type":"object","properties":{"memory_name":{"type":"string"},"content":{"type":"string"}}})).with_annotations(mutating.clone()),
-        Tool::new("delete_memory", "[CodeLens:Memory] Delete a project memory file.", json!({"required":["memory_name"],"type":"object","properties":{"memory_name":{"type":"string"}}})).with_annotations(destructive.clone()),
-        Tool::new("rename_memory", "[CodeLens:Memory] Rename a project memory file.", json!({"required":["old_name","new_name"],"type":"object","properties":{"old_name":{"type":"string"},"new_name":{"type":"string"}}})).with_annotations(mut_p.clone()),
-    ]);
-
-    // ── Semantic (feature-gated) ────────────────────────────────────
     #[cfg(feature = "semantic")]
-    {
-        tools.push(Tool::new("semantic_search", "[CodeLens:Symbol] Natural language code search via embeddings — find code by meaning.", json!({"required":["query"],"type":"object","properties":{"query":{"type":"string","description":"Natural language search query"},"max_results":{"type":"integer","description":"Max results (default 20)"}}})).with_output_schema(semantic_search_output_schema()).with_annotations(ro_p.clone()));
-        tools.push(Tool::new("index_embeddings", "[CodeLens:Symbol] Build semantic embedding index and optionally prewarm query embeddings. Required before semantic_search.", json!({"type":"object","properties":{"background":{"type":"boolean","description":"Run as a durable background job and poll with get_analysis_job"},"prewarm_queries":{"type":"array","items":{"type":"string"},"description":"Representative semantic_search queries to warm immediately after indexing"},"prewarm_limit":{"type":"integer","description":"Maximum prewarm query count (default 128, max 1024)"}}})).with_annotations(ro.clone()));
-        tools.push(Tool::new("find_similar_code", "[CodeLens:Analysis] Find semantically similar code to a given symbol — clone detection, reuse opportunities.", json!({"required":["file_path","symbol_name"],"type":"object","properties":{"file_path":{"type":"string","description":"File containing the symbol"},"symbol_name":{"type":"string","description":"Symbol to find similar code for"},"max_results":{"type":"integer","description":"Max results (default 10)"}}})).with_output_schema(find_similar_code_output_schema()).with_annotations(ro_a.clone()));
-        tools.push(Tool::new("find_code_duplicates", "[CodeLens:Analysis] Find near-duplicate code pairs across the codebase — DRY violations.", json!({"type":"object","properties":{"threshold":{"type":"number","description":"Cosine similarity threshold (default 0.85)"},"max_pairs":{"type":"integer","description":"Max pairs to return (default 20)"}}})).with_output_schema(find_code_duplicates_output_schema()).with_annotations(ro_a.clone()));
-        tools.push(Tool::new("classify_symbol", "[CodeLens:Analysis] Zero-shot classify a symbol into categories — e.g. error handling, auth, database.", json!({"required":["file_path","symbol_name","categories"],"type":"object","properties":{"file_path":{"type":"string"},"symbol_name":{"type":"string"},"categories":{"type":"array","items":{"type":"string"},"description":"Category labels to classify against"}}})).with_output_schema(classify_symbol_output_schema()).with_annotations(ro_a.clone()));
-        tools.push(Tool::new("find_misplaced_code", "[CodeLens:Analysis] Find symbols that are semantic outliers in their file — possible misplacement.", json!({"type":"object","properties":{"max_results":{"type":"integer","description":"Max outliers to return (default 10)"}}})).with_output_schema(find_misplaced_code_output_schema()).with_annotations(ro));
-    }
+    tools.extend(super::generated::semantic_tools(&ro, &ro_a, &ro_p));
 
     for tool in &mut tools {
         let annotations = tool

--- a/crates/codelens-mcp/src/tool_defs/generated/build_generated.rs
+++ b/crates/codelens-mcp/src/tool_defs/generated/build_generated.rs
@@ -357,6 +357,91 @@ pub fn lsp_tools(ro_a: &ToolAnnotations, ro_p: &ToolAnnotations) -> Vec<Tool> {
     ]
 }
 
+pub fn memory_tools(
+    destructive: &ToolAnnotations,
+    mut_p: &ToolAnnotations,
+    mutating: &ToolAnnotations,
+    ro_p: &ToolAnnotations,
+) -> Vec<Tool> {
+    vec![
+        Tool::new(
+            "list_memories",
+            "[CodeLens:Memory] List project memory files under .codelens/memories.",
+            json!({"type":"object","properties":{"topic":{"type":"string","description":"Optional topic to filter"}}}),
+        ).with_output_schema(memory_list_output_schema()).with_annotations(ro_p.clone()),
+        Tool::new(
+            "read_memory",
+            "[CodeLens:Memory] Read a named project memory file.",
+            json!({"type":"object","required":["memory_name"],"properties":{"memory_name":{"type":"string"}}}),
+        ).with_annotations(ro_p.clone()),
+        Tool::new(
+            "write_memory",
+            "[CodeLens:Memory] Create or overwrite a project memory file.",
+            json!({"type":"object","required":["memory_name","content"],"properties":{"memory_name":{"type":"string"},"content":{"type":"string"}}}),
+        ).with_annotations(mutating.clone()),
+        Tool::new(
+            "delete_memory",
+            "[CodeLens:Memory] Delete a project memory file.",
+            json!({"type":"object","required":["memory_name"],"properties":{"memory_name":{"type":"string"}}}),
+        ).with_annotations(destructive.clone()),
+        Tool::new(
+            "rename_memory",
+            "[CodeLens:Memory] Rename a project memory file.",
+            json!({"type":"object","required":["old_name","new_name"],"properties":{"old_name":{"type":"string"},"new_name":{"type":"string"}}}),
+        ).with_annotations(mut_p.clone()),
+    ]
+}
+
+pub fn rule_corpus_tools(ro_a: &ToolAnnotations) -> Vec<Tool> {
+    vec![
+        Tool::new(
+            "find_relevant_rules",
+            "[CodeLens:Workflow] BM25 search over CLAUDE.md + project memory for policy snippets matching a query. Separate corpus from code retrieval — rule text never pollutes semantic_search results.",
+            json!({"type":"object","required":["query"],"properties":{"query":{"type":"string","description":"Natural-language query; identifier tokens are preserved"},"top_k":{"type":"integer","description":"Top-K results (1-20, default 3)"}}}),
+        ).with_annotations(ro_a.clone()).with_max_response_tokens(2048),
+    ]
+}
+
+#[cfg(feature = "semantic")]
+pub fn semantic_tools(
+    ro: &ToolAnnotations,
+    ro_a: &ToolAnnotations,
+    ro_p: &ToolAnnotations,
+) -> Vec<Tool> {
+    vec![
+        Tool::new(
+            "semantic_search",
+            "[CodeLens:Symbol] Natural language code search via embeddings — find code by meaning.",
+            json!({"type":"object","required":["query"],"properties":{"query":{"type":"string","description":"Natural language search query"},"max_results":{"type":"integer","description":"Max results (default 20)"}}}),
+        ).with_output_schema(semantic_search_output_schema()).with_annotations(ro_p.clone()),
+        Tool::new(
+            "index_embeddings",
+            "[CodeLens:Symbol] Build semantic embedding index and optionally prewarm query embeddings. Required before semantic_search.",
+            json!({"type":"object","properties":{"background":{"type":"boolean","description":"Run as a durable background job and poll with get_analysis_job"},"prewarm_queries":{"type":"array","items":{"type":"string"},"description":"Representative semantic_search queries to warm immediately after indexing"},"prewarm_limit":{"type":"integer","description":"Maximum prewarm query count (default 128, max 1024)"}}}),
+        ).with_annotations(ro.clone()),
+        Tool::new(
+            "find_similar_code",
+            "[CodeLens:Analysis] Find semantically similar code to a given symbol — clone detection, reuse opportunities.",
+            json!({"type":"object","required":["file_path","symbol_name"],"properties":{"file_path":{"type":"string","description":"File containing the symbol"},"symbol_name":{"type":"string","description":"Symbol to find similar code for"},"max_results":{"type":"integer","description":"Max results (default 10)"}}}),
+        ).with_output_schema(find_similar_code_output_schema()).with_annotations(ro_a.clone()),
+        Tool::new(
+            "find_code_duplicates",
+            "[CodeLens:Analysis] Find near-duplicate code pairs across the codebase — DRY violations.",
+            json!({"type":"object","properties":{"threshold":{"type":"number","description":"Cosine similarity threshold (default 0.85)"},"max_pairs":{"type":"integer","description":"Max pairs to return (default 20)"}}}),
+        ).with_output_schema(find_code_duplicates_output_schema()).with_annotations(ro_a.clone()),
+        Tool::new(
+            "classify_symbol",
+            "[CodeLens:Analysis] Zero-shot classify a symbol into categories — e.g. error handling, auth, database.",
+            json!({"type":"object","required":["file_path","symbol_name","categories"],"properties":{"file_path":{"type":"string"},"symbol_name":{"type":"string"},"categories":{"type":"array","items":{"type":"string"},"description":"Category labels to classify against"}}}),
+        ).with_output_schema(classify_symbol_output_schema()).with_annotations(ro_a.clone()),
+        Tool::new(
+            "find_misplaced_code",
+            "[CodeLens:Analysis] Find symbols that are semantic outliers in their file — possible misplacement.",
+            json!({"type":"object","properties":{"max_results":{"type":"integer","description":"Max outliers to return (default 10)"}}}),
+        ).with_output_schema(find_misplaced_code_output_schema()).with_annotations(ro.clone()),
+    ]
+}
+
 pub fn session_tools(
     mut_coord: &ToolAnnotations,
     mut_p: &ToolAnnotations,

--- a/crates/codelens-mcp/src/tool_defs/generated/mod.rs
+++ b/crates/codelens-mcp/src/tool_defs/generated/mod.rs
@@ -15,6 +15,9 @@ mod build_generated;
 // `pub(super)` of *this* module (i.e., visible to `tool_defs`). Keeps
 // the call site in `build.rs` short and stable across migration PRs.
 pub(super) use build_generated::{
-    analysis_tools, composite_tools, editing_tools, file_io_tools, lsp_tools, session_tools,
-    symbol_tools, workflow_first_tools,
+    analysis_tools, composite_tools, editing_tools, file_io_tools, lsp_tools, memory_tools,
+    rule_corpus_tools, session_tools, symbol_tools, workflow_first_tools,
 };
+
+#[cfg(feature = "semantic")]
+pub(super) use build_generated::semantic_tools;

--- a/crates/codelens-mcp/tools.toml
+++ b/crates/codelens-mcp/tools.toml
@@ -23,15 +23,16 @@
 #   ✓ editing          — PR-C
 #   ✓ analysis         — PR-C
 #   ✓ composite        — PR-D
-#   ✓ workflow_first   — PR-E (this PR)
-#   ✓ session          — PR-E (this PR)
-#   ☐ memory           — PR-F
-#   ☐ rule_corpus      — PR-F
-#   ☐ semantic         — PR-F (cfg-gated)
+#   ✓ workflow_first   — PR-E
+#   ✓ session          — PR-E
+#   ✓ rule_corpus      — PR-F (this PR)
+#   ✓ memory           — PR-F (this PR)
+#   ✓ semantic         — PR-F (this PR; cfg-gated via feature_gate)
 #
-# Until all categories are migrated, the legacy hand-rolled rows
-# remain in `src/tool_defs/build.rs`. The dispatcher composes the
-# generated rows with the legacy ones.
+# All categories are now migrated. `build.rs` retains only the
+# annotation-binding locals and per-tool postprocessing (namespace,
+# title, estimated_tokens) — the Tool registry itself is fully
+# declarative.
 
 schema_version = "v1"
 
@@ -1627,3 +1628,174 @@ annotations = "ro_w"
 type = "object"
 required = ["path"]
 properties = { path = { type = "string", description = "File path to summarize" } }
+
+# ── Rule corpus retrieval ────────────────────────────────────────────
+
+[[tool]]
+name = "find_relevant_rules"
+category = "rule_corpus"
+description = "[CodeLens:Workflow] BM25 search over CLAUDE.md + project memory for policy snippets matching a query. Separate corpus from code retrieval — rule text never pollutes semantic_search results."
+annotations = "ro_a"
+max_response_tokens = 2048
+
+[tool.input_schema]
+type = "object"
+required = ["query"]
+properties = { query = { type = "string", description = "Natural-language query; identifier tokens are preserved" }, top_k = { type = "integer", description = "Top-K results (1-20, default 3)" } }
+
+# ── Memory ───────────────────────────────────────────────────────────
+
+[[tool]]
+name = "list_memories"
+category = "memory"
+description = "[CodeLens:Memory] List project memory files under .codelens/memories."
+annotations = "ro_p"
+output_schema = "memory_list_output_schema"
+
+[tool.input_schema]
+type = "object"
+properties = { topic = { type = "string", description = "Optional topic to filter" } }
+
+# ─────
+
+[[tool]]
+name = "read_memory"
+category = "memory"
+description = "[CodeLens:Memory] Read a named project memory file."
+annotations = "ro_p"
+
+[tool.input_schema]
+type = "object"
+required = ["memory_name"]
+properties = { memory_name = { type = "string" } }
+
+# ─────
+
+[[tool]]
+name = "write_memory"
+category = "memory"
+description = "[CodeLens:Memory] Create or overwrite a project memory file."
+annotations = "mutating"
+
+[tool.input_schema]
+type = "object"
+required = ["memory_name", "content"]
+properties = { memory_name = { type = "string" }, content = { type = "string" } }
+
+# ─────
+
+[[tool]]
+name = "delete_memory"
+category = "memory"
+description = "[CodeLens:Memory] Delete a project memory file."
+annotations = "destructive"
+
+[tool.input_schema]
+type = "object"
+required = ["memory_name"]
+properties = { memory_name = { type = "string" } }
+
+# ─────
+
+[[tool]]
+name = "rename_memory"
+category = "memory"
+description = "[CodeLens:Memory] Rename a project memory file."
+annotations = "mut_p"
+
+[tool.input_schema]
+type = "object"
+required = ["old_name", "new_name"]
+properties = { old_name = { type = "string" }, new_name = { type = "string" } }
+
+# ── Semantic (cfg-gated by `feature = "semantic"`) ──────────────────
+
+[[tool]]
+name = "semantic_search"
+category = "semantic"
+description = "[CodeLens:Symbol] Natural language code search via embeddings — find code by meaning."
+annotations = "ro_p"
+output_schema = "semantic_search_output_schema"
+feature_gate = "semantic"
+
+[tool.input_schema]
+type = "object"
+required = ["query"]
+properties = { query = { type = "string", description = "Natural language search query" }, max_results = { type = "integer", description = "Max results (default 20)" } }
+
+# ─────
+
+[[tool]]
+name = "index_embeddings"
+category = "semantic"
+description = "[CodeLens:Symbol] Build semantic embedding index and optionally prewarm query embeddings. Required before semantic_search."
+annotations = "ro"
+feature_gate = "semantic"
+
+[tool.input_schema]
+type = "object"
+[tool.input_schema.properties]
+background = { type = "boolean", description = "Run as a durable background job and poll with get_analysis_job" }
+prewarm_queries = { type = "array", items = { type = "string" }, description = "Representative semantic_search queries to warm immediately after indexing" }
+prewarm_limit = { type = "integer", description = "Maximum prewarm query count (default 128, max 1024)" }
+
+# ─────
+
+[[tool]]
+name = "find_similar_code"
+category = "semantic"
+description = "[CodeLens:Analysis] Find semantically similar code to a given symbol — clone detection, reuse opportunities."
+annotations = "ro_a"
+output_schema = "find_similar_code_output_schema"
+feature_gate = "semantic"
+
+[tool.input_schema]
+type = "object"
+required = ["file_path", "symbol_name"]
+[tool.input_schema.properties]
+file_path = { type = "string", description = "File containing the symbol" }
+symbol_name = { type = "string", description = "Symbol to find similar code for" }
+max_results = { type = "integer", description = "Max results (default 10)" }
+
+# ─────
+
+[[tool]]
+name = "find_code_duplicates"
+category = "semantic"
+description = "[CodeLens:Analysis] Find near-duplicate code pairs across the codebase — DRY violations."
+annotations = "ro_a"
+output_schema = "find_code_duplicates_output_schema"
+feature_gate = "semantic"
+
+[tool.input_schema]
+type = "object"
+properties = { threshold = { type = "number", description = "Cosine similarity threshold (default 0.85)" }, max_pairs = { type = "integer", description = "Max pairs to return (default 20)" } }
+
+# ─────
+
+[[tool]]
+name = "classify_symbol"
+category = "semantic"
+description = "[CodeLens:Analysis] Zero-shot classify a symbol into categories — e.g. error handling, auth, database."
+annotations = "ro_a"
+output_schema = "classify_symbol_output_schema"
+feature_gate = "semantic"
+
+[tool.input_schema]
+type = "object"
+required = ["file_path", "symbol_name", "categories"]
+properties = { file_path = { type = "string" }, symbol_name = { type = "string" }, categories = { type = "array", items = { type = "string" }, description = "Category labels to classify against" } }
+
+# ─────
+
+[[tool]]
+name = "find_misplaced_code"
+category = "semantic"
+description = "[CodeLens:Analysis] Find symbols that are semantic outliers in their file — possible misplacement."
+annotations = "ro"
+output_schema = "find_misplaced_code_output_schema"
+feature_gate = "semantic"
+
+[tool.input_schema]
+type = "object"
+properties = { max_results = { type = "integer", description = "Max outliers to return (default 10)" } }

--- a/docs/adr/ADR-0013-tool-defs-codegen.md
+++ b/docs/adr/ADR-0013-tool-defs-codegen.md
@@ -137,13 +137,26 @@ to TOML and verifies that the `tools/list` output is byte-identical to
 the previous build:
 
 ```
-PR-A: scaffolding + File I/O   (this PR)             — 7 tools
-PR-B: Symbol + LSP                                    — 16 tools
-PR-C: Editing + Analysis                              — 15 tools
-PR-D: Composite (excluding workflow-first 7)         — 22 tools
-PR-E: Workflow-first 7 + Session 23                  — 30 tools
-PR-F: Memory + Rule corpus + Semantic + cleanup      — 22 tools  (final, removes legacy hand-rolled blocks)
+PR-A: scaffolding + File I/O                          —  7 tools  ✓ #128
+PR-B: Symbol + LSP                                    — 16 tools  ✓ #129
+PR-C: Editing + Analysis                              — 25 tools  ✓ #130
+PR-D: Composite (excluding workflow-first 7)          — 22 tools  ✓ #131
+PR-E: Workflow-first 7 + Session 23                   — 30 tools  ✓ #132
+PR-F: Memory 5 + Rule corpus 1 + Semantic 6 (final)   — 12 tools  ✓ this PR
 ```
+
+**Status as of PR-F merge:** every tool in the static `TOOLS` registry
+is declared in `tools.toml`. `build.rs` retains only the
+annotation-binding locals (`ro_p`, `ro_a`, `ro_w`, `mut_p`, `mut_w`,
+`mutating`, `destructive`, `dest_a`, `mut_coord`) consumed by the
+generated category functions, plus the post-build pass that attaches
+namespace, title, and `estimated_tokens`. The semantic category is
+emitted under `#[cfg(feature = "semantic")]` via an opt-in
+`feature_gate = "semantic"` field in TOML — codegen detects when every
+tool in a category shares a feature gate and lifts it onto the
+generated function. The original tool counts (15 for Editing+Analysis
+in the plan) under-counted the unified-edit and refactor entries; the
+actual migration was 25 tools in PR-C. All other PR sizes match.
 
 Considered alternative: atomic migration (single PR). Rejected because
 (a) review is impossible, and (b) git bisect on tool-related regressions

--- a/scripts/regen-tool-defs.py
+++ b/scripts/regen-tool-defs.py
@@ -107,6 +107,25 @@ def render_tool(tool: dict[str, Any]) -> list[str]:
     ]
 
 
+def category_feature_gate(tools: list[dict[str, Any]]) -> str | None:
+    """Return the shared `feature_gate` if every tool agrees, else None.
+
+    The codegen only supports an all-or-nothing feature gate per
+    category — the calling convention in `build.rs` extends one Vec
+    per category, so a mixed category would need per-Tool cfg
+    attributes inside the vec, which the script does not emit. If a
+    future PR needs a mixed category, update this function and the
+    Tool::new emit path together.
+    """
+    gates = {tool.get("feature_gate") for tool in tools}
+    if len(gates) > 1:
+        raise SystemExit(
+            f"tools in the same category disagree on feature_gate: {gates}. "
+            "Split into separate categories."
+        )
+    return next(iter(gates))
+
+
 def render_category(category: str, tools: list[dict[str, Any]]) -> str:
     bindings = bindings_for_category(tools)
     args = ", ".join(f"{ANNOTATION_BINDINGS[b]}: &ToolAnnotations" for b in bindings)
@@ -114,10 +133,12 @@ def render_category(category: str, tools: list[dict[str, Any]]) -> str:
     # narrow `pub(super) use` re-export in `tool_defs/generated/mod.rs`
     # is what actually constrains visibility to `tool_defs`. See
     # ADR-0013 for the visibility model.
-    lines = [
-        f"pub fn {category}_tools({args}) -> Vec<Tool> {{",
-        "    vec![",
-    ]
+    lines: list[str] = []
+    gate = category_feature_gate(tools)
+    if gate is not None:
+        lines.append(f'#[cfg(feature = "{gate}")]')
+    lines.append(f"pub fn {category}_tools({args}) -> Vec<Tool> {{")
+    lines.append("    vec![")
     for t in tools:
         lines.extend(render_tool(t))
     lines.append("    ]")


### PR DESCRIPTION
## Summary
Final migration PR for ADR-0013. Moves the last 12 hand-rolled tool rows (1 rule_corpus + 5 memory + 6 cfg-gated semantic) into \`tools.toml\` and retires the legacy \`tools.extend(vec![...])\` and \`#[cfg(feature = \"semantic\")] { tools.push(...) }\` blocks in \`build.rs\`.

### Codegen extension
- Per-tool \`feature_gate = \"<name>\"\` in TOML. The generator detects when every tool in a category shares the same gate and lifts a single \`#[cfg(feature = \"...\")]\` onto the generated \`pub fn\`. Mixed-gate categories raise \`SystemExit\` with a \"split into separate categories\" hint.
- Call site in \`build.rs\` stays a one-liner: \`#[cfg(feature = \"semantic\")] tools.extend(super::generated::semantic_tools(...));\`

### \`build.rs\` is now small
\`build.rs\` retains only the annotation-binding locals (\`ro_p\`, \`ro_a\`, \`ro_w\`, \`mut_p\`, \`mut_w\`, \`mutating\`, \`destructive\`, \`dest_a\`, \`mut_coord\`) and the post-build pass that attaches \`namespace\` / \`title\` / \`estimated_tokens\`. The Tool registry itself is **fully declarative**.

### ADR-0013 closure
- Updated the migration table with merged PR numbers (#128–#132 + this PR).
- Added a \"Status as of PR-F merge\" note clarifying the new \`build.rs\` vs \`tools.toml\` split.

## Stack
- Base: \`feat/tool-defs-codegen-workflow-session\` (PR-E, #132)
- After this lands: ADR-0013 fully merged, Track 3 (ADR-0014 AppState decomposition) becomes the next move.

## Test plan
- [x] \`cargo build\` (default + \`--no-default-features\`)
- [x] \`cargo test -p codelens-mcp\` — 530 / 530
- [x] \`cargo test -p codelens-mcp --no-default-features\` — 530 / 530
- [x] \`cargo clippy --all-targets -- -D warnings\` (both feature sets)
- [x] \`python3 scripts/regen-tool-defs.py --check\`
- [x] \`cargo fmt --check\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)