### PR TITLE
fix(#170): soft alias for find_symbol name_path + surface unknown_args warnings

### DIFF
--- a/crates/codelens-mcp/src/integration_tests/readonly.rs
+++ b/crates/codelens-mcp/src/integration_tests/readonly.rs
@@ -31,8 +31,8 @@ fn returns_symbols_via_tool_call() {
 // P1-B contract: every read-only tool in the second wave must
 // 1) honor `limit` / `top_k` aliases for whatever its canonical
 //    limit field is (or skip the alias if it has no limit field),
-// 2) surface unknown top-level keys in `unknown_args: [...]` so
-//    silent drops of agent input become observable.
+// 2) surface unknown top-level keys (`unknown_args` for legacy tools,
+//    `warnings` for find_symbol) so silent drops of agent input become observable.
 //
 // Doc: docs/design/arg-validation-policy.md
 #[test]
@@ -80,10 +80,14 @@ fn p1_b_arg_validation_contract_across_five_tools() {
         json!({"name": "alpha", "limit": 3, "carrot": "c"}),
     );
     assert_eq!(p["success"], json!(true));
-    assert_eq!(
-        p["data"]["unknown_args"],
-        json!(["carrot"]),
-        "find_symbol must surface unknown carrot key"
+    let warnings = p["data"]["warnings"]
+        .as_array()
+        .expect("find_symbol must have top-level warnings array");
+    assert!(
+        warnings
+            .iter()
+            .any(|w| w.as_str().map(|s| s.contains("carrot")).unwrap_or(false)),
+        "find_symbol must surface unknown carrot key in warnings"
     );
 
     // find_referencing_symbols — limit alias on tree-sitter fallback path

--- a/crates/codelens-mcp/src/tools/symbols/handlers.rs
+++ b/crates/codelens-mcp/src/tools/symbols/handlers.rs
@@ -80,10 +80,22 @@ pub fn find_symbol(state: &AppState, arguments: &Value) -> ToolResult {
         "body_full",
         "body_line_limit",
         "body_char_limit",
+        "name_path", // legacy alias for `name`; deprecated since v1.13.23
     ];
     let symbol_id = optional_string(arguments, "symbol_id");
+    let name_path_alias = optional_string(arguments, "name_path");
+    let mut deprecation_warnings: Vec<String> = Vec::new();
+    if name_path_alias.is_some()
+        && optional_string(arguments, "name").is_none()
+        && symbol_id.is_none()
+    {
+        deprecation_warnings.push(
+            "`name_path` is deprecated; use `name` (will be removed in v1.14.0)".to_owned(),
+        );
+    }
     let name = symbol_id
         .or_else(|| optional_string(arguments, "name"))
+        .or(name_path_alias)
         .ok_or_else(|| CodeLensError::MissingParam("symbol_id or name".into()))?;
     let file_path = optional_string(arguments, "file_path");
     let include_body = optional_bool(arguments, "include_body", false);
@@ -157,10 +169,14 @@ pub fn find_symbol(state: &AppState, arguments: &Value) -> ToolResult {
                 "backend": "scip",
                 "evidence": evidence,
             });
-            if !unknown_args.is_empty()
-                && let Some(map) = payload.as_object_mut()
-            {
-                map.insert("unknown_args".to_owned(), json!(unknown_args));
+            if let Some(map) = payload.as_object_mut() {
+                map.insert("deprecation_warnings".to_owned(), json!(deprecation_warnings));
+                if !unknown_args.is_empty() {
+                    map.insert(
+                        "warnings".to_owned(),
+                        json!([format!("unknown args ignored: {:?}", unknown_args)]),
+                    );
+                }
             }
             return Ok((payload, meta));
         }
@@ -228,8 +244,12 @@ pub fn find_symbol(state: &AppState, arguments: &Value) -> ToolResult {
                         ),
                     ),
                 );
+                map.insert("deprecation_warnings".to_owned(), json!(deprecation_warnings));
                 if !unknown_args.is_empty() {
-                    map.insert("unknown_args".to_owned(), json!(unknown_args));
+                    map.insert(
+                        "warnings".to_owned(),
+                        json!([format!("unknown args ignored: {:?}", unknown_args)]),
+                    );
                 }
             }
             (payload, meta)
@@ -851,6 +871,59 @@ fn suggested_follow_up(kind: &str, exported: bool) -> Vec<&'static str> {
         return with_refs;
     }
     base
