### PR TITLE
feat(v1.13.2): find_redundant_definitions tool (Phase 2-A)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-engine"
-version = "1.13.1"
+version = "1.13.2"
 dependencies = [
  "anyhow",
  "criterion",
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-mcp"
-version = "1.13.1"
+version = "1.13.2"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-tui"
-version = "1.13.1"
+version = "1.13.2"
 dependencies = [
  "anyhow",
  "codelens-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "Apache-2.0"
-version = "1.13.1"
+version = "1.13.2"
 description = "Harness-native Rust MCP server for code intelligence with generated surface governance, hybrid retrieval, and mutation-gated workflows"
 repository = "https://github.com/mupozg823/codelens-mcp-plugin"
 homepage = "https://github.com/mupozg823/codelens-mcp-plugin"

--- a/crates/codelens-engine/src/lib.rs
+++ b/crates/codelens-engine/src/lib.rs
@@ -45,6 +45,7 @@ pub mod lang_registry;
 pub mod lsp;
 pub mod memory;
 pub mod project;
+pub mod redundant_definitions;
 pub mod rename;
 pub mod scope_analysis;
 pub mod search;

--- a/crates/codelens-engine/src/redundant_definitions.rs
+++ b/crates/codelens-engine/src/redundant_definitions.rs
@@ -1,0 +1,171 @@
+//! Detects "thin wrapper" definitions — functions whose entire body is a
+//! single call to another function with one literal default argument
+//! (e.g. `pub fn record_X(&self) { self.record_X_for_session(None) }`).
+//!
+//! This is a syntactic-only detector that catches the exact pattern flagged
+//! by self-dogfooding in v1.13.0 Phase 1-A: 16 `record_*` wrappers all
+//! forwarding to their `_for_session(None)` substrate. The substrate could
+//! be flagged by `find_dead_code_v2` only AFTER the wrappers were removed,
+//! so this complement helps surface the cluster pre-deletion.
+
+use crate::project::{collect_files, ProjectRoot};
+use anyhow::Result;
+use regex::Regex;
+use serde::Serialize;
+use std::path::Path;
+use std::sync::LazyLock;
+
+/// Matches a Rust one-line wrapper:
+///   `pub fn NAME(args) [-> RetType] { self.OTHER(args, LITERAL) [;] }`
+///   `fn NAME(args) [-> RetType] { OTHER(args, LITERAL) [;] }`
+/// where LITERAL is one of: `None`, `Default::default()`, `false`, `true`,
+/// a bare integer literal, or a quoted string literal.
+static RUST_ONE_LINE_WRAPPER_RE: LazyLock<Regex> = LazyLock::new(|| {
+    // (?m): multiline (^/$ are line anchors)
+    Regex::new(
+        r#"(?m)^\s*(?:pub(?:\([^)]*\))?\s+)?fn\s+(?P<wrapper>[A-Za-z_][A-Za-z0-9_]*)\s*\([^)]*\)\s*(?:->\s*[^{]+?)?\s*\{\s*(?:self\.|Self::)?(?P<target>[A-Za-z_][A-Za-z0-9_]*)\s*\([^)]*?(?P<default>None|Default::default\(\)|true|false|-?\d+|"[^"]*")?\s*\)\s*;?\s*\}\s*$"#
+    ).unwrap()
+});
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RedundantDefinitionEntry {
+    pub file: String,
+    pub wrapper: String,
+    pub target: String,
+    pub line: usize,
+    pub default_arg: Option<String>,
+    pub kind: &'static str,
+}
+
+/// Finds Rust one-line wrappers in the project.
+///
+/// Returns a list of (wrapper, target) pairs. Callers can group by `target`
+/// to find substrates with multiple wrappers — the highest-leverage cleanup
+/// opportunity per Phase 1-A's findings.
+pub fn find_redundant_definitions(
+    project: &ProjectRoot,
+    max_results: usize,
+) -> Result<Vec<RedundantDefinitionEntry>> {
+    let mut results: Vec<RedundantDefinitionEntry> = Vec::new();
+    let candidates = collect_files(project.as_path(), is_rust_file)?;
+
+    for path in &candidates {
+        let source = match std::fs::read_to_string(path) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        let relative = project.to_relative(path);
+        scan_rust_source(&source, &relative, &mut results);
+        if max_results > 0 && results.len() >= max_results {
+            break;
+        }
+    }
+
+    results.sort_by(|a, b| {
+        a.target
+            .cmp(&b.target)
+            .then(a.file.cmp(&b.file))
+            .then(a.line.cmp(&b.line))
+    });
+    if max_results > 0 && results.len() > max_results {
+        results.truncate(max_results);
+    }
+    Ok(results)
+}
+
+fn scan_rust_source(source: &str, file: &str, out: &mut Vec<RedundantDefinitionEntry>) {
+    for m in RUST_ONE_LINE_WRAPPER_RE.captures_iter(source) {
+        let wrapper = m
+            .name("wrapper")
+            .map(|m| m.as_str().to_owned())
+            .unwrap_or_default();
+        let target = m
+            .name("target")
+            .map(|m| m.as_str().to_owned())
+            .unwrap_or_default();
+        if wrapper.is_empty() || target.is_empty() || wrapper == target {
+            continue;
+        }
+        let default_arg = m.name("default").map(|m| m.as_str().to_owned());
+        let line = byte_offset_to_line(source, m.get(0).map(|m| m.start()).unwrap_or(0));
+        out.push(RedundantDefinitionEntry {
+            file: file.to_owned(),
+            wrapper,
+            target,
+            line,
+            default_arg,
+            kind: "rust_one_line_wrapper",
+        });
+    }
+}
+
+fn byte_offset_to_line(source: &str, offset: usize) -> usize {
+    source[..offset.min(source.len())].matches('\n').count() + 1
+}
+
+fn is_rust_file(path: &Path) -> bool {
+    path.extension().and_then(|s| s.to_str()) == Some("rs")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_self_dot_wrapper_with_none_default() {
+        let source = r#"
+impl Foo {
+    pub fn record_x(&self) { self.record_x_for_session(None) }
+    pub fn record_y(&self) { self.record_y_for_session(None); }
+}
+        "#;
+        let mut out = Vec::new();
+        scan_rust_source(source, "telemetry.rs", &mut out);
+        assert_eq!(out.len(), 2, "got: {:?}", out);
+        assert_eq!(out[0].wrapper, "record_x");
+        assert_eq!(out[0].target, "record_x_for_session");
+        assert_eq!(out[0].default_arg.as_deref(), Some("None"));
+        assert_eq!(out[1].wrapper, "record_y");
+    }
+
+    #[test]
+    fn detects_bare_function_wrapper() {
+        let source = r#"
+pub fn helper(x: u32) -> bool { inner(x, false) }
+        "#;
+        let mut out = Vec::new();
+        scan_rust_source(source, "lib.rs", &mut out);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].wrapper, "helper");
+        assert_eq!(out[0].target, "inner");
+        assert_eq!(out[0].default_arg.as_deref(), Some("false"));
+    }
+
+    #[test]
+    fn skips_self_recursive_call() {
+        let source = r#"
+pub fn loop_me(&self) { self.loop_me(0) }
+        "#;
+        let mut out = Vec::new();
+        scan_rust_source(source, "x.rs", &mut out);
+        // wrapper == target → not flagged (would be infinite recursion, not delegation)
+        assert!(out.is_empty(), "got: {:?}", out);
+    }
+
+    #[test]
+    fn skips_multi_statement_body() {
+        let source = r#"
+pub fn complex(&self) {
+    let x = 1;
+    self.do_thing(x, None);
+}
+        "#;
+        let mut out = Vec::new();
+        scan_rust_source(source, "x.rs", &mut out);
+        assert!(
+            out.is_empty(),
+            "multi-statement should not match: {:?}",
+            out
+        );
+    }
+}

