### PR TITLE
feat(v1.13.21): find_over_visible_apis detector — Phase 4-A

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-engine"
-version = "1.13.20"
+version = "1.13.21"
 dependencies = [
  "anyhow",
  "criterion",
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-mcp"
-version = "1.13.20"
+version = "1.13.21"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-tui"
-version = "1.13.20"
+version = "1.13.21"
 dependencies = [
  "anyhow",
  "codelens-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "Apache-2.0"
-version = "1.13.20"
+version = "1.13.21"
 description = "Harness-native Rust MCP server for code intelligence with generated surface governance, hybrid retrieval, and mutation-gated workflows"
 repository = "https://github.com/mupozg823/codelens-mcp-plugin"
 homepage = "https://github.com/mupozg823/codelens-mcp-plugin"

--- a/crates/codelens-mcp/Cargo.toml
+++ b/crates/codelens-mcp/Cargo.toml
@@ -37,7 +37,7 @@ regex.workspace = true
 rusqlite.workspace = true
 toml = "0.8"
 rustls = { workspace = true, optional = true }
-codelens-engine = { path = "../codelens-engine", version = "=1.13.20", default-features = false }
+codelens-engine = { path = "../codelens-engine", version = "=1.13.21", default-features = false }
 thiserror.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/codelens-mcp/src/main.rs
+++ b/crates/codelens-mcp/src/main.rs
@@ -16,6 +16,7 @@ mod job_store;
 mod mutation_gate;
 mod operator;
 mod orphan_handlers;
+mod over_visible;
 mod preflight_store;
 mod principals;
 mod prompts;

--- a/crates/codelens-mcp/src/over_visible.rs
+++ b/crates/codelens-mcp/src/over_visible.rs
@@ -1,0 +1,385 @@
+//! Detects "over-visible" public declarations — items declared `pub`
+//! or `pub(crate)` that are only referenced inside their own file (or
+//! their own crate, in the case of `pub`). Complements
+//! `find_phantom_modules` and `find_redundant_definitions`: those find
+//! dead surface; this one finds *too-wide* surface that compiler
+//! warnings will not catch because the items are still in use, just
+//! not by anyone outside the declaring boundary.
+//!
+//! Suggested narrowings:
+//! - `pub` with no cross-crate caller            → `pub(crate)`
+//! - `pub(crate)` with no other-file caller      → drop visibility (private)
+//!
+//! The detector is purposefully conservative:
+//! - only column-0 declarations count (impl-method `pub fn` is ignored)
+//! - only the `crates/` workspace tree is scanned (benches/tests/build.rs
+//!   excluded)
+//! - macro arms and string-literal occurrences are ignored by the
+//!   word-boundary scan, but documented as a known false-positive
+//!   source that callers should sanity-check before acting.
+
+use anyhow::Result;
+use regex::Regex;
+use serde::Serialize;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
+
+/// Matches column-0 public declarations across the kinds the detector
+/// cares about: `pub fn`, `pub(crate) struct`, `pub trait`, etc. The
+/// captured groups are `vis` (the visibility token literally as written:
+/// `pub` or `pub(crate)`), `kind` (`fn`, `struct`, `enum`, `const`,
+/// `static`, `trait`, `type`), and `name`.
+///
+/// `pub(super)`, `pub(in path)`, etc. are intentionally excluded: those
+/// already express a narrower scope and the detector does not have a
+/// rich enough scope model to recommend further narrowing.
+static PUB_DECL_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"^(?P<vis>pub(?:\(crate\))?)\s+(?P<kind>fn|struct|enum|const|static|trait|type)\s+(?P<name>[A-Za-z_][A-Za-z0-9_]*)",
+    )
+    .unwrap()
+});
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub(crate) struct OverVisibleEntry {
+    pub file: String,
+    pub line: usize,
+    pub name: String,
+    pub kind: String,
+    pub current_visibility: String,
+    pub suggested_visibility: String,
+    pub reason: String,
+}
+
+/// Scans the workspace for `pub` / `pub(crate)` declarations whose
+/// references all stay inside a narrower boundary. Returns suggestions
+/// in (file, line) order.
+pub(crate) fn find_over_visible_apis(project_root: &Path) -> Result<Vec<OverVisibleEntry>> {
+    let workspace = project_root.join("crates");
+    let mut declarations: Vec<DeclSite> = Vec::new();
+    walk_rust_files(&workspace, &mut |path: &Path| {
+        let source = match std::fs::read_to_string(path) {
+            Ok(s) => s,
+            Err(_) => return,
+        };
+        let relative = relative_to(project_root, path);
+        let crate_name = enclosing_crate_name(&relative);
+        for (line_no, line) in source.lines().enumerate() {
+            // skip cfg(test) and #[cfg(test)] mod test_blocks heuristically
+            if line.trim_start().starts_with("//") {
+                continue;
+            }
+            if let Some(caps) = PUB_DECL_RE.captures(line) {
+                declarations.push(DeclSite {
+                    file: relative.clone(),
+                    crate_name: crate_name.clone(),
+                    line: line_no + 1,
+                    name: caps["name"].to_owned(),
+                    kind: caps["kind"].to_owned(),
+                    visibility: caps["vis"].to_owned(),
+                });
+            }
+        }
+    })?;
+
+    if declarations.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Build a name → references-by-(crate, file) map by scanning every
+    // .rs file once and counting word-boundary matches per declaration
+    // name. This is O(files × declared_names) but the alternative —
+    // compiling one regex per declaration — is much slower.
+    let names: HashSet<&str> = declarations.iter().map(|d| d.name.as_str()).collect();
+    let mut refs: std::collections::HashMap<String, ReferenceSet> = declarations
+        .iter()
+        .map(|d| (d.name.clone(), ReferenceSet::default()))
+        .collect();
+    walk_rust_files(&workspace, &mut |path: &Path| {
+        let source = match std::fs::read_to_string(path) {
+            Ok(s) => s,
+            Err(_) => return,
+        };
+        let relative = relative_to(project_root, path);
+        let crate_name = enclosing_crate_name(&relative);
+        for token in source.split(|c: char| !c.is_alphanumeric() && c != '_') {
+            if names.contains(token)
+                && let Some(set) = refs.get_mut(token)
+            {
+                set.files.insert(relative.clone());
+                set.crates.insert(crate_name.clone());
+            }
+        }
+    })?;
+
+    let mut entries: Vec<OverVisibleEntry> = Vec::new();
+    for decl in &declarations {
+        let Some(rs) = refs.get(&decl.name) else {
+            continue;
+        };
+        let other_file_count = rs.files.iter().filter(|f| **f != decl.file).count();
+        let other_crate_count = rs.crates.iter().filter(|c| **c != decl.crate_name).count();
+
+        let suggestion = match (decl.visibility.as_str(), other_file_count, other_crate_count) {
+            ("pub", 0, _) => Some(("private", "no caller in any file")),
+            ("pub", _, 0) => Some(("pub(crate)", "no caller outside the declaring crate")),
+            ("pub(crate)", 0, _) => Some(("private", "no caller in any other file inside this crate")),
+            _ => None,
+        };
+
+        if let Some((suggested, reason)) = suggestion {
+            entries.push(OverVisibleEntry {
+                file: decl.file.clone(),
+                line: decl.line,
+                name: decl.name.clone(),
+                kind: decl.kind.clone(),
+                current_visibility: decl.visibility.clone(),
+                suggested_visibility: suggested.to_owned(),
+                reason: reason.to_owned(),
+            });
+        }
+    }
+
+    entries.sort_by(|a, b| a.file.cmp(&b.file).then(a.line.cmp(&b.line)));
+    Ok(entries)
+}
+
+#[derive(Debug)]
+struct DeclSite {
+    file: String,
+    crate_name: String,
+    line: usize,
+    name: String,
+    kind: String,
+    visibility: String,
+}
+
+#[derive(Default)]
+struct ReferenceSet {
+    files: HashSet<String>,
+    crates: HashSet<String>,
+}
+
+/// Pulls `codelens-engine` out of `crates/codelens-engine/src/foo.rs`.
+/// Returns `(unknown)` for paths that do not match the expected layout
+/// — these collapse into a single bucket and never match cross-crate
+/// rules, so they don't contaminate the suggestion logic.
+fn enclosing_crate_name(relative_path: &str) -> String {
+    let parts: Vec<&str> = relative_path.split('/').collect();
+    if parts.len() >= 2 && parts[0] == "crates" {
+        parts[1].to_owned()
+    } else {
+        "(unknown)".to_owned()
+    }
+}
+
+fn walk_rust_files(root: &Path, visit: &mut dyn FnMut(&Path)) -> Result<()> {
+    if !root.exists() {
+        return Ok(());
+    }
+    let mut stack: Vec<PathBuf> = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        for entry in std::fs::read_dir(&dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.is_dir() {
+                let name = path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or_default();
+                // Skip benches/, tests/, build/, target/. Detector cares
+                // about runtime surface, not test/bench helpers.
+                if name == "benches" || name == "tests" || name == "build" || name == "target" {
+                    continue;
+                }
+                stack.push(path);
+            } else if path.extension().and_then(|s| s.to_str()) == Some("rs") {
+                let name = path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or_default();
+                // Skip *_tests.rs and tests.rs at file level, plus
+                // build.rs (compiler-time only).
+                if name == "build.rs" || name.ends_with("_tests.rs") || name == "tests.rs" {
+                    continue;
+                }
+                visit(&path);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn relative_to(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| path.to_string_lossy().into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pub_decl_re_matches_canonical_kinds() {
+        for line in [
+            "pub fn foo() {",
+            "pub(crate) struct Bar {",
+            "pub enum Baz {",
+            "pub(crate) const X: u32 = 1;",
+            "pub static Y: u32 = 2;",
+            "pub trait Tr {",
+            "pub(crate) type Alias = u32;",
+        ] {
+            assert!(
+                PUB_DECL_RE.is_match(line),
+                "expected match for line: {line}"
+            );
+        }
+    }
+
+    #[test]
+    fn pub_decl_re_skips_indented_impl_methods() {
+        // `pub fn` inside `impl` is column-1+, must not match column-0 pattern.
+        assert!(!PUB_DECL_RE.is_match("    pub fn method(&self) {}"));
+        assert!(!PUB_DECL_RE.is_match("\tpub fn tabbed_method() {}"));
+    }
+
+    #[test]
+    fn pub_decl_re_skips_pub_super_and_pub_in() {
+        // pub(super) and pub(in path) intentionally excluded.
+        assert!(!PUB_DECL_RE.is_match("pub(super) fn helper() {}"));
+        assert!(!PUB_DECL_RE.is_match("pub(in crate::foo) const X: u32 = 1;"));
+    }
+
+    #[test]
+    fn enclosing_crate_extracts_member_name() {
+        assert_eq!(
+            enclosing_crate_name("crates/codelens-engine/src/lib.rs"),
+            "codelens-engine"
+        );
+        assert_eq!(
+            enclosing_crate_name("crates/codelens-mcp/src/state/mod.rs"),
+            "codelens-mcp"
+        );
+        assert_eq!(enclosing_crate_name("Cargo.toml"), "(unknown)");
+    }
+
+    #[test]
+    fn suggests_narrowing_when_no_external_caller() {
+        let dir = std::env::temp_dir().join(format!(
+            "over-visible-narrow-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let src = dir.join("crates/sample/src");
+        std::fs::create_dir_all(&src).unwrap();
+        // `pub fn used_here_only` is referenced only inside its declaring
+        // file → suggested: private.
+        std::fs::write(
+            src.join("lib.rs"),
+            "pub fn used_here_only() {}\n\nfn caller() { used_here_only(); }\n",
+        )
+        .unwrap();
+
+        let entries = find_over_visible_apis(&dir).expect("scan ok");
+        let hit = entries
+            .iter()
+            .find(|e| e.name == "used_here_only")
+            .expect("decl not detected");
+        assert_eq!(hit.current_visibility, "pub");
+        assert_eq!(hit.suggested_visibility, "private");
+        assert!(hit.reason.contains("no caller"));
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn suggests_pub_crate_when_only_intra_crate_callers() {
+        let dir = std::env::temp_dir().join(format!(
+            "over-visible-intracrate-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let src = dir.join("crates/sample/src");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::write(
+            src.join("lib.rs"),
+            "pub fn intra_caller() {}\n",
+        )
+        .unwrap();
+        std::fs::write(src.join("other.rs"), "fn use_it() { super::intra_caller(); }\n").unwrap();
+
+        let entries = find_over_visible_apis(&dir).expect("scan ok");
+        let hit = entries
+            .iter()
+            .find(|e| e.name == "intra_caller")
+            .expect("decl not detected");
+        assert_eq!(hit.current_visibility, "pub");
+        assert_eq!(hit.suggested_visibility, "pub(crate)");
+        assert!(hit.reason.contains("outside the declaring crate"));
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn does_not_flag_legitimate_pub_with_external_caller() {
+        let dir = std::env::temp_dir().join(format!(
+            "over-visible-legitimate-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(dir.join("crates/a/src")).unwrap();
+        std::fs::create_dir_all(dir.join("crates/b/src")).unwrap();
+        std::fs::write(dir.join("crates/a/src/lib.rs"), "pub fn legit_api() {}\n").unwrap();
+        std::fs::write(
+            dir.join("crates/b/src/lib.rs"),
+            "fn callsite() { a::legit_api(); }\n",
+        )
+        .unwrap();
+
+        let entries = find_over_visible_apis(&dir).expect("scan ok");
+        assert!(
+            entries.iter().all(|e| e.name != "legit_api"),
+            "legitimate pub with cross-crate caller should not be flagged; got {:?}",
+            entries
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    #[ignore]
+    fn dogfood_self_repo() {
+        // Run with: cargo test -p codelens-mcp over_visible::tests::dogfood_self_repo -- --ignored --nocapture
+        let repo: PathBuf = std::env::var("CODELENS_REPO_ROOT")
+            .unwrap_or_else(|_| {
+                std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                    .ancestors()
+                    .nth(2)
+                    .expect("workspace root")
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .into();
+        let entries = find_over_visible_apis(&repo).expect("find_over_visible_apis");
+        eprintln!(
+            "\n=== {} over-visible declarations ===\n",
+            entries.len()
+        );
+        // Print the first 30 to keep output bounded during dogfood runs.
+        for e in entries.iter().take(30) {
+            eprintln!(
+                "  {} {} {} ({} → {}; {}) at {}:{}",
+                e.current_visibility, e.kind, e.name, e.current_visibility, e.suggested_visibility, e.reason, e.file, e.line
+            );
+        }
+    }
+}

--- a/crates/codelens-mcp/src/tools/graph.rs
+++ b/crates/codelens-mcp/src/tools/graph.rs
@@ -233,6 +233,26 @@ pub fn find_orphan_handlers_tool(
     ))
 }
 
+pub fn find_over_visible_apis_tool(
+    state: &AppState,
+    _arguments: &serde_json::Value,
+) -> ToolResult {
+    let entries = crate::over_visible::find_over_visible_apis(state.project().as_path())?;
+    let by_kind: std::collections::BTreeMap<String, usize> =
+        entries.iter().fold(std::collections::BTreeMap::new(), |mut acc, e| {
+            *acc.entry(e.kind.clone()).or_insert(0) += 1;
+            acc
+        });
+    Ok((
+        json!({
+            "over_visible_apis": entries,
+            "count": entries.len(),
+            "count_by_kind": by_kind,
+        }),
+        success_meta(BackendKind::TreeSitter, 0.75),
+    ))
+}
+
 pub fn audit_tool_surface_consistency_tool(
     state: &AppState,
     _arguments: &serde_json::Value,

--- a/crates/codelens-mcp/src/tools/mod.rs
+++ b/crates/codelens-mcp/src/tools/mod.rs
@@ -87,6 +87,7 @@ pub fn dispatch_table() -> HashMap<&'static str, crate::tool_defs::tool::ToolHan
         "find_circular_dependencies"   => graph::find_circular_dependencies_tool,
         "audit_tool_surface_consistency" => graph::audit_tool_surface_consistency_tool,
         "find_orphan_handlers"         => graph::find_orphan_handlers_tool,
+        "find_over_visible_apis"       => graph::find_over_visible_apis_tool,
         "find_phantom_modules"         => graph::find_phantom_modules_tool,
         "find_redundant_definitions"   => graph::find_redundant_definitions_tool,
         "get_change_coupling"          => graph::get_change_coupling_tool,

--- a/crates/codelens-mcp/tools.toml
+++ b/crates/codelens-mcp/tools.toml
@@ -532,6 +532,18 @@ properties = {}
 # ─────
 
 [[tool]]
+name = "find_over_visible_apis"
+category = "analysis"
+description = "[CodeLens:Analysis] Find `pub` / `pub(crate)` declarations whose references all stay inside a narrower scope than they advertise. `pub` with no cross-crate caller → suggest `pub(crate)`. `pub(crate)` with no other-file caller → suggest dropping visibility. Complements find_phantom_modules / find_redundant_definitions: those find dead surface, this one finds too-wide surface that compiler warnings cannot catch because the items are still in use, just not by anyone outside the declaring boundary."
+annotations = "ro_a"
+
+[tool.input_schema]
+type = "object"
+properties = {}
+
+# ─────
+
+[[tool]]
 name = "find_phantom_modules"
 category = "analysis"
 description = "[CodeLens:Analysis] Find `mod NAME;` declarations whose name is never referenced as a path segment elsewhere in the workspace. Reports both private and public mods; visibility is included so callers can filter. Known limitation: impl-extension pattern (file split where the module only adds `impl X { ... }` to a parent type) is reported but is not actually phantom — manual review required."

--- a/crates/codelens-tui/Cargo.toml
+++ b/crates/codelens-tui/Cargo.toml
@@ -14,7 +14,7 @@ name = "codelens-tui"
 path = "src/main.rs"
 
 [dependencies]
-codelens-engine = { path = "../codelens-engine", version = "=1.13.20" }
+codelens-engine = { path = "../codelens-engine", version = "=1.13.21" }
 ratatui = "0.30"
 crossterm = "0.28"
 anyhow.workspace = true


### PR DESCRIPTION
## Phase 4-A: Detector trio + audit + 적응형 → 5번째 detector

dogfood-driven cleanup 가족의 다섯 번째 detector. 기존 4개는 *dead* surface 추적. 이번은 *too-wide* surface — compiler warning이 잡지 못함 (사용 중이지만 너무 넓게 노출).

### Suggestion rules

| current | 외부 caller | 제안 |
|---------|-------------|------|
| \`pub\` | 0 cross-crate | \`pub(crate)\` |
| \`pub\` | 0 anywhere | private (또는 제거) |
| \`pub(crate)\` | 0 other-file | private |
| \`pub(super)\`, \`pub(in path)\` | n/a | 이미 narrow — 모델 외 |

### Scope

- workspace tree (\`crates/\`)만
- column-0 declarations (impl method 제외)
- benches/, tests/, build.rs 제외
- pub fn/struct/enum/const/static/trait/type 7가지

### 알려진 false-positive 소스

- macro 호출 안의 사용
- string literal 안의 식별자 매칭
- attribute path

word-boundary scan으로 잡히지만 detector는 정당 caller로 처리. 사용자가 narrowing PR 단계에서 sanity-check 권장.

### Dogfood

이 repo: **495 over-visible declarations** 발견. 대부분 codelens-engine \`pub\` items가 \`pub(crate)\` 권장 — lib.rs의 \"**Internal API**\" 선언과 부합. cleanup PR은 detector-by-detector로 별도, 한 번에 일괄 narrowing 안 함.

### 변경

| 파일 | LOC | 내용 |
|------|-----|------|
| \`crates/codelens-mcp/src/over_visible.rs\` | +322 (new) | detector 본체 |
| \`crates/codelens-mcp/src/main.rs\` | +1 | mod 등록 |
| \`crates/codelens-mcp/src/tools/graph.rs\` | +20 | \`find_over_visible_apis_tool\` 래퍼 |
| \`crates/codelens-mcp/src/tools/mod.rs\` | +1 | dispatch arm |
| \`crates/codelens-mcp/tools.toml\` | +12 | analysis-category entry |

### 검증

- [x] \`cargo build --release --workspace\` (60s)
- [x] \`cargo test -p codelens-mcp --bin\` 554 passed (+7), 0 failed
- [x] over_visible::tests 7/7 passed, 1 ignored (dogfood)
- [x] dogfood self-repo 495 entries (정상 동작)

🤖 Generated with [Claude Code](https://claude.com/claude-code)