### PR TITLE
feat(v1.13.19): mark 4 ToolProfiles for v2.0 removal (Phase 5-A)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-engine"
-version = "1.13.18"
+version = "1.13.19"
 dependencies = [
  "anyhow",
  "criterion",
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-mcp"
-version = "1.13.18"
+version = "1.13.19"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-tui"
-version = "1.13.18"
+version = "1.13.19"
 dependencies = [
  "anyhow",
  "codelens-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "Apache-2.0"
-version = "1.13.18"
+version = "1.13.19"
 description = "Harness-native Rust MCP server for code intelligence with generated surface governance, hybrid retrieval, and mutation-gated workflows"
 repository = "https://github.com/mupozg823/codelens-mcp-plugin"
 homepage = "https://github.com/mupozg823/codelens-mcp-plugin"

--- a/crates/codelens-mcp/Cargo.toml
+++ b/crates/codelens-mcp/Cargo.toml
@@ -37,7 +37,7 @@ regex.workspace = true
 rusqlite.workspace = true
 toml = "0.8"
 rustls = { workspace = true, optional = true }
-codelens-engine = { path = "../codelens-engine", version = "=1.13.18", default-features = false }
+codelens-engine = { path = "../codelens-engine", version = "=1.13.19", default-features = false }
 thiserror.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/codelens-mcp/src/surface_manifest.rs
+++ b/crates/codelens-mcp/src/surface_manifest.rs
@@ -94,14 +94,20 @@ pub(crate) fn build_surface_manifest(
         .map(|profile| {
             let surface = ToolSurface::Profile(*profile);
             let visible = visible_tools(surface);
-            json!({
+            let deprecated = profile.is_deprecated();
+            let mut entry = json!({
                 "name": profile.as_str(),
                 "tool_count": visible.len(),
                 "preferred_namespaces": preferred_namespaces(surface),
                 "preferred_tiers": preferred_tier_labels(surface),
                 "preferred_phases": preferred_phase_labels(surface),
                 "tools": visible.iter().map(|tool| tool.name).collect::<Vec<_>>(),
-            })
+                "deprecated": deprecated,
+            });
+            if let Some(target) = profile.deprecation_target() {
+                entry["deprecation_target"] = json!(target);
+            }
+            entry
         })
         .collect::<Vec<_>>();
 

--- a/crates/codelens-mcp/src/surface_manifest/tests.rs
+++ b/crates/codelens-mcp/src/surface_manifest/tests.rs
@@ -87,6 +87,26 @@ fn manifest_matches_registry_counts() {
             entry["tool_count"],
             json!(visible_tools(ToolSurface::Profile(*profile)).len())
         );
+        assert_eq!(
+            entry["deprecated"],
+            json!(profile.is_deprecated()),
+            "deprecated flag mismatch for {:?}",
+            profile
+        );
+        if let Some(target) = profile.deprecation_target() {
+            assert_eq!(
+                entry["deprecation_target"],
+                json!(target),
+                "deprecation_target mismatch for {:?}",
+                profile
+            );
+        } else {
+            assert!(
+                entry.get("deprecation_target").is_none(),
+                "active profile {:?} should not carry deprecation_target",
+                profile
+            );
+        }
     }
 
     let manifest_presets = manifest["surfaces"]["presets"]

--- a/crates/codelens-mcp/src/tool_defs/presets.rs
+++ b/crates/codelens-mcp/src/tool_defs/presets.rs
@@ -66,6 +66,32 @@ impl ToolProfile {
             Self::WorkflowFirst => "workflow-first",
         }
     }
+
+    /// Profiles slated for removal in v2.0. The enum entries stay so existing
+    /// `from_str` callers and host overlays keep working through the
+    /// deprecation window; surface_manifest exposes the marker so hosts can
+    /// stop advertising them ahead of the cut.
+    ///
+    /// Rationale: the four below are either redundant aliases of the core
+    /// trio (planner/builder/reviewer) or were aspirational profiles that
+    /// never accumulated a distinct toolset. Keeping seven entries means
+    /// the surface routing matrix has more cells to maintain than realised
+    /// behaviour change. v2.0 collapses to the core trio.
+    pub fn is_deprecated(&self) -> bool {
+        matches!(
+            self,
+            Self::EvaluatorCompact | Self::RefactorFull | Self::CiAudit | Self::WorkflowFirst
+        )
+    }
+
+    /// Removal target version for deprecated profiles. None for active ones.
+    pub fn deprecation_target(&self) -> Option<&'static str> {
+        if self.is_deprecated() {
+            Some("v2.0")
+        } else {
+            None
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1298,6 +1324,55 @@ pub(crate) fn tool_namespace(name: &str) -> &'static str {
 }
 
 #[cfg(test)]
+mod deprecation_tests {
+    use super::*;
+
+    #[test]
+    fn core_trio_is_active() {
+        for p in [
+            ToolProfile::PlannerReadonly,
+            ToolProfile::BuilderMinimal,
+            ToolProfile::ReviewerGraph,
+        ] {
+            assert!(!p.is_deprecated(), "{:?} should be active", p);
+            assert_eq!(p.deprecation_target(), None, "{:?}", p);
+        }
+    }
+
+    #[test]
+    fn four_profiles_marked_for_v2_removal() {
+        for p in [
+            ToolProfile::EvaluatorCompact,
+            ToolProfile::RefactorFull,
+            ToolProfile::CiAudit,
+            ToolProfile::WorkflowFirst,
+        ] {
+            assert!(p.is_deprecated(), "{:?} should be deprecated", p);
+            assert_eq!(p.deprecation_target(), Some("v2.0"));
+        }
+    }
+
+    #[test]
+    fn from_str_still_resolves_deprecated_aliases() {
+        // Deprecation does not break parsing — host overlays may still
+        // request these profiles through the v1.13 deprecation window.
+        assert_eq!(
+            ToolProfile::from_str("evaluator-compact"),
+            Some(ToolProfile::EvaluatorCompact)
+        );
+        assert_eq!(
+            ToolProfile::from_str("refactor"),
+            Some(ToolProfile::RefactorFull)
+        );
+        assert_eq!(ToolProfile::from_str("ci"), Some(ToolProfile::CiAudit));
+        assert_eq!(
+            ToolProfile::from_str("workflow"),
+            Some(ToolProfile::WorkflowFirst)
+        );
+    }
+}
+
+#[cfg(test)]
 mod overlay_tests {
     use super::*;
 
@@ -1323,10 +1398,9 @@ mod overlay_tests {
         let plan = compile_surface_overlay(full_surface(), Some(HostContext::ClaudeCode), None);
         assert!(plan.applied());
         assert_eq!(plan.preferred_executor_bias, Some("claude"));
-        assert!(
-            plan.preferred_entrypoints
-                .contains(&"analyze_change_request")
-        );
+        assert!(plan
+            .preferred_entrypoints
+            .contains(&"analyze_change_request"));
         assert!(!plan.routing_notes.is_empty());
     }
 
@@ -1351,10 +1425,9 @@ mod overlay_tests {
                 "planning overlay should avoid {mutation}"
             );
         }
-        assert!(
-            plan.preferred_entrypoints
-                .contains(&"analyze_change_request")
-        );
+        assert!(plan
+            .preferred_entrypoints
+            .contains(&"analyze_change_request"));
     }
 
     #[test]
