### PR TITLE
fix(v1.12.4): Kotlin callable references (Codex P1 follow-up)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-engine"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "criterion",
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-mcp"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-tui"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "codelens-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "Apache-2.0"
-version = "1.13.0"
+version = "1.13.1"
 description = "Harness-native Rust MCP server for code intelligence with generated surface governance, hybrid retrieval, and mutation-gated workflows"
 repository = "https://github.com/mupozg823/codelens-mcp-plugin"
 homepage = "https://github.com/mupozg823/codelens-mcp-plugin"

--- a/benchmarks/call-graph-accuracy/expected.json
+++ b/benchmarks/call-graph-accuracy/expected.json
@@ -88,7 +88,9 @@
         { "caller": "start", "callee": "submit" },
         { "caller": "start", "callee": "register" },
         { "caller": "start", "callee": "onTick" },
-        { "caller": "start", "callee": "onError" }
+        { "caller": "start", "callee": "onError" },
+        { "caller": "start", "callee": "handleAll" },
+        { "caller": "start", "callee": "shutdown" }
       ]
     }
   ]

--- a/benchmarks/call-graph-accuracy/fixtures/kotlin/Service.kt
+++ b/benchmarks/call-graph-accuracy/fixtures/kotlin/Service.kt
@@ -9,6 +9,9 @@
 //   - direct call:        prepare()
 //   - method invocation:  exec.submit(...)
 //   - function reference: exec.submit(onTick), bus.register("err", onError)
+//   - callable reference (v1.12.4): exec.submit(::onTick),
+//                                   bus.register("err", ::onError),
+//                                   exec.submit(this::onTick)
 
 class Service {
     fun onTick() {}
@@ -17,9 +20,22 @@ class Service {
 
     fun prepare() {}
 
+    // v1.12.4: regression guards — these symbols are reachable ONLY via
+    // callable references; if KOTLIN_CALL_QUERY's callable_reference /
+    // qualified-navigation patterns are removed, the bench loses these
+    // edges and F1 drops below threshold.
+    fun handleAll() {}
+
+    fun shutdown() {}
+
     fun start(exec: Executor, bus: Bus) {
         exec.submit(onTick)
         bus.register("err", onError)
         prepare()
+
+        // v1.12.4 callable-reference forms (Codex P1 follow-up)
+        exec.submit(::handleAll)
+        bus.register("err", ::onError)
+        exec.submit(this::shutdown)
     }
 }

--- a/crates/codelens-engine/src/call_graph.rs
+++ b/crates/codelens-engine/src/call_graph.rs
@@ -897,6 +897,24 @@ const KOTLIN_CALL_QUERY: &str = r#"
   (value_arguments
     (value_argument
       (identifier) @callee)))
+
+;; v1.12.4 (Codex P1): Kotlin callable references.
+;; - bare form `::onTick` parses as
+;;     value_argument > callable_reference > identifier.
+;; - qualified form `this::onTick` parses as
+;;     value_argument > navigation_expression(`::`) > identifier
+;;   (tree-sitter-kotlin-ng folds the `::` token into a
+;;   navigation_expression rather than a dedicated callable_reference
+;;   node). Both shapes are common in Executor / event-bus callbacks.
+(call_expression
+  (value_arguments
+    (value_argument
+      (callable_reference (identifier) @callee))))
+
+(call_expression
+  (value_arguments
+    (value_argument
+      (navigation_expression (identifier) @callee .))))
 "#;
 
 const RUST_FUNC_QUERY: &str = r#"

--- a/crates/codelens-mcp/Cargo.toml
+++ b/crates/codelens-mcp/Cargo.toml
@@ -36,7 +36,7 @@ url.workspace = true
 rusqlite.workspace = true
 toml = "0.8"
 rustls = { workspace = true, optional = true }
-codelens-engine = { path = "../codelens-engine", version = "=1.13.0", default-features = false }
+codelens-engine = { path = "../codelens-engine", version = "=1.13.1", default-features = false }
 thiserror.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/codelens-tui/Cargo.toml
+++ b/crates/codelens-tui/Cargo.toml
@@ -14,7 +14,7 @@ name = "codelens-tui"
 path = "src/main.rs"
 
 [dependencies]
-codelens-engine = { path = "../codelens-engine", version = "=1.13.0" }
+codelens-engine = { path = "../codelens-engine", version = "=1.13.1" }
 ratatui = "0.30"
 crossterm = "0.28"
 anyhow.workspace = true


### PR DESCRIPTION
## Summary
Closes the Codex P1 review on PR #143 — `KOTLIN_CALL_QUERY` shipped in v1.12.3 captured plain-identifier callback args but silently missed Kotlin's callable-reference syntax (`::onTick`, `this::onTick`, `Class::onX`). These are extremely common in Executor / event-bus callbacks and parse to entirely different AST nodes.

## Root cause
- Bare `::onTick` → `value_argument > callable_reference > identifier`
- Qualified `this::onTick` → `value_argument > navigation_expression(::) > identifier` (tree-sitter-kotlin-ng folds `::` into a navigation_expression rather than emitting a dedicated callable_reference node)

Verified via a one-off cargo example dumping AST for `exec.submit(::onTick)` and `exec.submit(this::onTick)`.

## Fix
Two new patterns appended to `KOTLIN_CALL_QUERY`:
```scheme
(call_expression
  (value_arguments
    (value_argument
      (callable_reference (identifier) @callee))))

(call_expression
  (value_arguments
    (value_argument
      (navigation_expression (identifier) @callee .))))
```
Last-child anchor `.` keeps the qualified form pinned to the function name even on chained `a.b::c`.

## Regression guard
Fixture gains `handleAll` + `shutdown` which are reachable ONLY via `::handleAll` and `this::shutdown` calls. Removing either new query branch drops these edges from the bench and would fail the gate.

## Bench
```
kotlin/Service.kt   TP=7  FP=0 FN=0  P=1.000 R=1.000 F1=1.000
OVERALL             TP=49 FP=5 FN=1  P=0.907 R=0.980 F1=0.942
                                            threshold=0.850
```

## Test plan
- [x] `cargo test -p codelens-engine --test call_graph_accuracy` (F1=0.942, was 0.940)
- [x] `cargo test -p codelens-engine`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo build --release --workspace`

🤖 Generated with [Claude Code](https://claude.com/claude-code)