### PR TITLE
feat(v1.13.16): PageRank import-graph importance signal in symbol ranking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-engine"
-version = "1.13.15"
+version = "1.13.16"
 dependencies = [
  "anyhow",
  "criterion",
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-mcp"
-version = "1.13.15"
+version = "1.13.16"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-tui"
-version = "1.13.15"
+version = "1.13.16"
 dependencies = [
  "anyhow",
  "codelens-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "Apache-2.0"
-version = "1.13.15"
+version = "1.13.16"
 description = "Harness-native Rust MCP server for code intelligence with generated surface governance, hybrid retrieval, and mutation-gated workflows"
 repository = "https://github.com/mupozg823/codelens-mcp-plugin"
 homepage = "https://github.com/mupozg823/codelens-mcp-plugin"

--- a/crates/codelens-engine/src/search.rs
+++ b/crates/codelens-engine/src/search.rs
@@ -23,6 +23,11 @@ pub struct SearchResult {
     pub match_type: String, // "exact", "substring", "fuzzy"
 }
 
+/// Maximum PageRank boost added to a result when its file ranks at the top
+/// of the import graph. Sized to be smaller than fuzzy/FTS spread so it tilts
+/// near-ties toward globally important files without overpowering text relevance.
+pub const PAGERANK_MAX_BOOST: f64 = 5.0;
+
 /// Hybrid symbol search: exact → FTS5 → fuzzy → semantic.
 ///
 /// `fuzzy_threshold` — minimum jaro_winkler similarity (0.0–1.0).
@@ -37,16 +42,22 @@ pub fn search_symbols_hybrid(
     max_results: usize,
     fuzzy_threshold: f64,
 ) -> Result<Vec<SearchResult>> {
-    search_symbols_hybrid_with_semantic(project, query, max_results, fuzzy_threshold, None)
+    search_symbols_hybrid_with_semantic(project, query, max_results, fuzzy_threshold, None, None)
 }
 
-/// Full hybrid search with optional semantic scores.
+/// Full hybrid search with optional semantic scores and PageRank file importance.
+///
+/// `pagerank_scores` — optional per-file PageRank values from `GraphCache::file_pagerank_scores`.
+/// When supplied, the top-ranked file in the import graph gains `PAGERANK_MAX_BOOST`
+/// points; lower-ranked files scale linearly. The boost is applied before the
+/// final sort so it can break near-ties between text-relevance matches.
 pub fn search_symbols_hybrid_with_semantic(
     project: &ProjectRoot,
     query: &str,
     max_results: usize,
     fuzzy_threshold: f64,
     semantic_scores: Option<&std::collections::HashMap<String, f64>>,
+    pagerank_scores: Option<&std::collections::HashMap<String, f64>>,
 ) -> Result<Vec<SearchResult>> {
     let db_path = index_db_path(project.as_path());
     let db = IndexDb::open(&db_path)?;
@@ -162,6 +173,10 @@ pub fn search_symbols_hybrid_with_semantic(
         }
     }
 
+    if let Some(pr) = pagerank_scores {
+        apply_pagerank_boost(&mut results, pr, PAGERANK_MAX_BOOST);
+    }
+
     results.sort_by(|a, b| {
         b.score
             .partial_cmp(&a.score)
@@ -191,6 +206,29 @@ pub fn search_symbols_hybrid_with_semantic(
 
     results.truncate(max_results);
     Ok(results)
+}
+
+/// Adds a PageRank-derived boost (0 .. `max_boost`) to each result based on
+/// where its file ranks in the import graph. Uses max-normalization so the
+/// boost magnitude is independent of graph size or absolute PageRank values.
+/// Applied in-place before the final sort.
+fn apply_pagerank_boost(
+    results: &mut [SearchResult],
+    pagerank_scores: &std::collections::HashMap<String, f64>,
+    max_boost: f64,
+) {
+    let max_pr = pagerank_scores
+        .values()
+        .copied()
+        .fold(0.0_f64, f64::max);
+    if max_pr <= 0.0 {
+        return;
+    }
+    for result in results.iter_mut() {
+        if let Some(&pr) = pagerank_scores.get(&result.file) {
+            result.score += (pr / max_pr) * max_boost;
+        }
+    }
 }
 
 #[cfg(test)]
@@ -328,6 +366,7 @@ mod tests {
             10,
             0.99, // high fuzzy threshold to disable fuzzy path
             Some(&scores),
+            None,
         )
         .unwrap();
 
@@ -354,9 +393,15 @@ mod tests {
         let mut scores = std::collections::HashMap::new();
         scores.insert("main.py:ServiceManager".to_owned(), 0.9);
 
-        let boosted =
-            search_symbols_hybrid_with_semantic(&project, "ServiceManager", 10, 0.5, Some(&scores))
-                .unwrap();
+        let boosted = search_symbols_hybrid_with_semantic(
+            &project,
+            "ServiceManager",
+            10,
+            0.5,
+            Some(&scores),
+            None,
+        )
+        .unwrap();
 
         assert!(
             boosted[0].score > baseline_score,
@@ -379,6 +424,7 @@ mod tests {
             10,
             0.99,
             Some(&scores),
+            None,
         )
         .unwrap();
 
@@ -399,14 +445,88 @@ mod tests {
         scores.insert("main.py:ServiceManager".to_owned(), 0.9);
         scores.insert("main.py:helper".to_owned(), 0.7);
 
-        let results =
-            search_symbols_hybrid_with_semantic(&project, "ServiceManager", 20, 0.5, Some(&scores))
-                .unwrap();
+        let results = search_symbols_hybrid_with_semantic(
+            &project,
+            "ServiceManager",
+            20,
+            0.5,
+            Some(&scores),
+            None,
+        )
+        .unwrap();
 
         let mut keys = std::collections::HashSet::new();
         for r in &results {
             let key = (r.name.clone(), r.file.clone(), r.line);
             assert!(keys.insert(key.clone()), "duplicate entry found: {:?}", key);
         }
+    }
+
+    #[test]
+    fn pagerank_boost_max_normalized_by_top_file() {
+        let mut results = vec![
+            SearchResult {
+                name: "a".into(),
+                kind: "function".into(),
+                file: "popular.py".into(),
+                line: 1,
+                signature: "".into(),
+                name_path: "a".into(),
+                score: 50.0,
+                match_type: "fts".into(),
+            },
+            SearchResult {
+                name: "b".into(),
+                kind: "function".into(),
+                file: "obscure.py".into(),
+                line: 2,
+                signature: "".into(),
+                name_path: "b".into(),
+                score: 50.0,
+                match_type: "fts".into(),
+            },
+        ];
+        let mut pr = std::collections::HashMap::new();
+        pr.insert("popular.py".into(), 0.4);
+        pr.insert("obscure.py".into(), 0.05);
+        apply_pagerank_boost(&mut results, &pr, 5.0);
+        // popular.py is the max → +5.0; obscure.py is at 0.05/0.4 → +0.625
+        assert!((results[0].score - 55.0).abs() < 1e-6);
+        assert!((results[1].score - 50.625).abs() < 1e-6);
+    }
+
+    #[test]
+    fn pagerank_boost_skips_unranked_files() {
+        let mut results = vec![SearchResult {
+            name: "a".into(),
+            kind: "function".into(),
+            file: "unmapped.py".into(),
+            line: 1,
+            signature: "".into(),
+            name_path: "a".into(),
+            score: 50.0,
+            match_type: "fts".into(),
+        }];
+        let mut pr = std::collections::HashMap::new();
+        pr.insert("other.py".into(), 0.3);
+        apply_pagerank_boost(&mut results, &pr, 5.0);
+        assert_eq!(results[0].score, 50.0);
+    }
+
+    #[test]
+    fn pagerank_boost_zero_max_is_noop() {
+        let mut results = vec![SearchResult {
+            name: "a".into(),
+            kind: "function".into(),
+            file: "x.py".into(),
+            line: 1,
+            signature: "".into(),
+            name_path: "a".into(),
+            score: 50.0,
+            match_type: "fts".into(),
+        }];
+        let pr = std::collections::HashMap::new();
+        apply_pagerank_boost(&mut results, &pr, 5.0);
+        assert_eq!(results[0].score, 50.0);
     }
 }

--- a/crates/codelens-mcp/Cargo.toml
+++ b/crates/codelens-mcp/Cargo.toml
@@ -37,7 +37,7 @@ regex.workspace = true
 rusqlite.workspace = true
 toml = "0.8"
 rustls = { workspace = true, optional = true }
-codelens-engine = { path = "../codelens-engine", version = "=1.13.15", default-features = false }
+codelens-engine = { path = "../codelens-engine", version = "=1.13.16", default-features = false }
 thiserror.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/codelens-mcp/src/tools/symbols/handlers.rs
+++ b/crates/codelens-mcp/src/tools/symbols/handlers.rs
@@ -758,12 +758,20 @@ pub fn search_symbols_fuzzy(state: &AppState, arguments: &Value) -> ToolResult {
         BackendKind::Sqlite
     };
 
+    let pagerank_scores = state.graph_cache().file_pagerank_scores(&state.project());
+    let pagerank_ref = if pagerank_scores.is_empty() {
+        None
+    } else {
+        Some(&pagerank_scores)
+    };
+
     Ok(search_symbols_hybrid_with_semantic(
         &state.project(),
         query,
         max_results,
         fuzzy_threshold,
         sem_ref,
+        pagerank_ref,
     )
     .map(|value| {
         (

--- a/crates/codelens-tui/Cargo.toml
+++ b/crates/codelens-tui/Cargo.toml
@@ -14,7 +14,7 @@ name = "codelens-tui"
 path = "src/main.rs"
 
 [dependencies]
-codelens-engine = { path = "../codelens-engine", version = "=1.13.15" }
+codelens-engine = { path = "../codelens-engine", version = "=1.13.16" }
 ratatui = "0.30"
 crossterm = "0.28"
 anyhow.workspace = true


### PR DESCRIPTION
## Phase 3-A: PageRank → search ranking 통합

기존에 \`GraphCache::file_pagerank_scores\`로 import 그래프 위 PageRank가 이미
계산되고 있었지만, \`get_importance\` 도구에만 노출되고 \`search_symbols_hybrid\`
ranking에는 들어가지 않았음. 이번 PR로 query-independent global file
importance가 ranking pipeline에 합류.

## 통합 지점

| 변경 | 위치 |
|------|------|
| signature | \`search.rs::search_symbols_hybrid_with_semantic\` 6번째 파라미터 \`pagerank_scores: Option<&HashMap<...>>\` |
| boost 로직 | \`search.rs::apply_pagerank_boost\` (max-normalized, 0..\`PAGERANK_MAX_BOOST\`) |
| 호출 통합 | \`handlers.rs::search_symbols_fuzzy_tool\`에서 \`graph_cache().file_pagerank_scores\` 결과 전달 |

## boost 설계

- max-normalize: \`(pr / max_pr) × max_boost\`
  - 그래프 크기·절대 PageRank 값에 독립
  - top 파일은 항상 \`max_boost\`, 다른 파일은 비례 감소
- \`PAGERANK_MAX_BOOST = 5.0\`
  - BM25/FTS 점수 범위 40–100, semantic boost cap 10에 비해 작음
  - text relevance 압도 X, near-tie tilt만

## 동작

| 상황 | 동작 |
|------|------|
| pagerank_scores = None | 기존 ranking 그대로 |
| 빈 HashMap | no-op (max=0) |
| 결과 file이 PR map에 없음 | 해당 결과 보존, 다른 결과만 boost |
| 정상 | sort 직전 boost → diversity pass → truncate |

## 테스트

3개 단위 테스트 추가 (\`search.rs::tests\`):
- \`pagerank_boost_max_normalized_by_top_file\`: 0.4 → +5.0, 0.05 → +0.625
- \`pagerank_boost_skips_unranked_files\`: 매핑 없는 file → 점수 변화 없음
- \`pagerank_boost_zero_max_is_noop\`: 빈 PR map → no-op

## 회귀 검증

- [x] \`cargo build --release --workspace\` (56s)
- [x] \`cargo test -p codelens-engine --lib search::\` (12 passed)
- [x] \`cargo test -p codelens-mcp --bin codelens-mcp\` (536 passed, 0 failed)
- [x] handlers.rs 통합으로 실제 search_symbols_fuzzy 호출 path 검증

## 후속 (Phase 6-A)

PageRank 영향이 MRR/Accuracy@k에 어떻게 나타나는지는 benchmarks fixture
재측정으로 별도 PR (회귀 게이트 강화). 이번 PR은 통합 자체에 한정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)