### PR TITLE
fix(v1.13.4): find_redundant_definitions rejects closure-arg calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-engine"
-version = "1.13.3"
+version = "1.13.4"
 dependencies = [
  "anyhow",
  "criterion",
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-mcp"
-version = "1.13.3"
+version = "1.13.4"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-tui"
-version = "1.13.3"
+version = "1.13.4"
 dependencies = [
  "anyhow",
  "codelens-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "Apache-2.0"
-version = "1.13.3"
+version = "1.13.4"
 description = "Harness-native Rust MCP server for code intelligence with generated surface governance, hybrid retrieval, and mutation-gated workflows"
 repository = "https://github.com/mupozg823/codelens-mcp-plugin"
 homepage = "https://github.com/mupozg823/codelens-mcp-plugin"

--- a/crates/codelens-engine/src/redundant_definitions.rs
+++ b/crates/codelens-engine/src/redundant_definitions.rs
@@ -21,9 +21,13 @@ use std::sync::LazyLock;
 /// where LITERAL is one of: `None`, `Default::default()`, `false`, `true`,
 /// a bare integer literal, or a quoted string literal.
 static RUST_ONE_LINE_WRAPPER_RE: LazyLock<Regex> = LazyLock::new(|| {
-    // (?m): multiline (^/$ are line anchors)
+    // (?m): multiline (^/$ are line anchors).
+    // Inner args use [^){};|] to reject:
+    //   - `;` (statement boundary — would mean multi-statement body)
+    //   - `{` `}` (block — closure body, struct literal)
+    //   - `|` (closure pipe — `|x| ...` indicates non-trivial logic, not a literal default)
     Regex::new(
-        r#"(?m)^\s*(?:pub(?:\([^)]*\))?\s+)?fn\s+(?P<wrapper>[A-Za-z_][A-Za-z0-9_]*)\s*\([^)]*\)\s*(?:->\s*[^{]+?)?\s*\{\s*(?:self\.|Self::)?(?P<target>[A-Za-z_][A-Za-z0-9_]*)\s*\([^)]*?(?P<default>None|Default::default\(\)|true|false|-?\d+|"[^"]*")?\s*\)\s*;?\s*\}\s*$"#
+        r#"(?m)^\s*(?:pub(?:\([^)]*\))?\s+)?fn\s+(?P<wrapper>[A-Za-z_][A-Za-z0-9_]*)\s*\([^)]*\)\s*(?:->\s*[^{]+?)?\s*\{\s*(?:self\.|Self::)?(?P<target>[A-Za-z_][A-Za-z0-9_]*)\s*\([^){};|]*?(?P<default>None|Default::default\(\)|true|false|-?\d+|"[^"]*")?\s*\)\s*;?\s*\}\s*$"#
     ).unwrap()
 });
 
@@ -235,6 +239,23 @@ pub fn helper(x: u32) -> bool { inner(x, false) }
         assert_eq!(out[0].wrapper, "helper");
         assert_eq!(out[0].target, "inner");
         assert_eq!(out[0].default_arg.as_deref(), Some("false"));
+    }
+
+    #[test]
+    fn skips_call_with_closure_arg() {
+        // Detector v3: a body that passes a closure to its delegate is NOT a thin
+        // wrapper — the closure carries logic. This was the false-positive shape
+        // that flagged `mutate_session_metrics` 13× during v1.13.3 dogfooding.
+        let source = r#"
+pub fn record_x(&self) {
+    self.mutate_session_metrics(None, |session| {
+        session.foo += 1;
+    });
+}
+        "#;
+        let mut out = Vec::new();
+        scan_rust_source(source, "events.rs", &mut out);
+        assert!(out.is_empty(), "closure-arg call must not match: {:?}", out);
     }
 
     #[test]

--- a/crates/codelens-mcp/Cargo.toml
+++ b/crates/codelens-mcp/Cargo.toml
@@ -36,7 +36,7 @@ url.workspace = true
 rusqlite.workspace = true
 toml = "0.8"
 rustls = { workspace = true, optional = true }
-codelens-engine = { path = "../codelens-engine", version = "=1.13.3", default-features = false }
+codelens-engine = { path = "../codelens-engine", version = "=1.13.4", default-features = false }
 thiserror.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/codelens-tui/Cargo.toml
+++ b/crates/codelens-tui/Cargo.toml
@@ -14,7 +14,7 @@ name = "codelens-tui"
 path = "src/main.rs"
 
 [dependencies]
-codelens-engine = { path = "../codelens-engine", version = "=1.13.3" }
+codelens-engine = { path = "../codelens-engine", version = "=1.13.4" }
 ratatui = "0.30"
 crossterm = "0.28"
 anyhow.workspace = true


### PR DESCRIPTION
**Detector v3 fix driven by v1.13.3 dogfooding.** First-principles refinement of the wrapper definition.

## Why
v1.13.3 dogfooding flagged \`mutate_session_metrics\` 13 times in \`telemetry/registry/events.rs\`. Each "wrapper" looked like:
\`\`\`rust
pub fn record_X(&self, ..., id: Option<&str>) {
    self.mutate_session_metrics(id, |session| {
        session.foo += 1;          // ← unique per wrapper
        session.guidance.bar = ...; // ← unique per wrapper
    });
}
\`\`\`
A closure as an argument carries logic. The "wrappers" were 13 distinct telemetry handlers, not delegation. Detector should not have matched them.

## Fix
Inner-args character class changed from \`[^)]*?\` to \`[^){}|]*?\`:
- \`;\` — multi-statement body
- \`{\` / \`}\` — block / struct literal / nested scope
- \`|\` — **closure pipe** (the actual fix)

## Dogfood result on this repo
| Version | Entries | Multi-wrapper clusters |
|---------|---------|------------------------|
| v1.13.2 | 39      | 2                      |
| v1.13.3 | 34      | 2                      |
| v1.13.4 | **20**  | **1** (legitimate branch) |

Remaining cluster is \`reusable_embedding_key_for_chunk\` / \`_for_symbol\` — a legitimate semantic split that the detector correctly surfaces but humans should not act on. Signal is now clean.

## Test
- New unit test \`skips_call_with_closure_arg\` covers the exact false-positive shape
- 7 unit tests + 1 ignored dogfood test pass
- \`cargo build --release --workspace\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)