### PR TITLE
feat(v1.13.7): find_orphan_handlers tool (Phase 2-D)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-engine"
-version = "1.13.6"
+version = "1.13.7"
 dependencies = [
  "anyhow",
  "criterion",
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-mcp"
-version = "1.13.6"
+version = "1.13.7"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -532,6 +532,7 @@ dependencies = [
  "opentelemetry_sdk",
  "rayon",
  "rcgen",
+ "regex",
  "rusqlite",
  "rustls",
  "serde",
@@ -553,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-tui"
-version = "1.13.6"
+version = "1.13.7"
 dependencies = [
  "anyhow",
  "codelens-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "Apache-2.0"
-version = "1.13.6"
+version = "1.13.7"
 description = "Harness-native Rust MCP server for code intelligence with generated surface governance, hybrid retrieval, and mutation-gated workflows"
 repository = "https://github.com/mupozg823/codelens-mcp-plugin"
 homepage = "https://github.com/mupozg823/codelens-mcp-plugin"

--- a/crates/codelens-mcp/Cargo.toml
+++ b/crates/codelens-mcp/Cargo.toml
@@ -33,10 +33,11 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 url.workspace = true
+regex.workspace = true
 rusqlite.workspace = true
 toml = "0.8"
 rustls = { workspace = true, optional = true }
-codelens-engine = { path = "../codelens-engine", version = "=1.13.6", default-features = false }
+codelens-engine = { path = "../codelens-engine", version = "=1.13.7", default-features = false }
 thiserror.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/codelens-mcp/src/main.rs
+++ b/crates/codelens-mcp/src/main.rs
@@ -15,6 +15,7 @@ mod error;
 mod job_store;
 mod mutation_gate;
 mod operator;
+mod orphan_handlers;
 mod preflight_store;
 mod principals;
 mod prompts;

--- a/crates/codelens-mcp/src/orphan_handlers.rs
+++ b/crates/codelens-mcp/src/orphan_handlers.rs
@@ -1,0 +1,165 @@
+//! Detects "orphan handlers" — functions in `crates/codelens-mcp/src/tools/`
+//! that match the `ToolHandler` signature but are not registered in
+//! `dispatch_table()`. Complements `find_redundant_definitions` and
+//! `find_phantom_modules`: those find dead delegations and dead module
+//! lines; this one finds dead routing surface.
+//!
+//! A handler-shaped function that no dispatch arm references will be
+//! `dead_code` once the build is green, so this overlaps with the rust
+//! compiler's lint, but it produces a structured audit list (handler →
+//! file → line → reason) that is much easier to act on than scrolling a
+//! warnings buffer, and it deliberately scans test-private handlers too.
+
+use anyhow::Result;
+use regex::Regex;
+use serde::Serialize;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
+
+/// Matches `pub fn NAME(state: &AppState, arguments: &Value) -> ToolResult`
+/// and the common variants (underscore-prefixed param names, and the
+/// fully-qualified `serde_json::Value`). Allows multi-line signatures.
+static HANDLER_SIG_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r#"(?ms)pub\s+fn\s+(?P<fn>[A-Za-z_][A-Za-z0-9_]*)\s*\(\s*(?:_)?state\s*:\s*&AppState\s*,\s*(?:_)?arguments\s*:\s*&(?:serde_json::)?Value\s*,?\s*\)\s*->\s*ToolResult"#,
+    )
+    .unwrap()
+});
+
+/// Matches arms inside the `dispatch_table` macro body:
+///   `"tool_name" => module::handler_fn,`
+/// Captures both the tool name and the handler symbol.
+static DISPATCH_ARM_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r#""(?P<tool>[A-Za-z_][A-Za-z0-9_]*)"\s*=>\s*[A-Za-z_][A-Za-z0-9_:]*::(?P<handler>[A-Za-z_][A-Za-z0-9_]*)"#,
+    )
+    .unwrap()
+});
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub(crate) struct OrphanHandlerEntry {
+    pub file: String,
+    pub function_name: String,
+    pub line: usize,
+}
+
+/// Scans `crates/codelens-mcp/src/tools/` for handler-shaped functions and
+/// reports the ones that no `dispatch_table` arm names.
+pub(crate) fn find_orphan_handlers(project_root: &Path) -> Result<Vec<OrphanHandlerEntry>> {
+    let tools_dir = project_root.join("crates/codelens-mcp/src/tools");
+    let mut handler_decls: Vec<OrphanHandlerEntry> = Vec::new();
+    walk_rust_files(&tools_dir, &mut |path: &Path| {
+        let source = match std::fs::read_to_string(path) {
+            Ok(s) => s,
+            Err(_) => return,
+        };
+        let relative = relative_to(project_root, path);
+        for caps in HANDLER_SIG_RE.captures_iter(&source) {
+            let fn_name = match caps.name("fn") {
+                Some(m) => m.as_str().to_owned(),
+                None => continue,
+            };
+            let line = caps
+                .get(0)
+                .map(|m| source[..m.start()].matches('\n').count() + 1)
+                .unwrap_or(0);
+            handler_decls.push(OrphanHandlerEntry {
+                file: relative.clone(),
+                function_name: fn_name,
+                line,
+            });
+        }
+    })?;
+
+    let mod_rs = project_root.join("crates/codelens-mcp/src/tools/mod.rs");
+    let dispatched: HashSet<String> = match std::fs::read_to_string(&mod_rs) {
+        Ok(source) => DISPATCH_ARM_RE
+            .captures_iter(&source)
+            .filter_map(|c| c.name("handler").map(|m| m.as_str().to_owned()))
+            .collect(),
+        Err(_) => HashSet::new(),
+    };
+
+    let mut orphans: Vec<OrphanHandlerEntry> = handler_decls
+        .into_iter()
+        .filter(|h| !dispatched.contains(&h.function_name))
+        .collect();
+    orphans.sort_by(|a, b| a.file.cmp(&b.file).then(a.line.cmp(&b.line)));
+    Ok(orphans)
+}
+
+fn walk_rust_files(root: &Path, visit: &mut dyn FnMut(&Path)) -> Result<()> {
+    if !root.exists() {
+        return Ok(());
+    }
+    let mut stack: Vec<PathBuf> = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        for entry in std::fs::read_dir(&dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if path.extension().and_then(|s| s.to_str()) == Some("rs") {
+                visit(&path);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn relative_to(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| path.to_string_lossy().into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn handler_sig_re_matches_canonical_signature() {
+        let source =
+            "pub fn rename_symbol(state: &AppState, arguments: &serde_json::Value) -> ToolResult {";
+        let m = HANDLER_SIG_RE.captures(source).expect("match");
+        assert_eq!(m.name("fn").unwrap().as_str(), "rename_symbol");
+    }
+
+    #[test]
+    fn handler_sig_re_matches_underscore_prefix() {
+        let source = "pub fn h(_state: &AppState, _arguments: &Value) -> ToolResult {";
+        let m = HANDLER_SIG_RE.captures(source).expect("match");
+        assert_eq!(m.name("fn").unwrap().as_str(), "h");
+    }
+
+    #[test]
+    fn dispatch_arm_re_captures_handler_symbol() {
+        let source = r#""find_symbol" => symbols::find_symbol,"#;
+        let m = DISPATCH_ARM_RE.captures(source).expect("match");
+        assert_eq!(m.name("tool").unwrap().as_str(), "find_symbol");
+        assert_eq!(m.name("handler").unwrap().as_str(), "find_symbol");
+    }
+
+    #[test]
+    fn dispatch_arm_re_handles_renamed_handler() {
+        let source = r#""read_file" => filesystem::read_file_tool,"#;
+        let m = DISPATCH_ARM_RE.captures(source).expect("match");
+        assert_eq!(m.name("tool").unwrap().as_str(), "read_file");
+        assert_eq!(m.name("handler").unwrap().as_str(), "read_file_tool");
+    }
+
+    #[test]
+    #[ignore]
+    fn dogfood_self_repo() {
+        // Run with: cargo test -p codelens-mcp orphan_handlers::tests::dogfood_self_repo -- --ignored --nocapture
+        let repo: PathBuf = std::env::var("CODELENS_REPO_ROOT")
+            .unwrap_or_else(|_| "/Users/bagjaeseog/codelens-mcp-plugin".to_owned())
+            .into();
+        let orphans = find_orphan_handlers(&repo).expect("find_orphan_handlers");
+        eprintln!("\n=== {} orphan handlers ===\n", orphans.len());
+        for o in &orphans {
+            eprintln!("  {}() at {}:{}", o.function_name, o.file, o.line);
+        }
+    }
+}

--- a/crates/codelens-mcp/src/tools/graph.rs
+++ b/crates/codelens-mcp/src/tools/graph.rs
@@ -219,6 +219,20 @@ pub(crate) fn find_dead_code_v2_tool(
     )
 }
 
+pub fn find_orphan_handlers_tool(
+    state: &AppState,
+    _arguments: &serde_json::Value,
+) -> ToolResult {
+    let entries = crate::orphan_handlers::find_orphan_handlers(state.project().as_path())?;
+    Ok((
+        json!({
+            "orphan_handlers": entries,
+            "count": entries.len(),
+        }),
+        success_meta(BackendKind::TreeSitter, 0.78),
+    ))
+}
+
 pub fn find_phantom_modules_tool(
     state: &AppState,
     arguments: &serde_json::Value,

--- a/crates/codelens-mcp/src/tools/mod.rs
+++ b/crates/codelens-mcp/src/tools/mod.rs
@@ -85,6 +85,7 @@ pub fn dispatch_table() -> HashMap<&'static str, crate::tool_defs::tool::ToolHan
         "get_callers"                  => graph::get_callers_tool,
         "get_callees"                  => graph::get_callees_tool,
         "find_circular_dependencies"   => graph::find_circular_dependencies_tool,
+        "find_orphan_handlers"         => graph::find_orphan_handlers_tool,
         "find_phantom_modules"         => graph::find_phantom_modules_tool,
         "find_redundant_definitions"   => graph::find_redundant_definitions_tool,
         "get_change_coupling"          => graph::get_change_coupling_tool,

--- a/crates/codelens-mcp/tools.toml
+++ b/crates/codelens-mcp/tools.toml
@@ -507,6 +507,18 @@ properties = { max_results = { type = "integer" } }
 # ─────
 
 [[tool]]
+name = "find_orphan_handlers"
+category = "analysis"
+description = "[CodeLens:Analysis] Find ToolHandler-shaped functions in `crates/codelens-mcp/src/tools/` that are NOT registered in `dispatch_table()`. Production audit for routing surface — overlaps the `dead_code` lint but emits structured (file, line, function) entries that are easier to act on than the warnings buffer. Known limitation: handler-shaped helpers shared between handlers (called from another `*_tool` function rather than dispatched directly) are reported but are not actually orphan; v2 will add workspace-wide path-reference check."
+annotations = "ro_a"
+
+[tool.input_schema]
+type = "object"
+properties = {}
+
+# ─────
+
+[[tool]]
 name = "find_phantom_modules"
 category = "analysis"
 description = "[CodeLens:Analysis] Find `mod NAME;` declarations whose name is never referenced as a path segment elsewhere in the workspace. Reports both private and public mods; visibility is included so callers can filter. Known limitation: impl-extension pattern (file split where the module only adds `impl X { ... }` to a parent type) is reported but is not actually phantom — manual review required."

--- a/crates/codelens-tui/Cargo.toml
+++ b/crates/codelens-tui/Cargo.toml
@@ -14,7 +14,7 @@ name = "codelens-tui"
 path = "src/main.rs"
 
 [dependencies]
-codelens-engine = { path = "../codelens-engine", version = "=1.13.6" }
+codelens-engine = { path = "../codelens-engine", version = "=1.13.7" }
 ratatui = "0.30"
 crossterm = "0.28"
 anyhow.workspace = true


### PR DESCRIPTION
**Phase 2-D**. Third dogfooding detector: ToolHandler-shaped functions in \`crates/codelens-mcp/src/tools/\` that are not registered in \`dispatch_table()\`.

## Why
Completes the Phase 2 trio identified during Phase 1-A dogfooding:
- v1.13.2 \`find_redundant_definitions\` — dead delegation
- v1.13.5 \`find_phantom_modules\` — dead \`mod\` lines
- v1.13.7 \`find_orphan_handlers\` — dead routing surface

## How
- \`HANDLER_SIG_RE\` matches \`pub fn NAME(state: &AppState, arguments: &Value) -> ToolResult\` (and underscore-prefix / qualified-Value variants).
- \`DISPATCH_ARM_RE\` matches \`\"tool_name\" => module::handler_name\` and captures the handler symbol.
- Orphan = handler-shaped functions \\ dispatched-handler-symbols.

## Dogfood result on this repo
1 hit (real but expected): \`eval_session_audit\` at \`eval_reports.rs:175\` — a handler-shaped helper called from another \`*_tool\` via \`reports::\` reexport. **Known v1 limitation** documented in the tool description; v2 will add workspace-wide path-reference checking so handler-helpers don't surface.

## Test
- 4 unit tests for regex shapes (canonical, underscore-prefix, dispatch arms)
- 1 ignored \`dogfood_self_repo\` test for stable reproduction
- \`cargo test -p codelens-mcp\` — 531 passed (was 527; +4 new, +0 regressions)
- \`cargo build --release --workspace\` — clean

## Other
Added \`regex.workspace = true\` to \`codelens-mcp/Cargo.toml\` (workspace already declared it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)