### PR TITLE
feat(v1.13.18): get_ranked_context adaptive budget by host context window

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-engine"
-version = "1.13.17"
+version = "1.13.18"
 dependencies = [
  "anyhow",
  "criterion",
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-mcp"
-version = "1.13.17"
+version = "1.13.18"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-tui"
-version = "1.13.17"
+version = "1.13.18"
 dependencies = [
  "anyhow",
  "codelens-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "Apache-2.0"
-version = "1.13.17"
+version = "1.13.18"
 description = "Harness-native Rust MCP server for code intelligence with generated surface governance, hybrid retrieval, and mutation-gated workflows"
 repository = "https://github.com/mupozg823/codelens-mcp-plugin"
 homepage = "https://github.com/mupozg823/codelens-mcp-plugin"

--- a/crates/codelens-mcp/Cargo.toml
+++ b/crates/codelens-mcp/Cargo.toml
@@ -37,7 +37,7 @@ regex.workspace = true
 rusqlite.workspace = true
 toml = "0.8"
 rustls = { workspace = true, optional = true }
-codelens-engine = { path = "../codelens-engine", version = "=1.13.17", default-features = false }
+codelens-engine = { path = "../codelens-engine", version = "=1.13.18", default-features = false }
 thiserror.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/codelens-mcp/src/tools/symbols/handlers.rs
+++ b/crates/codelens-mcp/src/tools/symbols/handlers.rs
@@ -382,6 +382,25 @@ pub fn bm25_symbol_search(state: &AppState, arguments: &Value) -> ToolResult {
     ))
 }
 
