### PR TITLE
feat(v1.11.0): tree-sitter call-graph extracts Rust function references (F1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-engine"
-version = "1.10.1"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-mcp"
-version = "1.10.1"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-tui"
-version = "1.10.1"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "codelens-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "Apache-2.0"
-version = "1.10.1"
+version = "1.11.0"
 description = "Harness-native Rust MCP server for code intelligence with generated surface governance, hybrid retrieval, and mutation-gated workflows"
 repository = "https://github.com/mupozg823/codelens-mcp-plugin"
 homepage = "https://github.com/mupozg823/codelens-mcp-plugin"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Pure Rust MCP server for multi-agent harnesses with hybrid retrieval (tree-sitte
 <!-- SURFACE_MANIFEST_README_SNAPSHOT:BEGIN -->
 ## Surface Snapshot
 
-- Workspace version: `1.10.1`
+- Workspace version: `1.11.0`
 - Workspace members: `3` (`crates/codelens-engine`, `crates/codelens-mcp`, `crates/codelens-tui`)
 - Registered tool definitions: `106`
 - Tool output schemas: `77 / 106`

--- a/crates/codelens-engine/src/call_graph.rs
+++ b/crates/codelens-engine/src/call_graph.rs
@@ -851,6 +851,22 @@ const RUST_CALL_QUERY: &str = r#"
 (call_expression function: (scoped_identifier name: (identifier) @callee))
 (macro_invocation macro: (identifier) @callee)
 (macro_invocation macro: (scoped_identifier name: (identifier) @callee))
+;; v1.11.0 (F1): function-reference patterns. A function passed as an
+;; argument (closure construction, callback registration, builder
+;; accumulators) is a real caller→callee edge that the call_expression
+;; rules above miss. Examples:
+;;   LazyLock::new(build_tools)
+;;   OnceCell::get_or_init(make_state)
+;;   iter.map(parse_line).collect()
+;;   bus.register("evt", on_event)
+;; Many argument identifiers are variables, not functions. The
+;; resolution cascade in `resolve_call_edges` filters those: the name
+;; must exist in the symbol DB or the edge is dropped as `unresolved`
+;; (confidence 0). Genuine function references resolve via Stage 5
+;; (unique_name) at confidence 0.5 — honest, lower than import_map but
+;; higher than nothing.
+(arguments (identifier) @callee)
+(arguments (scoped_identifier name: (identifier) @callee))
 "#;
 
 #[cfg(test)]
@@ -1146,6 +1162,86 @@ fn run() {
                 .iter()
                 .any(|e| e.caller_name == "handler" && e.callee_name == "verify"),
             "expected handler->verify edge, got {edges:?}"
+        );
+    }
+
+    /// v1.11.0 (F1): function-reference callers — a function passed as an
+    /// argument is a real caller→callee edge. Pre-v1.11.0 these were
+    /// silently dropped because the tree-sitter call query only matched
+    /// `call_expression`, not identifiers in argument position. The
+    /// canonical cliff was the registry pattern in
+    /// `codelens-mcp/src/tool_defs/build.rs`:
+    /// `static TOOLS: LazyLock<Vec<Tool>> = LazyLock::new(build_tools);`
+    /// where `get_callers("build_tools")` returned 0 callers.
+    ///
+    /// This test pins the regression by reproducing the same shape: a
+    /// function used as a function-reference argument to `LazyLock::new`,
+    /// and a closure-style `iter.map(parse_line)` reference. Both must
+    /// surface as `<top>` callers (no enclosing fn) for the named
+    /// callee.
+    #[test]
+    fn extracts_rust_function_reference_arguments() {
+        let dir = temp_dir("rs-fn-refs");
+        let path = dir.join("registry.rs");
+        fs::write(
+            &path,
+            r#"
+fn build_tools() -> Vec<u32> { vec![1, 2, 3] }
+fn parse_line(s: &str) -> u32 { s.len() as u32 }
+
+static TOOLS: std::sync::LazyLock<Vec<u32>> =
+    std::sync::LazyLock::new(build_tools);
+
+fn run() {
+    let lines = ["a", "bb"];
+    let parsed: Vec<_> = lines.iter().map(parse_line).collect();
+    let _ = parsed;
+}
+"#,
+        )
+        .expect("write");
+        let edges = extract_calls(&path);
+        assert!(
+            edges.iter().any(|e| e.callee_name == "build_tools"),
+            "expected a function-reference caller for build_tools, got {edges:?}"
+        );
+        assert!(
+            edges.iter().any(|e| e.callee_name == "parse_line"),
+            "expected a function-reference caller for parse_line, got {edges:?}"
+        );
+    }
+
+    /// v1.11.0 (F1): false-positive guard. A bare variable passed as an
+    /// argument (e.g., `f(local_var)`) is also an `(arguments
+    /// (identifier))` shape, but `local_var` is not a function in the
+    /// project symbol DB. The 6-stage resolution cascade should mark it
+    /// `unresolved` (confidence 0). Without DB access we just verify
+    /// the extractor doesn't blow up on this shape — resolution is
+    /// covered by the integration tests in `codelens-mcp` that drive
+    /// the whole pipeline.
+    #[test]
+    fn function_reference_extraction_is_resilient_to_variable_arguments() {
+        let dir = temp_dir("rs-fn-ref-noise");
+        let path = dir.join("noise.rs");
+        fs::write(
+            &path,
+            r#"
+fn outer(local_var: i32) {
+    println!("v={}", local_var);
+    let other = local_var + 1;
+    consume(other);
+}
+fn consume(x: i32) -> i32 { x }
+"#,
+        )
+        .expect("write");
+        // Should not panic and should still find the direct call to consume.
+        let edges = extract_calls(&path);
+        assert!(
+            edges
+                .iter()
+                .any(|e| e.caller_name == "outer" && e.callee_name == "consume"),
+            "direct call edge outer->consume must survive function-reference extraction, got {edges:?}"
         );
     }
 

--- a/crates/codelens-mcp/Cargo.toml
+++ b/crates/codelens-mcp/Cargo.toml
@@ -36,7 +36,7 @@ url.workspace = true
 rusqlite.workspace = true
 toml = "0.8"
 rustls = { workspace = true, optional = true }
-codelens-engine = { path = "../codelens-engine", version = "=1.10.1", default-features = false }
+codelens-engine = { path = "../codelens-engine", version = "=1.11.0", default-features = false }
 thiserror.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/codelens-mcp/src/integration_tests/protocol_tools_list.rs
+++ b/crates/codelens-mcp/src/integration_tests/protocol_tools_list.rs
@@ -450,8 +450,10 @@ fn deferred_tools_list_defaults_to_preferred_namespaces_only() {
     .unwrap();
     let encoded = serde_json::to_string(&list_resp).unwrap();
     assert!(encoded.contains("\"deferred_loading_active\":true"));
-    assert!(encoded
-        .contains("\"preferred_namespaces\":[\"reports\",\"graph\",\"symbols\",\"session\"]"));
+    assert!(
+        encoded
+            .contains("\"preferred_namespaces\":[\"reports\",\"graph\",\"symbols\",\"session\"]")
+    );
     assert!(encoded.contains("\"preferred_tiers\":[\"workflow\"]"));
     assert!(encoded.contains("\"loaded_tiers\":[]"));
     assert!(encoded.contains("\"review_architecture\""));

--- a/crates/codelens-tui/Cargo.toml
+++ b/crates/codelens-tui/Cargo.toml
@@ -14,7 +14,7 @@ name = "codelens-tui"
 path = "src/main.rs"
 
 [dependencies]
-codelens-engine = { path = "../codelens-engine", version = "=1.10.1" }
+codelens-engine = { path = "../codelens-engine", version = "=1.11.0" }
 ratatui = "0.30"
 crossterm = "0.28"
 anyhow.workspace = true

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,7 +6,7 @@
 ## Current Snapshot (2026-04-25)
 
 <!-- SURFACE_MANIFEST_ARCHITECTURE_SNAPSHOT:BEGIN -->
-- Workspace version: `1.10.1`
+- Workspace version: `1.11.0`
 - Workspace members: `3` (`crates/codelens-engine`, `crates/codelens-mcp`, `crates/codelens-tui`)
 - Registered tool definitions in source: `106`
 - Tool output schemas in source: `77 / 106`

--- a/docs/eval/v1.10.0-post-release-eval.md
+++ b/docs/eval/v1.10.0-post-release-eval.md
@@ -208,3 +208,17 @@ curl -s http://127.0.0.1:7839/mcp -X POST -H 'Content-Type: application/json' \
 - F4: task-template-aware `verify_change_readiness` summaries.
 
 The deferred items are larger surgery on the engine; bundling them into a patch release would inflate scope and dilute the value of the immediate UX fix (F2).
+
+---
+
+## v1.11.0 follow-up — F1 closure (2026-05-02)
+
+F1 shipped in v1.11.0:
+
+- Extended `RUST_CALL_QUERY` with `(arguments (identifier) @callee)` and `(arguments (scoped_identifier name: (identifier) @callee))` patterns to capture function-reference arguments (`LazyLock::new(fn)`, `iter.map(parse_line)`, callback registration).
+- The 6-stage resolution cascade in `resolve_call_edges` already filters extracted candidates against the symbol DB: variable arguments (`f(local_var)`) where the name isn't a known function fall to `unresolved` and are dropped at confidence 0. Genuine function references resolve via Stage 5 (`unique_name`) at confidence 0.5 — honest, lower than `import_map` but no longer silently 0.
+- Two regression tests pin the canonical cliff: `extracts_rust_function_reference_arguments` reproduces the `build_tools` / `LazyLock::new` shape; `function_reference_extraction_is_resilient_to_variable_arguments` ensures variable arguments don't break direct-call extraction.
+
+Other languages (TS/JS callbacks, Python `register("evt", fn)`, Java method references already partially covered) are still on the deferred list — each language grammar needs its own argument-position pattern. Tracked separately.
+
+F4 (task-template-aware `verify_change_readiness`) remains deferred. The UX work needs task-shape pattern-matching infrastructure large enough to warrant its own ADR.

--- a/docs/generated/surface-manifest.json
+++ b/docs/generated/surface-manifest.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "codelens-surface-manifest-v1",
   "workspace": {
-    "version": "1.10.1",
+    "version": "1.11.0",
     "description": "Harness-native Rust MCP server for code intelligence with generated surface governance, hybrid retrieval, and mutation-gated workflows",
     "members": [
       "crates/codelens-engine",
@@ -3148,7 +3148,7 @@
   },
   "runtime": {
     "server_name": "codelens-mcp",
-    "version": "1.10.1",
+    "version": "1.11.0",
     "transport": [
       "stdio",
       "streamable-http"
@@ -3183,7 +3183,7 @@
     ]
   },
   "summary": {
-    "workspace_version": "1.10.1",
+    "workspace_version": "1.11.0",
     "workspace_member_count": 3,
     "registered_tool_definitions": 106,
     "tool_output_schemas": {

--- a/docs/platform-setup.md
+++ b/docs/platform-setup.md
@@ -587,7 +587,7 @@ agent = client.agents.create(
 ## Preset Comparison
 
 <!-- SURFACE_MANIFEST_PLATFORM_SURFACES:BEGIN -->
-- Workspace version: `1.10.1`
+- Workspace version: `1.11.0`
 - Presets: `minimal` (27), `balanced` (77), `full` (106)
 - Profiles: `planner-readonly` (32), `builder-minimal` (36), `reviewer-graph` (36), `evaluator-compact` (14), `refactor-full` (50), `ci-audit` (43), `workflow-first` (19)
 - Canonical manifest: [`docs/generated/surface-manifest.json`](generated/surface-manifest.json)


### PR DESCRIPTION
## Summary
Closes the F1 finding from the v1.10.0 post-release evaluation — \`get_callers\` returning 0 for functions passed as arguments instead of called directly. Canonical reproducer: \`LazyLock::new(build_tools)\` in this repo's own \`build.rs\` returned 0 callers.

## Fix
- Extended \`RUST_CALL_QUERY\` with two argument-position patterns:
  - \`(arguments (identifier) @callee)\`
  - \`(arguments (scoped_identifier name: (identifier) @callee))\`
- The 6-stage resolution cascade in \`resolve_call_edges\` filters captured candidates against the project symbol DB. Variable arguments (\`f(local_var)\`) where the name isn't a known function fall to \`unresolved\` (confidence 0). Genuine function references resolve via Stage 5 (\`unique_name\`) at confidence 0.5.

## Regression tests
- \`extracts_rust_function_reference_arguments\` — \`LazyLock::new(build_tools)\` and \`iter.map(parse_line)\` shapes.
- \`function_reference_extraction_is_resilient_to_variable_arguments\` — variable arguments don't break direct-call extraction.

## Verification
- [x] \`cargo test -p codelens-engine\` — 341 / 341 (+2 new)
- [x] \`cargo test -p codelens-mcp\` — 530 / 530
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`regen-tool-defs.py --check\`, \`surface-manifest.py --check\`, \`cargo fmt --check\`

## Out of scope (future patches)
- TS/JS function-reference patterns (callbacks, \`.then(fn)\`, \`setTimeout(fn)\`)
- Python \`register("evt", fn)\` / decorator argument patterns
- F4 (task-template-aware \`verify_change_readiness\`) — needs its own ADR

🤖 Generated with [Claude Code](https://claude.com/claude-code)