### PR TITLE
fix(v1.13.10): codex P2 cross-detector polish + audit dispatch/table integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-engine"
-version = "1.13.9"
+version = "1.13.10"
 dependencies = [
  "anyhow",
  "criterion",
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-mcp"
-version = "1.13.9"
+version = "1.13.10"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-tui"
-version = "1.13.9"
+version = "1.13.10"
 dependencies = [
  "anyhow",
  "codelens-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "Apache-2.0"
-version = "1.13.9"
+version = "1.13.10"
 description = "Harness-native Rust MCP server for code intelligence with generated surface governance, hybrid retrieval, and mutation-gated workflows"
 repository = "https://github.com/mupozg823/codelens-mcp-plugin"
 homepage = "https://github.com/mupozg823/codelens-mcp-plugin"

--- a/crates/codelens-engine/src/phantom_modules.rs
+++ b/crates/codelens-engine/src/phantom_modules.rs
@@ -117,10 +117,14 @@ fn scan_declarations(source: &str, file: &str, out: &mut Vec<PhantomModuleEntry>
     }
 }
 
-/// Returns true when the line immediately above `offset` is a
-/// `#[cfg(test)]`-style attribute. Walks one line back, skipping blank
-/// lines but not other attributes (so `#[derive(...)]` followed by mod
-/// is *not* treated as cfg-gated).
+/// Returns true when the line immediately above `offset` is a positive
+/// `#[cfg(test)]`-style attribute (i.e. test-only). Walks one line back,
+/// skipping blank lines but not other attributes.
+///
+/// Codex P2 (PR #154): the previous predicate matched any cfg attribute
+/// containing the substring `test`, which incorrectly skipped
+/// `#[cfg(not(test))] mod live;` (production-only). Now: explicit
+/// rejection of `not(test)` patterns.
 fn line_before_is_cfg_test(source: &str, offset: usize) -> bool {
     let line_start = source[..offset]
         .rfind('\n')
@@ -134,13 +138,26 @@ fn line_before_is_cfg_test(source: &str, offset: usize) -> bool {
         let prev_start = source[..prev_end].rfind('\n').map(|i| i + 1).unwrap_or(0);
         let prev_line = source[prev_start..prev_end].trim();
         if !prev_line.is_empty() {
-            return prev_line.starts_with("#[cfg") && prev_line.contains("test");
+            return is_positive_cfg_test_attribute(prev_line);
         }
         if prev_start == 0 {
             return false;
         }
         prev_end = prev_start - 1;
     }
+}
+
+fn is_positive_cfg_test_attribute(line: &str) -> bool {
+    if !line.starts_with("#[cfg") {
+        return false;
+    }
+    // Reject negation forms: `#[cfg(not(test))]`, `#[cfg(all(not(test), ...))]`,
+    // and `#[cfg(any(not(test), ...))]`. These gate code INTO production,
+    // not out of it.
+    if line.contains("not(test)") {
+        return false;
+    }
+    line.contains("test")
 }
 
 /// Adds every identifier that participates in any `::`-adjacent position
@@ -239,6 +256,21 @@ mod tests {
         scan_declarations("mod inline { fn x() {} }\n", "lib.rs", &mut decls);
         // inline `mod NAME { ... }` should NOT match (no trailing `;`)
         assert!(decls.is_empty(), "got: {:?}", decls);
+    }
+
+    #[test]
+    fn cfg_not_test_is_not_treated_as_cfg_test() {
+        // Codex P2 (PR #154): #[cfg(not(test))] is production-only — must NOT
+        // be skipped by the cfg-test filter.
+        let mut decls = Vec::new();
+        scan_declarations(
+            "#[cfg(not(test))]\nmod live;\n#[cfg(any(not(test), feature = \"x\"))]\nmod live2;\n",
+            "lib.rs",
+            &mut decls,
+        );
+        assert_eq!(decls.len(), 2, "got: {:?}", decls);
+        assert_eq!(decls[0].module_name, "live");
+        assert_eq!(decls[1].module_name, "live2");
     }
 
     #[test]

--- a/crates/codelens-mcp/Cargo.toml
+++ b/crates/codelens-mcp/Cargo.toml
@@ -37,7 +37,7 @@ regex.workspace = true
 rusqlite.workspace = true
 toml = "0.8"
 rustls = { workspace = true, optional = true }
-codelens-engine = { path = "../codelens-engine", version = "=1.13.9", default-features = false }
+codelens-engine = { path = "../codelens-engine", version = "=1.13.10", default-features = false }
 thiserror.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/codelens-mcp/src/surface_audit.rs
+++ b/crates/codelens-mcp/src/surface_audit.rs
@@ -26,6 +26,15 @@ static DISPATCH_ARM_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r#""(?P<tool>[A-Za-z_][A-Za-z0-9_]*)"\s*=>\s*[A-Za-z_][A-Za-z0-9_:]*::"#).unwrap()
 });
 
