### PR TITLE
feat(v1.11.1): function-reference call-graph extends to JS/TS + Python

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-engine"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "anyhow",
  "criterion",
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-mcp"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-tui"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "anyhow",
  "codelens-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "Apache-2.0"
-version = "1.11.0"
+version = "1.11.1"
 description = "Harness-native Rust MCP server for code intelligence with generated surface governance, hybrid retrieval, and mutation-gated workflows"
 repository = "https://github.com/mupozg823/codelens-mcp-plugin"
 homepage = "https://github.com/mupozg823/codelens-mcp-plugin"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Pure Rust MCP server for multi-agent harnesses with hybrid retrieval (tree-sitte
 <!-- SURFACE_MANIFEST_README_SNAPSHOT:BEGIN -->
 ## Surface Snapshot
 
-- Workspace version: `1.11.0`
+- Workspace version: `1.11.1`
 - Workspace members: `3` (`crates/codelens-engine`, `crates/codelens-mcp`, `crates/codelens-tui`)
 - Registered tool definitions: `106`
 - Tool output schemas: `77 / 106`

--- a/crates/codelens-engine/src/call_graph.rs
+++ b/crates/codelens-engine/src/call_graph.rs
@@ -784,6 +784,16 @@ const PYTHON_CALL_QUERY: &str = r#"
 (decorator (call function: (identifier) @callee))
 (decorator (attribute attribute: (identifier) @callee))
 (decorator (call function: (attribute attribute: (identifier) @callee)))
+;; v1.11.1 (F1 follow-up): function-reference arguments. Python
+;; callback patterns include `register("evt", handler)`,
+;; `dispatcher.on(name, callback)`, `signal.connect(slot)`, plus
+;; decorator factories like `@retry(handler)`. The 6-stage
+;; resolution cascade filters identifier-arg captures against the
+;; project symbol DB; variable arguments fall to `unresolved` and
+;; genuine function references resolve via Stage 5 (`unique_name`)
+;; at confidence 0.5.
+(call arguments: (argument_list (identifier) @callee))
+(call arguments: (argument_list (attribute attribute: (identifier) @callee)))
 "#;
 
 const JS_FUNC_QUERY: &str = r#"
@@ -802,6 +812,15 @@ const JS_FUNC_QUERY: &str = r#"
 const JS_CALL_QUERY: &str = r#"
 (call_expression function: (identifier) @callee)
 (call_expression function: (member_expression property: (property_identifier) @callee))
+;; v1.11.1 (F1 follow-up): function-reference arguments. JS/TS frequently
+;; pass functions as callbacks — `setTimeout(handler, 100)`,
+;; `arr.map(parseLine)`, `bus.on("evt", onEvent)`, `.then(success)`.
+;; The 6-stage resolution cascade in `resolve_call_edges` filters these
+;; against the symbol DB, so variable arguments fall to `unresolved`
+;; while genuine function references resolve via Stage 5
+;; (`unique_name`) at confidence 0.5.
+(arguments (identifier) @callee)
+(arguments (member_expression property: (property_identifier) @callee))
 "#;
 
 // JSX/TSX adds React-style component usage (`<Foo />`, `<Foo>`) as caller→callee
@@ -814,6 +833,9 @@ const JS_JSX_CALL_QUERY: &str = r#"
 (jsx_opening_element name: (identifier) @callee)
 (jsx_self_closing_element name: (member_expression property: (property_identifier) @callee))
 (jsx_opening_element name: (member_expression property: (property_identifier) @callee))
+;; v1.11.1: same function-reference patterns as JS_CALL_QUERY.
+(arguments (identifier) @callee)
+(arguments (member_expression property: (property_identifier) @callee))
 "#;
 
 const GO_FUNC_QUERY: &str = r#"
@@ -1209,6 +1231,79 @@ fn run() {
             edges.iter().any(|e| e.callee_name == "parse_line"),
             "expected a function-reference caller for parse_line, got {edges:?}"
         );
+    }
+
+    /// v1.11.1 (F1 follow-up): JS/TS function-reference callbacks. The
+    /// canonical patterns are `setTimeout(handler, 100)`,
+    /// `arr.map(parseLine)`, `bus.on("evt", onEvent)`, `.then(success)`.
+    /// Pre-v1.11.1 these were silently dropped because the JS call
+    /// query only matched `call_expression`-position function nodes.
+    #[test]
+    fn extracts_js_function_reference_arguments() {
+        let dir = temp_dir("js-fn-refs");
+        let path = dir.join("callbacks.js");
+        fs::write(
+            &path,
+            r#"
+function parseLine(line) { return line.trim(); }
+function onEvent(payload) { return payload; }
+function timeoutHandler() { return 1; }
+
+function setup() {
+    const lines = ["a", "b"];
+    const parsed = lines.map(parseLine);
+    bus.on("evt", onEvent);
+    setTimeout(timeoutHandler, 100);
+    return parsed;
+}
+"#,
+        )
+        .expect("write");
+        let edges = extract_calls(&path);
+        for callee in ["parseLine", "onEvent", "timeoutHandler"] {
+            assert!(
+                edges
+                    .iter()
+                    .any(|e| e.caller_name == "setup" && e.callee_name == callee),
+                "expected setup->{callee} function-reference edge, got {edges:?}"
+            );
+        }
+    }
+
+    /// v1.11.1: Python function-reference arguments — the
+    /// `register("evt", handler)` and `dispatcher.on(name, callback)`
+    /// shapes that callback-heavy Python code uses. Like the JS path,
+    /// this depends on the resolution cascade filtering variable
+    /// arguments against the symbol DB.
+    #[test]
+    fn extracts_python_function_reference_arguments() {
+        let dir = temp_dir("py-fn-refs");
+        let path = dir.join("registry.py");
+        fs::write(
+            &path,
+            r#"
+def parse_line(line):
+    return line.strip()
+
+def on_event(payload):
+    return payload
+
+def setup():
+    register("evt", on_event)
+    pipe = list(map(parse_line, ["a", "b"]))
+    return pipe
+"#,
+        )
+        .expect("write");
+        let edges = extract_calls(&path);
+        for callee in ["parse_line", "on_event"] {
+            assert!(
+                edges
+                    .iter()
+                    .any(|e| e.caller_name == "setup" && e.callee_name == callee),
+                "expected setup->{callee} function-reference edge, got {edges:?}"
+            );
+        }
     }
 
     /// v1.11.0 (F1): false-positive guard. A bare variable passed as an

