### PR TITLE
chore(release): v1.10.0 — bump workspace + refresh generated docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-engine"
-version = "1.9.60"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-mcp"
-version = "1.9.60"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-tui"
-version = "1.9.60"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "codelens-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "Apache-2.0"
-version = "1.9.60"
+version = "1.10.0"
 description = "Harness-native Rust MCP server for code intelligence with generated surface governance, hybrid retrieval, and mutation-gated workflows"
 repository = "https://github.com/mupozg823/codelens-mcp-plugin"
 homepage = "https://github.com/mupozg823/codelens-mcp-plugin"

--- a/README.md
+++ b/README.md
@@ -17,16 +17,15 @@ Pure Rust MCP server for multi-agent harnesses with hybrid retrieval (tree-sitte
 </div>
 
 <!-- SURFACE_MANIFEST_README_SNAPSHOT:BEGIN -->
-
 ## Surface Snapshot
 
-- Workspace version: `1.9.60`
-- Workspace members: `2` (`crates/codelens-engine`, `crates/codelens-mcp`)
-- Registered tool definitions: `112`
-- Tool output schemas: `82 / 112`
+- Workspace version: `1.10.0`
+- Workspace members: `3` (`crates/codelens-engine`, `crates/codelens-mcp`, `crates/codelens-tui`)
+- Registered tool definitions: `106`
+- Tool output schemas: `77 / 106`
 - Supported language families: `30` across `49` extensions
-- Profiles: `planner-readonly` (34), `builder-minimal` (38), `reviewer-graph` (36), `evaluator-compact` (14), `refactor-full` (50), `ci-audit` (43), `workflow-first` (19)
-- Presets: `minimal` (27), `balanced` (83), `full` (112)
+- Profiles: `planner-readonly` (32), `builder-minimal` (36), `reviewer-graph` (36), `evaluator-compact` (14), `refactor-full` (50), `ci-audit` (43), `workflow-first` (19)
+- Presets: `minimal` (27), `balanced` (77), `full` (106)
 - Canonical manifest: [`docs/generated/surface-manifest.json`](docs/generated/surface-manifest.json)
 <!-- SURFACE_MANIFEST_README_SNAPSHOT:END -->
 
@@ -358,13 +357,11 @@ verify_change_readiness → "ready" → rename_symbol
 ## Language Support
 
 <!-- SURFACE_MANIFEST_README_LANGUAGES:BEGIN -->
-
 Canonical parser families (30): C, Clojure/ClojureScript, C++, C#, CSS, Dart, Erlang, Elixir, Go, Haskell, HTML, Java, Julia, JavaScript, Kotlin, Lua, OCaml, PHP, Python, R, Ruby, Rust, Scala, Bash/Shell, Swift, TOML, TypeScript, TSX/JSX, YAML, Zig
 
 Import-graph capable families: C, C++, C#, CSS, Dart, Go, Java, JavaScript, Kotlin, PHP, Python, Ruby, Rust, Scala, Swift, TypeScript, TSX/JSX
 
 The canonical family/extension inventory is generated from `codelens_engine::lang_registry` and published in [`docs/generated/surface-manifest.json`](docs/generated/surface-manifest.json).
-
 <!-- SURFACE_MANIFEST_README_LANGUAGES:END -->
 
 ## Performance

--- a/crates/codelens-mcp/Cargo.toml
+++ b/crates/codelens-mcp/Cargo.toml
@@ -36,7 +36,7 @@ url.workspace = true
 rusqlite.workspace = true
 toml = "0.8"
 rustls = { workspace = true, optional = true }
-codelens-engine = { path = "../codelens-engine", version = "=1.9.60", default-features = false }
+codelens-engine = { path = "../codelens-engine", version = "=1.10.0", default-features = false }
 thiserror.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/codelens-tui/Cargo.toml
+++ b/crates/codelens-tui/Cargo.toml
@@ -14,7 +14,7 @@ name = "codelens-tui"
 path = "src/main.rs"
 
 [dependencies]
-codelens-engine = { path = "../codelens-engine", version = "=1.9.60" }
+codelens-engine = { path = "../codelens-engine", version = "=1.10.0" }
 ratatui = "0.30"
 crossterm = "0.28"
 anyhow.workspace = true

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -4,17 +4,20 @@ This directory contains all Architecture Decision Records for the CodeLens proje
 
 ## Index
 
-| ADR | Title | Status | Date | Supersedes |
-|-----|-------|--------|------|------------|
-| [ADR-0001](ADR-0001-runtime-boundaries-and-single-source-registries.md) | Runtime Boundaries and Single-Source Registries | Proposed | 2026-04-12 | — |
-| [ADR-0002](ADR-0002-enterprise-productization-evaluation-and-release-gates.md) | Enterprise Productization, Evaluation, and Release Gates | Proposed | 2026-04-13 | — |
-| [ADR-0004](ADR-0004-multi-agent-concurrency-primitives.md) | Multi-Agent Concurrency Primitives (Bounded-Evidence Only) | **Accepted** | 2026-04-15 | — |
-| [ADR-0005](ADR-0005-harness-v2.md) | Harness v2 — CodeLens as shared substrate for role-specialized agent hosts | **Accepted** | 2026-04-18 | — |
-| [ADR-0006](ADR-0006-agent-routing-enforcement.md) | Agent Routing Enforcement (server-side `preferred_executor` metadata) | **Accepted** | 2026-04-18 | — |
-| [ADR-0007](ADR-0007-symbiote-rebrand.md) | Symbiote as the v2 product metaphor and candidate rename | **Accepted** (pending trademark) | 2026-04-18 | — |
-| [ADR-0008](ADR-0008-serena-upper-compatible-absorption.md) | Serena Upper-Compatible Absorption (P1-P4, passive first) | **Accepted** | 2026-04-19 | — |
-| [ADR-0009](ADR-0009-mutation-trust-substrate.md) | Mutation Trust Substrate | Proposed | 2026-04-26 | Internal G4/G7 notes |
-| [ADR-0010](0010-telemetry-driven-tool-diet.md) | Telemetry-Driven Tool Surface Diet | Proposed | 2026-04-30 | — |
+| ADR                                                                            | Title                                                                      | Status                           | Date       | Supersedes           |
+| ------------------------------------------------------------------------------ | -------------------------------------------------------------------------- | -------------------------------- | ---------- | -------------------- |
+| [ADR-0001](ADR-0001-runtime-boundaries-and-single-source-registries.md)        | Runtime Boundaries and Single-Source Registries                            | Proposed                         | 2026-04-12 | —                    |
+| [ADR-0002](ADR-0002-enterprise-productization-evaluation-and-release-gates.md) | Enterprise Productization, Evaluation, and Release Gates                   | Proposed                         | 2026-04-13 | —                    |
+| [ADR-0004](ADR-0004-multi-agent-concurrency-primitives.md)                     | Multi-Agent Concurrency Primitives (Bounded-Evidence Only)                 | **Accepted**                     | 2026-04-15 | —                    |
+| [ADR-0005](ADR-0005-harness-v2.md)                                             | Harness v2 — CodeLens as shared substrate for role-specialized agent hosts | **Accepted**                     | 2026-04-18 | —                    |
+| [ADR-0006](ADR-0006-agent-routing-enforcement.md)                              | Agent Routing Enforcement (server-side `preferred_executor` metadata)      | **Accepted**                     | 2026-04-18 | —                    |
+| [ADR-0007](ADR-0007-symbiote-rebrand.md)                                       | Symbiote as the v2 product metaphor and candidate rename                   | **Accepted** (pending trademark) | 2026-04-18 | —                    |
+| [ADR-0008](ADR-0008-serena-upper-compatible-absorption.md)                     | Serena Upper-Compatible Absorption (P1-P4, passive first)                  | **Accepted**                     | 2026-04-19 | —                    |
+| [ADR-0009](ADR-0009-mutation-trust-substrate.md)                               | Mutation Trust Substrate                                                   | Proposed                         | 2026-04-26 | Internal G4/G7 notes |
+| [ADR-0010](0010-telemetry-driven-tool-diet.md)                                 | Telemetry-Driven Tool Surface Diet                                         | Proposed                         | 2026-04-30 | —                    |
+| [ADR-0011](ADR-0011-control-plane-sprawl-resolution.md)                        | Control-Plane Sprawl Resolution                                            | **Accepted**                     | 2026-05-01 | —                    |
+| [ADR-0012](ADR-0012-onnx-default-off.md)                                       | Default-Off Semantic on Cargo-Install Path                                 | **Accepted**                     | 2026-05-02 | —                    |
+| [ADR-0013](ADR-0013-tool-defs-codegen.md)                                      | TOML-Driven Codegen for Tool Definitions                                   | **Accepted**                     | 2026-05-02 | —                    |
 
 ## Status Legend
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,11 +6,10 @@
 ## Current Snapshot (2026-04-25)
 
 <!-- SURFACE_MANIFEST_ARCHITECTURE_SNAPSHOT:BEGIN -->
-
-- Workspace version: `1.9.60`
-- Workspace members: `2` (`crates/codelens-engine`, `crates/codelens-mcp`)
-- Registered tool definitions in source: `112`
-- Tool output schemas in source: `82 / 112`
+- Workspace version: `1.10.0`
+- Workspace members: `3` (`crates/codelens-engine`, `crates/codelens-mcp`, `crates/codelens-tui`)
+- Registered tool definitions in source: `106`
+- Tool output schemas in source: `77 / 106`
 - Supported language families: `30` across `49` extensions
 - Canonical manifest: [`docs/generated/surface-manifest.json`](generated/surface-manifest.json)
 <!-- SURFACE_MANIFEST_ARCHITECTURE_SNAPSHOT:END -->
@@ -464,13 +463,11 @@ MINIMAL  (20)   ██████████████                      
 ## 5. Language Support
 
 <!-- SURFACE_MANIFEST_ARCHITECTURE_LANGUAGES:BEGIN -->
-
 Canonical parser families (30): C, Clojure/ClojureScript, C++, C#, CSS, Dart, Erlang, Elixir, Go, Haskell, HTML, Java, Julia, JavaScript, Kotlin, Lua, OCaml, PHP, Python, R, Ruby, Rust, Scala, Bash/Shell, Swift, TOML, TypeScript, TSX/JSX, YAML, Zig
 
 Import-graph capable families: C, C++, C#, CSS, Dart, Go, Java, JavaScript, Kotlin, PHP, Python, Ruby, Rust, Scala, Swift, TypeScript, TSX/JSX
 
 The canonical family/extension inventory is generated from `codelens_engine::lang_registry` and published in [`docs/generated/surface-manifest.json`](generated/surface-manifest.json).
-
 <!-- SURFACE_MANIFEST_ARCHITECTURE_LANGUAGES:END -->
 
 ---

--- a/docs/generated/surface-manifest.json
+++ b/docs/generated/surface-manifest.json
@@ -1,41 +1,42 @@
 {
   "schema_version": "codelens-surface-manifest-v1",
   "workspace": {
-    "version": "1.9.60",
+    "version": "1.10.0",
     "description": "Harness-native Rust MCP server for code intelligence with generated surface governance, hybrid retrieval, and mutation-gated workflows",
     "members": [
       "crates/codelens-engine",
-      "crates/codelens-mcp"
+      "crates/codelens-mcp",
+      "crates/codelens-tui"
     ],
-    "member_count": 2
+    "member_count": 3
   },
   "tool_registry": {
-    "definition_count": 112,
-    "output_schema_count": 82,
+    "definition_count": 106,
+    "output_schema_count": 77,
     "namespaces": {
       "filesystem": 6,
-      "graph": 12,
+      "graph": 8,
       "lsp": 3,
       "memory": 5,
       "mutation": 16,
       "reports": 25,
       "session": 34,
-      "symbols": 11
+      "symbols": 9
     },
     "tiers": {
-      "analysis": 26,
-      "primitive": 56,
+      "analysis": 23,
+      "primitive": 53,
       "workflow": 30
     },
     "phases": {
       "agnostic": 41,
       "build": 18,
       "eval": 8,
-      "plan": 27,
-      "review": 18
+      "plan": 24,
+      "review": 15
     },
     "preferred_executors": {
-      "any": 86,
+      "any": 80,
       "claude": 9,
       "codex-builder": 17
     },
@@ -473,24 +474,6 @@
         "estimated_tokens": 611
       },
       {
-        "name": "explore_codebase",
-        "namespace": "reports",
-        "tier": "workflow",
-        "phase": "plan",
-        "preferred_executor": null,
-        "has_output_schema": true,
-        "estimated_tokens": 204
-      },
-      {
-        "name": "trace_request_path",
-        "namespace": "reports",
-        "tier": "workflow",
-        "phase": "plan",
-        "preferred_executor": "claude",
-        "has_output_schema": true,
-        "estimated_tokens": 186
-      },
-      {
         "name": "explain_code_flow",
         "namespace": "session",
         "tier": "analysis",
@@ -498,51 +481,6 @@
         "preferred_executor": null,
         "has_output_schema": false,
         "estimated_tokens": 131
-      },
-      {
-        "name": "review_architecture",
-        "namespace": "reports",
-        "tier": "workflow",
-        "phase": "plan",
-        "preferred_executor": "claude",
-        "has_output_schema": true,
-        "estimated_tokens": 176
-      },
-      {
-        "name": "plan_safe_refactor",
-        "namespace": "reports",
-        "tier": "workflow",
-        "phase": "plan",
-        "preferred_executor": "claude",
-        "has_output_schema": true,
-        "estimated_tokens": 198
-      },
-      {
-        "name": "cleanup_duplicate_logic",
-        "namespace": "reports",
-        "tier": "workflow",
-        "phase": "build",
-        "preferred_executor": "claude",
-        "has_output_schema": true,
-        "estimated_tokens": 196
-      },
-      {
-        "name": "review_changes",
-        "namespace": "reports",
-        "tier": "workflow",
-        "phase": "review",
-        "preferred_executor": "claude",
-        "has_output_schema": true,
-        "estimated_tokens": 200
-      },
-      {
-        "name": "diagnose_issues",
-        "namespace": "reports",
-        "tier": "workflow",
-        "phase": "review",
-        "preferred_executor": null,
-        "has_output_schema": true,
-        "estimated_tokens": 191
       },
       {
         "name": "onboard_project",
@@ -734,58 +672,67 @@
         "estimated_tokens": 134
       },
       {
-        "name": "find_relevant_rules",
+        "name": "explore_codebase",
         "namespace": "reports",
-        "tier": "analysis",
-        "phase": null,
-        "preferred_executor": null,
-        "has_output_schema": false,
-        "estimated_tokens": 159
-      },
-      {
-        "name": "list_memories",
-        "namespace": "memory",
-        "tier": "primitive",
-        "phase": null,
+        "tier": "workflow",
+        "phase": "plan",
         "preferred_executor": null,
         "has_output_schema": true,
-        "estimated_tokens": 125
+        "estimated_tokens": 204
       },
       {
-        "name": "read_memory",
-        "namespace": "memory",
-        "tier": "primitive",
-        "phase": null,
-        "preferred_executor": null,
-        "has_output_schema": false,
-        "estimated_tokens": 86
+        "name": "trace_request_path",
+        "namespace": "reports",
+        "tier": "workflow",
+        "phase": "plan",
+        "preferred_executor": "claude",
+        "has_output_schema": true,
+        "estimated_tokens": 186
       },
       {
-        "name": "write_memory",
-        "namespace": "memory",
-        "tier": "primitive",
-        "phase": null,
-        "preferred_executor": null,
-        "has_output_schema": false,
-        "estimated_tokens": 94
+        "name": "review_architecture",
+        "namespace": "reports",
+        "tier": "workflow",
+        "phase": "plan",
+        "preferred_executor": "claude",
+        "has_output_schema": true,
+        "estimated_tokens": 176
       },
       {
-        "name": "delete_memory",
-        "namespace": "memory",
-        "tier": "primitive",
-        "phase": null,
-        "preferred_executor": null,
-        "has_output_schema": false,
-        "estimated_tokens": 89
+        "name": "plan_safe_refactor",
+        "namespace": "reports",
+        "tier": "workflow",
+        "phase": "plan",
+        "preferred_executor": "claude",
+        "has_output_schema": true,
+        "estimated_tokens": 198
       },
       {
-        "name": "rename_memory",
-        "namespace": "memory",
-        "tier": "primitive",
-        "phase": null,
+        "name": "cleanup_duplicate_logic",
+        "namespace": "reports",
+        "tier": "workflow",
+        "phase": "build",
+        "preferred_executor": "claude",
+        "has_output_schema": true,
+        "estimated_tokens": 196
+      },
+      {
+        "name": "review_changes",
+        "namespace": "reports",
+        "tier": "workflow",
+        "phase": "review",
+        "preferred_executor": "claude",
+        "has_output_schema": true,
+        "estimated_tokens": 200
+      },
+      {
+        "name": "diagnose_issues",
+        "namespace": "reports",
+        "tier": "workflow",
+        "phase": "review",
         "preferred_executor": null,
-        "has_output_schema": false,
-        "estimated_tokens": 102
+        "has_output_schema": true,
+        "estimated_tokens": 191
       },
       {
         "name": "activate_project",
@@ -995,58 +942,58 @@
         "estimated_tokens": 101
       },
       {
-        "name": "semantic_search",
-        "namespace": "symbols",
-        "tier": "primitive",
-        "phase": "plan",
-        "preferred_executor": null,
-        "has_output_schema": true,
-        "estimated_tokens": 304
-      },
-      {
-        "name": "index_embeddings",
-        "namespace": "symbols",
-        "tier": "primitive",
-        "phase": "plan",
+        "name": "find_relevant_rules",
+        "namespace": "reports",
+        "tier": "analysis",
+        "phase": null,
         "preferred_executor": null,
         "has_output_schema": false,
-        "estimated_tokens": 179
+        "estimated_tokens": 159
       },
       {
-        "name": "find_similar_code",
-        "namespace": "graph",
-        "tier": "analysis",
-        "phase": "plan",
-        "preferred_executor": null,
-        "has_output_schema": true,
-        "estimated_tokens": 276
-      },
-      {
-        "name": "find_code_duplicates",
-        "namespace": "graph",
-        "tier": "analysis",
-        "phase": "review",
-        "preferred_executor": null,
-        "has_output_schema": true,
-        "estimated_tokens": 221
-      },
-      {
-        "name": "classify_symbol",
-        "namespace": "graph",
-        "tier": "analysis",
-        "phase": "review",
-        "preferred_executor": null,
-        "has_output_schema": true,
-        "estimated_tokens": 212
-      },
-      {
-        "name": "find_misplaced_code",
-        "namespace": "graph",
+        "name": "list_memories",
+        "namespace": "memory",
         "tier": "primitive",
-        "phase": "review",
+        "phase": null,
         "preferred_executor": null,
         "has_output_schema": true,
-        "estimated_tokens": 195
+        "estimated_tokens": 125
+      },
+      {
+        "name": "read_memory",
+        "namespace": "memory",
+        "tier": "primitive",
+        "phase": null,
+        "preferred_executor": null,
+        "has_output_schema": false,
+        "estimated_tokens": 86
+      },
+      {
+        "name": "write_memory",
+        "namespace": "memory",
+        "tier": "primitive",
+        "phase": null,
+        "preferred_executor": null,
+        "has_output_schema": false,
+        "estimated_tokens": 94
+      },
+      {
+        "name": "delete_memory",
+        "namespace": "memory",
+        "tier": "primitive",
+        "phase": null,
+        "preferred_executor": null,
+        "has_output_schema": false,
+        "estimated_tokens": 89
+      },
+      {
+        "name": "rename_memory",
+        "namespace": "memory",
+        "tier": "primitive",
+        "phase": null,
+        "preferred_executor": null,
+        "has_output_schema": false,
+        "estimated_tokens": 102
       }
     ]
   },
