### PR TITLE
chore(v1.13.14): remove dead source param from to_symbol_info_with_source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-engine"
-version = "1.13.13"
+version = "1.13.14"
 dependencies = [
  "anyhow",
  "criterion",
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-mcp"
-version = "1.13.13"
+version = "1.13.14"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-tui"
-version = "1.13.13"
+version = "1.13.14"
 dependencies = [
  "anyhow",
  "codelens-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "Apache-2.0"
-version = "1.13.13"
+version = "1.13.14"
 description = "Harness-native Rust MCP server for code intelligence with generated surface governance, hybrid retrieval, and mutation-gated workflows"
 repository = "https://github.com/mupozg823/codelens-mcp-plugin"
 homepage = "https://github.com/mupozg823/codelens-mcp-plugin"

--- a/crates/codelens-engine/src/symbols/parser.rs
+++ b/crates/codelens-engine/src/symbols/parser.rs
@@ -1,5 +1,5 @@
+use super::types::{make_symbol_id, ParsedSymbol, SymbolInfo, SymbolKind, SymbolProvenance};
 use super::LanguageConfig;
-use super::types::{ParsedSymbol, SymbolInfo, SymbolKind, SymbolProvenance, make_symbol_id};
 use anyhow::{Context, Result};
 use std::collections::{HashSet, VecDeque};
 use std::sync::{Arc, LazyLock, Mutex};
@@ -115,19 +115,11 @@ pub(crate) fn flatten_symbol_infos(mut symbol: SymbolInfo) -> Vec<SymbolInfo> {
 }
 
 pub(crate) fn to_symbol_info(symbol: ParsedSymbol, depth: usize) -> SymbolInfo {
-    to_symbol_info_with_source(symbol, depth, None)
-}
-
-pub(crate) fn to_symbol_info_with_source(
-    symbol: ParsedSymbol,
-    depth: usize,
-    source: Option<&str>,
-) -> SymbolInfo {
     let children = if depth == 0 || depth > 1 {
         symbol
             .children
             .into_iter()
-            .map(|child| to_symbol_info_with_source(child, depth.saturating_sub(1), source))
+            .map(|child| to_symbol_info(child, depth.saturating_sub(1)))
             .collect()
     } else {
         Vec::new()
@@ -145,9 +137,7 @@ pub(crate) fn to_symbol_info_with_source(
         name_path: symbol.name_path,
         id,
         provenance,
-        body: source
-            .map(|source| slice_source(source, symbol.start_byte, symbol.end_byte))
-            .or(symbol.body),
+        body: symbol.body,
         children,
         start_byte: symbol.start_byte,
         end_byte: symbol.end_byte,

--- a/crates/codelens-mcp/Cargo.toml
+++ b/crates/codelens-mcp/Cargo.toml
@@ -37,7 +37,7 @@ regex.workspace = true
 rusqlite.workspace = true
 toml = "0.8"
 rustls = { workspace = true, optional = true }
-codelens-engine = { path = "../codelens-engine", version = "=1.13.13", default-features = false }
+codelens-engine = { path = "../codelens-engine", version = "=1.13.14", default-features = false }
 thiserror.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/codelens-tui/Cargo.toml
+++ b/crates/codelens-tui/Cargo.toml
@@ -14,7 +14,7 @@ name = "codelens-tui"
 path = "src/main.rs"
 
 [dependencies]
-codelens-engine = { path = "../codelens-engine", version = "=1.13.13" }
+codelens-engine = { path = "../codelens-engine", version = "=1.13.14" }
 ratatui = "0.30"
 crossterm = "0.28"
 anyhow.workspace = true


### PR DESCRIPTION
## Summary

Closes one of 4 wrappers reported by `find_redundant_definitions` v2.
`to_symbol_info` was the only one where the inner function had **zero
external callers** — meaning the `source: Option<&str>` parameter was
always passed `None`, making the body-slicing branch unreachable.

## Workspace audit (4 wrappers)

| Wrapper | Inner external callers | Wrapper external callers | Action |
|---------|------------------------|--------------------------|--------|
| `build_host_adapters` | 1 (production) | 1 (production) | preserve — ergonomic |
| `record_call` | 1 (production) | 14 (tests) | preserve — test convenience |
| `search_symbols_hybrid` | 1 (production) | 5 (bench) | preserve — bench API |
| `to_symbol_info` | **0** | 6 | **remove inner + dead param** |

## What changed

- Collapse `to_symbol_info_with_source` into `to_symbol_info`
- Drop `source: Option<&str>` parameter (always `None`)
- Drop unreachable `body: source.map(...).or(symbol.body)` → `body: symbol.body`
- `slice_source` itself stays — used by ranking.rs, mod.rs, reader.rs

## Dogfood progression for `find_redundant_definitions`

| Version | Entries | Notes |
|---------|---------|-------|
| v1.13.4  | 39 | initial regex (closure-arg false positives) |
| v1.13.6  | 4  | P1 fixes (closure args, cfg(test) ranges) |
| v1.13.14 | 3  | real wrapper deleted; remaining are legitimate ergonomic APIs |

## Test plan
- [x] `cargo build --release --workspace` (57s)
- [x] `cargo check --workspace` (3.81s)
- [x] `cargo test -p codelens-engine --lib` (361 passed, 0 failed)
- [x] `find_redundant_definitions` dogfood: 4 → 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)