+}
+
+#[cfg(test)]
+mod find_symbol_argument_tests {
+    use super::find_symbol;
+    use crate::test_helpers::fixtures::temp_project_root;
+    use crate::tool_defs::ToolPreset;
+    use serde_json::json;
+
+    fn test_state(label: &str) -> crate::AppState {
+        let project = temp_project_root(label);
+        crate::AppState::new_minimal(project, ToolPreset::Full)
+    }
+
+    #[test]
+    fn name_path_alias_resolves_with_deprecation_warning() {
+        let state = test_state("find-symbol-name-path-alias");
+
+        let (payload, _) = find_symbol(&state, &json!({ "name_path": "find_symbol" }))
+            .expect("name_path alias should resolve without MissingParam");
+
+        let warnings = payload["deprecation_warnings"]
+            .as_array()
+            .expect("deprecation_warnings should be an array");
+        assert_eq!(warnings.len(), 1);
+        assert!(
+            warnings
+                .first()
+                .and_then(|warning| warning.as_str())
+                .is_some_and(|warning| warning.contains("name_path"))
+        );
+    }
+
+    #[test]
+    fn unknown_args_surfaced_in_top_level_warnings() {
+        let state = test_state("find-symbol-unknown-args");
+
+        let (payload, _) = find_symbol(
+            &state,
+            &json!({ "name": "find_symbol", "nonexistent_arg": "value" }),
+        )
+        .expect("unknown args should be ignored");
+
+        let warnings = payload["warnings"]
+            .as_array()
+            .expect("warnings should be a top-level array");
+        assert!(!warnings.is_empty());
+        assert!(warnings.iter().any(|warning| {
+            warning
+                .as_str()
+                .is_some_and(|warning| warning.contains("nonexistent_arg"))
+        }));
+    }
 }
 
 #[cfg(test)]

--- a/crates/codelens-mcp/tools.toml
+++ b/crates/codelens-mcp/tools.toml
@@ -155,7 +155,7 @@ properties = { path = { type = "string" }, depth = { type = "integer" } }
 [[tool]]
 name = "find_symbol"
 category = "symbol"
-description = "[CodeLens:Symbol] Find function/class by exact name. Returns signature + body."
+description = "[CodeLens:Symbol] Find function/class by exact name. Returns signature + body. Use `name` (canonical). Legacy `name_path` is accepted for one release with deprecation warning. `include_body=true` returns full body via tree-sitter; SCIP backend currently returns signature only (#172)."
 annotations = "ro_p"
 output_schema = "symbol_output_schema"
 
@@ -168,6 +168,7 @@ file_path = { type = "string" }
 include_body = { type = "boolean" }
 exact_match = { type = "boolean" }
 max_matches = { type = "integer" }
+name_path = { type = "string", description = "DEPRECATED v1.13.23 — use `name`. Soft alias maintained until v1.14.0." }
 
 # ─────
 


### PR DESCRIPTION
## Summary

- Adds `name_path` as a soft alias for `name` in `find_symbol`, accepted for one release window (until v1.14.0 — see also #172 for SCIP body gap context).
- Emits a `deprecation_warnings` top-level field in every `find_symbol` response (empty array when nothing is deprecated, so callers can always key on it).
- Surfaces unknown arguments as a top-level `warnings` field (human-readable formatted string) instead of the raw `unknown_args` array that was buried and easy to miss.
- Updates integration test `p1_b_arg_validation_contract_across_five_tools` to assert the new `warnings` shape for `find_symbol` (other four tools — `get_callers`, `get_callees`, `find_referencing_symbols`, `get_ranked_context` — keep their existing `unknown_args` behaviour unchanged).
- Adds two unit tests: `name_path_alias_resolves_with_deprecation_warning` and `unknown_args_surfaced_in_top_level_warnings`.

Resolves #170. `name_path` will be removed in v1.14.0.

## Test plan

- [x] `cargo test -p codelens-mcp` — 556 passed, 0 failed
- [x] `cargo clippy -p codelens-mcp -- -W clippy::all` — 0 new warnings (2 pre-existing in `codelens-engine`)
- [x] Existing `name` / `symbol_id` callers unaffected (regression: 0)
- [x] `name_path`-only call returns correct result + `deprecation_warnings` array with 1 entry
- [x] Unknown argument call returns top-level `warnings` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)