+/// Captures `m.insert("tool_name", ...)` form used by `dispatch/table.rs`
+/// for feature-gated handler registration on top of the structural
+/// `tools::dispatch_table()` map. v1 of this audit only saw the macro
+/// arm shape, so every semantic tool registered through `m.insert` was a
+/// false `missing_in_dispatch` (codex-style drift caught by dogfood).
+static DISPATCH_INSERT_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"\.insert\s*\(\s*"(?P<tool>[A-Za-z_][A-Za-z0-9_]*)"\s*,"#).unwrap()
+});
+
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub(crate) struct SurfaceAuditReport {
     pub missing_in_dispatch: Vec<String>,
@@ -37,24 +46,46 @@ pub(crate) struct SurfaceAuditReport {
 /// Builds a side-by-side audit. Both sets are alphabetized.
 pub(crate) fn audit_tool_surface_consistency(project_root: &Path) -> Result<SurfaceAuditReport> {
     let toml_path = project_root.join("crates/codelens-mcp/tools.toml");
-    let dispatch_path = project_root.join("crates/codelens-mcp/src/tools/mod.rs");
+    let dispatch_macro_path = project_root.join("crates/codelens-mcp/src/tools/mod.rs");
+    let dispatch_static_path = project_root.join("crates/codelens-mcp/src/dispatch/table.rs");
 
-    let toml_source = std::fs::read_to_string(&toml_path).unwrap_or_default();
-    let dispatch_source = std::fs::read_to_string(&dispatch_path).unwrap_or_default();
+    // Codex P2 (PR #155): propagate read errors instead of silently
+    // returning empty content. Missing files would otherwise produce a
+    // clean-looking but completely misleading "everything missing"
+    // report.
+    let toml_source = std::fs::read_to_string(&toml_path)
+        .map_err(|e| anyhow::anyhow!("read {}: {}", toml_path.display(), e))?;
+    let dispatch_macro_source = std::fs::read_to_string(&dispatch_macro_path)
+        .map_err(|e| anyhow::anyhow!("read {}: {}", dispatch_macro_path.display(), e))?;
+    // The combined static table at `dispatch/table.rs` is allowed to
+    // not exist on older checkouts; fall back to empty.
+    let dispatch_static_source = std::fs::read_to_string(&dispatch_static_path).unwrap_or_default();
+
     // dogfood-driven fix: doc comments inside the dispatch macro contain
     // placeholder strings like `"tool_name" => module::handler_fn` that
     // would otherwise pollute the captured set. Strip line comments
-    // before matching so only real macro arms feed the audit.
-    let dispatch_source = strip_line_comments(&dispatch_source);
+    // before matching so only real macro arms / inserts feed the audit.
+    let dispatch_macro_source = strip_line_comments(&dispatch_macro_source);
+    let dispatch_static_source = strip_line_comments(&dispatch_static_source);
 
     let toml_names: HashSet<String> = TOML_TOOL_NAME_RE
         .captures_iter(&toml_source)
         .filter_map(|c| c.name("name").map(|m| m.as_str().to_owned()))
         .collect();
-    let dispatch_names: HashSet<String> = DISPATCH_ARM_RE
-        .captures_iter(&dispatch_source)
+
+    // Tools registered via the `tool_registry!` macro arms in
+    // `tools/mod.rs`, plus tools registered via `m.insert("name", ...)`
+    // in `dispatch/table.rs` (feature-gated handlers). Both surfaces
+    // contribute to the runtime dispatch map.
+    let mut dispatch_names: HashSet<String> = DISPATCH_ARM_RE
+        .captures_iter(&dispatch_macro_source)
         .filter_map(|c| c.name("tool").map(|m| m.as_str().to_owned()))
         .collect();
+    for caps in DISPATCH_INSERT_RE.captures_iter(&dispatch_static_source) {
+        if let Some(m) = caps.name("tool") {
+            dispatch_names.insert(m.as_str().to_owned());
+        }
+    }
 
     let mut missing_in_dispatch: Vec<String> =
         toml_names.difference(&dispatch_names).cloned().collect();
@@ -111,6 +142,30 @@ category = "symbol"
         let source = r#""find_symbol" => symbols::find_symbol,"#;
         let m = DISPATCH_ARM_RE.captures(source).expect("match");
         assert_eq!(m.name("tool").unwrap().as_str(), "find_symbol");
+    }
+
+    #[test]
+    fn dispatch_insert_re_captures_inserted_tools() {
+        // dogfood-driven: dispatch/table.rs registers feature-gated tools
+        // via `m.insert("name", Arc::new(handler))` — initial v1 audit
+        // missed every one of these and reported false drift.
+        let source = r#"m.insert("semantic_search", std::sync::Arc::new(handler));"#;
+        let m = DISPATCH_INSERT_RE.captures(source).expect("match");
+        assert_eq!(m.name("tool").unwrap().as_str(), "semantic_search");
+    }
+
+    #[test]
+    fn missing_toml_file_is_propagated_as_error() {
+        // Codex P2 (PR #155): silent file-read failure made the audit
+        // misreport. Now both required files must exist.
+        let tmp = std::env::temp_dir().join("codelens-audit-empty");
+        let _ = std::fs::create_dir_all(&tmp);
+        let result = audit_tool_surface_consistency(&tmp);
+        assert!(
+            result.is_err(),
+            "missing tools.toml should error, got {:?}",
+            result
+        );
     }
 
     #[test]

--- a/crates/codelens-tui/Cargo.toml
+++ b/crates/codelens-tui/Cargo.toml
@@ -14,7 +14,7 @@ name = "codelens-tui"
 path = "src/main.rs"
 
 [dependencies]
-codelens-engine = { path = "../codelens-engine", version = "=1.13.9" }
+codelens-engine = { path = "../codelens-engine", version = "=1.13.10" }
 ratatui = "0.30"
 crossterm = "0.28"
 anyhow.workspace = true


### PR DESCRIPTION
**Three precision fixes** from codex review on PRs #154/#155 and the Phase 2-C dogfood loop itself.

## surface_audit (PR #155 P2 + dogfood) — recognize feature-gated dispatch
v1.13.9 reported 6 false \`missing_in_dispatch\` (\`semantic_search\`, \`classify_symbol\`, etc). They are all registered via \`m.insert(\"name\", Arc::new(handler))\` in \`dispatch/table.rs\` (the static table that wraps \`tools::dispatch_table()\` plus semantic feature-gated handlers). New \`DISPATCH_INSERT_RE\` covers that surface.

After fix: **116 toml × 116 dispatch, drift = 0**.

## surface_audit (PR #155 P2) — propagate read failures
\`unwrap_or_default()\` made a missing workspace look like a clean run. Required files now error with a path-tagged message; the optional \`dispatch/table.rs\` is still allowed to be absent.

## phantom_modules (PR #154 P2) — reject negation cfg attrs
Old predicate matched any \`#[cfg(...)] test\` substring, classifying \`#[cfg(not(test))] mod live;\` as test-only and skipping it. Fix: explicit \`not(test)\` rejection.

## Codex P2 deferred
PR #153 (orphan_handlers — module-qualified path tracking). Same-name collisions in \`tools/*\` are not present today; v2 will add module qualification together with the planned workspace-wide path-reference check that distinguishes shared helpers from real orphans.

## Verification
- 9 phantom_modules unit tests (added cfg_not_test_is_not_treated_as_cfg_test)
- 5 surface_audit unit tests (added dispatch_insert_re_captures_inserted_tools, missing_toml_file_is_propagated_as_error)
- \`cargo test -p codelens-mcp\` — 536 passed (+2)
- \`cargo build --release --workspace\` — clean

## Dogfood result on this repo (v1.13.10)
| Detector | Entries |
|----------|---------|
| find_redundant_definitions | 4 |
| find_phantom_modules | 13 (state.rs split-impl pattern) |
| find_orphan_handlers | 1 (handler-helper, documented limit) |
| audit_tool_surface_consistency | **0 drift** (fixed via dispatch/table.rs scan) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)