### PR TITLE
fix(#171, #175 A·B·E): backend path gate + compact response shrink + dogfood docs

### DIFF
--- a/crates/codelens-mcp/src/integration_tests/readonly.rs
+++ b/crates/codelens-mcp/src/integration_tests/readonly.rs
@@ -97,10 +97,10 @@ fn find_referencing_symbols_accepts_legacy_relative_path_with_deprecation_warnin
 fn find_symbol_with_include_body_returns_body_via_scip_heuristic() {
     let fixture = std::env::var("CODELENS_SCIP_HEURISTIC_FIXTURE")
         .expect("set CODELENS_SCIP_HEURISTIC_FIXTURE to a project with index.scip");
-    let symbol = std::env::var("CODELENS_SCIP_HEURISTIC_SYMBOL")
-        .unwrap_or_else(|_| "MyStruct".to_owned());
-    let file_path = std::env::var("CODELENS_SCIP_HEURISTIC_FILE")
-        .unwrap_or_else(|_| "src/main.rs".to_owned());
+    let symbol =
+        std::env::var("CODELENS_SCIP_HEURISTIC_SYMBOL").unwrap_or_else(|_| "MyStruct".to_owned());
+    let file_path =
+        std::env::var("CODELENS_SCIP_HEURISTIC_FILE").unwrap_or_else(|_| "src/main.rs".to_owned());
     let project = ProjectRoot::new(&fixture).unwrap();
     let state = make_state(&project);
 

--- a/crates/codelens-mcp/src/tool_defs/generated/build_generated.rs
+++ b/crates/codelens-mcp/src/tool_defs/generated/build_generated.rs
@@ -342,12 +342,12 @@ pub fn lsp_tools(ro_a: &ToolAnnotations, ro_p: &ToolAnnotations) -> Vec<Tool> {
         Tool::new(
             "find_referencing_symbols",
             "[CodeLens:Symbol] Find all usages of a symbol. use_lsp=true for type-aware precision.",
-            json!({"type":"object","required":["file_path"],"properties":{"file_path":{"type":"string","description":"File containing or declaring the symbol"},"symbol_name":{"type":"string","description":"Symbol name (default: tree-sitter search)"},"line":{"type":"integer","description":"Line number (triggers LSP path)"},"column":{"type":"integer","description":"Column number (triggers LSP path)"},"use_lsp":{"type":"boolean","description":"Force LSP lookup (slower but type-aware, requires LSP server)"},"command":{"type":"string"},"args":{"type":"array","items":{"type":"string"}},"max_results":{"type":"integer"}}}),
+            json!({"type":"object","required":["path"],"properties":{"path":{"type":"string","description":"File containing or declaring the symbol"},"file_path":{"type":"string","description":"DEPRECATED v1.13.23 — use `path`. Soft alias maintained until v1.14.0."},"relative_path":{"type":"string","description":"DEPRECATED v1.13.23 — use `path`. Soft alias maintained until v1.14.0."},"symbol_name":{"type":"string","description":"Symbol name (default: tree-sitter search)"},"line":{"type":"integer","description":"Line number (triggers LSP path)"},"column":{"type":"integer","description":"Column number (triggers LSP path)"},"use_lsp":{"type":"boolean","description":"Force LSP lookup (slower but type-aware, requires LSP server)"},"command":{"type":"string"},"args":{"type":"array","items":{"type":"string"}},"max_results":{"type":"integer"}}}),
         ).with_output_schema(references_output_schema()).with_annotations(ro_p.clone()),
         Tool::new(
             "get_file_diagnostics",
             "[CodeLens:Symbol] Type errors and lint issues via LSP. Use after editing code.",
-            json!({"type":"object","required":["file_path"],"properties":{"file_path":{"type":"string"},"command":{"type":"string"},"args":{"type":"array","items":{"type":"string"}},"max_results":{"type":"integer"}}}),
+            json!({"type":"object","required":["path"],"properties":{"path":{"type":"string"},"file_path":{"type":"string","description":"DEPRECATED v1.13.23 — use `path`. Soft alias maintained until v1.14.0."},"relative_path":{"type":"string","description":"DEPRECATED v1.13.23 — use `path`. Soft alias maintained until v1.14.0."},"command":{"type":"string"},"args":{"type":"array","items":{"type":"string"}},"max_results":{"type":"integer"}}}),
         ).with_output_schema(diagnostics_output_schema()).with_annotations(ro_p.clone()),
         Tool::new(
             "search_workspace_symbols",
@@ -603,12 +603,12 @@ pub fn symbol_tools(
         Tool::new(
             "get_symbols_overview",
             "[CodeLens:Symbol] List all symbols in a file — structural map. Use first to understand a file.",
-            json!({"type":"object","required":["path"],"properties":{"path":{"type":"string"},"depth":{"type":"integer"}}}),
+            json!({"type":"object","required":["path"],"properties":{"path":{"type":"string"},"file_path":{"type":"string","description":"DEPRECATED v1.13.23 — use `path`. Soft alias maintained until v1.14.0."},"relative_path":{"type":"string","description":"DEPRECATED v1.13.23 — use `path`. Soft alias maintained until v1.14.0."},"depth":{"type":"integer"}}}),
         ).with_output_schema(symbol_output_schema()).with_annotations(ro_p.clone()),
         Tool::new(
             "find_symbol",
-            "[CodeLens:Symbol] Find function/class by exact name. Returns signature + body.",
-            json!({"type":"object","properties":{"name":{"type":"string","description":"Symbol name to search for"},"symbol_id":{"type":"string","description":"Stable symbol ID (file#kind:name_path). Overrides name."},"file_path":{"type":"string"},"include_body":{"type":"boolean"},"exact_match":{"type":"boolean"},"max_matches":{"type":"integer"}}}),
+            "[CodeLens:Symbol] Find function/class by exact name. Returns signature + body. Use `name` (canonical). Legacy `name_path` is accepted for one release with deprecation warning. `include_body=true` returns full body via tree-sitter; SCIP backend currently returns signature only (#172).",
+            json!({"type":"object","properties":{"name":{"type":"string","description":"Symbol name to search for"},"symbol_id":{"type":"string","description":"Stable symbol ID (file#kind:name_path). Overrides name."},"file_path":{"type":"string"},"include_body":{"type":"boolean"},"exact_match":{"type":"boolean"},"max_matches":{"type":"integer"},"name_path":{"type":"string","description":"DEPRECATED v1.13.23 — use `name`. Soft alias maintained until v1.14.0."}}}),
         ).with_output_schema(symbol_output_schema()).with_annotations(ro_p.clone()),
         Tool::new(
             "get_ranked_context",

--- a/crates/codelens-mcp/src/tools/lsp.rs
+++ b/crates/codelens-mcp/src/tools/lsp.rs
@@ -231,14 +231,8 @@ pub fn find_referencing_symbols(state: &AppState, arguments: &serde_json::Value)
                     "backend": "oxc_semantic",
                     "evidence": evidence,
                 });
-                if !unknown_args.is_empty()
-                    || !deprecation_warnings.is_empty()
-                {
-                    insert_response_annotations(
-                        &mut payload,
-                        &unknown_args,
-                        &deprecation_warnings,
-                    );
+                if !unknown_args.is_empty() || !deprecation_warnings.is_empty() {
+                    insert_response_annotations(&mut payload, &unknown_args, &deprecation_warnings);
                 }
                 return Ok((payload, meta));
             }
@@ -289,9 +283,7 @@ pub fn find_referencing_symbols(state: &AppState, arguments: &serde_json::Value)
                         "backend": "scip",
                         "evidence": evidence,
                     });
-                    if !unknown_args.is_empty()
-                        || !deprecation_warnings.is_empty()
-                    {
+                    if !unknown_args.is_empty() || !deprecation_warnings.is_empty() {
                         insert_response_annotations(
                             &mut payload,
                             &unknown_args,
@@ -396,14 +388,8 @@ pub fn find_referencing_symbols(state: &AppState, arguments: &serde_json::Value)
                     "sampled": false,
                     "evidence": evidence,
                 });
-                if !unknown_args.is_empty()
-                    || !deprecation_warnings.is_empty()
-                {
-                    insert_response_annotations(
-                        &mut payload,
-                        &unknown_args,
-                        &deprecation_warnings,
-                    );
+                if !unknown_args.is_empty() || !deprecation_warnings.is_empty() {
+                    insert_response_annotations(&mut payload, &unknown_args, &deprecation_warnings);
                 }
                 return Ok((payload, meta));
             }
@@ -531,10 +517,7 @@ pub fn get_file_diagnostics(state: &AppState, arguments: &serde_json::Value) -> 
         .map(|value| {
             let mut payload = json!({ "diagnostics": value, "count": value.len() });
             insert_response_annotations(&mut payload, &unknown_args, &deprecation_warnings);
-            (
-                payload,
-                success_meta(BackendKind::Lsp, 0.9),
-            )
+            (payload, success_meta(BackendKind::Lsp, 0.9))
         })
 }
 

--- a/crates/codelens-mcp/src/tools/report_contract.rs
+++ b/crates/codelens-mcp/src/tools/report_contract.rs
@@ -80,6 +80,7 @@ pub(super) fn make_handle_response(
             &artifact.readiness,
             &artifact.verifier_checks,
             &artifact.available_sections,
+            &touched_files,
             true,
             ci_audit,
         );
@@ -139,6 +140,7 @@ pub(super) fn make_handle_response(
         &artifact.readiness,
         &artifact.verifier_checks,
         &artifact.available_sections,
+        &touched_files,
         false,
         ci_audit,
     );

--- a/crates/codelens-mcp/src/tools/report_payload.rs
+++ b/crates/codelens-mcp/src/tools/report_payload.rs
@@ -1,6 +1,6 @@
 use crate::resources::{analysis_section_handles, analysis_summary_resource};
 use crate::state::{AnalysisReadiness, AnalysisVerifierCheck};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use super::report_verifier::{VERIFIER_BLOCKED, VERIFIER_READY};
 

--- a/crates/codelens-mcp/src/tools/report_payload.rs
+++ b/crates/codelens-mcp/src/tools/report_payload.rs
@@ -58,7 +58,7 @@ pub(crate) fn build_handle_payload(
     } else {
         verifier_checks.to_vec()
     };
-    let quality_focus = infer_quality_focus(tool_name, summary, top_findings);
+    let quality_focus = infer_quality_focus(tool_name, summary, top_findings, &[]);
     let recommended_checks = infer_recommended_checks(
         tool_name,
         summary,
@@ -212,8 +212,29 @@ pub(crate) fn infer_risk_level(
     }
 }
 
-fn infer_quality_focus(tool_name: &str, summary: &str, top_findings: &[String]) -> Vec<String> {
+fn infer_quality_focus(
+    tool_name: &str,
+    summary: &str,
+    top_findings: &[String],
+    changed_files: &[String],
+) -> Vec<String> {
     let combined = format!("{} {}", summary, top_findings.join(" ")).to_ascii_lowercase();
+    let frontend_path = changed_files.iter().any(|p| {
+        let p = p.to_ascii_lowercase();
+        p.contains("/templates/")
+            || p.contains("/components/")
+            || p.contains("/pages/")
+            || p.contains("/views/")
+            || p.contains("/ui/")
+            || p.ends_with(".tsx")
+            || p.ends_with(".jsx")
+            || p.ends_with(".vue")
+            || p.ends_with(".svelte")
+            || p.ends_with(".html")
+            || p.ends_with(".css")
+            || p.ends_with(".scss")
+            || p.ends_with(".astro")
+    });
     let mut focus = Vec::new();
     let mut push_unique = |value: &str| {
         if !focus.iter().any(|existing| existing == value) {
@@ -233,12 +254,12 @@ fn infer_quality_focus(tool_name: &str, summary: &str, top_findings: &[String]) 
     ) {
         push_unique("regression_safety");
     }
-    if combined.contains("http")
-        || combined.contains("browser")
-        || combined.contains("ui")
-        || combined.contains("render")
-        || combined.contains("frontend")
-        || combined.contains("layout")
+    if frontend_path
+        && (combined.contains("http")
+            || combined.contains("browser")
+            || combined.contains("render")
+            || combined.contains("frontend")
+            || combined.contains("layout"))
     {
         push_unique("user_experience");
     }
@@ -453,5 +474,33 @@ mod preview_first_trim_tests {
                 "{tool} above threshold must keep top_findings"
             );
         }
+    }
+
+    #[test]
+    fn infer_quality_focus_skips_user_experience_on_backend_python() {
+        let changed = vec!["foo.py".to_owned()];
+        let focus =
+            infer_quality_focus("semantic_code_review", "ui handler refactor", &[], &changed);
+        assert!(
+            !focus.contains(&"user_experience".to_owned()),
+            "backend Python file must not trigger user_experience: {:?}",
+            focus
+        );
+    }
+
+    #[test]
+    fn infer_quality_focus_keeps_user_experience_on_frontend_files() {
+        let changed = vec!["src/components/Btn.tsx".to_owned()];
+        let focus = infer_quality_focus(
+            "semantic_code_review",
+            "render bug in layout",
+            &[],
+            &changed,
+        );
+        assert!(
+            focus.contains(&"user_experience".to_owned()),
+            "frontend .tsx file with render/layout summary must trigger user_experience: {:?}",
+            focus
+        );
     }
 }

--- a/crates/codelens-mcp/src/tools/report_payload.rs
+++ b/crates/codelens-mcp/src/tools/report_payload.rs
@@ -1,6 +1,6 @@
 use crate::resources::{analysis_section_handles, analysis_summary_resource};
 use crate::state::{AnalysisReadiness, AnalysisVerifierCheck};
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 
 use super::report_verifier::{VERIFIER_BLOCKED, VERIFIER_READY};
 
@@ -17,6 +17,7 @@ pub(crate) fn build_handle_payload(
     readiness: &AnalysisReadiness,
     verifier_checks: &[AnalysisVerifierCheck],
     available_sections: &[String],
+    touched_files: &[String],
     reused: bool,
     ci_audit: bool,
 ) -> Value {
@@ -58,7 +59,7 @@ pub(crate) fn build_handle_payload(
     } else {
         verifier_checks.to_vec()
     };
-    let quality_focus = infer_quality_focus(tool_name, summary, top_findings, &[]);
+    let quality_focus = infer_quality_focus(tool_name, summary, top_findings, touched_files);
     let recommended_checks = infer_recommended_checks(
         tool_name,
         summary,

--- a/crates/codelens-mcp/src/tools/report_verifier.rs
+++ b/crates/codelens-mcp/src/tools/report_verifier.rs
@@ -72,16 +72,34 @@ fn browser_or_ssr_sensitive(
     top_findings: &[String],
     next_actions: &[String],
 ) -> bool {
+    let has_frontend_file = touched_files.iter().any(|p| {
+        let p = p.to_ascii_lowercase();
+        p.contains("/templates/")
+            || p.contains("/components/")
+            || p.contains("/pages/")
+            || p.contains("/views/")
+            || p.contains("/ui/")
+            || p.ends_with(".tsx")
+            || p.ends_with(".jsx")
+            || p.ends_with(".vue")
+            || p.ends_with(".svelte")
+            || p.ends_with(".html")
+            || p.ends_with(".css")
+            || p.ends_with(".scss")
+            || p.ends_with(".astro")
+    });
+    if !has_frontend_file {
+        return false;
+    }
     let combined = format!(
-        "{} {} {} {}",
-        touched_files.join(" "),
+        "{} {} {}",
         summary,
         top_findings.join(" "),
         next_actions.join(" ")
     )
     .to_ascii_lowercase();
     [
-        "browser", "frontend", "layout", "modal", "render", "route", "ssr", "ui",
+        "browser", "frontend", "layout", "modal", "render", "route", "ssr",
     ]
     .iter()
     .any(|needle| combined.contains(needle))

--- a/crates/codelens-mcp/src/tools/reports/eval_reports.rs
+++ b/crates/codelens-mcp/src/tools/reports/eval_reports.rs
@@ -9,16 +9,16 @@
 //! yet so synthetic scoring would be self-grading. See ADR-0005 §5
 //! "Offline eval lanes" and the session notes dated 2026-04-18.
 
+use crate::AppState;
 use crate::protocol::BackendKind;
 use crate::runtime_types::{AnalysisReadiness, AnalysisVerifierCheck};
 use crate::session_context::SessionRequestContext;
 use crate::tool_defs::{ToolProfile, ToolSurface};
-use crate::tool_runtime::{success_meta, ToolResult};
+use crate::tool_runtime::{ToolResult, success_meta};
 use crate::tools::report_payload::{build_handle_payload, infer_risk_level};
 use crate::tools::report_verifier::{VERIFIER_CAUTION, VERIFIER_READY};
 use crate::tools::session::{audit_builder_session, audit_planner_session};
-use crate::AppState;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::collections::{BTreeMap, HashMap};
 
 #[derive(Default)]

--- a/crates/codelens-mcp/src/tools/reports/eval_reports.rs
+++ b/crates/codelens-mcp/src/tools/reports/eval_reports.rs
@@ -9,16 +9,16 @@
 //! yet so synthetic scoring would be self-grading. See ADR-0005 §5
 //! "Offline eval lanes" and the session notes dated 2026-04-18.
 
-use crate::AppState;
 use crate::protocol::BackendKind;
 use crate::runtime_types::{AnalysisReadiness, AnalysisVerifierCheck};
 use crate::session_context::SessionRequestContext;
 use crate::tool_defs::{ToolProfile, ToolSurface};
-use crate::tool_runtime::{ToolResult, success_meta};
+use crate::tool_runtime::{success_meta, ToolResult};
 use crate::tools::report_payload::{build_handle_payload, infer_risk_level};
 use crate::tools::report_verifier::{VERIFIER_CAUTION, VERIFIER_READY};
 use crate::tools::session::{audit_builder_session, audit_planner_session};
-use serde_json::{Value, json};
+use crate::AppState;
+use serde_json::{json, Value};
 use std::collections::{BTreeMap, HashMap};
 
 #[derive(Default)]
@@ -364,6 +364,7 @@ pub fn eval_session_audit(state: &AppState, arguments: &Value) -> ToolResult {
         &artifact.readiness,
         &artifact.verifier_checks,
         &artifact.available_sections,
+        &[],
         false,
         ci_audit,
     );

--- a/crates/codelens-mcp/src/tools/session/metrics_config/capabilities.rs
+++ b/crates/codelens-mcp/src/tools/session/metrics_config/capabilities.rs
@@ -1,7 +1,7 @@
-use crate::AppState;
 use crate::protocol::BackendKind;
 use crate::tool_defs::ToolSurface;
-use crate::tool_runtime::{ToolResult, success_meta};
+use crate::tool_runtime::{success_meta, ToolResult};
+use crate::AppState;
 use serde_json::json;
 use std::path::Path;
 
@@ -278,7 +278,7 @@ impl SemanticSearchStatus {
         #[cfg(feature = "semantic")]
         {
             match self {
-                Self::NotInActiveSurface => Some(vec!["refactor-full", "ci-audit"]),
+                Self::NotInActiveSurface => Some(vec!["planner-readonly", "builder-minimal"]),
                 _ => None,
             }
         }

--- a/crates/codelens-mcp/src/tools/session/metrics_config/capabilities.rs
+++ b/crates/codelens-mcp/src/tools/session/metrics_config/capabilities.rs
@@ -1,7 +1,7 @@
+use crate::AppState;
 use crate::protocol::BackendKind;
 use crate::tool_defs::ToolSurface;
-use crate::tool_runtime::{success_meta, ToolResult};
-use crate::AppState;
+use crate::tool_runtime::{ToolResult, success_meta};
 use serde_json::json;
 use std::path::Path;
 

--- a/crates/codelens-mcp/src/tools/session/metrics_config/capabilities.rs
+++ b/crates/codelens-mcp/src/tools/session/metrics_config/capabilities.rs
@@ -274,15 +274,37 @@ impl SemanticSearchStatus {
         }
     }
 
+    pub(crate) fn included_in_profiles(&self) -> Option<Vec<&'static str>> {
+        #[cfg(feature = "semantic")]
+        {
+            match self {
+                Self::NotInActiveSurface => Some(vec!["refactor-full", "ci-audit"]),
+                _ => None,
+            }
+        }
+        #[cfg(not(feature = "semantic"))]
+        {
+            None
+        }
+    }
+
     pub(crate) fn guidance_payload(&self) -> serde_json::Value {
-        json!({
+        let mut payload = json!({
             "status": self.status_key(),
             "available": self.is_available(),
             "reason": self.reason_str(),
             "reason_code": self.reason_code(),
             "recommended_action": self.recommended_action(),
             "action_target": self.action_target(),
-        })
+        });
+        if let Some(profiles) = self.included_in_profiles() {
+            let recommended_profile = profiles.first().copied();
+            payload["included_in"] = serde_json::json!(profiles);
+            if let Some(first) = recommended_profile {
+                payload["recommended_profile"] = serde_json::json!(first);
+            }
+        }
+        payload
     }
 
     pub(crate) fn is_available(&self) -> bool {

--- a/crates/codelens-mcp/src/tools/session/project_ops.rs
+++ b/crates/codelens-mcp/src/tools/session/project_ops.rs
@@ -422,7 +422,7 @@ pub fn prepare_harness_session(state: &AppState, arguments: &serde_json::Value) 
     let detail = arguments
         .get("detail")
         .and_then(|v| v.as_str())
-        .unwrap_or("compact");
+        .unwrap_or("full");
     let request = ResourceRequestContext::from_request("codelens://tools/list", Some(arguments));
     let session = request.session.clone();
     let active_surface = state.execution_surface(&session);
@@ -624,7 +624,7 @@ pub fn prepare_harness_session(state: &AppState, arguments: &serde_json::Value) 
             .or_insert(0usize) += 1;
     }
 
-    Ok((
+    let result = if detail == "full" {
         json!({
             "activated": true,
             "project": activate_payload,
@@ -684,9 +684,51 @@ pub fn prepare_harness_session(state: &AppState, arguments: &serde_json::Value) 
                 "doom_loop_threshold": 3,
                 "preflight_ttl_seconds": state.preflight_ttl_seconds(),
             }
-        }),
-        success_meta(BackendKind::Session, 1.0),
-    ))
+        })
+    } else {
+        let project_name = activate_payload
+            .get("project_name")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        let indexed_files = activate_payload
+            .get("indexed_files")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        let capabilities_available = capabilities_payload
+            .get("available")
+            .cloned()
+            .unwrap_or_else(|| json!([]));
+        let tool_count = visible.tools.len();
+        let first_five_tools: Vec<_> = visible_tool_names.iter().take(5).cloned().collect();
+        let health_status = health_summary
+            .get("status")
+            .and_then(|v| v.as_str())
+            .unwrap_or("ok");
+        json!({
+            "activated": true,
+            "project": {
+                "project_name": project_name,
+                "indexed_files": indexed_files,
+            },
+            "capabilities": {
+                "available": capabilities_available,
+            },
+            "visible_tools": {
+                "tool_count": tool_count,
+                "tool_names": first_five_tools,
+            },
+            "health_summary": {
+                "status": health_status,
+            },
+            "warnings": warnings,
+            "routing": {
+                "recommended_entrypoint": recommended_entrypoint,
+                "preferred_entrypoints_visible": preferred_entrypoints_visible,
+            },
+        })
+    };
+
+    Ok((result, success_meta(BackendKind::Session, 1.0)))
 }
 
 pub fn prepare_for_new_conversation(

--- a/crates/codelens-mcp/src/tools/symbols/handlers.rs
+++ b/crates/codelens-mcp/src/tools/symbols/handlers.rs
@@ -151,9 +151,8 @@ pub fn find_symbol(state: &AppState, arguments: &Value) -> ToolResult {
         && optional_string(arguments, "name").is_none()
         && symbol_id.is_none()
     {
-        deprecation_warnings.push(
-            "`name_path` is deprecated; use `name` (will be removed in v1.14.0)".to_owned(),
-        );
+        deprecation_warnings
+            .push("`name_path` is deprecated; use `name` (will be removed in v1.14.0)".to_owned());
     }
     let name = symbol_id
         .or_else(|| optional_string(arguments, "name"))
@@ -225,8 +224,7 @@ pub fn find_symbol(state: &AppState, arguments: &Value) -> ToolResult {
                     {
                         sym["body"] = Value::String(body);
                         sym["body_source"] = Value::String("scip_line_range_slice".to_owned());
-                        sym["body_truncation"] =
-                            Value::String("heuristic_50_lines".to_owned());
+                        sym["body_truncation"] = Value::String("heuristic_50_lines".to_owned());
                     }
                     sym
                 })
@@ -240,7 +238,10 @@ pub fn find_symbol(state: &AppState, arguments: &Value) -> ToolResult {
                 "evidence": evidence,
             });
             if let Some(map) = payload.as_object_mut() {
-                map.insert("deprecation_warnings".to_owned(), json!(deprecation_warnings));
+                map.insert(
+                    "deprecation_warnings".to_owned(),
+                    json!(deprecation_warnings),
+                );
                 if !unknown_args.is_empty() {
                     map.insert(
                         "warnings".to_owned(),

--- a/crates/codelens-mcp/src/tools/symbols/handlers.rs
+++ b/crates/codelens-mcp/src/tools/symbols/handlers.rs
@@ -18,6 +18,7 @@ use crate::symbol_retrieval::{ScoredSymbol, search_symbols_bm25f, unique_query_t
 use codelens_engine::{SymbolInfo, SymbolKind, read_file, search_symbols_hybrid_with_semantic};
 use serde_json::{Value, json};
 
+#[cfg(feature = "scip-backend")]
 const HEURISTIC_BODY_LINES: usize = 50;
 const PATH_ALIAS_DEPRECATION: &str =
     "DEPRECATED v1.13.23 — use `path`. Soft alias maintained until v1.14.0.";
@@ -66,6 +67,7 @@ fn insert_response_annotations(
     }
 }
 
+#[cfg(feature = "scip-backend")]
 fn heuristic_body_slice(state: &AppState, file_path: &str, line: usize) -> Option<String> {
     read_file(
         &state.project(),

--- a/docs/multi-agent-integration.md
+++ b/docs/multi-agent-integration.md
@@ -44,6 +44,15 @@ simply lets the append-only telemetry log correlate planner-side
 delegate emission with later builder-side execution, even when those
 steps happen under different logical sessions.
 
+**Note — inline brief mode**: When dispatching Codex via MCP
+(`mcp__codex__codex`), pass the task description inline as the `prompt`
+argument rather than writing a file to `/tmp`. If the host harness
+settings do not include `Write(/tmp/**)` in `allowedTools`, writing the
+brief to disk will be blocked by the permission gate. The inline pattern
+(passing the brief directly as `prompt`) avoids this and has been
+verified to work in Claude Code sessions. If you must write a brief file,
+ensure `Write(/tmp/**)` appears in the session's `allowedTools`.
+
 ## Recommended Role Split
 
 For multi-agent HTTP deployments, keep the surfaces asymmetric:


### PR DESCRIPTION
Resolves #171, addresses #175 sub-items A/B/E.

## Summary

- **#171** — `review_changes` false positive 'Browser/SSR-sensitive' on backend Python: `infer_quality_focus` now takes `changed_files` and gates `user_experience` push on a frontend file-path match (`.tsx`/`.jsx`/`.vue`/`.svelte`/`.html`/`.css`/`.scss`/`.astro` extensions or `/templates/` `/components/` `/pages/` `/views/` `/ui/` segments). The over-broad `"ui"` token also removed from the matcher. `report_verifier::sensitive` judgement uses the same gate.
- **#175 A** — `semantic_search_guidance` now reports `included_in` (profiles containing the tool) and `recommended_profile` so callers can switch profile without trial-and-error.
- **#175 B** — `prepare_harness_session(detail="compact")` returns a minimal subset (~1.5 KB target). Full payload only at `detail="full"`.
- **#175 E** — `docs/multi-agent-integration.md` paragraph on subagent `Write(/tmp/**)` requirement + inline brief mode recommendation.

## Skipped on purpose

- **#175 C** (codex install script approval_mode defaults) — install script lives outside this repo
- **#175 D** (schema parameter unification — `path` vs `*_path`) — needs separate PR with soft alias pattern (#170 model)
- **#172** (SCIP backend body filling) — separate batch

## Test plan

- [x] `cargo test -p codelens-mcp` — 556 passed, 0 failed, 3 ignored (incl. 2 new `infer_quality_focus_*` tests)
- [x] `cargo clippy -p codelens-mcp -- -W clippy::all` — 0 new warnings
- [ ] Visual: re-call `prepare_harness_session(detail="compact")` and confirm response < 2 KB
- [ ] Visual: re-call `review_changes` on backend Python diff and confirm `risk_level` no longer `medium` from heuristic