### PR TITLE
feat(v1.12.0): multi-language call-graph accuracy bench with regression gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,17 @@ jobs:
       - name: cargo test (semantic-off)
         run: cargo nextest run --workspace --no-default-features
 
+      # v1.12.0: explicit call-graph accuracy gate. The
+      # `call_graph_accuracy_meets_threshold` integration test is
+      # already exercised by the workspace nextest run above; this step
+      # surfaces it as a named CI gate so an accuracy regression
+      # (precision/recall/F1 dipping below the threshold declared in
+      # benchmarks/call-graph-accuracy/expected.json) shows up as a
+      # discrete failure with the per-fixture diff in stdout. See
+      # crates/codelens-engine/tests/call_graph_accuracy.rs.
+      - name: call-graph accuracy bench
+        run: cargo test -p codelens-engine --test call_graph_accuracy -- --nocapture
+
       - name: cargo doctest
         run: cargo test --doc --workspace
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-engine"
-version = "1.11.2"
+version = "1.12.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-mcp"
-version = "1.11.2"
+version = "1.12.0"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-tui"
-version = "1.11.2"
+version = "1.12.0"
 dependencies = [
  "anyhow",
  "codelens-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "Apache-2.0"
-version = "1.11.2"
+version = "1.12.0"
 description = "Harness-native Rust MCP server for code intelligence with generated surface governance, hybrid retrieval, and mutation-gated workflows"
 repository = "https://github.com/mupozg823/codelens-mcp-plugin"
 homepage = "https://github.com/mupozg823/codelens-mcp-plugin"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Pure Rust MCP server for multi-agent harnesses with hybrid retrieval (tree-sitte
 <!-- SURFACE_MANIFEST_README_SNAPSHOT:BEGIN -->
 ## Surface Snapshot
 
-- Workspace version: `1.11.2`
+- Workspace version: `1.12.0`
 - Workspace members: `3` (`crates/codelens-engine`, `crates/codelens-mcp`, `crates/codelens-tui`)
 - Registered tool definitions: `106`
 - Tool output schemas: `77 / 106`

--- a/benchmarks/call-graph-accuracy/expected.json
+++ b/benchmarks/call-graph-accuracy/expected.json
@@ -1,0 +1,60 @@
+{
+  "schema_version": "v1",
+  "description": "Ground-truth caller→callee edges for the v1.11+ multi-language call-graph accuracy bench. Each `edges` list is the set the extractor SHOULD produce; `caller` is the enclosing function name from the tree-sitter func query (or '<module>' for top-level), and `callee` is the resolved target name. Edges that the noise filter drops (println, list, len, str, etc.) are intentionally absent.",
+  "f1_threshold": 0.85,
+  "fixtures": [
+    {
+      "path": "benchmarks/call-graph-accuracy/fixtures/rust/registry.rs",
+      "edges": [
+        { "caller": "handler", "callee": "build_tools" },
+        { "caller": "<module>", "callee": "build_tools" },
+        { "caller": "run", "callee": "handler" },
+        { "caller": "run", "callee": "my_log" },
+        { "caller": "run", "callee": "parse_line" }
+      ]
+    },
+    {
+      "path": "benchmarks/call-graph-accuracy/fixtures/js/callbacks.js",
+      "edges": [
+        { "caller": "handleRequest", "callee": "validateUser" },
+        { "caller": "handleRequest", "callee": "run" },
+        { "caller": "handleRequest", "callee": "map" },
+        { "caller": "handleRequest", "callee": "on" },
+        { "caller": "handleRequest", "callee": "parseLine" },
+        { "caller": "handleRequest", "callee": "onEvent" },
+        { "caller": "handleRequest", "callee": "timeoutHandler" }
+      ]
+    },
+    {
+      "path": "benchmarks/call-graph-accuracy/fixtures/python/registry.py",
+      "edges": [
+        { "caller": "setup", "callee": "register" },
+        { "caller": "setup", "callee": "parse_line" },
+        { "caller": "setup", "callee": "on_event" },
+        { "caller": "wrap", "callee": "fn" },
+        { "caller": "<module>", "callee": "log_calls" }
+      ]
+    },
+    {
+      "path": "benchmarks/call-graph-accuracy/fixtures/go/server.go",
+      "edges": [
+        { "caller": "setup", "callee": "Register" },
+        { "caller": "setup", "callee": "Schedule" },
+        { "caller": "setup", "callee": "handler" },
+        { "caller": "setup", "callee": "teardown" },
+        { "caller": "run", "callee": "handler" },
+        { "caller": "run", "callee": "setup" }
+      ]
+    },
+    {
+      "path": "benchmarks/call-graph-accuracy/fixtures/java/Service.java",
+      "edges": [
+        { "caller": "start", "callee": "submit" },
+        { "caller": "start", "callee": "register" },
+        { "caller": "start", "callee": "process" },
+        { "caller": "start", "callee": "onTick" },
+        { "caller": "start", "callee": "onError" }
+      ]
+    }
+  ]
+}

--- a/benchmarks/call-graph-accuracy/fixtures/go/server.go
+++ b/benchmarks/call-graph-accuracy/fixtures/go/server.go
@@ -1,0 +1,20 @@
+// Call-graph accuracy fixture (Go).
+// Patterns:
+//   - direct call:    handler(w, r) inside run
+//   - selector:       server.Listen()
+//   - function reference (v1.11.2+): Register("/api", handler), Schedule(teardown)
+package main
+
+func handler(w int, r int) {}
+
+func teardown() {}
+
+func setup() {
+	Register("/api", handler)
+	Schedule(teardown)
+}
+
+func run() {
+	handler(0, 0)
+	setup()
+}

--- a/benchmarks/call-graph-accuracy/fixtures/java/Service.java
+++ b/benchmarks/call-graph-accuracy/fixtures/java/Service.java
@@ -1,0 +1,19 @@
+// Call-graph accuracy fixture (Java).
+// Patterns:
+//   - direct call:        process(payload) inside start
+//   - method_reference:   Service::onTick (covered earlier)
+//   - function reference (v1.11.2+): exec.submit(onTick), bus.register("err", onError)
+
+class Service {
+    public void onTick() {}
+
+    public void onError(String e) {}
+
+    public void process(String payload) {}
+
+    public void start(Executor exec, Bus bus) {
+        exec.submit(onTick);
+        bus.register("err", onError);
+        process("seed");
+    }
+}

--- a/benchmarks/call-graph-accuracy/fixtures/js/callbacks.js
+++ b/benchmarks/call-graph-accuracy/fixtures/js/callbacks.js
@@ -1,0 +1,31 @@
+// Call-graph accuracy fixture (JS).
+// Patterns:
+//   - direct call: validateUser(req) inside handleRequest
+//   - method:      service.run(req)
+//   - function reference (v1.11.1+): setTimeout(timeoutHandler), arr.map(parseLine), bus.on("evt", onEvent)
+
+function parseLine(line) {
+  return line.trim();
+}
+
+function onEvent(payload) {
+  return payload;
+}
+
+function timeoutHandler() {
+  return 1;
+}
+
+function validateUser(req) {
+  return req && req.user;
+}
+
+const handleRequest = async (req) => {
+  validateUser(req);
+  service.run(req);
+  const lines = ["a", "bb"];
+  const parsed = lines.map(parseLine);
+  bus.on("evt", onEvent);
+  setTimeout(timeoutHandler, 100);
+  return parsed;
+};

--- a/benchmarks/call-graph-accuracy/fixtures/python/registry.py
+++ b/benchmarks/call-graph-accuracy/fixtures/python/registry.py
@@ -1,0 +1,28 @@
+# Call-graph accuracy fixture (Python).
+# Patterns:
+#   - direct call:    parse_line() inside setup()
+#   - decorator:      @log_calls
+#   - function reference (v1.11.1+): register("evt", on_event), map(parse_line, ...)
+
+
+def log_calls(fn):
+    def wrap(*a, **kw):
+        return fn(*a, **kw)
+
+    return wrap
+
+
+def parse_line(line):
+    return line.strip()
+
+
+def on_event(payload):
+    return payload
+
+
+@log_calls
+def setup():
+    register("evt", on_event)
+    pipe = list(map(parse_line, ["a", "b"]))
+    parse_line("seed")
+    return pipe

--- a/benchmarks/call-graph-accuracy/fixtures/rust/registry.rs
+++ b/benchmarks/call-graph-accuracy/fixtures/rust/registry.rs
@@ -1,0 +1,31 @@
+// Call-graph accuracy fixture (Rust).
+// Patterns:
+//   - direct call: handler() inside run()
+//   - method chain: builder.with_x().with_y()
+//   - macro:        my_log!()
+//   - function reference (v1.11.0+): LazyLock::new(build_tools), iter.map(parse_line)
+
+fn build_tools() -> Vec<u32> {
+    vec![1, 2, 3]
+}
+
+fn parse_line(s: &str) -> u32 {
+    s.len() as u32
+}
+
+fn handler() {
+    let _ = build_tools();
+}
+
+macro_rules! my_log {
+    ($($t:tt)*) => {};
+}
+
+static TOOLS: std::sync::LazyLock<Vec<u32>> = std::sync::LazyLock::new(build_tools);
+
+fn run() {
+    handler();
+    my_log!("hi");
+    let lines = ["a", "bb"];
+    let _: Vec<_> = lines.iter().map(parse_line).collect();
+}

--- a/crates/codelens-engine/tests/call_graph_accuracy.rs
+++ b/crates/codelens-engine/tests/call_graph_accuracy.rs
@@ -1,0 +1,229 @@
+//! Multi-language call-graph accuracy bench (v1.12.0).
+//!
+//! Runs `extract_calls` against the fixtures under
+//! `benchmarks/call-graph-accuracy/fixtures/{rust,js,python,go,java}/` and
+//! computes precision / recall / F1 against the ground truth in
+//! `benchmarks/call-graph-accuracy/expected.json`. Fails the test (and
+//! therefore CI) when overall F1 dips below the threshold declared in
+//! `expected.json` (`f1_threshold`).
+//!
+//! Why a regression test rather than `cargo bench`:
+//! - we want CI to fail on accuracy regressions, which `cargo test`
+//!   already does automatically; criterion's bench harness does not
+//!   gate CI by default.
+//! - precision / recall / F1 are exact numbers — there is no
+//!   meaningful "warmup" phase that criterion would help with.
+//! - keeping this in the engine's `tests/` directory means contributors
+//!   running `cargo test -p codelens-engine` see the bench results
+//!   inline with the rest of the test suite.
+//!
+//! Adding a new fixture: drop the source file under `fixtures/<lang>/`,
+//! append a `{"path": ..., "edges": [...]}` entry to `expected.json`,
+//! and rerun `cargo test -p codelens-engine call_graph_accuracy`. If the
+//! tree-sitter extractor disagrees with your hand-written ground truth,
+//! the test prints a diff so you can decide which side is wrong.
+
+use codelens_engine::extract_calls;
+use serde::Deserialize;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Deserialize)]
+struct Manifest {
+    f1_threshold: f64,
+    fixtures: Vec<Fixture>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Fixture {
+    path: String,
+    edges: Vec<ExpectedEdge>,
+}
+
+#[derive(Debug, Deserialize, Clone, Eq, PartialEq, Hash)]
+struct ExpectedEdge {
+    caller: String,
+    callee: String,
+}
+
+fn workspace_root() -> PathBuf {
+    // tests/ runs from the engine crate dir; back up to the workspace root.
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("workspace root")
+        .to_path_buf()
+}
+
+fn load_manifest() -> Manifest {
+    let manifest_path = workspace_root()
+        .join("benchmarks")
+        .join("call-graph-accuracy")
+        .join("expected.json");
+    let body = std::fs::read_to_string(&manifest_path).unwrap_or_else(|err| {
+        panic!(
+            "failed to read manifest at {}: {err}",
+            manifest_path.display()
+        )
+    });
+    serde_json::from_str(&body).expect("manifest must parse as v1 schema")
+}
+
+fn extract_observed(path: &Path) -> HashSet<ExpectedEdge> {
+    extract_calls(path)
+        .into_iter()
+        .map(|edge| ExpectedEdge {
+            caller: edge.caller_name,
+            callee: edge.callee_name,
+        })
+        .collect()
+}
+
+#[derive(Debug, Default)]
+struct FixtureScore {
+    name: String,
+    tp: usize,
+    fp: usize,
+    fn_: usize,
+    missing: Vec<ExpectedEdge>,
+    spurious: Vec<ExpectedEdge>,
+}
+
+impl FixtureScore {
+    fn precision(&self) -> f64 {
+        let denom = (self.tp + self.fp) as f64;
+        if denom == 0.0 {
+            0.0
+        } else {
+            self.tp as f64 / denom
+        }
+    }
+
+    fn recall(&self) -> f64 {
+        let denom = (self.tp + self.fn_) as f64;
+        if denom == 0.0 {
+            0.0
+        } else {
+            self.tp as f64 / denom
+        }
+    }
+
+    fn f1(&self) -> f64 {
+        let p = self.precision();
+        let r = self.recall();
+        if p + r == 0.0 {
+            0.0
+        } else {
+            2.0 * p * r / (p + r)
+        }
+    }
+}
+
+fn score(
+    name: String,
+    expected: &[ExpectedEdge],
+    observed: &HashSet<ExpectedEdge>,
+) -> FixtureScore {
+    let expected_set: HashSet<ExpectedEdge> = expected.iter().cloned().collect();
+    let mut s = FixtureScore {
+        name,
+        ..Default::default()
+    };
+    for edge in &expected_set {
+        if observed.contains(edge) {
+            s.tp += 1;
+        } else {
+            s.fn_ += 1;
+            s.missing.push(edge.clone());
+        }
+    }
+    for edge in observed {
+        if !expected_set.contains(edge) {
+            s.fp += 1;
+            s.spurious.push(edge.clone());
+        }
+    }
+    s.missing.sort_by(|a, b| {
+        (a.caller.as_str(), a.callee.as_str()).cmp(&(b.caller.as_str(), b.callee.as_str()))
+    });
+    s.spurious.sort_by(|a, b| {
+        (a.caller.as_str(), a.callee.as_str()).cmp(&(b.caller.as_str(), b.callee.as_str()))
+    });
+    s
+}
+
+#[test]
+fn call_graph_accuracy_meets_threshold() {
+    let manifest = load_manifest();
+    let root = workspace_root();
+    let mut total_tp = 0usize;
+    let mut total_fp = 0usize;
+    let mut total_fn = 0usize;
+    let mut per_fixture = Vec::new();
+    for fixture in &manifest.fixtures {
+        let abs = root.join(&fixture.path);
+        assert!(abs.exists(), "fixture missing: {}", abs.display());
+        let observed = extract_observed(&abs);
+        let s = score(fixture.path.clone(), &fixture.edges, &observed);
+        total_tp += s.tp;
+        total_fp += s.fp;
+        total_fn += s.fn_;
+        per_fixture.push(s);
+    }
+
+    println!("\n── Call-graph accuracy bench (v1.12.0) ──");
+    println!(
+        "{:<54}  {:>3}  {:>3}  {:>3}  {:>6}  {:>6}  {:>6}",
+        "fixture", "TP", "FP", "FN", "P", "R", "F1"
+    );
+    for s in &per_fixture {
+        println!(
+            "{:<54}  {:>3}  {:>3}  {:>3}  {:>6.3}  {:>6.3}  {:>6.3}",
+            s.name,
+            s.tp,
+            s.fp,
+            s.fn_,
+            s.precision(),
+            s.recall(),
+            s.f1()
+        );
+        if !s.missing.is_empty() {
+            println!("  missing edges (FN):");
+            for edge in &s.missing {
+                println!("    - {}->{}", edge.caller, edge.callee);
+            }
+        }
+        if !s.spurious.is_empty() {
+            println!("  spurious edges (FP):");
+            for edge in &s.spurious {
+                println!("    - {}->{}", edge.caller, edge.callee);
+            }
+        }
+    }
+
+    let total_p = if total_tp + total_fp == 0 {
+        0.0
+    } else {
+        total_tp as f64 / (total_tp + total_fp) as f64
+    };
+    let total_r = if total_tp + total_fn == 0 {
+        0.0
+    } else {
+        total_tp as f64 / (total_tp + total_fn) as f64
+    };
+    let total_f1 = if total_p + total_r == 0.0 {
+        0.0
+    } else {
+        2.0 * total_p * total_r / (total_p + total_r)
+    };
+    println!("\nOVERALL  TP={total_tp}  FP={total_fp}  FN={total_fn}  P={total_p:.3}  R={total_r:.3}  F1={total_f1:.3}  threshold={threshold:.3}",
+        threshold = manifest.f1_threshold);
+
+    assert!(
+        total_f1 >= manifest.f1_threshold,
+        "call-graph accuracy regression: overall F1={total_f1:.3} < threshold {:.3}. \
+         See per-fixture diffs above; either the extractor regressed or \
+         expected.json needs an explicit update.",
+        manifest.f1_threshold
+    );
+}

--- a/crates/codelens-mcp/Cargo.toml
+++ b/crates/codelens-mcp/Cargo.toml
@@ -36,7 +36,7 @@ url.workspace = true
 rusqlite.workspace = true
 toml = "0.8"
 rustls = { workspace = true, optional = true }
-codelens-engine = { path = "../codelens-engine", version = "=1.11.2", default-features = false }
+codelens-engine = { path = "../codelens-engine", version = "=1.12.0", default-features = false }
 thiserror.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/codelens-tui/Cargo.toml
+++ b/crates/codelens-tui/Cargo.toml
@@ -14,7 +14,7 @@ name = "codelens-tui"
 path = "src/main.rs"
 
 [dependencies]
-codelens-engine = { path = "../codelens-engine", version = "=1.11.2" }
+codelens-engine = { path = "../codelens-engine", version = "=1.12.0" }
 ratatui = "0.30"
 crossterm = "0.28"
 anyhow.workspace = true

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,7 +6,7 @@
 ## Current Snapshot (2026-04-25)
 
 <!-- SURFACE_MANIFEST_ARCHITECTURE_SNAPSHOT:BEGIN -->
-- Workspace version: `1.11.2`
+- Workspace version: `1.12.0`
 - Workspace members: `3` (`crates/codelens-engine`, `crates/codelens-mcp`, `crates/codelens-tui`)
 - Registered tool definitions in source: `106`
 - Tool output schemas in source: `77 / 106`

--- a/docs/eval/v1.10.0-post-release-eval.md
+++ b/docs/eval/v1.10.0-post-release-eval.md
@@ -222,3 +222,27 @@ F1 shipped in v1.11.0:
 Other languages (TS/JS callbacks, Python `register("evt", fn)`, Java method references already partially covered) are still on the deferred list — each language grammar needs its own argument-position pattern. Tracked separately.
 
 F4 (task-template-aware `verify_change_readiness`) remains deferred. The UX work needs task-shape pattern-matching infrastructure large enough to warrant its own ADR.
+
+---
+
+## v1.12.0 follow-up — multi-language F1 closure + accuracy bench (2026-05-02)
+
+After v1.11.x extended function-reference call-graph extraction to JS/TS, Python, Go, and Java/Kotlin (matching the Rust closure in v1.11.0), v1.12.0 adds a **regression-gated accuracy bench** so future refactors of the extractor cannot silently regress.
+
+- Fixture set: `benchmarks/call-graph-accuracy/fixtures/{rust,js,python,go,java}/` — one source file per language, mixing direct calls, method chains, macros / decorators, and the v1.11.x function-reference patterns.
+- Ground truth: `benchmarks/call-graph-accuracy/expected.json` — declarative `(caller, callee)` set per fixture, plus an overall `f1_threshold` (0.85 in v1.12.0).
+- Runner: `crates/codelens-engine/tests/call_graph_accuracy.rs` — an integration test, so `cargo test -p codelens-engine` already gates CI; a named CI step (`call-graph accuracy bench`) surfaces it as a discrete check with per-fixture diff in stdout.
+- Initial measurement (v1.12.0 release):
+
+      | Fixture                | TP | FP | FN |   P   |   R   |  F1   |
+      | ---------------------- | -: | -: | -: | ----- | ----- | ----- |
+      | rust/registry.rs       |  5 |  2 |  0 | 0.714 | 1.000 | 0.833 |
+      | js/callbacks.js        |  6 |  1 |  1 | 0.857 | 0.857 | 0.857 |
+      | python/registry.py     |  5 |  0 |  0 | 1.000 | 1.000 | 1.000 |
+      | go/server.go           |  6 |  0 |  0 | 1.000 | 1.000 | 1.000 |
+      | java/Service.java      |  5 |  0 |  0 | 1.000 | 1.000 | 1.000 |
+      | **OVERALL**            | 27 |  3 |  1 | 0.900 | 0.964 | **0.931** |
+
+  Threshold 0.85, observed 0.931 — passing with headroom. The Rust / JS spurious edges are raw `extract_calls` artifacts that the runtime resolution cascade in `resolve_call_edges` filters out via the symbol DB; the bench intentionally evaluates the raw extractor surface so changes to the tree-sitter queries are caught earlier than the resolver's downstream filter.
+
+Future bumps to `f1_threshold` happen as the extractor improves — the bench fixture set itself is stable, so ratchet-up edits to the threshold alone are reviewable in isolation.

--- a/docs/generated/surface-manifest.json
+++ b/docs/generated/surface-manifest.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "codelens-surface-manifest-v1",
   "workspace": {
-    "version": "1.11.2",
+    "version": "1.12.0",
     "description": "Harness-native Rust MCP server for code intelligence with generated surface governance, hybrid retrieval, and mutation-gated workflows",
     "members": [
       "crates/codelens-engine",
@@ -3148,7 +3148,7 @@
   },
   "runtime": {
     "server_name": "codelens-mcp",
-    "version": "1.11.2",
+    "version": "1.12.0",
     "transport": [
       "stdio",
       "streamable-http"
@@ -3183,7 +3183,7 @@
     ]
   },
   "summary": {
-    "workspace_version": "1.11.2",
+    "workspace_version": "1.12.0",
     "workspace_member_count": 3,
     "registered_tool_definitions": 106,
     "tool_output_schemas": {

--- a/docs/platform-setup.md
+++ b/docs/platform-setup.md
@@ -587,7 +587,7 @@ agent = client.agents.create(
 ## Preset Comparison
 
 <!-- SURFACE_MANIFEST_PLATFORM_SURFACES:BEGIN -->
-- Workspace version: `1.11.2`
+- Workspace version: `1.12.0`
 - Presets: `minimal` (27), `balanced` (77), `full` (106)
 - Profiles: `planner-readonly` (32), `builder-minimal` (36), `reviewer-graph` (36), `evaluator-compact` (14), `refactor-full` (50), `ci-audit` (43), `workflow-first` (19)
 - Canonical manifest: [`docs/generated/surface-manifest.json`](generated/surface-manifest.json)


### PR DESCRIPTION
## Summary
Closes the v1.10.0 evaluation roadmap. After v1.11.0–v1.11.2 closed the function-reference cliff across 5 languages (Rust, JS/TS, Python, Go, Java/Kotlin), v1.12.0 ratchets that into a **CI-gated accuracy bench** so future refactors of the extractor cannot silently regress.

## What landed
- \`benchmarks/call-graph-accuracy/fixtures/{rust,js,python,go,java}/\` — five language fixtures mixing direct calls, method chains, macros / decorators / method references, and the v1.11.x function-reference patterns.
- \`benchmarks/call-graph-accuracy/expected.json\` — declarative ground truth (caller, callee) per fixture + \`f1_threshold\`.
- \`crates/codelens-engine/tests/call_graph_accuracy.rs\` — integration test runs \`extract_calls\` on every fixture, computes precision / recall / F1, fails when overall F1 < threshold. Per-fixture diffs print to stdout.
- \`.github/workflows/ci.yml\` — explicit named CI step.

## Initial measurement (this PR)
| Fixture | TP | FP | FN | P | R | F1 |
|---|---:|---:|---:|---:|---:|---:|
| rust/registry.rs | 5 | 2 | 0 | 0.714 | 1.000 | 0.833 |
| js/callbacks.js | 6 | 1 | 1 | 0.857 | 0.857 | 0.857 |
| python/registry.py | 5 | 0 | 0 | 1.000 | 1.000 | 1.000 |
| go/server.go | 6 | 0 | 0 | 1.000 | 1.000 | 1.000 |
| java/Service.java | 5 | 0 | 0 | 1.000 | 1.000 | 1.000 |
| **OVERALL** | 27 | 3 | 1 | 0.900 | 0.964 | **0.931** |

Threshold 0.85, observed 0.931 — passing with headroom. The Rust / JS spurious edges are raw extractor artefacts that the runtime resolution cascade filters via the symbol DB; the bench evaluates raw output so query regressions surface earlier than the resolver's downstream filter.

## Verification
- [x] \`cargo test --workspace\` — 345 (engine, +1 new accuracy test) + 530 (mcp) all green
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`regen-tool-defs.py --check\`, \`surface-manifest.py --check\`, \`cargo fmt --check\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)