@@ -1054,7 +1001,7 @@
     "profiles": [
       {
         "name": "planner-readonly",
-        "tool_count": 34,
+        "tool_count": 32,
         "preferred_namespaces": [
           "reports",
           "symbols",
@@ -1073,8 +1020,6 @@
           "review_architecture",
           "review_changes",
           "prepare_harness_session",
-          "plan_safe_refactor",
-          "diagnose_issues",
           "onboard_project",
           "analyze_change_request",
           "verify_change_readiness",
@@ -1082,14 +1027,14 @@
           "mermaid_module_graph",
           "impact_report",
           "start_analysis_job",
+          "plan_safe_refactor",
+          "diagnose_issues",
           "get_analysis_job",
           "get_analysis_section",
           "get_symbols_overview",
           "find_symbol",
           "get_ranked_context",
           "find_referencing_symbols",
-          "semantic_search",
-          "index_embeddings",
           "get_changed_files",
           "get_current_config",
           "activate_project",
@@ -1107,7 +1052,7 @@
       },
       {
         "name": "builder-minimal",
-        "tool_count": 38,
+        "tool_count": 36,
         "preferred_namespaces": [
           "reports",
           "symbols",
@@ -1143,8 +1088,6 @@
           "get_symbols_overview",
           "find_symbol",
           "find_referencing_symbols",
-          "semantic_search",
-          "index_embeddings",
           "find_tests",
           "get_current_config",
           "analyze_missing_imports",
@@ -1185,7 +1128,6 @@
           "review_changes",
           "cleanup_duplicate_logic",
           "prepare_harness_session",
-          "diagnose_issues",
           "verify_change_readiness",
           "summarize_symbol_impact",
           "module_boundary_report",
@@ -1194,6 +1136,7 @@
           "refactor_safety_report",
           "diff_aware_references",
           "start_analysis_job",
+          "diagnose_issues",
           "semantic_code_review",
           "get_analysis_job",
           "get_analysis_section",
@@ -1271,9 +1214,6 @@
           "review_changes",
           "trace_request_path",
           "prepare_harness_session",
-          "explore_codebase",
-          "review_architecture",
-          "diagnose_issues",
           "verify_change_readiness",
           "safe_rename_report",
           "unresolved_reference_check",
@@ -1281,6 +1221,9 @@
           "refactor_safety_report",
           "diff_aware_references",
           "start_analysis_job",
+          "explore_codebase",
+          "review_architecture",
+          "diagnose_issues",
           "replace_symbol_body",
           "refactor_extract_function",
           "refactor_inline_function",
@@ -1339,8 +1282,6 @@
           "cleanup_duplicate_logic",
           "review_architecture",
           "prepare_harness_session",
-          "explore_codebase",
-          "diagnose_issues",
           "analyze_change_request",
           "verify_change_readiness",
           "summarize_symbol_impact",
@@ -1351,6 +1292,8 @@
           "refactor_safety_report",
           "diff_aware_references",
           "start_analysis_job",
+          "explore_codebase",
+          "diagnose_issues",
           "get_analysis_job",
           "get_analysis_section",
           "get_changed_files",
@@ -1392,6 +1335,8 @@
         ],
         "preferred_phases": [],
         "tools": [
+          "onboard_project",
+          "analyze_change_request",
           "explore_codebase",
           "trace_request_path",
           "review_architecture",
@@ -1399,8 +1344,6 @@
           "cleanup_duplicate_logic",
           "review_changes",
           "diagnose_issues",
-          "onboard_project",
-          "analyze_change_request",
           "get_current_config",
           "activate_project",
           "register_agent_work",
@@ -1459,7 +1402,7 @@
       },
       {
         "name": "balanced",
-        "tool_count": 83,
+        "tool_count": 77,
         "preferred_namespaces": [
           "reports",
           "symbols",
@@ -1476,10 +1419,6 @@
           "review_architecture",
           "review_changes",
           "prepare_harness_session",
-          "trace_request_path",
-          "plan_safe_refactor",
-          "cleanup_duplicate_logic",
-          "diagnose_issues",
           "onboard_project",
           "analyze_change_request",
           "verify_change_readiness",
@@ -1495,6 +1434,10 @@
           "diff_aware_references",
           "start_analysis_job",
           "cancel_analysis_job",
+          "trace_request_path",
+          "plan_safe_refactor",
+          "cleanup_duplicate_logic",
+          "diagnose_issues",
           "refresh_symbol_index",
           "propagate_deletions",
           "semantic_code_review",
@@ -1508,9 +1451,6 @@
           "get_callers",
           "get_callees",
           "find_scoped_references",
-          "find_similar_code",
-          "find_code_duplicates",
-          "classify_symbol",
           "resolve_symbol_target",
           "explain_code_flow",
           "query_project",
@@ -1523,10 +1463,7 @@
           "find_symbol",
           "find_referencing_symbols",
           "search_workspace_symbols",
-          "semantic_search",
-          "index_embeddings",
           "get_changed_files",
-          "find_misplaced_code",
           "find_annotations",
           "find_tests",
           "get_current_config",
@@ -1559,7 +1496,7 @@
       },
       {
         "name": "full",
-        "tool_count": 112,
+        "tool_count": 106,
         "preferred_namespaces": [
           "filesystem",
           "graph",
@@ -1583,10 +1520,6 @@
           "replace_symbol_body",
           "refactor_extract_function",
           "refactor_inline_function",
-          "trace_request_path",
-          "cleanup_duplicate_logic",
-          "review_changes",
-          "diagnose_issues",
           "onboard_project",
           "analyze_change_request",
           "verify_change_readiness",
@@ -1602,6 +1535,10 @@
           "diff_aware_references",
           "start_analysis_job",
           "cancel_analysis_job",
+          "trace_request_path",
+          "cleanup_duplicate_logic",
+          "review_changes",
+          "diagnose_issues",
           "refresh_symbol_index",
           "propagate_deletions",
           "semantic_code_review",
@@ -1614,9 +1551,6 @@
           "get_symbol_importance",
           "find_circular_dependencies",
           "get_change_coupling",
-          "find_similar_code",
-          "find_code_duplicates",
-          "classify_symbol",
           "rename_symbol",
           "refactor_move_to_file",
           "refactor_change_signature",
@@ -1640,7 +1574,6 @@
           "find_annotations",
           "find_tests",
           "get_changed_files",
-          "find_misplaced_code",
           "get_file_diagnostics",
           "check_lsp_status",
           "get_lsp_recipe",
@@ -1685,9 +1618,7 @@
           "get_symbols_overview",
           "find_symbol",
           "find_referencing_symbols",
-          "search_workspace_symbols",
-          "semantic_search",
-          "index_embeddings"
+          "search_workspace_symbols"
         ]
       }
     ]
@@ -1721,11 +1652,11 @@
             "profiles": [
               {
                 "name": "planner-readonly",
-                "tool_count": 34
+                "tool_count": 32
               },
               {
                 "name": "builder-minimal",
-                "tool_count": 38
+                "tool_count": 36
               }
             ]
           }
@@ -1763,7 +1694,7 @@
             "profiles": [
               {
                 "name": "planner-readonly",
-                "tool_count": 34
+                "tool_count": 32
               },
               {
                 "name": "reviewer-graph",
@@ -1778,7 +1709,7 @@
             "profiles": [
               {
                 "name": "builder-minimal",
-                "tool_count": 38
+                "tool_count": 36
               },
               {
                 "name": "refactor-full",
@@ -1928,7 +1859,7 @@
             "profiles": [
               {
                 "name": "planner-readonly",
-                "tool_count": 34
+                "tool_count": 32
               },
               {
                 "name": "reviewer-graph",
@@ -1943,7 +1874,7 @@
             "profiles": [
               {
                 "name": "builder-minimal",
-                "tool_count": 38
+                "tool_count": 36
               },
               {
                 "name": "refactor-full",
@@ -2455,7 +2386,12 @@
           "trace_request_path",
           "plan_safe_refactor",
           "verify_change_readiness",
-          "get_file_diagnostics"
+          "get_file_diagnostics",
+          "rename_symbol",
+          "replace_symbol_body",
+          "insert_content",
+          "replace",
+          "add_import"
         ],
         "native_primitives": [
           "AGENTS.md",
@@ -2556,7 +2492,12 @@
           "get_file_diagnostics",
           "verify_change_readiness",
           "trace_request_path",
-          "plan_safe_refactor"
+          "plan_safe_refactor",
+          "rename_symbol",
+          "replace_symbol_body",
+          "insert_content",
+          "replace",
+          "add_import"
         ],
         "native_primitives": [
           "interactive permissioned terminal execution",
@@ -2603,7 +2544,12 @@
           "trace_request_path",
           "plan_safe_refactor",
           "verify_change_readiness",
-          "get_file_diagnostics"
+          "get_file_diagnostics",
+          "rename_symbol",
+          "replace_symbol_body",
+          "insert_content",
+          "replace",
+          "add_import"
         ],
         "native_primitives": [
           "global MCP config",
@@ -3202,16 +3148,16 @@
   },
   "runtime": {
     "server_name": "codelens-mcp",
-    "version": "1.9.59",
+    "version": "1.10.0",
     "transport": [
       "stdio",
       "streamable-http"
     ],
     "active_surface": "preset:balanced",
-    "visible_tool_count": 83,
+    "visible_tool_count": 77,
     "daemon_mode": "standard",
     "supports_http": true,
-    "supports_semantic": true,
+    "supports_semantic": false,
     "supports_scip_backend": false,
     "supports_otel": false,
     "server_card_features": [
@@ -3233,17 +3179,16 @@
       "host-adapter-spec",
       "agent-experience-spec",
       "handoff-artifact-schema",
-      "semantic-search",
       "streamable-http"
     ]
   },
   "summary": {
-    "workspace_version": "1.9.59",
+    "workspace_version": "1.10.0",
     "workspace_member_count": 3,
-    "registered_tool_definitions": 112,
+    "registered_tool_definitions": 106,
     "tool_output_schemas": {
-      "declared": 82,
-      "total": 112
+      "declared": 77,
+      "total": 106
     },
     "harness_mode_count": 4,
     "harness_contract_count": 3,

--- a/docs/harness-modes.md
+++ b/docs/harness-modes.md
@@ -28,7 +28,7 @@ Single-agent local work without cross-agent coordination overhead.
 - Daemon shape: `single-session`
 - Recommended ports: none
 - Roles:
-  - `solo-agent`: `planner-readonly` (34), `builder-minimal` (38); mutate=`false`; one session handles both planning and implementation
+  - `solo-agent`: `planner-readonly` (32), `builder-minimal` (36); mutate=`false`; one session handles both planning and implementation
 - Recommended flow:
   - `prepare_harness_session`
   - `explore_codebase`
@@ -49,8 +49,8 @@ Primary multi-agent pattern: read-only planning/review paired with mutation-enab
 - Daemon shape: `dual-daemon`
 - Recommended ports: `7837`, `7838`
 - Roles:
-  - `planner-reviewer`: `planner-readonly` (34), `reviewer-graph` (36); mutate=`false`; bootstrap, rank context, and verify change readiness before dispatch
-  - `builder-refactor`: `builder-minimal` (38), `refactor-full` (50); mutate=`true`; execute bounded edits after preflight, diagnostics, and claims
+  - `planner-reviewer`: `planner-readonly` (32), `reviewer-graph` (36); mutate=`false`; bootstrap, rank context, and verify change readiness before dispatch
+  - `builder-refactor`: `builder-minimal` (36), `refactor-full` (50); mutate=`true`; execute bounded edits after preflight, diagnostics, and claims
 - Recommended flow:
   - `prepare_harness_session`
   - `get_symbols_overview per target file`

--- a/docs/harness-spec.md
+++ b/docs/harness-spec.md
@@ -27,8 +27,8 @@ This document is generated from the same canonical manifest that powers the runt
 - Mode: `planner-builder`
 - Intent: Planner/reviewer session prepares bounded evidence, then a mutation-enabled builder session executes the change under explicit coordination.
 - Roles:
-  - `planner-reviewer`: `planner-readonly` (34), `reviewer-graph` (36); mutate=`false`; collect structure, diagnostics, and readiness evidence before dispatch
-  - `builder-refactor`: `builder-minimal` (38), `refactor-full` (50); mutate=`true`; perform bounded mutation only after preflight, diagnostics, and coordination
+  - `planner-reviewer`: `planner-readonly` (32), `reviewer-graph` (36); mutate=`false`; collect structure, diagnostics, and readiness evidence before dispatch
+  - `builder-refactor`: `builder-minimal` (36), `refactor-full` (50); mutate=`true`; perform bounded mutation only after preflight, diagnostics, and coordination
 
 **Preflight Sequence**
 - 1. `prepare_harness_session` | required=`true` | when: planner or builder bootstrap | purpose: establish session-local project view, visible surface, and health summary

--- a/docs/host-adaptive-harness.md
+++ b/docs/host-adaptive-harness.md
@@ -45,7 +45,7 @@ Generated from the canonical surface manifest. Runtime resources remain the auth
 - Recommended modes: `solo-local`, `planner-builder`, `batch-analysis`
 - Preferred profiles: `builder-minimal`, `refactor-full`, `ci-audit`
 - Default compiled overlay: profile=`builder-minimal`, task_overlay=`editing`
-- Primary bootstrap sequence: `prepare_harness_session` -> `explore_codebase` -> `trace_request_path` -> `plan_safe_refactor` -> `verify_change_readiness` -> `get_file_diagnostics`
+- Primary bootstrap sequence: `prepare_harness_session` -> `explore_codebase` -> `trace_request_path` -> `plan_safe_refactor` -> `verify_change_readiness` -> `get_file_diagnostics` -> `rename_symbol` -> `replace_symbol_body` -> `insert_content` -> `replace` -> `add_import`
 - Compiler targets: `AGENTS.md`, `~/.codex/config.toml`, `repo-local skill files`
 
 ### `cursor`
@@ -65,7 +65,7 @@ Generated from the canonical surface manifest. Runtime resources remain the auth
 - Recommended modes: `solo-local`, `planner-builder`
 - Preferred profiles: `builder-minimal`, `reviewer-graph`
 - Default compiled overlay: profile=`builder-minimal`, task_overlay=`editing`
-- Primary bootstrap sequence: `prepare_harness_session` -> `get_file_diagnostics` -> `verify_change_readiness` -> `trace_request_path` -> `plan_safe_refactor`
+- Primary bootstrap sequence: `prepare_harness_session` -> `get_file_diagnostics` -> `verify_change_readiness` -> `trace_request_path` -> `plan_safe_refactor` -> `rename_symbol` -> `replace_symbol_body` -> `insert_content` -> `replace` -> `add_import`
 - Compiler targets: `mcp_servers.json`, `.clinerules`, `repo instructions`
 
 ### `windsurf`
@@ -75,7 +75,7 @@ Generated from the canonical surface manifest. Runtime resources remain the auth
 - Recommended modes: `solo-local`, `reviewer-gate`
 - Preferred profiles: `builder-minimal`, `planner-readonly`
 - Default compiled overlay: profile=`builder-minimal`, task_overlay=`editing`
-- Primary bootstrap sequence: `prepare_harness_session` -> `explore_codebase` -> `trace_request_path` -> `plan_safe_refactor` -> `verify_change_readiness` -> `get_file_diagnostics`
+- Primary bootstrap sequence: `prepare_harness_session` -> `explore_codebase` -> `trace_request_path` -> `plan_safe_refactor` -> `verify_change_readiness` -> `get_file_diagnostics` -> `rename_symbol` -> `replace_symbol_body` -> `insert_content` -> `replace` -> `add_import`
 - Compiler targets: `~/.codeium/windsurf/mcp_config.json`
 <!-- SURFACE_MANIFEST_HOST_ADAPTER_SUMMARY:END -->
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,15 @@
 
 CodeLens MCP is a pure Rust MCP server for multi-agent coding harnesses. This directory contains operational docs for architecture, setup, release verification, and ADRs.
 
+## Releases
+
+<!-- SURFACE_MANIFEST_INDEX_RELEASE:BEGIN -->
+- [Latest GitHub Release](https://github.com/mupozg823/codelens-mcp-plugin/releases/latest)
+- [All tagged releases](https://github.com/mupozg823/codelens-mcp-plugin/releases)
+- [Repository README](https://github.com/mupozg823/codelens-mcp-plugin/blob/main/README.md)
+- [Current source tree](https://github.com/mupozg823/codelens-mcp-plugin)
+<!-- SURFACE_MANIFEST_INDEX_RELEASE:END -->
+
 ## Start Here
 
 - [README](../README.md) — overview, install, setup

--- a/docs/platform-setup.md
+++ b/docs/platform-setup.md
@@ -587,9 +587,9 @@ agent = client.agents.create(
 ## Preset Comparison
 
 <!-- SURFACE_MANIFEST_PLATFORM_SURFACES:BEGIN -->
-- Workspace version: `1.9.59`
-- Presets: `minimal` (27), `balanced` (83), `full` (112)
-- Profiles: `planner-readonly` (34), `builder-minimal` (38), `reviewer-graph` (36), `evaluator-compact` (14), `refactor-full` (50), `ci-audit` (43), `workflow-first` (19)
+- Workspace version: `1.10.0`
+- Presets: `minimal` (27), `balanced` (77), `full` (106)
+- Profiles: `planner-readonly` (32), `builder-minimal` (36), `reviewer-graph` (36), `evaluator-compact` (14), `refactor-full` (50), `ci-audit` (43), `workflow-first` (19)
 - Canonical manifest: [`docs/generated/surface-manifest.json`](generated/surface-manifest.json)
 <!-- SURFACE_MANIFEST_PLATFORM_SURFACES:END -->
 


### PR DESCRIPTION
## Summary
Version bump and post-PR-#134 doc refresh for the v1.10.0 release.

- Workspace \`1.9.60 → 1.10.0\` (Cargo.toml + pinned engine refs).
- \`scripts/surface-manifest.py --write\` regenerated docs blocks across README, architecture, platform-setup, harness, host-adaptive.
- ADR index now lists ADR-0011 / ADR-0012 / ADR-0013.
- \`docs/index.md\` gains the \`SURFACE_MANIFEST_INDEX_RELEASE\` marker pair the script expects.

## Verification
- [x] cargo build / test default — 530 / 530 pass
- [x] \`scripts/regen-tool-defs.py --check\`
- [x] \`scripts/surface-manifest.py --check\`
- [x] \`cargo fmt --check\`

## Next
After merge: tag \`v1.10.0\`, GitHub Release, crates.io publish (engine → mcp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)