### PR TITLE
feat(v1.13.22): PageRank ranking signal regression gate (Phase 6-A)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,16 @@ jobs:
       - name: call-graph accuracy bench
         run: cargo test -p codelens-engine --test call_graph_accuracy -- --nocapture
 
+      # v1.13.22: ranking signal regression gate. The PageRank →
+      # search_symbols_hybrid integration shipped in v1.13.16 (Phase
+      # 3-A) is wired through several hops; isolated unit tests in
+      # search.rs::tests cannot catch a hop being silently disconnected
+      # (e.g. handler.rs forgetting to forward the Option, or signature
+      # contract drifting). Running this on its own line surfaces such
+      # regressions as a discrete CI failure.
+      - name: ranking signal regression gate
+        run: cargo test -p codelens-engine --test ranking_pagerank_effect -- --nocapture
+
       - name: cargo doctest
         run: cargo test --doc --workspace
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-engine"
-version = "1.13.21"
+version = "1.13.22"
 dependencies = [
  "anyhow",
  "criterion",
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-mcp"
-version = "1.13.21"
+version = "1.13.22"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "codelens-tui"
-version = "1.13.21"
+version = "1.13.22"
 dependencies = [
  "anyhow",
  "codelens-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "Apache-2.0"
-version = "1.13.21"
+version = "1.13.22"
 description = "Harness-native Rust MCP server for code intelligence with generated surface governance, hybrid retrieval, and mutation-gated workflows"
 repository = "https://github.com/mupozg823/codelens-mcp-plugin"
 homepage = "https://github.com/mupozg823/codelens-mcp-plugin"

--- a/crates/codelens-engine/tests/ranking_pagerank_effect.rs
+++ b/crates/codelens-engine/tests/ranking_pagerank_effect.rs
@@ -1,0 +1,165 @@
+//! Regression gate for the PageRank → ranking integration shipped in
+//! v1.13.16 (Phase 3-A). The PR added a fifth signal to
+//! `search_symbols_hybrid_with_semantic`: per-file PageRank scores
+//! drawn from the import graph, applied as a max-normalised boost up
+//! to `PAGERANK_MAX_BOOST` (5.0) before the final sort.
+//!
+//! What we want to keep working:
+//! 1. The boost is ZERO when no PageRank scores are supplied — i.e.
+//!    callers that never opt in are not silently affected.
+//! 2. When PageRank scores ARE supplied and one file ranks higher than
+//!    another, the corresponding result's score reflects that ordering
+//!    — i.e. the integration is wired all the way to the returned
+//!    `SearchResult`, not gated out by a feature flag or unwrapped to
+//!    None somewhere in the chain.
+//!
+//! This file complements the unit tests inside `search.rs::tests`
+//! (`pagerank_boost_max_normalized_by_top_file` etc.) by exercising
+//! the full search pipeline against a real on-disk SQLite index.
+//! Failure here means the integration regressed even though the helper
+//! function still works in isolation — exactly the kind of bug a
+//! signal-level CI gate should catch.
+
+use codelens_engine::{search_symbols_hybrid_with_semantic, ProjectRoot};
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn temp_project(prefix: &str) -> (PathBuf, ProjectRoot) {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!("codelens_pr_test_{prefix}_{nanos}"));
+    std::fs::create_dir_all(&root).unwrap();
+    std::fs::write(root.join("hello.txt"), "hello").unwrap();
+    let project = ProjectRoot::new(root.to_str().unwrap()).unwrap();
+    (root, project)
+}
+
+fn seed_two_file_index(project: &ProjectRoot) {
+    use codelens_engine::db::{index_db_path, IndexDb, NewSymbol};
+    let db = IndexDb::open(&index_db_path(project.as_path())).unwrap();
+    let popular = db
+        .upsert_file("popular.py", 100, "h1", 10, Some("py"))
+        .unwrap();
+    let obscure = db
+        .upsert_file("obscure.py", 100, "h2", 10, Some("py"))
+        .unwrap();
+    db.insert_symbols(
+        popular,
+        &[NewSymbol {
+            name: "shared_helper",
+            kind: "function",
+            line: 1,
+            column_num: 0,
+            start_byte: 0,
+            end_byte: 50,
+            signature: "def shared_helper():",
+            name_path: "shared_helper",
+            parent_id: None,
+        }],
+    )
+    .unwrap();
+    db.insert_symbols(
+        obscure,
+        &[NewSymbol {
+            name: "shared_helper",
+            kind: "function",
+            line: 1,
+            column_num: 0,
+            start_byte: 0,
+            end_byte: 50,
+            signature: "def shared_helper():",
+            name_path: "shared_helper",
+            parent_id: None,
+        }],
+    )
+    .unwrap();
+}
+
+#[test]
+fn pagerank_boost_changes_result_score() {
+    let (_root, project) = temp_project("changes_score");
+    seed_two_file_index(&project);
+
+    let baseline =
+        search_symbols_hybrid_with_semantic(&project, "shared_helper", 20, 0.5, None, None)
+            .expect("baseline search");
+    assert_eq!(baseline.len(), 2, "expected one hit per file");
+    let baseline_popular = baseline
+        .iter()
+        .find(|r| r.file == "popular.py")
+        .expect("popular hit");
+    let baseline_obscure = baseline
+        .iter()
+        .find(|r| r.file == "obscure.py")
+        .expect("obscure hit");
+
+    // Without PageRank, both files have identical exact-match scores.
+    assert_eq!(
+        baseline_popular.score, baseline_obscure.score,
+        "exact-match path should give identical scores absent PageRank"
+    );
+
+    // Now feed PageRank scores: popular.py is the import-graph leader.
+    let mut pr = HashMap::new();
+    pr.insert("popular.py".to_owned(), 0.4);
+    pr.insert("obscure.py".to_owned(), 0.05);
+    let boosted =
+        search_symbols_hybrid_with_semantic(&project, "shared_helper", 20, 0.5, None, Some(&pr))
+            .expect("boosted search");
+    let boosted_popular = boosted
+        .iter()
+        .find(|r| r.file == "popular.py")
+        .expect("popular hit");
+    let boosted_obscure = boosted
+        .iter()
+        .find(|r| r.file == "obscure.py")
+        .expect("obscure hit");
+
+    assert!(
+        boosted_popular.score > baseline_popular.score,
+        "popular.py score should rise with PageRank: {} → {}",
+        baseline_popular.score,
+        boosted_popular.score
+    );
+    assert!(
+        boosted_popular.score > boosted_obscure.score,
+        "popular.py should outrank obscure.py once PageRank is applied: {} > {}",
+        boosted_popular.score,
+        boosted_obscure.score
+    );
+}
+
+#[test]
+fn empty_pagerank_map_is_indistinguishable_from_none() {
+    let (_root, project) = temp_project("empty_map");
+    seed_two_file_index(&project);
+
+    let none_result =
+        search_symbols_hybrid_with_semantic(&project, "shared_helper", 20, 0.5, None, None)
+            .expect("none search");
+    let empty_result = search_symbols_hybrid_with_semantic(
+        &project,
+        "shared_helper",
+        20,
+        0.5,
+        None,
+        Some(&HashMap::new()),
+    )
+    .expect("empty search");
+
+    // Both should return the same number of hits with the same scores —
+    // an empty PR map is a no-op (max_pr == 0 → boost skipped).
+    assert_eq!(none_result.len(), empty_result.len());
+    for (n, e) in none_result.iter().zip(empty_result.iter()) {
+        assert_eq!(n.file, e.file);
+        assert!(
+            (n.score - e.score).abs() < 1e-9,
+            "empty PR map must not perturb scores: {} vs {}",
+            n.score,
+            e.score
+        );
+    }
+}

--- a/crates/codelens-mcp/Cargo.toml
+++ b/crates/codelens-mcp/Cargo.toml
@@ -37,7 +37,7 @@ regex.workspace = true
 rusqlite.workspace = true
 toml = "0.8"
 rustls = { workspace = true, optional = true }
-codelens-engine = { path = "../codelens-engine", version = "=1.13.21", default-features = false }
+codelens-engine = { path = "../codelens-engine", version = "=1.13.22", default-features = false }
 thiserror.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/codelens-tui/Cargo.toml
+++ b/crates/codelens-tui/Cargo.toml
@@ -14,7 +14,7 @@ name = "codelens-tui"
 path = "src/main.rs"
 
 [dependencies]
-codelens-engine = { path = "../codelens-engine", version = "=1.13.21" }
+codelens-engine = { path = "../codelens-engine", version = "=1.13.22" }
 ratatui = "0.30"
 crossterm = "0.28"
 anyhow.workspace = true


### PR DESCRIPTION
## Phase 6-A: regression gate

v1.13.16의 PageRank → search 통합이 silent disconnect 되어도 catch하는 integration-level gate. search.rs::tests의 unit test는 helper logic만 검증 — wiring/feature gate/signature drift 회귀는 못 잡음.

### 추가

\`tests/ranking_pagerank_effect.rs\` (2 cases):
1. \`pagerank_boost_changes_result_score\` — 실제 SQLite index에 두 file 동일 BM25 → PageRank 활성 시 popular > obscure 순서 + score 상승 검증
2. \`empty_pagerank_map_is_indistinguishable_from_none\` — empty map = None no-op 계약

### CI

\`ci.yml\`에 \`ranking signal regression gate\` step 추가 (call-graph accuracy bench 다음). 회귀 시 별도 step으로 fail 표시.

### 검증

- [x] cargo build --release --workspace (60s)
- [x] ranking_pagerank_effect: 2/2 passed
- [x] call_graph_accuracy: 1/1 passed (기존 게이트 유지)

### 후속 (별도 phase)

- SCIP-on/off cross-file accuracy 비교 — fixture project + index.scip 체크인 필요 (큰 작업)
- MRR/Accuracy@k workloads — hand-crafted fixture + ground truth 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)