--- a/crates/codelens-mcp/Cargo.toml
+++ b/crates/codelens-mcp/Cargo.toml
@@ -36,7 +36,7 @@ url.workspace = true
 rusqlite.workspace = true
 toml = "0.8"
 rustls = { workspace = true, optional = true }
-codelens-engine = { path = "../codelens-engine", version = "=1.13.1", default-features = false }
+codelens-engine = { path = "../codelens-engine", version = "=1.13.2", default-features = false }
 thiserror.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/codelens-mcp/src/tools/graph.rs
+++ b/crates/codelens-mcp/src/tools/graph.rs
@@ -7,7 +7,7 @@ use crate::tools::symbols::flatten_symbols;
 use codelens_engine::{
     find_circular_dependencies, find_dead_code_v2, find_scoped_references, get_blast_radius,
     get_callees, get_callers, get_change_coupling, get_changed_files, get_importance,
-    get_importers,
+    get_importers, redundant_definitions,
 };
 use serde_json::{Map, Value, json};
 
@@ -217,6 +217,37 @@ pub(crate) fn find_dead_code_v2_tool(
             )
         })?,
     )
+}
+
+pub fn find_redundant_definitions_tool(
+    state: &AppState,
+    arguments: &serde_json::Value,
+) -> ToolResult {
+    let max_results = optional_usize(arguments, "max_results", 50);
+    let entries =
+        redundant_definitions::find_redundant_definitions(&state.project(), max_results)?;
+    let mut groups: std::collections::BTreeMap<String, Vec<&_>> = std::collections::BTreeMap::new();
+    for entry in &entries {
+        groups.entry(entry.target.clone()).or_default().push(entry);
+    }
+    let grouped = groups
+        .iter()
+        .map(|(target, members)| {
+            json!({
+                "target": target,
+                "wrapper_count": members.len(),
+                "wrappers": members,
+            })
+        })
+        .collect::<Vec<_>>();
+    Ok((
+        json!({
+            "redundant_definitions": entries,
+            "count": entries.len(),
+            "grouped_by_target": grouped,
+        }),
+        success_meta(BackendKind::TreeSitter, 0.85),
+    ))
 }
 
 pub fn find_scoped_references_tool(state: &AppState, arguments: &serde_json::Value) -> ToolResult {

--- a/crates/codelens-mcp/src/tools/mod.rs
+++ b/crates/codelens-mcp/src/tools/mod.rs
@@ -85,6 +85,7 @@ pub fn dispatch_table() -> HashMap<&'static str, crate::tool_defs::tool::ToolHan
         "get_callers"                  => graph::get_callers_tool,
         "get_callees"                  => graph::get_callees_tool,
         "find_circular_dependencies"   => graph::find_circular_dependencies_tool,
+        "find_redundant_definitions"   => graph::find_redundant_definitions_tool,
         "get_change_coupling"          => graph::get_change_coupling_tool,
         // ── Edit (individual) ──
         "rename_symbol"                => mutation::rename_symbol,

--- a/crates/codelens-mcp/tools.toml
+++ b/crates/codelens-mcp/tools.toml
@@ -495,6 +495,18 @@ properties = { max_results = { type = "integer" } }
 # ─────
 
 [[tool]]
+name = "find_redundant_definitions"
+category = "analysis"
+description = "[CodeLens:Analysis] Find Rust thin-wrapper functions whose body is a single call to another function with one literal default. Output groups by target so multi-wrapper substrates surface as cleanup clusters."
+annotations = "ro_a"
+
+[tool.input_schema]
+type = "object"
+properties = { max_results = { type = "integer" } }
+
+# ─────
+
+[[tool]]
 name = "get_change_coupling"
 category = "analysis"
 description = "[CodeLens:Analysis] Files that frequently change together in git history."

--- a/crates/codelens-tui/Cargo.toml
+++ b/crates/codelens-tui/Cargo.toml
@@ -14,7 +14,7 @@ name = "codelens-tui"
 path = "src/main.rs"
 
 [dependencies]
-codelens-engine = { path = "../codelens-engine", version = "=1.13.1" }
+codelens-engine = { path = "../codelens-engine", version = "=1.13.2" }
 ratatui = "0.30"
 crossterm = "0.28"
 anyhow.workspace = true


### PR DESCRIPTION
**Phase 2-A** of the post-v1.13.0 dogfooding sprint. Adds the detector that should have surfaced v1.13.0 Phase 1-A's wrapper cluster pre-deletion.

## Why
Phase 1-A removed 16 `#[allow(dead_code)] // compatibility wrapper` methods plus 1 orphan substrate. The wrapper cluster was found via grep + manual review; the orphan substrate was only found by rust-analyzer after the wrappers were already gone. CodeLens couldn't surface either side of the pattern.

## What
A syntactic detector for the exact pattern the wrappers exhibited:
```rust
pub fn record_X(&self) { self.record_X_for_session(None) }
```
- Engine module: `redundant_definitions.rs` (one regex, file-by-file scan).
- MCP tool: `find_redundant_definitions` with `max_results` arg.
- Output groups results by `target` so multi-wrapper substrates appear as cleanup clusters — the same signal that made the 16-wrapper batch obvious.

## Test plan
- [x] 4 new unit tests for the engine detector (none/false-default detection, self-recursion guard, multi-statement guard)
- [x] `cargo test -p codelens-mcp` — 527 passed
- [x] `cargo build --release --workspace` — clean

## Tradeoffs
- Rust-only. Other languages need their own regex.
- Syntactic-only. No call-graph traversal; won't catch runtime trampolines or cross-file wrappers.
- Misses multi-line wrappers. v2 can promote to tree-sitter once the regex approach proves useful in dogfooding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)