@@ -1371,10 +1444,9 @@ mod overlay_tests {
                 "editing overlay should emphasize {mutation}"
             );
         }
-        assert!(
-            plan.preferred_entrypoints
-                .contains(&"verify_change_readiness")
-        );
+        assert!(plan
+            .preferred_entrypoints
+            .contains(&"verify_change_readiness"));
         assert!(plan.avoid_tools.is_empty());
     }
 
@@ -1435,11 +1507,9 @@ mod overlay_tests {
             Some(HostContext::ClaudeCode),
             None,
         );
-        assert!(
-            !plan
-                .preferred_entrypoints
-                .contains(&"analyze_change_request")
-        );
+        assert!(!plan
+            .preferred_entrypoints
+            .contains(&"analyze_change_request"));
     }
 
     #[test]

--- a/crates/codelens-tui/Cargo.toml
+++ b/crates/codelens-tui/Cargo.toml
@@ -14,7 +14,7 @@ name = "codelens-tui"
 path = "src/main.rs"
 
 [dependencies]
-codelens-engine = { path = "../codelens-engine", version = "=1.13.18" }
+codelens-engine = { path = "../codelens-engine", version = "=1.13.19" }
 ratatui = "0.30"
 crossterm = "0.28"
 anyhow.workspace = true


### PR DESCRIPTION
## Phase 5-A

EvaluatorCompact, RefactorFull, CiAudit, WorkflowFirst — 4개 \`ToolProfile\`을
v2.0 제거 대상으로 마킹. 코어 trio (PlannerReadonly, BuilderMinimal,
ReviewerGraph)만 v2.0에서 살아남음.

## 외부 contract 보호

| 보호 항목 | 상태 |
|-----------|------|
| ALL_PROFILES | 7개 그대로 유지 (host overlay 호환) |
| from_str | deprecated alias 모두 resolve 유지 |
| as_str / profile_token_budget | 변경 없음 |
| visible_tools | 동일 결과 반환 (silent behavior shift 없음) |

## host에 노출되는 신호

surface_manifest의 profile entries에:
- \`\"deprecated\": true | false\`
- \`\"deprecation_target\": \"v2.0\"\` (deprecated일 때만)

host는 onboarding에서 4개를 advertise 안하면 됨. 기존 client는 변경 없이 계속 동작.

## 왜 이 4개

- EvaluatorCompact / RefactorFull / CiAudit / WorkflowFirst: 코어 trio의 redundant alias이거나 distinct toolset 미축적된 aspirational profile
- 7개 profile cell 유지 비용 (overlay logic, manifest 생성, host adapter rules) > 실제 차이
- v2.0에서 trio 단일화 → routing matrix 축소

## 테스트

3개 신규 (\`presets::deprecation_tests\`):
- \`core_trio_is_active\`: planner/builder/reviewer 미마킹
- \`four_profiles_marked_for_v2_removal\`: target == \"v2.0\"
- \`from_str_still_resolves_deprecated_aliases\`: parsing 유지

\`surface_manifest::tests::manifest_matches_registry_counts\` 확장:
- deprecated/deprecation_target 필드 검증 (active profile은 deprecation_target 없음)

## 검증

- [x] cargo build --release --workspace (60s)
- [x] cargo test -p codelens-mcp --bin: 547 passed (+3), 0 failed
- [x] deprecation_tests 3/3
- [x] surface_manifest::tests 3/3

## 후속 (v2.0 PR, 별도)

4개 enum variant 삭제 + ALL_PROFILES 정리 + host_adapter overlay 정리. deprecation window는 v1.13.x line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)