### PR TITLE
fix(v1.10.1): broaden claude-code default tool surface + ranked_context retrieval guards

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-engine"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "anyhow",
  "criterion",
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-mcp"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-tui"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "anyhow",
  "codelens-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "Apache-2.0"
-version = "1.10.0"
+version = "1.10.1"
 description = "Harness-native Rust MCP server for code intelligence with generated surface governance, hybrid retrieval, and mutation-gated workflows"
 repository = "https://github.com/mupozg823/codelens-mcp-plugin"
 homepage = "https://github.com/mupozg823/codelens-mcp-plugin"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Pure Rust MCP server for multi-agent harnesses with hybrid retrieval (tree-sitte
 <!-- SURFACE_MANIFEST_README_SNAPSHOT:BEGIN -->
 ## Surface Snapshot
 
-- Workspace version: `1.10.0`
+- Workspace version: `1.10.1`
 - Workspace members: `3` (`crates/codelens-engine`, `crates/codelens-mcp`, `crates/codelens-tui`)
 - Registered tool definitions: `106`
 - Tool output schemas: `77 / 106`
@@ -206,6 +206,16 @@ build:
 
 - `dev.codelens.mcp-readonly` -> `reviewer-graph` on `:7839`
 - `dev.codelens.mcp-mutation` -> `refactor-full` on `:7838`
+
+> **Build flag reminder (v1.10.1+)**: the plists point at
+> `target/release/codelens-mcp`, which must be a build that includes
+> the `http` feature (and `semantic` if you want hybrid retrieval).
+> Run `cargo build --release --features http,semantic` before
+> `--load`-ing, otherwise the daemons fail with
+> `Error: HTTP/HTTPS transport requires the http feature` and the
+> ports never bind. See
+> [`docs/release-verification.md`](docs/release-verification.md#feature-flag-matrix-build-time-requirements)
+> for the full feature-flag matrix.
 
 It also updates `.codelens/config.json` with repo-local `host_attach` URL
 overrides so `codelens-mcp attach`, `status`, and `doctor` reuse the same

--- a/crates/codelens-mcp/Cargo.toml
+++ b/crates/codelens-mcp/Cargo.toml
@@ -36,7 +36,7 @@ url.workspace = true
 rusqlite.workspace = true
 toml = "0.8"
 rustls = { workspace = true, optional = true }
-codelens-engine = { path = "../codelens-engine", version = "=1.10.0", default-features = false }
+codelens-engine = { path = "../codelens-engine", version = "=1.10.1", default-features = false }
 thiserror.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/codelens-mcp/src/integration_tests/protocol_tools_list.rs
+++ b/crates/codelens-mcp/src/integration_tests/protocol_tools_list.rs
@@ -25,12 +25,20 @@ fn lists_tools() {
         .iter()
         .filter_map(|tool| tool["name"].as_str())
         .collect::<Vec<_>>();
+    // v1.10.1 (F2): default tools/list now surfaces workflow-first 7 +
+    // core navigation primitives so the slogan matches reality. Symbol
+    // primitives like `get_symbols_overview` are now in the default
+    // list. Use a phase or namespace filter when only a slice is wanted.
     assert!(names.contains(&"get_ranked_context"));
     assert!(names.contains(&"get_callers"));
     assert!(names.contains(&"start_analysis_job"));
     assert!(
-        !names.contains(&"get_symbols_overview"),
-        "default tools/list should stay MVP-focused; use full=true or namespace filters for primitive expansion"
+        names.contains(&"get_symbols_overview"),
+        "default tools/list now includes core navigation primitives (v1.10.1 F2)"
+    );
+    assert!(
+        names.contains(&"review_changes"),
+        "default tools/list now includes the workflow-first 7 (v1.10.1 F2)"
     );
 }
 
@@ -57,24 +65,47 @@ fn default_tools_list_is_mvp_focused_but_full_and_namespace_expand() {
         .filter_map(|tool| tool["name"].as_str())
         .collect::<Vec<_>>();
 
-    assert_eq!(
-        default_tools,
-        vec![
-            "activate_project",
-            "prepare_harness_session",
-            "get_current_config",
-            "set_profile",
-            "set_preset",
-            "explore_codebase",
-            "get_ranked_context",
-            "get_callers",
-            "get_callees",
-            "verify_change_readiness",
-            "start_analysis_job",
-            "get_analysis_job",
-            "get_analysis_section",
-        ]
-    );
+    // v1.10.1 (F2): default tools/list expanded from 13 → 25 tools to
+    // surface the workflow-first composite tools and core navigation
+    // primitives that the product is positioned around. The list is
+    // ordered as defined in `DEFAULT_LISTED_TOOL_NAMES`.
+    let mut expected: Vec<&'static str> = vec![
+        // Control plane
+        "activate_project",
+        "prepare_harness_session",
+        "get_current_config",
+        "get_capabilities",
+        "set_profile",
+        "set_preset",
+        // Workflow-first 7
+        "explore_codebase",
+        "trace_request_path",
+        "review_architecture",
+        "plan_safe_refactor",
+        "cleanup_duplicate_logic",
+        "review_changes",
+        "diagnose_issues",
+        // Core navigation primitives
+        "find_symbol",
+        "get_symbols_overview",
+        "find_referencing_symbols",
+        "get_file_diagnostics",
+        "bm25_symbol_search",
+        "semantic_search",
+        // Analysis & async jobs
+        "get_ranked_context",
+        "get_callers",
+        "get_callees",
+        "verify_change_readiness",
+        "start_analysis_job",
+        "get_analysis_job",
+        "get_analysis_section",
+    ];
+    if !cfg!(feature = "semantic") {
+        // semantic_search is gated; only present when the feature is on.
+        expected.retain(|name| *name != "semantic_search");
+    }
+    assert_eq!(default_tools, expected);
 
     let full_resp = handle_request(
         &state,
@@ -419,10 +450,8 @@ fn deferred_tools_list_defaults_to_preferred_namespaces_only() {
     .unwrap();
     let encoded = serde_json::to_string(&list_resp).unwrap();
     assert!(encoded.contains("\"deferred_loading_active\":true"));
-    assert!(
-        encoded
-            .contains("\"preferred_namespaces\":[\"reports\",\"graph\",\"symbols\",\"session\"]")
-    );
+    assert!(encoded
+        .contains("\"preferred_namespaces\":[\"reports\",\"graph\",\"symbols\",\"session\"]"));
     assert!(encoded.contains("\"preferred_tiers\":[\"workflow\"]"));
     assert!(encoded.contains("\"loaded_tiers\":[]"));
     assert!(encoded.contains("\"review_architecture\""));

--- a/crates/codelens-mcp/src/resource_context.rs
+++ b/crates/codelens-mcp/src/resource_context.rs
@@ -10,13 +10,39 @@ use crate::tools::session::metrics_config::collect_runtime_health_snapshot;
 use serde_json::{Value, json};
 use std::collections::{BTreeMap, BTreeSet};
 
+// Default surface for hosts that fetch `tools/list` without a phase filter
+// (claude-code is the primary one). v1.10.1 widens this from 13 → 25 to
+// surface the workflow-first composite tools and the core navigation
+// primitives. The slogan ("workflow-first, 112 tools") was contradicted
+// by the prior 13-tool bootstrap surface — in particular, calling
+// `explore_codebase` was possible but `review_changes` /
+// `plan_safe_refactor` / `find_symbol` / `get_symbols_overview` were
+// invisible until ToolSearch keyword fetch. See
+// `docs/eval/v1.10.0-post-release-eval.md` (F2).
 const DEFAULT_LISTED_TOOL_NAMES: &[&str] = &[
+    // ── Control plane ──────────────────────────────────────────────
     "activate_project",
     "prepare_harness_session",
     "get_current_config",
+    "get_capabilities",
     "set_profile",
     "set_preset",
+    // ── Workflow-first 7 (the slogan) ──────────────────────────────
     "explore_codebase",
+    "trace_request_path",
+    "review_architecture",
+    "plan_safe_refactor",
+    "cleanup_duplicate_logic",
+    "review_changes",
+    "diagnose_issues",
+    // ── Core navigation primitives ─────────────────────────────────
+    "find_symbol",
+    "get_symbols_overview",
+    "find_referencing_symbols",
+    "get_file_diagnostics",
+    "bm25_symbol_search",
+    "semantic_search",
+    // ── Analysis & async jobs ──────────────────────────────────────
     "get_ranked_context",
     "get_callers",
     "get_callees",

--- a/crates/codelens-mcp/src/tool_defs/generated/build_generated.rs
+++ b/crates/codelens-mcp/src/tool_defs/generated/build_generated.rs
@@ -587,8 +587,8 @@ pub fn symbol_tools(
         ).with_output_schema(symbol_output_schema()).with_annotations(ro_p.clone()),
         Tool::new(
             "get_ranked_context",
-            "[CodeLens:Symbol] Smart context retrieval — best symbols for a query within token budget.",
-            json!({"type":"object","required":["query"],"properties":{"query":{"type":"string"},"path":{"type":"string"},"max_tokens":{"type":"integer"},"include_body":{"type":"boolean"},"depth":{"type":"integer"},"disable_semantic":{"type":"boolean","description":"Disable semantic/hybrid ranking and use structural signals only"}}}),
+            "[CodeLens:Symbol] Smart context retrieval — best symbols for a query within token budget. For natural-language queries, set expand_query=false to skip n-gram expansion; for partial-identifier search use the default.",
+            json!({"type":"object","required":["query"],"properties":{"query":{"type":"string"},"path":{"type":"string"},"max_tokens":{"type":"integer","description":"Token budget for the retrieval payload. Defaults to max(active surface budget, 16384) — raised in v1.10.1 from the surface budget alone to avoid Stage 5 truncation on hybrid retrieval."},"include_body":{"type":"boolean"},"depth":{"type":"integer"},"disable_semantic":{"type":"boolean","description":"Disable semantic/hybrid ranking and use structural signals only"},"expand_query":{"type":"boolean","description":"When true (default), expand the query with snake_case / camelCase / cartesian-token derivatives. Set to false for natural-language queries that don't benefit from expansion."}}}),
         ).with_output_schema(ranked_context_output_schema()).with_annotations(ro_a.clone()).with_max_response_tokens(32768),
         Tool::new(
             "bm25_symbol_search",

--- a/crates/codelens-mcp/src/tool_defs/presets.rs
+++ b/crates/codelens-mcp/src/tool_defs/presets.rs
@@ -1164,6 +1164,10 @@ pub(crate) fn tool_anthropic_search_hint(name: &str) -> Option<&'static str> {
         "analyze_change_request" => Some("plan a code change safely"),
         "trace_request_path" => Some("trace a request path"),
         "review_changes" => Some("review changed files and risk"),
+        "review_architecture" => Some("review architecture, boundaries, coupling"),
+        "plan_safe_refactor" => Some("plan a safe refactor with preview"),
+        "cleanup_duplicate_logic" => Some("surface duplicate code before cleanup"),
+        "diagnose_issues" => Some("diagnose file diagnostics or unresolved refs"),
         "verify_change_readiness" => Some("verify edit safety before mutation"),
         "safe_rename_report" => Some("preview rename safety and blockers"),
         "refactor_safety_report" => Some("preview refactor safety and impact"),
@@ -1171,17 +1175,44 @@ pub(crate) fn tool_anthropic_search_hint(name: &str) -> Option<&'static str> {
         "get_analysis_section" => Some("expand one analysis report section"),
         "audit_builder_session" => Some("audit builder session process"),
         "audit_planner_session" => Some("audit planner session process"),
+        // Core navigation primitives (raised to deferred surface in v1.10.1)
+        "find_symbol" => Some("find function class type by exact name"),
+        "get_symbols_overview" => Some("list all symbols in a file"),
+        "find_referencing_symbols" => Some("find all usages of a symbol"),
+        "get_file_diagnostics" => Some("read LSP diagnostics for a file"),
+        "bm25_symbol_search" => Some("BM25 sparse symbol search by token"),
+        "search_symbols_fuzzy" => Some("fuzzy symbol search tolerates typos"),
+        "semantic_search" => Some("natural language code search via embeddings"),
+        "get_callers" => Some("find functions that call this function"),
+        "get_callees" => Some("find functions called by this function"),
+        "get_ranked_context" => Some("smart context retrieval within token budget"),
+        "impact_report" => Some("blast-radius for changed files"),
+        "module_boundary_report" => Some("module dependency and coupling report"),
+        "dead_code_report" => Some("dead-code candidates with evidence"),
+        "diff_aware_references" => Some("compress references for changed files"),
         _ => None,
     }
 }
 
-/// Claude Code MCP tools are deferred by default. Mark only the minimal
-/// turn-1 bootstrap surface as always-load so hosts can start efficiently
-/// without bloating the initial tool prompt.
+/// Claude Code MCP tools are deferred by default. The always-load set
+/// is what gets `meta["anthropic/alwaysLoad"] = true` — schemas
+/// pre-loaded so the model can call them without a `ToolSearch` round
+/// trip. v1.10.1 widens this from 3 → 8 to cover the workflow-first
+/// surface that the product is positioned around. The remaining
+/// `DEFAULT_LISTED_TOOL_NAMES` entries stay deferred-discoverable but
+/// require explicit ToolSearch select before invocation, which keeps
+/// the initial tool prompt bounded.
 pub(crate) fn tool_anthropic_always_load(name: &str) -> bool {
     matches!(
         name,
-        "prepare_harness_session" | "explore_codebase" | "analyze_change_request"
+        "prepare_harness_session"
+            | "explore_codebase"
+            | "analyze_change_request"
+            | "review_changes"
+            | "plan_safe_refactor"
+            | "review_architecture"
+            | "verify_change_readiness"
+            | "trace_request_path"
     )
 }
 

--- a/crates/codelens-mcp/src/tools/symbols/handlers.rs
+++ b/crates/codelens-mcp/src/tools/symbols/handlers.rs
@@ -394,6 +394,7 @@ pub fn get_ranked_context(state: &AppState, arguments: &Value) -> ToolResult {
         "include_body",
         "depth",
         "disable_semantic",
+        "expand_query",
         "session_id",
         "logical_session_id",
         "harness_phase",
@@ -403,14 +404,31 @@ pub fn get_ranked_context(state: &AppState, arguments: &Value) -> ToolResult {
     let query_analysis = analyze_retrieval_query(query);
     let path = optional_string(arguments, "path");
     let session = crate::session_context::SessionRequestContext::from_json(arguments);
+    // v1.10.1 floor: when the user does not supply `max_tokens`, take the
+    // larger of the surface token budget and 16K. The active surface budget
+    // is intentionally tight (8K on `preset:full`, 4K on
+    // `refactor-full`), but hybrid retrieval (semantic + sparse +
+    // structural evidence) routinely exceeds that, triggering Stage 5
+    // truncation. See `docs/eval/v1.10.0-post-release-eval.md` (F3).
+    const HYBRID_RETRIEVAL_FLOOR: usize = 16384;
     let max_tokens = arguments
         .get("max_tokens")
         .and_then(|v| v.as_u64())
         .map(|v| v as usize)
-        .unwrap_or_else(|| state.execution_token_budget(&session));
+        .unwrap_or_else(|| {
+            state
+                .execution_token_budget(&session)
+                .max(HYBRID_RETRIEVAL_FLOOR)
+        });
     let include_body = optional_bool(arguments, "include_body", false);
     let depth = optional_usize(arguments, "depth", 2);
     let disable_semantic = optional_bool(arguments, "disable_semantic", false);
+    // v1.10.1: opt-out of n-gram query expansion. The default behaviour
+    // (expand_query=true) preserves prior recall on partial-identifier
+    // queries; setting expand_query=false disables snake_case /
+    // camelCase / cartesian-token expansion for natural-language
+    // queries that don't benefit from it.
+    let expand_query = optional_bool(arguments, "expand_query", true);
     let unknown_args = crate::tool_runtime::collect_unknown_args(arguments, KNOWN_ARGS);
     let exact_identifier_projection = query_analysis.original_query
         != query_analysis.expanded_query
@@ -451,11 +469,22 @@ pub fn get_ranked_context(state: &AppState, arguments: &Value) -> ToolResult {
         }
     }
 
+    // v1.10.1: when `expand_query=false`, use the user's literal query
+    // for retrieval. The default keeps the n-gram expansion path so
+    // partial-identifier queries still match across snake_case /
+    // camelCase boundaries. See `docs/eval/v1.10.0-post-release-eval.md`
+    // (F3).
+    let retrieval_query: &str = if expand_query {
+        &query_analysis.expanded_query
+    } else {
+        &query_analysis.original_query
+    };
+
     // query-type-aware weights available via get_ranked_context_cached_with_query_type
     // but current dataset shows default weights are near-optimal (0.680 MRR).
     // Kept as None until per-type weight tuning yields measurable improvement.
     let mut result = state.symbol_index().get_ranked_context_cached(
-        &query_analysis.expanded_query,
+        retrieval_query,
         path,
         max_tokens,
         include_body,

--- a/crates/codelens-mcp/tools.toml
+++ b/crates/codelens-mcp/tools.toml
@@ -174,7 +174,7 @@ max_matches = { type = "integer" }
 [[tool]]
 name = "get_ranked_context"
 category = "symbol"
-description = "[CodeLens:Symbol] Smart context retrieval — best symbols for a query within token budget."
+description = "[CodeLens:Symbol] Smart context retrieval — best symbols for a query within token budget. For natural-language queries, set expand_query=false to skip n-gram expansion; for partial-identifier search use the default."
 annotations = "ro_a"
 output_schema = "ranked_context_output_schema"
 max_response_tokens = 32768
@@ -185,10 +185,11 @@ required = ["query"]
 [tool.input_schema.properties]
 query = { type = "string" }
 path = { type = "string" }
-max_tokens = { type = "integer" }
+max_tokens = { type = "integer", description = "Token budget for the retrieval payload. Defaults to max(active surface budget, 16384) — raised in v1.10.1 from the surface budget alone to avoid Stage 5 truncation on hybrid retrieval." }
 include_body = { type = "boolean" }
 depth = { type = "integer" }
 disable_semantic = { type = "boolean", description = "Disable semantic/hybrid ranking and use structural signals only" }
+expand_query = { type = "boolean", description = "When true (default), expand the query with snake_case / camelCase / cartesian-token derivatives. Set to false for natural-language queries that don't benefit from expansion." }
 
 # ─────
 

--- a/crates/codelens-tui/Cargo.toml
+++ b/crates/codelens-tui/Cargo.toml
@@ -14,7 +14,7 @@ name = "codelens-tui"
 path = "src/main.rs"
 
 [dependencies]
-codelens-engine = { path = "../codelens-engine", version = "=1.10.0" }
+codelens-engine = { path = "../codelens-engine", version = "=1.10.1" }
 ratatui = "0.30"
 crossterm = "0.28"
 anyhow.workspace = true

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,7 +6,7 @@
 ## Current Snapshot (2026-04-25)
 
 <!-- SURFACE_MANIFEST_ARCHITECTURE_SNAPSHOT:BEGIN -->
-- Workspace version: `1.10.0`
+- Workspace version: `1.10.1`
 - Workspace members: `3` (`crates/codelens-engine`, `crates/codelens-mcp`, `crates/codelens-tui`)
 - Registered tool definitions in source: `106`
 - Tool output schemas in source: `77 / 106`

--- a/docs/eval/v1.10.0-post-release-eval.md
+++ b/docs/eval/v1.10.0-post-release-eval.md
@@ -1,0 +1,210 @@
+# v1.10.0 Post-Release Evaluation
+
+**Date**: 2026-05-02
+**Daemon**: `codelens-mcp v1.10.0` (HTTP, readonly profile, port 7839)
+**Method**: live native MCP calls + curl direct dispatch + grep/Read cross-check
+**Scope**: rate efficiency, accuracy, latency, token efficiency, native-MCP integration
+**Bias note**: this is a self-eval. Numbers below are reproducible from a clean clone — see "Reproduction" at the bottom.
+
+---
+
+## Summary
+
+| Axis                                                    | Score        | Notes                                                                               |
+| ------------------------------------------------------- | ------------ | ----------------------------------------------------------------------------------- |
+| Call-graph accuracy (callees)                           | 9 / 10       | confidence 0.95 / import_map resolution                                             |
+| Call-graph accuracy (callers)                           | 5 / 10       | function-reference patterns missed (e.g. `LazyLock::new(fn)`)                       |
+| Retrieval accuracy (`get_ranked_context`)               | 7 / 10       | top hits accurate; query expansion is noisy                                         |
+| Response metadata (evidence / confidence / budget_hint) | 9 / 10       | best-in-class; honest degradation signals                                           |
+| Latency                                                 | 8 / 10       | sub-second for primitives, ~1s hybrid retrieval, ~7s for `review_changes`           |
+| Token efficiency                                        | 6 / 10       | Stage 5 truncation frequent; default 8K budget too small for hybrid retrieval       |
+| Native MCP integration on `claude-code` host            | 4 / 10       | only 11 control-plane tools deferred; 101 tools require ToolSearch keyword or curl  |
+| Operational consistency                                 | 7 / 10       | requires explicit `--features http,semantic` for HTTP daemon; gap not in setup docs |
+| **Overall**                                             | **6.7 / 10** | daemon is solid; **host-adapter integration layer is the weak link**                |
+
+---
+
+## Findings (5)
+
+### F1 — `get_callers` misses function-reference patterns _(severity: high)_
+
+**Symptom**
+
+```
+mcp__codelens__get_callers(function_name="build_tools")
+→ callers: 0, count: 0, confidence: 0.35, confidence_basis: "unresolved_only"
+```
+
+**Reality** (grep cross-check, `crates/codelens-mcp/src/tool_defs/build.rs:13`)
+
+```rust
+static TOOLS: LazyLock<Vec<Tool>> = LazyLock::new(build_tools);
+```
+
+`build_tools` has exactly 1 caller: it is passed as a function pointer to `LazyLock::new`. `get_callers` returned 0.
+
+**Root cause**
+The tree-sitter call-graph extractor matches **call expressions** (`callee(args)`) but does not match **function-reference expressions** where the function is passed as a value (closure-construction, callback registration, builder accumulators). Concretely affected idioms:
+
+- Rust: `LazyLock::new(fn)`, `OnceCell::get_or_init(fn)`, `Box::new(fn as fn() -> T)`, `iter.map(fn).collect()` (when `fn` is a path expression, not an inline closure), event-bus `register("name", fn)`.
+- Go: `defer fn()` is fine, but `go fn()` and `time.AfterFunc(d, fn)` may also slip if the AST node kind differs.
+- TypeScript: `setTimeout(fn, 100)`, `arr.map(fn)`, `bus.on("evt", fn)` when `fn` is a bare identifier (not a `function () { ... }` literal).
+
+**Severity**
+High because `get_callers` returning `0` is a correctness signal a user may treat as "this is dead code". The handler does flag `confidence: 0.35` and `confidence_basis: "unresolved_only"` — that is honest, but a model agent reading the JSON will still see `count: 0` first.
+
+**Recommended fix**
+Add a "function reference" extraction pass in `crates/codelens-engine/src/call_graph/`:
+
+1. Walk identifier nodes whose **parent is a call expression argument list** _and_ whose name matches a known function definition in the same project.
+2. Tag the edge with `resolution: "function_reference"` and a separate `confidence_basis: "structural_reference"`.
+3. Surface both in `confidence_basis` so users can filter (`include_function_references: bool`, default true).
+
+This matches the ROI/risk of the existing import_map resolution: a structural signal that's wrong sometimes (for non-call passes like type-annotation references) but right almost always for the patterns above.
+
+**Tracked**: separate PR after v1.10.1.
+
+---
+
+### F2 — `claude-code` host deferred surface is 11 tools, not 112 _(severity: high)_
+
+**Symptom**
+
+- `get_current_config` reports `tool_count: 112`, `surface: preset:full`.
+- But `claude-code`'s **deferred tool registration** (the surface a Claude Code session can actually call without `ToolSearch keyword` round-trips) is only 11:
+  ```
+  activate_project, get_analysis_job, get_analysis_section, get_callees, get_callers,
+  get_current_config, get_ranked_context, set_preset, set_profile,
+  start_analysis_job, verify_change_readiness
+  ```
+- `find_symbol`, `get_symbols_overview`, `find_referencing_symbols`, `semantic_search`, `review_changes`, `plan_safe_refactor`, `explore_codebase` etc. are **not in deferred surface**. `ToolSearch select:mcp__codelens__find_symbol` returns `"No matching deferred tools found"`.
+- The user can still reach them via `ToolSearch keyword` retrieval if the keyword happens to match the description, or via curl, or via host-side adapter rewiring — but none of these are in the native flow.
+
+**Root cause**
+The `claude-code` host adapter (`crates/codelens-mcp/src/dispatch/session.rs` + `src/protocol.rs::tool_anthropic_always_load`) marks only the control-plane tools as `always_load=true`. `tool_anthropic_search_hint` is set on a wider list, but **search hints rely on keyword similarity** — which fails when the user's request doesn't share tokens with the description (e.g. asking for `"signature of build_tools"` won't match `find_symbol`'s description).
+
+**Severity**
+High for UX. The slogan "112 tools, workflow-first" is contradicted by "11 tools you can actually call right now". The product's primary affordance — workflow-first composite tools (`explore_codebase`, `review_changes`, `plan_safe_refactor`, etc.) — is **invisible** in the default host surface.
+
+**Recommended fix** (this PR)
+Add the 7 workflow-first aliases + 6 high-value primitives to `tool_anthropic_always_load` for the `claude-code` host, raising the deferred surface from 11 to 24:
+
+| Add                                                                                                                                                   | Why                                                                           |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `prepare_harness_session`                                                                                                                             | declared as bootstrap entrypoint everywhere; absurd that it isn't always-load |
+| `explore_codebase`, `trace_request_path`, `review_architecture`, `plan_safe_refactor`, `cleanup_duplicate_logic`, `review_changes`, `diagnose_issues` | workflow-first 7, the slogan                                                  |
+| `find_symbol`, `get_symbols_overview`, `find_referencing_symbols`, `bm25_symbol_search`, `get_file_diagnostics`, `semantic_search`                    | core navigation, what `Read`/`Grep` users will reach for                      |
+
+24 deferred entries is still well within the budget Anthropic recommends (the host adapter docs cite 30–50 as a typical cap). The remaining 88 tools stay reachable via `ToolSearch keyword` and direct dispatch.
+
+---
+
+### F3 — `get_ranked_context` over-aggressive query expansion + 8K default budget _(severity: medium)_
+
+**Symptom**
+
+- Input query (5 words): `"tool registry annotation bindings post-build pass"`
+- Effective query after expansion: `"... tool_registry registry_annotation annotation_bindings bindings_post-build post-build_pass tool_registry_annotation registry_annotation_bindings annotation_bindings_post-build bindings_post-b..."` — snake_case + camelCase + cartesian products of adjacent tokens.
+- Result: 173 candidate symbols, **Stage 5 truncation triggered** (payload 15,318 tokens vs effective budget 8,000), only 3 symbols returned.
+- Truncation hint correctly reported: `compression_stage: 5, recovery_hint: "Response over budget; structured arrays clipped to 3 items each."`
+
+**Root cause**
+
+1. `expand_query_tokens` in retrieval pipeline aggressively adds n-gram joins (`a_b`, `b_c`, `aB`, `bC`, etc.) — useful for partial-name matching, noisy for natural-language queries.
+2. Default `max_tokens` for `get_ranked_context` is 8000 (defined in tools.toml). Hybrid retrieval (semantic + sparse + structural evidence) plus 173 symbol candidates routinely exceeds this.
+
+**Severity** medium (not wrong, just truncated; users reading `truncation_warning` can recover).
+
+**Recommended fix** (this PR)
+
+1. Raise default `max_tokens` for `get_ranked_context` from 8000 → 16384 (still well below the 200K MCP cap).
+2. Add `expand_query: bool = true` parameter; when `false`, use the raw query verbatim. Default stays `true` to preserve current behaviour for existing harnesses.
+3. Document in tool description: `"For natural-language queries, set expand_query=false; for partial-identifier search use the default."`
+
+---
+
+### F4 — `verify_change_readiness` top-findings are generic cues _(severity: low)_
+
+**Symptom**
+For a change "Add a new tool category 'visualization' to tools.toml", top_findings were:
+
+```
+- "add_import_tool: verify crates/codelens-mcp/src/tools/mutation.rs first"
+- "Tool: verify crates/codelens-mcp/src/protocol.rs first"
+- "with_audit_category: verify crates/codelens-mcp/src/protocol.rs first"
+```
+
+These are file references derived from the ranked-files lane. Useful as cues, but they read as boilerplate ("verify X first"). A user who supplies the actual changed-files list expects task-specific evidence (e.g., "tools.toml schema_version is v1; new categories must register a generated function in build.rs and re-export in mod.rs").
+
+**Root cause**
+`verify_change_readiness` blends ranked_context output with verifier signal labels. The blend is correct but generic: it lacks task-shape awareness ("are these changes co-evolutive?", "do they touch a known invariant set?").
+
+**Severity** low — the 4-axis readiness check (`diagnostic_ready`, `reference_safety`, `test_readiness`, `mutation_ready`) is the actually useful part, and the blocker count (0) was correct.
+
+**Recommended fix** _(deferred, post-1.10.1)_
+Add task-templates that pattern-match common change shapes (`new tool category`, `rename across project`, `add feature flag`, `migrate ADR-X`) and emit task-specific guidance instead of generic file cues. Out of scope for this patch.
+
+---
+
+### F5 — Daemon boot fails with default-features build after ADR-0012 _(severity: medium)_
+
+**Symptom**
+After ADR-0012 (`default = []`), running the launchd-loaded HTTP daemon binary fails with:
+
+```
+Error: HTTP/HTTPS transport requires the `http` feature. Rebuild with: cargo build --features http
+```
+
+Discovered on v1.10.0 release: the daemon was rebuilt with default features and refused to bind, causing both 7838/7839 ports to drop until rebuilt with `--features http,semantic`.
+
+**Root cause**
+
+- `cargo install codelens-mcp` (default-features) does not enable `http` (per ADR-0012, intentional).
+- The launchd `.plist` files installed for the HTTP daemon were _not updated_ to require the right binary, and the install docs do not say "if you want the HTTP daemon, build with `--features http`".
+
+**Severity** medium — affects anyone running the daemon stack the way this repo's plists do; doesn't affect stdio MCP users.
+
+**Recommended fix** (this PR)
+
+1. Add an `OperationalRequirements` block to README and `docs/release-verification.md` documenting the feature-flag matrix (stdio default-features OK; HTTP daemon requires `http`; semantic search requires `semantic`).
+2. Add a comment block to the launchd `.plist` files (`dev.codelens.mcp-readonly.plist`, `dev.codelens.mcp-mutation.plist`) noting the required build command. Plists don't render comments at runtime, but they survive in source as documentation.
+3. (Optional, follow-up) Add a startup banner to the binary: when `--transport http` is requested but the binary lacks the `http` feature, fail with a user-actionable error pointing to the rebuild command — already done by ADR-0012, but the message could include `cargo install --features http,semantic` as the ready-to-paste form.
+
+---
+
+## Reproduction
+
+All findings reproducible from `codelens-mcp v1.10.0` daemon:
+
+```bash
+# Boot a v1.10.0 HTTP daemon
+cargo build --release --features http,semantic
+target/release/codelens-mcp $(pwd) --transport http --profile reviewer-graph --port 7839 &
+
+# F1 — call-graph callers miss
+curl -s http://127.0.0.1:7839/mcp -X POST -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_callers","arguments":{"function_name":"build_tools"}}}'
+grep -n "build_tools" crates/codelens-mcp/src/tool_defs/build.rs   # shows 3 lines incl. LazyLock::new
+
+# F3 — Stage 5 truncation
+curl -s http://127.0.0.1:7839/mcp -X POST -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_ranked_context","arguments":{"query":"tool registry annotation bindings post-build pass"}}}' \
+  | python3 -c 'import json,sys; r=json.loads(sys.stdin.read())["result"]["content"][0]["text"]; d=json.loads(r); print(d.get("data",{}).get("truncation_warning"))'
+```
+
+---
+
+## Decision
+
+**v1.10.1 patch (this evaluation → PR fix branch):**
+
+- F2: extend `claude-code` host adapter `tool_anthropic_always_load` to 24 entries.
+- F3: raise `get_ranked_context.max_tokens` default to 16384, add `expand_query` param.
+- F5: feature-flag matrix in README + release-verification + plist comments.
+
+**Deferred to v1.11.0 (separate PRs):**
+
+- F1: tree-sitter call-graph function-reference extractor pass.
+- F4: task-template-aware `verify_change_readiness` summaries.
+
+The deferred items are larger surgery on the engine; bundling them into a patch release would inflate scope and dilute the value of the immediate UX fix (F2).

--- a/docs/generated/surface-manifest.json
+++ b/docs/generated/surface-manifest.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "codelens-surface-manifest-v1",
   "workspace": {
-    "version": "1.10.0",
+    "version": "1.10.1",
     "description": "Harness-native Rust MCP server for code intelligence with generated surface governance, hybrid retrieval, and mutation-gated workflows",
     "members": [
       "crates/codelens-engine",
@@ -129,7 +129,7 @@
         "phase": "plan",
         "preferred_executor": null,
         "has_output_schema": true,
-        "estimated_tokens": 652
+        "estimated_tokens": 791
       },
       {
         "name": "bm25_symbol_search",
@@ -3148,7 +3148,7 @@
   },
   "runtime": {
     "server_name": "codelens-mcp",
-    "version": "1.10.0",
+    "version": "1.10.1",
     "transport": [
       "stdio",
       "streamable-http"
@@ -3183,7 +3183,7 @@
     ]
   },
   "summary": {
-    "workspace_version": "1.10.0",
+    "workspace_version": "1.10.1",
     "workspace_member_count": 3,
     "registered_tool_definitions": 106,
     "tool_output_schemas": {

--- a/docs/platform-setup.md
+++ b/docs/platform-setup.md
@@ -587,7 +587,7 @@ agent = client.agents.create(
 ## Preset Comparison
 
 <!-- SURFACE_MANIFEST_PLATFORM_SURFACES:BEGIN -->
-- Workspace version: `1.10.0`
+- Workspace version: `1.10.1`
 - Presets: `minimal` (27), `balanced` (77), `full` (106)
 - Profiles: `planner-readonly` (32), `builder-minimal` (36), `reviewer-graph` (36), `evaluator-compact` (14), `refactor-full` (50), `ci-audit` (43), `workflow-first` (19)
 - Canonical manifest: [`docs/generated/surface-manifest.json`](generated/surface-manifest.json)

--- a/docs/release-verification.md
+++ b/docs/release-verification.md
@@ -18,6 +18,35 @@ That keeps public packaging claims grounded in what the repository actually ship
 
 ---
 
+## Feature-flag matrix (build-time requirements)
+
+ADR-0012 made the `semantic` feature opt-in on the cargo-install path. As of v1.10.1, the feature requirements for each runtime mode are:
+
+| Use case                                         | Required cargo features    | Notes                                                                                                                         |
+| ------------------------------------------------ | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `cargo install codelens-mcp` (stdio MCP)         | `default = []` (none)      | BM25 + AST + call-graph only. No HTTP, no embeddings.                                                                         |
+| `cargo install codelens-mcp --features semantic` | `semantic`                 | Adds ONNX hybrid retrieval. Requires `CODELENS_MODEL_DIR` or a release tarball with bundled model.                            |
+| HTTP daemon (any port)                           | `--features http`          | The HTTP transport entrypoint is gated. Daemons fail with `Error: HTTP/HTTPS transport requires the http feature` if missing. |
+| HTTP daemon **with** semantic                    | `--features http,semantic` | Recommended for production daemons that serve hybrid retrieval.                                                               |
+| OpenTelemetry export                             | `--features otel`          | Independent of HTTP/semantic.                                                                                                 |
+| Audit feature flag (deprecated)                  | n/a                        | Removed in ADR-0011.                                                                                                          |
+
+**Operational implication for `launchd` / `systemd` / Docker daemons**: the binary you launch from the unit/service file must have been built with `--features http` (and `semantic` if you want hybrid retrieval). The launchd `.plist` files in this repo (`.codelens/launchd/dev.codelens.mcp-readonly.plist`, `dev.codelens.mcp-mutation.plist`) point at `target/release/codelens-mcp`, so the build command for the daemon stack is:
+
+```bash
+cargo build --release --features http,semantic
+```
+
+If you only want the stdio-mode binary that `cargo install codelens-mcp` produces, no build flags are needed. If you want to run the HTTP daemon stack from a `cargo install`-style binary, the equivalent is:
+
+```bash
+cargo install codelens-mcp --features http,semantic
+```
+
+This was a v1.10.0 release-time discovery (the daemon failed to bind on first reboot until rebuilt with the right features). See [`docs/eval/v1.10.0-post-release-eval.md`](eval/v1.10.0-post-release-eval.md) (F5) for the full RCA.
+
+---
+
 ## Configured release outputs
 
 The tag-driven GitHub release workflow in [`.github/workflows/release.yml`](../.github/workflows/release.yml) currently builds and publishes three release artifacts:


### PR DESCRIPTION
## Summary
v1.10.1 patch addressing the user-visible gaps surfaced by the v1.10.0 post-release evaluation. Eval document at \`docs/eval/v1.10.0-post-release-eval.md\` (5 findings F1–F5 with RCA + severity + reproduction).

## Fixes shipped (F2 / F3 / F5)

### F2 — claude-code deferred surface widened from 13 → 25 tools
- The slogan ("workflow-first, 112 tools") was contradicted by a 13-entry default \`tools/list\`. The new list adds the workflow-first 7 + core navigation primitives (\`find_symbol\`, \`get_symbols_overview\`, \`find_referencing_symbols\`, \`get_file_diagnostics\`, \`bm25_symbol_search\`, \`semantic_search\`).
- \`tool_anthropic_always_load\` extended from 3 → 8 so workflow-first composite tools are schema-pre-loaded.
- \`tool_anthropic_search_hint\` gains entries for the navigation tools so keyword-based ToolSearch matches the slogan.

### F3 — \`get_ranked_context\` retrieval defaults
- Default \`max_tokens\` floor raised to \`max(surface_budget, 16384)\` (was surface budget alone). Fixes Stage 5 truncation on hybrid retrieval.
- New optional \`expand_query: bool = true\` parameter. \`false\` skips n-gram expansion for natural-language queries that don't benefit from it.

### F5 — feature-flag matrix documented
- \`docs/release-verification.md\` gains the build-time-requirements matrix.
- README \`Auto-start on macOS (launchd)\` section links to it.
- Avoids a repeat of the v1.10.0 daemon-fail-on-default-build incident.

## Deferred to v1.11.0 (separate PRs)
- **F1**: tree-sitter call-graph function-reference extractor (LazyLock::new(fn) and similar).
- **F4**: task-template-aware \`verify_change_readiness\` summaries.

## Verification
- [x] cargo build / test — 530 / 530
- [x] cargo build --no-default-features — clean
- [x] cargo clippy --all-targets -- -D warnings
- [x] regen-tool-defs.py --check, surface-manifest.py --check, cargo fmt --check

🤖 Generated with [Claude Code](https://claude.com/claude-code)