+/// Scale a base token budget to the host's advertised model context window.
+///
+/// Returns the smaller of (base × multiplier) and a per-tier ceiling so a
+/// 1M-context host doesn't end up with a budget larger than reasonably
+/// retrievable evidence, while a 32K host doesn't get pushed over its head.
+///
+/// Tiers are conservative on purpose. The intent is to widen room when there
+/// is room, not to fill the host's window — the host still owns the response
+/// and may apply its own truncation downstream.
+pub(crate) fn adapt_budget_to_context_window(base: usize, context_window: usize) -> usize {
+    let (multiplier, cap) = match context_window {
+        n if n >= 1_000_000 => (4.0_f64, 131_072_usize),
+        n if n >= 200_000 => (2.0_f64, 65_536_usize),
+        n if n >= 32_000 => (1.0_f64, 32_768_usize),
+        _ => (0.5_f64, 16_384_usize),
+    };
+    ((base as f64 * multiplier).round() as usize).min(cap)
+}
+
 pub fn get_ranked_context(state: &AppState, arguments: &Value) -> ToolResult {
     // P1-B — surface unknown_args. No `limit`/`top_k` alias here:
     // get_ranked_context's relevant control is `depth` (graph
@@ -391,6 +410,7 @@ pub fn get_ranked_context(state: &AppState, arguments: &Value) -> ToolResult {
         "path",
         "file_path",
         "max_tokens",
+        "context_window",
         "include_body",
         "depth",
         "disable_semantic",
@@ -411,14 +431,26 @@ pub fn get_ranked_context(state: &AppState, arguments: &Value) -> ToolResult {
     // structural evidence) routinely exceeds that, triggering Stage 5
     // truncation. See `docs/eval/v1.10.0-post-release-eval.md` (F3).
     const HYBRID_RETRIEVAL_FLOOR: usize = 16384;
+    // v1.13.18 adaptive: when the host advertises its model context window
+    // (e.g. 1M for Opus 4.7, 200K for Sonnet 4.6, 32K for older models),
+    // scale the budget so we don't waste headroom on huge contexts and
+    // don't blow up small ones. See `adapt_budget_to_context_window`.
+    let context_window = arguments
+        .get("context_window")
+        .and_then(|v| v.as_u64())
+        .map(|v| v as usize);
     let max_tokens = arguments
         .get("max_tokens")
         .and_then(|v| v.as_u64())
         .map(|v| v as usize)
         .unwrap_or_else(|| {
-            state
+            let base = state
                 .execution_token_budget(&session)
-                .max(HYBRID_RETRIEVAL_FLOOR)
+                .max(HYBRID_RETRIEVAL_FLOOR);
+            match context_window {
+                Some(window) => adapt_budget_to_context_window(base, window),
+                None => base,
+            }
         });
     let include_body = optional_bool(arguments, "include_body", false);
     let depth = optional_usize(arguments, "depth", 2);
@@ -819,6 +851,52 @@ fn suggested_follow_up(kind: &str, exported: bool) -> Vec<&'static str> {
         return with_refs;
     }
     base
+}
+
+#[cfg(test)]
+mod adapt_budget_tests {
+    use super::adapt_budget_to_context_window;
+
+    #[test]
+    fn small_window_halves_budget_capped_at_16k() {
+        // 8K context — base 32K halved to 16K, capped at 16K floor
+        assert_eq!(adapt_budget_to_context_window(32_768, 8_000), 16_384);
+        // base 8K halved to 4K — under cap
+        assert_eq!(adapt_budget_to_context_window(8_000, 16_000), 4_000);
+    }
+
+    #[test]
+    fn standard_window_passes_base_capped_at_32k() {
+        // 64K window → ×1, cap 32K
+        assert_eq!(adapt_budget_to_context_window(16_384, 64_000), 16_384);
+        assert_eq!(adapt_budget_to_context_window(40_000, 64_000), 32_768);
+    }
+
+    #[test]
+    fn large_window_doubles_budget_capped_at_64k() {
+        // 200K → ×2 cap 64K
+        assert_eq!(adapt_budget_to_context_window(16_384, 200_000), 32_768);
+        assert_eq!(adapt_budget_to_context_window(50_000, 200_000), 65_536);
+    }
+
+    #[test]
+    fn xl_window_quadruples_budget_capped_at_128k() {
+        // 1M → ×4 cap 128K
+        assert_eq!(adapt_budget_to_context_window(16_384, 1_000_000), 65_536);
+        assert_eq!(adapt_budget_to_context_window(40_000, 1_000_000), 131_072);
+    }
+
+    #[test]
+    fn boundary_at_32k_uses_standard_tier() {
+        // exactly 32K → standard tier (×1, cap 32K), not small tier
+        assert_eq!(adapt_budget_to_context_window(16_384, 32_000), 16_384);
+    }
+
+    #[test]
+    fn boundary_at_200k_uses_large_tier() {
+        // exactly 200K → large tier (×2, cap 64K)
+        assert_eq!(adapt_budget_to_context_window(16_384, 200_000), 32_768);
+    }
 }
 
 #[cfg(test)]

--- a/crates/codelens-mcp/tools.toml
+++ b/crates/codelens-mcp/tools.toml
@@ -186,6 +186,7 @@ required = ["query"]
 query = { type = "string" }
 path = { type = "string" }
 max_tokens = { type = "integer", description = "Token budget for the retrieval payload. Defaults to max(active surface budget, 16384) — raised in v1.10.1 from the surface budget alone to avoid Stage 5 truncation on hybrid retrieval." }
+context_window = { type = "integer", description = "Host model's context window in tokens (e.g. 1000000 for Opus 4.7, 200000 for Sonnet 4.6). When supplied AND max_tokens is unset, the budget scales adaptively: ≥1M → ×4 cap 128K, ≥200K → ×2 cap 64K, ≥32K → ×1 cap 32K, smaller → ×0.5 cap 16K. v1.13.18+." }
 include_body = { type = "boolean" }
 depth = { type = "integer" }
 disable_semantic = { type = "boolean", description = "Disable semantic/hybrid ranking and use structural signals only" }

--- a/crates/codelens-tui/Cargo.toml
+++ b/crates/codelens-tui/Cargo.toml
@@ -14,7 +14,7 @@ name = "codelens-tui"
 path = "src/main.rs"
 
 [dependencies]
-codelens-engine = { path = "../codelens-engine", version = "=1.13.17" }
+codelens-engine = { path = "../codelens-engine", version = "=1.13.18" }
 ratatui = "0.30"
 crossterm = "0.28"
 anyhow.workspace = true


### PR DESCRIPTION
## Phase 3-E

\`get_ranked_context\`에 \`context_window\` 인자 추가. 호스트가 모델
컨텍스트 한도를 명시하면 retrieval token budget이 적응적으로 스케일.

### Tier table

| \`context_window\` (tokens) | multiplier | cap |
|--------------------|------------|-----|
| ≥ 1,000,000 (Opus 4.7 1M) | ×4.0 | 131,072 |
| ≥ 200,000 (Sonnet 4.6) | ×2.0 |  65,536 |
| ≥ 32,000 (legacy) | ×1.0 |  32,768 |
| < 32,000 | ×0.5 |  16,384 |

경계 (32K, 200K)는 더 큰 tier로 흡수.

### 우선순위

| 인자 조합 | 동작 |
|-----------|------|
| \`max_tokens\` 명시 | 그 값 그대로 (host가 직접 결정) |
| \`context_window\` 명시 + \`max_tokens\` 미설정 | adaptive scaling |
| 둘 다 미설정 | 기존 surface budget ∨ 16K floor |

### 왜 explicit 인자 (\`_meta\` 아님)

MCP \`_meta\`는 tool argument 구조 외부의 metadata field. codelens는
이미 _meta를 *response* annotations에 쓰지만 *request* 쪽에서
파싱하려면 dispatch 변경 필요. explicit \`context_window\` 인자가
tool schema 내부로 contract 한정되어 host-agnostic.

### 변경

- \`handlers.rs\`: \`adapt_budget_to_context_window\` 함수 + KNOWN_ARGS + budget assignment
- \`tools.toml\`: get_ranked_context input_schema에 \`context_window\` property + tier table 문서화
- 6 unit tests: 각 tier + 경계 + cap

### 검증

- [x] cargo build --release --workspace (49s)
- [x] cargo test -p codelens-mcp --bin: 544 passed (+6 new), 0 failed
- [x] adapt_budget_tests 6/6 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)