--- a/crates/codelens-mcp/Cargo.toml
+++ b/crates/codelens-mcp/Cargo.toml
@@ -36,7 +36,7 @@ url.workspace = true
 rusqlite.workspace = true
 toml = "0.8"
 rustls = { workspace = true, optional = true }
-codelens-engine = { path = "../codelens-engine", version = "=1.11.0", default-features = false }
+codelens-engine = { path = "../codelens-engine", version = "=1.11.1", default-features = false }
 thiserror.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/codelens-tui/Cargo.toml
+++ b/crates/codelens-tui/Cargo.toml
@@ -14,7 +14,7 @@ name = "codelens-tui"
 path = "src/main.rs"
 
 [dependencies]
-codelens-engine = { path = "../codelens-engine", version = "=1.11.0" }
+codelens-engine = { path = "../codelens-engine", version = "=1.11.1" }
 ratatui = "0.30"
 crossterm = "0.28"
 anyhow.workspace = true

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,7 +6,7 @@
 ## Current Snapshot (2026-04-25)
 
 <!-- SURFACE_MANIFEST_ARCHITECTURE_SNAPSHOT:BEGIN -->
-- Workspace version: `1.11.0`
+- Workspace version: `1.11.1`
 - Workspace members: `3` (`crates/codelens-engine`, `crates/codelens-mcp`, `crates/codelens-tui`)
 - Registered tool definitions in source: `106`
 - Tool output schemas in source: `77 / 106`

--- a/docs/generated/surface-manifest.json
+++ b/docs/generated/surface-manifest.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "codelens-surface-manifest-v1",
   "workspace": {
-    "version": "1.11.0",
+    "version": "1.11.1",
     "description": "Harness-native Rust MCP server for code intelligence with generated surface governance, hybrid retrieval, and mutation-gated workflows",
     "members": [
       "crates/codelens-engine",
@@ -3148,7 +3148,7 @@
   },
   "runtime": {
     "server_name": "codelens-mcp",
-    "version": "1.11.0",
+    "version": "1.11.1",
     "transport": [
       "stdio",
       "streamable-http"
@@ -3183,7 +3183,7 @@
     ]
   },
   "summary": {
-    "workspace_version": "1.11.0",
+    "workspace_version": "1.11.1",
     "workspace_member_count": 3,
     "registered_tool_definitions": 106,
     "tool_output_schemas": {

--- a/docs/platform-setup.md
+++ b/docs/platform-setup.md
@@ -587,7 +587,7 @@ agent = client.agents.create(
 ## Preset Comparison
 
 <!-- SURFACE_MANIFEST_PLATFORM_SURFACES:BEGIN -->
-- Workspace version: `1.11.0`
+- Workspace version: `1.11.1`
 - Presets: `minimal` (27), `balanced` (77), `full` (106)
 - Profiles: `planner-readonly` (32), `builder-minimal` (36), `reviewer-graph` (36), `evaluator-compact` (14), `refactor-full` (50), `ci-audit` (43), `workflow-first` (19)
 - Canonical manifest: [`docs/generated/surface-manifest.json`](generated/surface-manifest.json)


### PR DESCRIPTION
## Summary
Follow-up to v1.11.0's F1 fix. The Rust function-reference path landed at v1.11.0; the same cliff existed on JS/TS callbacks (\`setTimeout(fn)\`, \`arr.map(fn)\`, \`bus.on(name, fn)\`) and Python registry patterns (\`register(\"evt\", fn)\`, \`dispatcher.on(name, fn)\`). This patch closes both.

## Pattern
Same approach as Rust:
1. Extend the language's CALL_QUERY with \`(arguments (identifier))\` (and member-expression / attribute variants).
2. The 6-stage \`resolve_call_edges\` cascade filters extracted candidates against the symbol DB. Variable arguments fall to \`unresolved\` (confidence 0); genuine function references resolve via Stage 5 (\`unique_name\`) at confidence 0.5.

## Regression tests
- \`extracts_js_function_reference_arguments\` — JS \`setTimeout\` / \`.map\` / \`.on\` patterns.
- \`extracts_python_function_reference_arguments\` — Python \`register\` / \`map\` patterns.

## Verification
- [x] cargo test -p codelens-engine — **343 / 343** (was 341, +2 new tests for JS/TS and Python)
- [x] cargo test -p codelens-mcp — 530 / 530
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] regen-tool-defs.py --check, surface-manifest.py --check, cargo fmt --check

## Out of scope (future patches)
- Go (\`time.AfterFunc(d, fn)\`, \`defer fn()\`)
- Kotlin lambda callbacks
- F4 (task-template-aware verify_change_readiness) — needs its own ADR

🤖 Generated with [Claude Code](https://claude.com/claude-code)