### PR TITLE
refactor(v1.13.15): split surface_manifest.rs into runtime vs docs/export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-engine"
-version = "1.13.14"
+version = "1.13.15"
 dependencies = [
  "anyhow",
  "criterion",
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-mcp"
-version = "1.13.14"
+version = "1.13.15"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-tui"
-version = "1.13.14"
+version = "1.13.15"
 dependencies = [
  "anyhow",
  "codelens-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "Apache-2.0"
-version = "1.13.14"
+version = "1.13.15"
 description = "Harness-native Rust MCP server for code intelligence with generated surface governance, hybrid retrieval, and mutation-gated workflows"
 repository = "https://github.com/mupozg823/codelens-mcp-plugin"
 homepage = "https://github.com/mupozg823/codelens-mcp-plugin"

--- a/crates/codelens-mcp/Cargo.toml
+++ b/crates/codelens-mcp/Cargo.toml
@@ -37,7 +37,7 @@ regex.workspace = true
 rusqlite.workspace = true
 toml = "0.8"
 rustls = { workspace = true, optional = true }
-codelens-engine = { path = "../codelens-engine", version = "=1.13.14", default-features = false }
+codelens-engine = { path = "../codelens-engine", version = "=1.13.15", default-features = false }
 thiserror.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/codelens-mcp/src/surface_manifest.rs
+++ b/crates/codelens-mcp/src/surface_manifest.rs
@@ -8,8 +8,11 @@ use crate::tool_defs::{
 use serde_json::{Value, json};
 use std::collections::{BTreeMap, BTreeSet};
 
+mod exports;
 mod harness;
 mod host_adapters;
+use exports::{build_agent_experience, build_harness_artifacts_summary};
+pub(crate) use exports::handoff_artifact_schema_json;
 use harness::{build_harness_modes, build_harness_spec};
 use host_adapters::{build_host_adapters, build_host_adapters_for_project};
 pub(crate) use host_adapters::{
@@ -21,7 +24,6 @@ pub(crate) const HARNESS_MODES_SCHEMA_VERSION: &str = "codelens-harness-modes-v1
 pub(crate) const HARNESS_SPEC_SCHEMA_VERSION: &str = "codelens-harness-spec-v1";
 pub(crate) const HOST_ADAPTERS_SCHEMA_VERSION: &str = "codelens-host-adapters-v1";
 pub(crate) const HARNESS_HOST_COMPAT_SCHEMA_VERSION: &str = "codelens-harness-host-v1";
-pub(crate) const AGENT_EXPERIENCE_SCHEMA_VERSION: &str = "codelens-agent-experience-v1";
 pub(crate) const HOST_ADAPTER_HOSTS: [&str; 5] =
     ["claude-code", "codex", "cursor", "cline", "windsurf"];
 #[cfg(feature = "http")]
@@ -29,15 +31,8 @@ pub(crate) const SURFACE_MANIFEST_DOC_PATH: &str = "docs/generated/surface-manif
 pub(crate) const HOST_ADAPTERS_DOC_PATH: &str = "docs/host-adaptive-harness.md";
 pub(crate) const HOST_ADAPTERS_RESOURCE_URI: &str = "codelens://harness/host-adapters";
 pub(crate) const HARNESS_HOST_COMPAT_RESOURCE_URI: &str = "codelens://harness/host";
-pub(crate) const AGENT_EXPERIENCE_DOC_PATH: &str = "docs/design/symbiote-ux-flows-v1.md";
-pub(crate) const AGENT_EXPERIENCE_RESOURCE_URI: &str = "codelens://design/agent-experience";
-pub(crate) const HANDOFF_ARTIFACT_SCHEMA_DOC_PATH: &str = "docs/schemas/handoff-artifact.v1.json";
-pub(crate) const HANDOFF_ARTIFACT_SCHEMA_RESOURCE_URI: &str =
-    "codelens://schemas/handoff-artifact/v1";
 
 const WORKSPACE_CARGO_TOML: &str = include_str!(concat!(env!("OUT_DIR"), "/workspace-cargo-toml"));
-const HANDOFF_ARTIFACT_SCHEMA_TEXT: &str =
-    include_str!(concat!(env!("OUT_DIR"), "/handoff-artifact.v1.json"));
 
 pub(crate) fn build_surface_manifest_for_state(state: &AppState) -> Value {
     let mut manifest = build_surface_manifest(*state.surface(), state.daemon_mode());
@@ -280,204 +275,6 @@ fn server_card_features() -> Vec<&'static str> {
         features.push("scip-precise-backend");
     }
     features
-}
-
-fn build_agent_experience() -> Value {
-    json!({
-        "schema_version": AGENT_EXPERIENCE_SCHEMA_VERSION,
-        "runtime_resource": AGENT_EXPERIENCE_RESOURCE_URI,
-        "doc_path": AGENT_EXPERIENCE_DOC_PATH,
-        "goal": "Expose a portable product and agent-flow contract that both humans and agent hosts can consume directly.",
-        "naming_policy": {
-            "public_primary_name": "CodeLens MCP",
-            "transition_codename": "Symbiote",
-            "runtime_aliases": ["symbiote://", "SYMBIOTE_*"],
-            "public_cutover_status": "blocked_pending_trademark_clearance",
-            "reason_codes": [
-                "existing_live_symbiote_marks_in_software_adjacent_classes",
-                "marvel_dominates_bare_symbiote_search_results",
-                "linux_rootkit_search_overlap"
-            ],
-            "rule": "Keep the product architecture and UX metaphor symbiotic, but do not flip the public primary install/docs/binary name until clearance is complete."
-        },
-        "information_architecture": {
-            "core_surfaces": [
-                {
-                    "id": "attach",
-                    "audience": ["human", "host"],
-                    "purpose": "Install, verify, and attach the MCP server to a host in under one minute."
-                },
-                {
-                    "id": "session_overview",
-                    "audience": ["human", "agent"],
-                    "purpose": "Show active profile, visible surface, health, and current session scope."
-                },
-                {
-                    "id": "task_router",
-                    "audience": ["agent"],
-                    "purpose": "Translate task phase and risk into role profile, preferred executor, and next-tool shortlist."
-                },
-                {
-                    "id": "audit_timeline",
-                    "audience": ["human", "agent", "ci"],
-                    "purpose": "Summarize bootstrap, verifier, mutation, and signoff evidence per session."
-                },
-                {
-                    "id": "handoff_inspector",
-                    "audience": ["human", "agent"],
-                    "purpose": "Inspect planner/builder/reviewer artifacts and synthetic delegation scaffolds without reading raw chat history."
-                },
-                {
-                    "id": "detach_or_migrate",
-                    "audience": ["human", "ops"],
-                    "purpose": "Remove or migrate the attachment cleanly without residue."
-                }
-            ]
-        },
-        "user_flow": {
-            "north_star": "under_60_seconds_to_first_compressed_answer",
-            "steps": [
-                "install_or_verify_binary",
-                "attach_to_host",
-                "prepare_harness_session",
-                "analyze_change_request",
-                "optional_audit_and_export"
-            ]
-        },
-        "agent_flow": {
-            "bootstrap_sequence": [
-                "prepare_harness_session",
-                "tools/list",
-                "analyze_change_request or get_ranked_context"
-            ],
-            "role_lattice": [
-                "planner-readonly",
-                "builder-minimal",
-                "reviewer-graph",
-                "refactor-full",
-                "evaluator-compact",
-                "ci-audit",
-                "workflow-first"
-            ],
-            "delegation_contract": {
-                "preferred_executor_field": "_meta.codelens/preferredExecutor",
-                "synthetic_delegate_action": "delegate_to_codex_builder",
-                "required_payload_fields": [
-                    "handoff_id",
-                    "delegate_tool",
-                    "delegate_arguments",
-                    "carry_forward",
-                    "briefing"
-                ],
-                "replay_rule": "preserve delegate_tool, delegate_arguments, carry_forward, and handoff_id verbatim for the first delegated builder call",
-                "correlation_rule": "hosts should replay delegate_arguments.handoff_id unchanged so planner-side delegate emission and builder-side execution can be correlated across sessions"
-            }
-        },
-        "host_guardrails": {
-            "delegate_scaffold": [
-                "treat delegate_to_codex_builder as synthetic advisory host action, not a server-callable tool",
-                "do not reconstruct delegated builder arguments from prose when delegate_arguments are present",
-                "preserve handoff_id at the scaffold top level and inside delegate_arguments for the first builder-heavy call"
-            ],
-            "session_closeout": [
-                "use export_session_markdown(session_id=...) as the canonical per-session artifact source",
-                "keep eval_session_audit as a runtime-scoped aggregate operator lane, not a stop-hook replacement"
-            ]
-        },
-        "telemetry_contract": {
-            "jsonl_fields": [
-                "delegate_hint_trigger",
-                "delegate_target_tool",
-                "delegate_handoff_id",
-                "handoff_id"
-            ],
-            "purpose": "measure delegate emission, builder consumption, and cross-session correlation without persisting tool arguments or user query text"
-        },
-        "tool_flow": {
-            "discover": [
-                "analyze_change_request",
-                "get_ranked_context"
-            ],
-            "investigate": [
-                "find_symbol",
-                "find_referencing_symbols",
-                "get_symbols_overview",
-                "semantic_search"
-            ],
-            "act": [
-                "plan_safe_refactor",
-                "verify_change_readiness",
-                "mutation_tools",
-                "review_changes"
-            ],
-            "verify": [
-                "get_file_diagnostics",
-                "audit_builder_session",
-                "audit_planner_session"
-            ],
-            "handoff": [
-                "export_session_markdown",
-                HANDOFF_ARTIFACT_SCHEMA_RESOURCE_URI
-            ]
-        },
-        "reference_flow": {
-            "primary_path": [
-                "find_symbol",
-                "find_referencing_symbols",
-                "get_impact_analysis",
-                "get_type_hierarchy"
-            ],
-            "fallback_ladder": [
-                "find_symbol",
-                "semantic_search",
-                "get_ranked_context",
-                "host_native_grep"
-            ]
-        },
-        "harness_flow": {
-            "recommended_modes": [
-                "solo-local",
-                "planner-builder",
-                "reviewer-gate",
-                "batch-analysis"
-            ],
-            "runtime_resources": [
-                "codelens://harness/modes",
-                "codelens://harness/spec",
-                HOST_ADAPTERS_RESOURCE_URI
-            ],
-            "host_resources": HOST_ADAPTER_HOSTS
-                .iter()
-                .map(|host| format!("codelens://host-adapters/{host}"))
-                .collect::<Vec<_>>()
-        }
-    })
-}
-
-pub(crate) fn handoff_artifact_schema_json() -> Value {
-    serde_json::from_str(HANDOFF_ARTIFACT_SCHEMA_TEXT)
-        .expect("handoff artifact schema must be valid JSON")
-}
-
-fn build_harness_artifacts_summary() -> Value {
-    let schema = handoff_artifact_schema_json();
-    let kinds = schema["properties"]["kind"]["enum"]
-        .as_array()
-        .cloned()
-        .unwrap_or_default();
-    json!({
-        "schemas": [
-            {
-                "name": "handoff-artifact-v1",
-                "title": schema["title"],
-                "schema_id": schema["$id"],
-                "schema_version": schema["properties"]["schema_version"]["const"],
-                "runtime_resource": HANDOFF_ARTIFACT_SCHEMA_RESOURCE_URI,
-                "doc_path": HANDOFF_ARTIFACT_SCHEMA_DOC_PATH,
-                "kinds": kinds,
-            }
-        ]
-    })
 }
 
 fn preset_label(preset: ToolPreset) -> &'static str {

--- a/crates/codelens-mcp/src/surface_manifest/exports.rs
+++ b/crates/codelens-mcp/src/surface_manifest/exports.rs
@@ -1,0 +1,220 @@
+//! Docs/export adapters for the surface manifest — agent-experience
+//! contract, handoff artifact schema, and harness artifact summary.
+//!
+//! Separated from `surface_manifest.rs` per the 2026-04-24 architecture
+//! audit P2.1 ("split surface_manifest.rs into runtime manifest vs
+//! docs/export adapters"). Runtime manifest concerns — server card,
+//! language inventory, profile/preset enumeration — stay in the parent
+//! module; this file owns the static contract surfaces consumed by
+//! external docs and resource URIs.
+
+use super::HOST_ADAPTER_HOSTS;
+use serde_json::{json, Value};
+
+pub(crate) const AGENT_EXPERIENCE_SCHEMA_VERSION: &str = "codelens-agent-experience-v1";
+pub(crate) const AGENT_EXPERIENCE_DOC_PATH: &str = "docs/design/symbiote-ux-flows-v1.md";
+pub(crate) const AGENT_EXPERIENCE_RESOURCE_URI: &str = "codelens://design/agent-experience";
+pub(crate) const HANDOFF_ARTIFACT_SCHEMA_DOC_PATH: &str = "docs/schemas/handoff-artifact.v1.json";
+pub(crate) const HANDOFF_ARTIFACT_SCHEMA_RESOURCE_URI: &str =
+    "codelens://schemas/handoff-artifact/v1";
+
+const HANDOFF_ARTIFACT_SCHEMA_TEXT: &str =
+    include_str!(concat!(env!("OUT_DIR"), "/handoff-artifact.v1.json"));
+
+pub(super) fn build_agent_experience() -> Value {
+    json!({
+        "schema_version": AGENT_EXPERIENCE_SCHEMA_VERSION,
+        "runtime_resource": AGENT_EXPERIENCE_RESOURCE_URI,
+        "doc_path": AGENT_EXPERIENCE_DOC_PATH,
+        "goal": "Expose a portable product and agent-flow contract that both humans and agent hosts can consume directly.",
+        "naming_policy": {
+            "public_primary_name": "CodeLens MCP",
+            "transition_codename": "Symbiote",
+            "runtime_aliases": ["symbiote://", "SYMBIOTE_*"],
+            "public_cutover_status": "blocked_pending_trademark_clearance",
+            "reason_codes": [
+                "existing_live_symbiote_marks_in_software_adjacent_classes",
+                "marvel_dominates_bare_symbiote_search_results",
+                "linux_rootkit_search_overlap"
+            ],
+            "rule": "Keep the product architecture and UX metaphor symbiotic, but do not flip the public primary install/docs/binary name until clearance is complete."
+        },
+        "information_architecture": {
+            "core_surfaces": [
+                {
+                    "id": "attach",
+                    "audience": ["human", "host"],
+                    "purpose": "Install, verify, and attach the MCP server to a host in under one minute."
+                },
+                {
+                    "id": "session_overview",
+                    "audience": ["human", "agent"],
+                    "purpose": "Show active profile, visible surface, health, and current session scope."
+                },
+                {
+                    "id": "task_router",
+                    "audience": ["agent"],
+                    "purpose": "Translate task phase and risk into role profile, preferred executor, and next-tool shortlist."
+                },
+                {
+                    "id": "audit_timeline",
+                    "audience": ["human", "agent", "ci"],
+                    "purpose": "Summarize bootstrap, verifier, mutation, and signoff evidence per session."
+                },
+                {
+                    "id": "handoff_inspector",
+                    "audience": ["human", "agent"],
+                    "purpose": "Inspect planner/builder/reviewer artifacts and synthetic delegation scaffolds without reading raw chat history."
+                },
+                {
+                    "id": "detach_or_migrate",
+                    "audience": ["human", "ops"],
+                    "purpose": "Remove or migrate the attachment cleanly without residue."
+                }
+            ]
+        },
+        "user_flow": {
+            "north_star": "under_60_seconds_to_first_compressed_answer",
+            "steps": [
+                "install_or_verify_binary",
+                "attach_to_host",
+                "prepare_harness_session",
+                "analyze_change_request",
+                "optional_audit_and_export"
+            ]
+        },
+        "agent_flow": {
+            "bootstrap_sequence": [
+                "prepare_harness_session",
+                "tools/list",
+                "analyze_change_request or get_ranked_context"
+            ],
+            "role_lattice": [
+                "planner-readonly",
+                "builder-minimal",
+                "reviewer-graph",
+                "refactor-full",
+                "evaluator-compact",
+                "ci-audit",
+                "workflow-first"
+            ],
+            "delegation_contract": {
+                "preferred_executor_field": "_meta.codelens/preferredExecutor",
+                "synthetic_delegate_action": "delegate_to_codex_builder",
+                "required_payload_fields": [
+                    "handoff_id",
+                    "delegate_tool",
+                    "delegate_arguments",
+                    "carry_forward",
+                    "briefing"
+                ],
+                "replay_rule": "preserve delegate_tool, delegate_arguments, carry_forward, and handoff_id verbatim for the first delegated builder call",
+                "correlation_rule": "hosts should replay delegate_arguments.handoff_id unchanged so planner-side delegate emission and builder-side execution can be correlated across sessions"
+            }
+        },
+        "host_guardrails": {
+            "delegate_scaffold": [
+                "treat delegate_to_codex_builder as synthetic advisory host action, not a server-callable tool",
+                "do not reconstruct delegated builder arguments from prose when delegate_arguments are present",
+                "preserve handoff_id at the scaffold top level and inside delegate_arguments for the first builder-heavy call"
+            ],
+            "session_closeout": [
+                "use export_session_markdown(session_id=...) as the canonical per-session artifact source",
+                "keep eval_session_audit as a runtime-scoped aggregate operator lane, not a stop-hook replacement"
+            ]
+        },
+        "telemetry_contract": {
+            "jsonl_fields": [
+                "delegate_hint_trigger",
+                "delegate_target_tool",
+                "delegate_handoff_id",
+                "handoff_id"
+            ],
+            "purpose": "measure delegate emission, builder consumption, and cross-session correlation without persisting tool arguments or user query text"
+        },
+        "tool_flow": {
+            "discover": [
+                "analyze_change_request",
+                "get_ranked_context"
+            ],
+            "investigate": [
+                "find_symbol",
+                "find_referencing_symbols",
+                "get_symbols_overview",
+                "semantic_search"
+            ],
+            "act": [
+                "plan_safe_refactor",
+                "verify_change_readiness",
+                "mutation_tools",
+                "review_changes"
+            ],
+            "verify": [
+                "get_file_diagnostics",
+                "audit_builder_session",
+                "audit_planner_session"
+            ],
+            "handoff": [
+                "export_session_markdown",
+                HANDOFF_ARTIFACT_SCHEMA_RESOURCE_URI
+            ]
+        },
+        "reference_flow": {
+            "primary_path": [
+                "find_symbol",
+                "find_referencing_symbols",
+                "get_impact_analysis",
+                "get_type_hierarchy"
+            ],
+            "fallback_ladder": [
+                "find_symbol",
+                "semantic_search",
+                "get_ranked_context",
+                "host_native_grep"
+            ]
+        },
+        "harness_flow": {
+            "recommended_modes": [
+                "solo-local",
+                "planner-builder",
+                "reviewer-gate",
+                "batch-analysis"
+            ],
+            "runtime_resources": [
+                "codelens://harness/modes",
+                "codelens://harness/spec",
+                super::HOST_ADAPTERS_RESOURCE_URI
+            ],
+            "host_resources": HOST_ADAPTER_HOSTS
+                .iter()
+                .map(|host| format!("codelens://host-adapters/{host}"))
+                .collect::<Vec<_>>()
+        }
+    })
+}
+
+pub(crate) fn handoff_artifact_schema_json() -> Value {
+    serde_json::from_str(HANDOFF_ARTIFACT_SCHEMA_TEXT)
+        .expect("handoff artifact schema must be valid JSON")
+}
+
+pub(super) fn build_harness_artifacts_summary() -> Value {
+    let schema = handoff_artifact_schema_json();
+    let kinds = schema["properties"]["kind"]["enum"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    json!({
+        "schemas": [
+            {
+                "name": "handoff-artifact-v1",
+                "title": schema["title"],
+                "schema_id": schema["$id"],
+                "schema_version": schema["properties"]["schema_version"]["const"],
+                "runtime_resource": HANDOFF_ARTIFACT_SCHEMA_RESOURCE_URI,
+                "doc_path": HANDOFF_ARTIFACT_SCHEMA_DOC_PATH,
+                "kinds": kinds,
+            }
+        ]
+    })
+}

--- a/crates/codelens-mcp/src/surface_manifest/tests.rs
+++ b/crates/codelens-mcp/src/surface_manifest/tests.rs
@@ -1,3 +1,4 @@
+use super::exports::HANDOFF_ARTIFACT_SCHEMA_RESOURCE_URI;
 use super::*;
 use crate::tool_defs::ToolProfile;
 use std::fs;
@@ -31,12 +32,10 @@ fn manifest_matches_registry_counts() {
     );
     assert_eq!(
         manifest["tool_registry"]["output_schema_count"],
-        json!(
-            tools()
-                .iter()
-                .filter(|tool| tool.output_schema.is_some())
-                .count()
-        )
+        json!(tools()
+            .iter()
+            .filter(|tool| tool.output_schema.is_some())
+            .count())
     );
     assert_eq!(
         manifest["runtime"]["visible_tool_count"],
@@ -60,28 +59,21 @@ fn manifest_matches_registry_counts() {
         manifest["harness_spec"]["schema_version"],
         json!(HARNESS_SPEC_SCHEMA_VERSION)
     );
-    assert!(
-        manifest["harness_modes"]["modes"]
-            .as_array()
-            .is_some_and(|modes| modes
-                .iter()
-                .any(|mode| mode["name"] == json!("planner-builder")))
-    );
-    assert!(
-        manifest["harness_spec"]["contracts"]
-            .as_array()
-            .is_some_and(|contracts| contracts
-                .iter()
-                .any(|contract| contract["name"] == json!("planner-builder-handoff")))
-    );
-    assert!(
-        manifest["harness_artifacts"]["schemas"]
-            .as_array()
-            .is_some_and(|schemas| schemas
-                .iter()
-                .any(|schema| schema["runtime_resource"]
-                    == json!(HANDOFF_ARTIFACT_SCHEMA_RESOURCE_URI)))
-    );
+    assert!(manifest["harness_modes"]["modes"]
+        .as_array()
+        .is_some_and(|modes| modes
+            .iter()
+            .any(|mode| mode["name"] == json!("planner-builder"))));
+    assert!(manifest["harness_spec"]["contracts"]
+        .as_array()
+        .is_some_and(|contracts| contracts
+            .iter()
+            .any(|contract| contract["name"] == json!("planner-builder-handoff"))));
+    assert!(manifest["harness_artifacts"]["schemas"]
+        .as_array()
+        .is_some_and(|schemas| schemas.iter().any(
+            |schema| schema["runtime_resource"] == json!(HANDOFF_ARTIFACT_SCHEMA_RESOURCE_URI)
+        )));
 
     let manifest_profiles = manifest["surfaces"]["profiles"]
         .as_array()

--- a/crates/codelens-tui/Cargo.toml
+++ b/crates/codelens-tui/Cargo.toml
@@ -14,7 +14,7 @@ name = "codelens-tui"
 path = "src/main.rs"
 
 [dependencies]
-codelens-engine = { path = "../codelens-engine", version = "=1.13.14" }
+codelens-engine = { path = "../codelens-engine", version = "=1.13.15" }
 ratatui = "0.30"
 crossterm = "0.28"
 anyhow.workspace = true


### PR DESCRIPTION
## Summary

Per architecture audit P2.1 (2026-04-24): split surface_manifest.rs
into runtime manifest concerns and docs/export adapter concerns.

## Audit reference

> P2.1: Split surface_manifest.rs into runtime manifest vs docs/export adapters.
> — docs/architecture-audit-2026-04-24.md:309

## What moved

| Item | From | To |
|------|------|-----|
| `build_agent_experience()` (171 LOC contract data) | surface_manifest.rs | surface_manifest/exports.rs |
| `handoff_artifact_schema_json()` (pub(crate)) | surface_manifest.rs | surface_manifest/exports.rs |
| `build_harness_artifacts_summary()` | surface_manifest.rs | surface_manifest/exports.rs |
| `AGENT_EXPERIENCE_SCHEMA_VERSION` + 4 sibling consts | surface_manifest.rs | surface_manifest/exports.rs |
| `HANDOFF_ARTIFACT_SCHEMA_TEXT` (include_str body) | surface_manifest.rs | surface_manifest/exports.rs |

## What stayed (runtime)

- `build_surface_manifest`, `build_surface_manifest_for_state`
- `build_server_card`, `transport_support`, `server_card_features`
- `workspace_members`, `build_language_inventory`, `LanguageFamily`
- `preset_label`
- Schema version constants tied to runtime registry shape

## LOC distribution

| File | Before | After |
|------|--------|-------|
| surface_manifest.rs | 609 | 406 (-203) |
| surface_manifest/exports.rs | 0 | 220 (+220, new) |

## Path preservation

`resources.rs:314` calls `crate::surface_manifest::handoff_artifact_schema_json()`.
A `pub(crate) use exports::handoff_artifact_schema_json` re-export from
the parent module preserves that path — no caller changes.

## Test plan

- [x] `cargo build --release --workspace` (59s)
- [x] `cargo check --workspace` (clean)
- [x] `cargo test -p codelens-mcp --bin codelens-mcp` (536 passed, 0 failed)
- [x] `surface_manifest::tests::*` (3 passed including manifest_matches_registry_counts)

Pure refactor. Zero behavior change.

## Follow-up candidate

The 4 docs/export constants (`AGENT_EXPERIENCE_*`, `HANDOFF_ARTIFACT_SCHEMA_DOC_PATH`)
have only same-module references but stayed `pub(crate)` to keep this
PR scoped. v1.13.16+ can tighten them to `pub(super)` or private.

🤖 Generated with [Claude Code](https://claude.com/claude-code)