### PR TITLE
docs: surface CodeLens 'wins' (resolves #173)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Pure Rust MCP server for multi-agent harnesses with hybrid retrieval (tree-sitte
 
 ## Surface Snapshot
 
-- Workspace version: `1.12.0`
+- Workspace version: `1.13.22`
 - Workspace members: `3` (`crates/codelens-engine`, `crates/codelens-mcp`, `crates/codelens-tui`)
 - Registered tool definitions: `106`
 - Tool output schemas: `77 / 106`
@@ -28,6 +28,7 @@ Pure Rust MCP server for multi-agent harnesses with hybrid retrieval (tree-sitte
 - Profiles: `planner-readonly` (32), `builder-minimal` (36), `reviewer-graph` (36), `evaluator-compact` (14), `refactor-full` (50), `ci-audit` (43), `workflow-first` (19)
 - Presets: `minimal` (27), `balanced` (77), `full` (106)
 - Canonical manifest: [`docs/generated/surface-manifest.json`](docs/generated/surface-manifest.json)
+
 <!-- SURFACE_MANIFEST_README_SNAPSHOT:END -->
 
 ---

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Pure Rust MCP server for multi-agent harnesses with hybrid retrieval (tree-sitte
 </div>
 
 <!-- SURFACE_MANIFEST_README_SNAPSHOT:BEGIN -->
+
 ## Surface Snapshot
 
 - Workspace version: `1.12.0`
@@ -364,14 +365,33 @@ verify_change_readiness → "ready" → rename_symbol
                         → "blocked" → fix blockers first
 ```
 
+## What CodeLens Does Well (vs native grep/ls)
+
+A complement to the existing routing matrix in `CLAUDE.md`. The cases below
+have shown up repeatedly across self-dogfood and external project sessions
+(see `benchmarks/cl-positive-findings-2026-05-03.md` for measurement notes).
+
+| Task                       | CodeLens                                                      | Native fallback               | Why CL wins                                                                                                |
+| -------------------------- | ------------------------------------------------------------- | ----------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| Project bootstrap          | `prepare_harness_session(profile=…, detail=compact)` — 1 call | `ls + cargo build + python …` | activation + index recovery + capability + tool surface together                                           |
+| Pre-merge change review    | `review_changes(changed_files=[…])`                           | manual diff inspection        | quantified 4-axis verifier (diagnostics / refs / tests / mutation), `readiness_score` 0–1, `blocker_count` |
+| Function definition lookup | `find_symbol(name=…)`                                         | `grep -rn "def X"`            | exact symbol kind + signature + nearby tests in one response                                               |
+
+For the full _when not_ matrix (where `Grep` / `Read` win), keep the
+`CLAUDE.md` "Tool Routing — honest scenario matrix" as the single source
+of truth. This section only fixes the recurring "I can use CodeLens for
+this?" gap.
+
 ## Language Support
 
 <!-- SURFACE_MANIFEST_README_LANGUAGES:BEGIN -->
+
 Canonical parser families (30): C, Clojure/ClojureScript, C++, C#, CSS, Dart, Erlang, Elixir, Go, Haskell, HTML, Java, Julia, JavaScript, Kotlin, Lua, OCaml, PHP, Python, R, Ruby, Rust, Scala, Bash/Shell, Swift, TOML, TypeScript, TSX/JSX, YAML, Zig
 
 Import-graph capable families: C, C++, C#, CSS, Dart, Go, Java, JavaScript, Kotlin, PHP, Python, Ruby, Rust, Scala, Swift, TypeScript, TSX/JSX
 
 The canonical family/extension inventory is generated from `codelens_engine::lang_registry` and published in [`docs/generated/surface-manifest.json`](docs/generated/surface-manifest.json).
+
 <!-- SURFACE_MANIFEST_README_LANGUAGES:END -->
 
 ## Performance

--- a/benchmarks/cl-positive-findings-2026-05-03.md
+++ b/benchmarks/cl-positive-findings-2026-05-03.md
@@ -1,0 +1,79 @@
+# CodeLens — Positive Findings (dogfood 2026-05-03)
+
+Source: Depixelate V3 (`/Users/bagjaeseog/3.0`, ~7K LOC Python) parent harness
+session. Build under test: `e45f1ceb` v1.13.22. Profile mostly
+`reviewer-graph` (token_budget 2400) with one `planner-readonly` bootstrap.
+
+This file accompanies the `## What CodeLens Does Well` README section. Goal:
+record concrete situations where CodeLens replaced a multi-step native flow
+with a single tool call so they can be surfaced to new agents/users.
+
+## 1. `prepare_harness_session` — single-call bootstrap
+
+```jsonc
+mcp__codelens__prepare_harness_session({
+  "project": "/Users/bagjaeseog/3.0",
+  "profile": "planner-readonly",
+  "detail": "compact"
+})
+```
+
+Returned in one response:
+
+- `activated: true`, `project_name: "3.0"`, `indexed_files: 137`
+- `index_recovery: { status: "not_needed" }` (auto-refresh logic ran first)
+- `capabilities: { intelligence_sources: ["tree_sitter"], available: [symbols, imports, calls, rename, search, blast_radius, dead_code, type_hierarchy_native] }`
+- `visible_tools.tool_count: 34` with full tool name list
+- `daemon_binary_drift: { status: "ok" }`
+- `health_summary: { status: "ok" }`
+
+Native equivalent ≈ `ls` + `cargo build --version` + `python -c 'import …'` +
+"check if MCP daemon matches binary" — multi-call, multi-second, requires
+shell knowledge.
+
+**Caveat**: subsequent `get_symbols_overview` calls hit the 2400-token budget
+and clipped 95-symbol files to 3 visible entries. See dogfood [#170 follow-up](https://github.com/mupozg823/codelens-mcp-plugin/issues/170#issuecomment-comments)
+for the in-array truncation marker proposal.
+
+## 2. `find_symbol(name=…)` — definition + tests in one shot
+
+Used to locate `diagnose_system` and `evaluate_mosaic_observability`:
+
+```jsonc
+mcp__codelens__find_symbol({ "name": "diagnose_system" })
+// → 1 def (mosaic_equation_accumulator.py:111) + 2 unit tests in 1 response
+```
+
+Native equivalent ≈ `grep -rn "diagnose_system" depixelate_v3/` (returns
+13+ candidates including doc strings/comments to filter manually).
+
+**Caveat**: `name_path` parameter is silently rejected (must be `name`),
+`include_body=true` did not return body on the tree-sitter backend during
+this session — see [#170](https://github.com/mupozg823/codelens-mcp-plugin/issues/170)
+and [#172](https://github.com/mupozg823/codelens-mcp-plugin/issues/172).
+
+## 3. `review_changes` — quantified pre-merge gate
+
+Across three Depixelate V3 changesets the tool returned a single
+verifier verdict per change instead of requiring manual diff inspection.
+
+| Changeset (project SHA)             | Files | `readiness_score` | `risk_level` | `blocker_count` |
+| ----------------------------------- | ----- | ----------------- | ------------ | --------------- |
+| F4 overlay export (aed74aa)         | 3     | 1.0               | low          | 0               |
+| F6 adapter hardening (82bee8a)      | 2     | 0.75              | medium       | 0               |
+| diagnose↔gate integration (547c19a) | 1     | 1.0               | low          | 0               |
+| F5 mode recommendation (8ecc1f2)    | 3     | 1.0               | low          | 0               |
+
+The 0.75 / `medium` case was a heuristic false positive (backend Python
+classified as Browser/SSR-sensitive) — see [#171](https://github.com/mupozg823/codelens-mcp-plugin/issues/171).
+Once the file-extension gate lands, this score should reach 1.0 too.
+
+Native equivalent: read every changed file, run tests/lint manually,
+guess at blast radius, look for callers — no quantified comparable.
+
+## How to update this file
+
+Append a new dogfood session as `## N. <title>` whenever a CodeLens call
+replaces ≥ 3 native steps. Cross-link to dogfood issues when behaviour
+diverges from expectations. Keep the existing `bench-accuracy-and-usefulness-*`
+files for retrieval-quality benchmarks; this file is for _workflow_ wins.

--- a/scripts/surface-manifest.py
+++ b/scripts/surface-manifest.py
@@ -119,7 +119,10 @@ def replace_block(text: str, begin: str, end: str, content: str) -> str:
     if start == -1 or finish == -1 or finish < start:
         raise SystemExit(f"missing marker pair: {begin} .. {end}")
     finish += len(end)
-    replacement = f"{begin}\n{content}\n{end}"
+    # Prettier inserts a blank line after HTML comments preceding markdown
+    # headings/content, so canonicalise the marker layout the same way to
+    # avoid permanent drift between this script and the editor formatter.
+    replacement = f"{begin}\n\n{content}\n\n{end}"
     return text[:start] + replacement + text[finish:]
 
 


### PR DESCRIPTION
Resolves #173.

## Summary

- Add **What CodeLens Does Well (vs native grep/ls)** section to `README.md` between *Mutation Safety* and *Language Support*. Lists 3 recurring wins: 1-call bootstrap, `review_changes` verifier signals, `find_symbol` definition+tests in one shot.
- New `benchmarks/cl-positive-findings-2026-05-03.md` with measurement notes from a fresh Depixelate V3 dogfood session (4 changesets, readiness 0.75–1.0, blockers 0, with cross-links to dogfood issues #170 / #171 / #172).
- README explicitly defers the *when not* matrix to `CLAUDE.md` "Tool Routing — honest scenario matrix" so the two stay synchronized.

## Why now

- Issue #173 (positive-findings dogfood feedback) — agents kept missing CodeLens wins until told.
- Mirror approach to existing `bench-accuracy-and-usefulness-2026-04-19.md` for retrieval quality, but workflow-focused.

## Test plan

- [ ] Visual check `README.md` rendering on GitHub
- [ ] Spot-check that the cross-linked issues (#170 / #171 / #172) still resolve