### PR TITLE
feat(v1.12.3): dedicated KOTLIN_CALL_QUERY (closes v1.12.1 deferred gap)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-engine"
-version = "1.12.2"
+version = "1.12.3"
 dependencies = [
  "anyhow",
  "criterion",
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-mcp"
-version = "1.12.2"
+version = "1.12.3"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-tui"
-version = "1.12.2"
+version = "1.12.3"
 dependencies = [
  "anyhow",
  "codelens-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "Apache-2.0"
-version = "1.12.2"
+version = "1.12.3"
 description = "Harness-native Rust MCP server for code intelligence with generated surface governance, hybrid retrieval, and mutation-gated workflows"
 repository = "https://github.com/mupozg823/codelens-mcp-plugin"
 homepage = "https://github.com/mupozg823/codelens-mcp-plugin"

--- a/benchmarks/call-graph-accuracy/expected.json
+++ b/benchmarks/call-graph-accuracy/expected.json
@@ -80,6 +80,16 @@
         { "caller": "Button", "callee": "button" },
         { "caller": "Card", "callee": "div" }
       ]
+    },
+    {
+      "path": "benchmarks/call-graph-accuracy/fixtures/kotlin/Service.kt",
+      "edges": [
+        { "caller": "start", "callee": "prepare" },
+        { "caller": "start", "callee": "submit" },
+        { "caller": "start", "callee": "register" },
+        { "caller": "start", "callee": "onTick" },
+        { "caller": "start", "callee": "onError" }
+      ]
     }
   ]
 }

--- a/benchmarks/call-graph-accuracy/fixtures/kotlin/Service.kt
+++ b/benchmarks/call-graph-accuracy/fixtures/kotlin/Service.kt
@@ -1,0 +1,25 @@
+// Call-graph accuracy fixture (Kotlin).
+// v1.12.3: dedicated KOTLIN_CALL_QUERY targets tree-sitter-kotlin-ng's
+// (call_expression / navigation_expression / value_arguments) shape — the
+// previously-shared JAVA_CALL_QUERY produced 0 edges because
+// tree-sitter-java uses completely different node names (method_invocation,
+// argument_list, ...). See docs/eval/v1.12.1-post-release-eval.md.
+//
+// Patterns covered:
+//   - direct call:        prepare()
+//   - method invocation:  exec.submit(...)
+//   - function reference: exec.submit(onTick), bus.register("err", onError)
+
+class Service {
+    fun onTick() {}
+
+    fun onError(msg: String) {}
+
+    fun prepare() {}
+
+    fun start(exec: Executor, bus: Bus) {
+        exec.submit(onTick)
+        bus.register("err", onError)
+        prepare()
+    }
+}

--- a/crates/codelens-engine/src/call_graph.rs
+++ b/crates/codelens-engine/src/call_graph.rs
@@ -181,7 +181,7 @@ fn call_language_for_path(path: &Path) -> Option<CallLanguageConfig> {
         "tsx" => ("tsx", JS_FUNC_QUERY, JS_JSX_CALL_QUERY),
         "go" => ("go", GO_FUNC_QUERY, GO_CALL_QUERY),
         "java" => ("java", JAVA_FUNC_QUERY, JAVA_CALL_QUERY),
-        "kt" => ("kt", KOTLIN_FUNC_QUERY, JAVA_CALL_QUERY),
+        "kt" => ("kt", KOTLIN_FUNC_QUERY, KOTLIN_CALL_QUERY),
         "rs" => ("rs", RUST_FUNC_QUERY, RUST_CALL_QUERY),
         _ => return None,
     };
@@ -877,7 +877,26 @@ const JAVA_CALL_QUERY: &str = r#"
 "#;
 
 const KOTLIN_FUNC_QUERY: &str = r#"
-(function_declaration name: (identifier) @func.name) @func.def
+(function_declaration (identifier) @func.name) @func.def
+"#;
+
+const KOTLIN_CALL_QUERY: &str = r#"
+;; Direct call: prepare()
+(call_expression (identifier) @callee)
+
+;; Method/navigation call: exec.submit(...) — last identifier in
+;; navigation_expression is the method name (anchor `.` selects last child).
+(call_expression
+  (navigation_expression
+    (identifier) @callee .))
+
+;; v1.12.3: function-reference arguments — submit(onTick),
+;; register("err", onError). Same noise-filter behavior as Rust:
+;; non-function identifiers (variables) are dropped at resolution time.
+(call_expression
+  (value_arguments
+    (value_argument
+      (identifier) @callee)))
 "#;
 
 const RUST_FUNC_QUERY: &str = r#"

--- a/crates/codelens-mcp/Cargo.toml
+++ b/crates/codelens-mcp/Cargo.toml
@@ -36,7 +36,7 @@ url.workspace = true
 rusqlite.workspace = true
 toml = "0.8"
 rustls = { workspace = true, optional = true }
-codelens-engine = { path = "../codelens-engine", version = "=1.12.2", default-features = false }
+codelens-engine = { path = "../codelens-engine", version = "=1.12.3", default-features = false }
 thiserror.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/codelens-tui/Cargo.toml
+++ b/crates/codelens-tui/Cargo.toml
@@ -14,7 +14,7 @@ name = "codelens-tui"
 path = "src/main.rs"
 
 [dependencies]
-codelens-engine = { path = "../codelens-engine", version = "=1.12.2" }
+codelens-engine = { path = "../codelens-engine", version = "=1.12.3" }
 ratatui = "0.30"
 crossterm = "0.28"
 anyhow.workspace = true


### PR DESCRIPTION
## Summary
- New `KOTLIN_CALL_QUERY` targeting tree-sitter-kotlin-ng's actual AST shape (`call_expression` / `navigation_expression` / `value_arguments`). The `kt` extension now maps to its own query rather than the misnamed JAVA_CALL_QUERY share.
- Kotlin bench fixture restored from v1.12.1 deferral. Bench: F1=1.000 for Kotlin, OVERALL F1=0.934 → 0.940 (threshold 0.85).
- Closes the Kotlin gap noted in `docs/eval/v1.12.1-post-release-eval.md`.

## Why JAVA_CALL_QUERY didn't work
`tree-sitter-java` uses `method_invocation` (with `name` field), `argument_list`, `field_access`. `tree-sitter-kotlin-ng` uses `call_expression`, `navigation_expression`, `value_arguments` with anonymous `(identifier)` children. Probe via a one-off cargo example confirmed 0 query matches before the fix.

## Patterns covered
| Source | Query branch | Captures |
|---|---|---|
| `prepare()` | `(call_expression (identifier) @callee)` | `prepare` |
| `exec.submit(onTick)` | `(call_expression (navigation_expression (identifier) @callee .))` | `submit` (last anchor `.`) |
| `submit(onTick)` callback arg | `(call_expression (value_arguments (value_argument (identifier) @callee)))` | `onTick` |

## Bench
```
kotlin/Service.kt    TP=5  FP=0  FN=0  P=1.000 R=1.000 F1=1.000
OVERALL              TP=47 FP=5  FN=1  P=0.904 R=0.979 F1=0.940
                                            threshold=0.850
```

## Test plan
- [x] `cargo test -p codelens-engine --test call_graph_accuracy` passes (F1=0.940)
- [x] `cargo test -p codelens-engine` passes
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo build --release --workspace` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)