### PR TITLE
feat(v1.13.17): SCIP precise backend on by default (Phase 3-B)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-engine"
-version = "1.13.16"
+version = "1.13.17"
 dependencies = [
  "anyhow",
  "criterion",
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-mcp"
-version = "1.13.16"
+version = "1.13.17"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-tui"
-version = "1.13.16"
+version = "1.13.17"
 dependencies = [
  "anyhow",
  "codelens-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "Apache-2.0"
-version = "1.13.16"
+version = "1.13.17"
 description = "Harness-native Rust MCP server for code intelligence with generated surface governance, hybrid retrieval, and mutation-gated workflows"
 repository = "https://github.com/mupozg823/codelens-mcp-plugin"
 homepage = "https://github.com/mupozg823/codelens-mcp-plugin"

--- a/crates/codelens-mcp/Cargo.toml
+++ b/crates/codelens-mcp/Cargo.toml
@@ -37,7 +37,7 @@ regex.workspace = true
 rusqlite.workspace = true
 toml = "0.8"
 rustls = { workspace = true, optional = true }
-codelens-engine = { path = "../codelens-engine", version = "=1.13.16", default-features = false }
+codelens-engine = { path = "../codelens-engine", version = "=1.13.17", default-features = false }
 thiserror.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
@@ -60,12 +60,17 @@ tempfile = "3"
 filetime = "0.2"
 
 [features]
-# Default is empty — `cargo install codelens-mcp` ships a BM25 + AST +
-# call-graph build that boots without an external model directory. Opt
-# into hybrid retrieval with `--features semantic` and supply the model
-# via `CODELENS_MODEL_DIR`, or use the GitHub Release tarball which
-# bundles the model. See ADR-0012.
-default = []
+# `cargo install codelens-mcp` ships a BM25 + AST + call-graph build
+# with the SCIP precise backend compiled in. SCIP itself activates only
+# when the project has an `index.scip` / `.scip/index.scip` /
+# `.codelens/index.scip` file — without one, runtime falls back to
+# tree-sitter. Cost of compiling SCIP into every default install:
+# ~99 KB binary, ~5 s build time (measured 2026-05-03 on M4 Pro).
+#
+# Hybrid retrieval (semantic embeddings) still requires `--features
+# semantic` plus a model directory via `CODELENS_MODEL_DIR`, or the
+# GitHub Release tarball that bundles the model. See ADR-0012.
+default = ["scip-backend"]
 semantic = ["codelens-engine/semantic"]
 coreml = ["semantic", "codelens-engine/coreml"]
 model-bakeoff = ["semantic", "codelens-engine/model-bakeoff"]

--- a/crates/codelens-tui/Cargo.toml
+++ b/crates/codelens-tui/Cargo.toml
@@ -14,7 +14,7 @@ name = "codelens-tui"
 path = "src/main.rs"
 
 [dependencies]
-codelens-engine = { path = "../codelens-engine", version = "=1.13.16" }
+codelens-engine = { path = "../codelens-engine", version = "=1.13.17" }
 ratatui = "0.30"
 crossterm = "0.28"
 anyhow.workspace = true


### PR DESCRIPTION
## Phase 3-B audit + 활성화

### Audit 결과

| 측면 | 상태 |
|------|------|
| ScipBackend infra | 완비 — load + detect + lazy init |
| graceful fallback | 안전 — feature 활성 + index 부재 → None → tree-sitter 자동 |
| ADR-0012 호환 | 유지 — \"외부 디렉토리 없이 부트\" 그대로 (SCIP는 index 있을 때만 활성) |
| binary 영향 | +99 KB (60.59 MB → 60.69 MB, +0.16%) |
| 빌드 시간 | +5 s (57 s → 62 s, +8.7%) |

측정: 2026-05-03 M4 Pro, release profile.

### 변경

- \`crates/codelens-mcp/Cargo.toml\`: \`default = []\` → \`default = [\"scip-backend\"]\`
- 코멘트 갱신 — 비용 수치 + hybrid retrieval 별도 opt-in 명시
- \`--no-default-features\`로 legacy minimal 빌드 유지

### 동작 매트릭스

| 사용자 환경 | 영향 |
|-------------|------|
| SCIP 인덱스 없음 | zero impact (tree-sitter 그대로) |
| index.scip / .scip/index.scip / .codelens/index.scip 존재 | 자동 활용, cross-file precision 향상 |
| \`cargo install --no-default-features\` | 기존 동작 (scip 미컴파일) |

### 회귀 검증

- [x] \`cargo build --release --workspace\` (60s)
- [x] \`cargo check -p codelens-mcp --no-default-features\` (4s) — legacy path 유지
- [x] \`cargo test -p codelens-mcp --bin codelens-mcp\` 538 passed (+2 vs v1.13.16, scip-gated tests now compile)
- [x] \`cargo test -p codelens-engine --lib\` 364 passed (+3)
- [x] tracing 로그: index 부재 시 \`info\` 한 번 + None 반환 (state/embedding_host.rs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)