### PR TITLE
fix(#172, #175 D): SCIP body heuristic + path soft alias on 3 tools

### DIFF
--- a/crates/codelens-mcp/src/dispatch/envelope.rs
+++ b/crates/codelens-mcp/src/dispatch/envelope.rs
@@ -37,11 +37,10 @@ impl ToolCallEnvelope {
         // name; the canonical key required by the handler is
         // populated alongside whatever the client sent.
         //
-        // `relative_path` is *not* aliased — mutation primitives use
-        // it as a deliberate "rooted at project, no escape" marker
-        // distinct from arbitrary paths. Preserving the divergence
-        // keeps that contract honest.
-        apply_path_alias_normalisation(&mut arguments);
+        // `relative_path` is only aliased for read-only soft-alias tools.
+        // Mutation primitives keep it as a deliberate "rooted at project,
+        // no escape" marker distinct from arbitrary paths.
+        apply_path_alias_normalisation(name.as_str(), &mut arguments);
         let session = crate::session_context::SessionRequestContext::from_json(&arguments);
         let default_budget = state.execution_token_budget(&session);
         // P2-A: honour explicit max_tokens parameter before profile defaults.
@@ -124,23 +123,37 @@ pub(crate) fn validate_required_params(
 /// caller's choice wins (we do not overwrite either side); if both are
 /// present and equal, this is a no-op.
 ///
-/// `relative_path` is intentionally NOT aliased — see envelope::parse
-/// for the rationale.
-fn apply_path_alias_normalisation(arguments: &mut serde_json::Value) {
+/// `relative_path` is intentionally only aliased for read-only tools that
+/// explicitly maintain it as a soft alias — see envelope::parse for the
+/// mutation-safety rationale.
+fn apply_path_alias_normalisation(tool_name: &str, arguments: &mut serde_json::Value) {
     let Some(obj) = arguments.as_object_mut() else {
         return;
     };
     let has_file_path = obj.contains_key("file_path");
     let has_path = obj.contains_key("path");
+    let has_relative_path = obj.contains_key("relative_path");
+    let supports_relative_path_alias = matches!(
+        tool_name,
+        "get_symbols_overview" | "find_referencing_symbols" | "get_file_diagnostics"
+    );
     match (has_file_path, has_path) {
         (true, false) => {
             if let Some(value) = obj.get("file_path").cloned() {
                 obj.insert("path".to_owned(), value);
+                obj.insert("_path_alias_source".to_owned(), json!("file_path"));
             }
         }
         (false, true) => {
             if let Some(value) = obj.get("path").cloned() {
                 obj.insert("file_path".to_owned(), value);
+            }
+        }
+        (false, false) if supports_relative_path_alias && has_relative_path => {
+            if let Some(value) = obj.get("relative_path").cloned() {
+                obj.insert("path".to_owned(), value.clone());
+                obj.insert("file_path".to_owned(), value);
+                obj.insert("_path_alias_source".to_owned(), json!("relative_path"));
             }
         }
         _ => {}
@@ -154,7 +167,7 @@ mod tests {
 
     fn run_alias(value: serde_json::Value) -> serde_json::Value {
         let mut v = value;
-        apply_path_alias_normalisation(&mut v);
+        apply_path_alias_normalisation("test_tool", &mut v);
         v
     }
 
@@ -163,6 +176,7 @@ mod tests {
         let out = run_alias(json!({ "file_path": "src/foo.rs" }));
         assert_eq!(out["file_path"], "src/foo.rs");
         assert_eq!(out["path"], "src/foo.rs");
+        assert_eq!(out["_path_alias_source"], "file_path");
     }
 
     #[test]
@@ -170,6 +184,7 @@ mod tests {
         let out = run_alias(json!({ "path": "src/bar.rs" }));
         assert_eq!(out["path"], "src/bar.rs");
         assert_eq!(out["file_path"], "src/bar.rs");
+        assert!(out.get("_path_alias_source").is_none());
     }
 
     #[test]
@@ -198,6 +213,16 @@ mod tests {
         assert_eq!(out["relative_path"], "src/foo.rs");
         assert!(out.get("file_path").is_none());
         assert!(out.get("path").is_none());
+    }
+
+    #[test]
+    fn relative_path_alias_is_limited_to_soft_alias_tools() {
+        let mut out = json!({ "relative_path": "src/foo.rs" });
+        apply_path_alias_normalisation("get_symbols_overview", &mut out);
+        assert_eq!(out["relative_path"], "src/foo.rs");
+        assert_eq!(out["file_path"], "src/foo.rs");
+        assert_eq!(out["path"], "src/foo.rs");
+        assert_eq!(out["_path_alias_source"], "relative_path");
     }
 
     #[test]

--- a/crates/codelens-mcp/src/integration_tests/lsp.rs
+++ b/crates/codelens-mcp/src/integration_tests/lsp.rs
@@ -2,39 +2,7 @@ use super::*;
 
 // ── LSP tool tests ───────────────────────────────────────────────────
 
-#[test]
-fn returns_lsp_references_via_tool_call() {
-    let project = project_root();
-    fs::write(
-        project.as_path().join("ref_target.py"),
-        "class MyClass:\n    pass\n\nobj = MyClass()\n",
-    )
-    .unwrap();
-    let state = make_state(&project);
-    let payload = call_tool(
-        &state,
-        "find_referencing_symbols",
-        json!({ "file_path": "ref_target.py", "symbol_name": "MyClass" }),
-    );
-    assert_eq!(payload["success"], json!(true));
-    assert_eq!(
-        payload["data"]["evidence"]["schema_version"],
-        json!("codelens-evidence-v1")
-    );
-    assert_eq!(payload["data"]["evidence"]["domain"], json!("references"));
-    assert_eq!(
-        payload["data"]["evidence"]["signals"]["precise_used"],
-        json!(false)
-    );
-    assert_eq!(
-        payload["data"]["evidence"]["signals"]["fallback_source"],
-        json!("tree_sitter")
-    );
-}
-
-#[test]
-fn returns_lsp_diagnostics_via_tool_call() {
-    let project = project_root();
+fn write_mock_diagnostics_lsp(project: &ProjectRoot, name: &str) -> std::path::PathBuf {
     let mock_lsp = concat!(
         "#!/usr/bin/env python3\n",
         "import sys, json\n",
@@ -69,13 +37,50 @@ fn returns_lsp_diagnostics_via_tool_call() {
         "    else:\n",
         "        send({'jsonrpc':'2.0','id':rid,'result':None})\n",
     );
-    let mock_path = project.as_path().join("mock_lsp.py");
+    let mock_path = project.as_path().join(name);
     fs::write(&mock_path, mock_lsp).unwrap();
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         fs::set_permissions(&mock_path, fs::Permissions::from_mode(0o755)).unwrap();
     }
+    mock_path
+}
+
+#[test]
+fn returns_lsp_references_via_tool_call() {
+    let project = project_root();
+    fs::write(
+        project.as_path().join("ref_target.py"),
+        "class MyClass:\n    pass\n\nobj = MyClass()\n",
+    )
+    .unwrap();
+    let state = make_state(&project);
+    let payload = call_tool(
+        &state,
+        "find_referencing_symbols",
+        json!({ "file_path": "ref_target.py", "symbol_name": "MyClass" }),
+    );
+    assert_eq!(payload["success"], json!(true));
+    assert_eq!(
+        payload["data"]["evidence"]["schema_version"],
+        json!("codelens-evidence-v1")
+    );
+    assert_eq!(payload["data"]["evidence"]["domain"], json!("references"));
+    assert_eq!(
+        payload["data"]["evidence"]["signals"]["precise_used"],
+        json!(false)
+    );
+    assert_eq!(
+        payload["data"]["evidence"]["signals"]["fallback_source"],
+        json!("tree_sitter")
+    );
+}
+
+#[test]
+fn returns_lsp_diagnostics_via_tool_call() {
+    let project = project_root();
+    let mock_path = write_mock_diagnostics_lsp(&project, "mock_lsp.py");
     fs::write(project.as_path().join("diag_target.py"), "x = 1\n").unwrap();
     let state = make_state(&project);
     let payload = call_tool(
@@ -84,6 +89,33 @@ fn returns_lsp_diagnostics_via_tool_call() {
         json!({ "file_path": "diag_target.py", "command": "python3", "args": [mock_path.to_string_lossy()] }),
     );
     assert_eq!(payload["success"], json!(true));
+}
+
+#[test]
+fn get_file_diagnostics_accepts_legacy_file_path_with_deprecation_warning() {
+    let project = project_root();
+    let mock_path = write_mock_diagnostics_lsp(&project, "mock_legacy_diag_lsp.py");
+    fs::write(project.as_path().join("legacy_diag.py"), "x = 1\n").unwrap();
+    let state = make_state(&project);
+
+    let payload = call_tool(
+        &state,
+        "get_file_diagnostics",
+        json!({ "file_path": "legacy_diag.py", "command": "python3", "args": [mock_path.to_string_lossy()] }),
+    );
+
+    assert_eq!(payload["success"], json!(true));
+    assert_eq!(
+        payload["data"]["deprecation_warnings"]
+            .as_array()
+            .expect("deprecation_warnings array")
+            .len(),
+        1
+    );
+    assert_eq!(
+        payload["data"]["deprecation_warnings"][0]["param"],
+        json!("file_path")
+    );
 }
 
 #[test]

--- a/crates/codelens-mcp/src/integration_tests/readonly.rs
+++ b/crates/codelens-mcp/src/integration_tests/readonly.rs
@@ -28,6 +28,107 @@ fn returns_symbols_via_tool_call() {
     assert_eq!(payload["success"], json!(true));
 }
 
+#[test]
+fn get_symbols_overview_accepts_legacy_file_path_with_deprecation_warning() {
+    let project = project_root();
+    fs::write(
+        project.as_path().join("legacy_overview.py"),
+        "def legacy_overview():\n    pass\n",
+    )
+    .unwrap();
+    let state = make_state(&project);
+
+    let payload = call_tool(
+        &state,
+        "get_symbols_overview",
+        json!({ "file_path": "legacy_overview.py" }),
+    );
+
+    assert_eq!(payload["success"], json!(true));
+    assert_eq!(
+        payload["data"]["deprecation_warnings"]
+            .as_array()
+            .expect("deprecation_warnings array")
+            .len(),
+        1
+    );
+    assert_eq!(
+        payload["data"]["deprecation_warnings"][0]["param"],
+        json!("file_path")
+    );
+}
+
+#[test]
+fn find_referencing_symbols_accepts_legacy_relative_path_with_deprecation_warning() {
+    let project = project_root();
+    fs::write(
+        project.as_path().join("legacy_refs.py"),
+        "def legacy_ref():\n    pass\n\nlegacy_ref()\n",
+    )
+    .unwrap();
+    let state = make_state(&project);
+
+    let payload = call_tool(
+        &state,
+        "find_referencing_symbols",
+        json!({ "relative_path": "legacy_refs.py", "symbol_name": "legacy_ref" }),
+    );
+
+    assert_eq!(payload["success"], json!(true));
+    assert_eq!(
+        payload["data"]["deprecation_warnings"]
+            .as_array()
+            .expect("deprecation_warnings array")
+            .len(),
+        1
+    );
+    assert_eq!(
+        payload["data"]["deprecation_warnings"][0]["param"],
+        json!("relative_path")
+    );
+}
+
+// Ignored because the repo's default integration-test fixture only creates
+// tree-sitter projects. Run manually with CODELENS_SCIP_HEURISTIC_FIXTURE,
+// CODELENS_SCIP_HEURISTIC_SYMBOL, and CODELENS_SCIP_HEURISTIC_FILE pointing
+// at a project that has a usable index.scip.
+#[test]
+#[ignore = "requires a real SCIP index fixture; default temp projects exercise tree-sitter only"]
+fn find_symbol_with_include_body_returns_body_via_scip_heuristic() {
+    let fixture = std::env::var("CODELENS_SCIP_HEURISTIC_FIXTURE")
+        .expect("set CODELENS_SCIP_HEURISTIC_FIXTURE to a project with index.scip");
+    let symbol = std::env::var("CODELENS_SCIP_HEURISTIC_SYMBOL")
+        .unwrap_or_else(|_| "MyStruct".to_owned());
+    let file_path = std::env::var("CODELENS_SCIP_HEURISTIC_FILE")
+        .unwrap_or_else(|_| "src/main.rs".to_owned());
+    let project = ProjectRoot::new(&fixture).unwrap();
+    let state = make_state(&project);
+
+    let payload = call_tool(
+        &state,
+        "find_symbol",
+        json!({ "name": symbol, "file_path": file_path, "include_body": true }),
+    );
+
+    assert_eq!(payload["success"], json!(true));
+    assert_eq!(payload["backend_used"], json!("scip"));
+    assert_eq!(payload["data"]["backend"], json!("scip"));
+    assert_eq!(payload["data"]["body_preview"], json!(true));
+    let symbols = payload["data"]["symbols"]
+        .as_array()
+        .expect("symbols array");
+    let first = symbols.first().expect("at least one SCIP symbol");
+    assert!(
+        first["body"]
+            .as_str()
+            .map(|body| !body.is_empty())
+            .unwrap_or(false),
+        "SCIP heuristic should populate body content"
+    );
+    assert_eq!(first["body_source"], json!("scip_line_range_slice"));
+    assert_eq!(first["body_truncation"], json!("heuristic_50_lines"));
+}
+
 // P1-B contract: every read-only tool in the second wave must
 // 1) honor `limit` / `top_k` aliases for whatever its canonical
 //    limit field is (or skip the alias if it has no limit field),

--- a/crates/codelens-mcp/src/tools/lsp.rs
+++ b/crates/codelens-mcp/src/tools/lsp.rs
@@ -11,7 +11,56 @@ use codelens_engine::{
     extract_word_at_position, find_referencing_symbols_via_text,
     get_lsp_recipe as core_get_lsp_recipe, get_type_hierarchy_native,
 };
-use serde_json::json;
+use serde_json::{Value, json};
+
+const PATH_ALIAS_DEPRECATION: &str =
+    "DEPRECATED v1.13.23 — use `path`. Soft alias maintained until v1.14.0.";
+
+fn path_alias_warning(alias: &str) -> Value {
+    json!({
+        "param": alias,
+        "replacement": "path",
+        "message": PATH_ALIAS_DEPRECATION,
+    })
+}
+
+fn resolve_path_argument(
+    arguments: &serde_json::Value,
+) -> Result<(&str, Vec<Value>), CodeLensError> {
+    if let Some(path) = optional_string(arguments, "path") {
+        if let Some(alias @ ("file_path" | "relative_path")) =
+            optional_string(arguments, "_path_alias_source")
+        {
+            return Ok((path, vec![path_alias_warning(alias)]));
+        }
+        return Ok((path, Vec::new()));
+    }
+    for alias in ["file_path", "relative_path"] {
+        if let Some(path) = optional_string(arguments, alias) {
+            return Ok((path, vec![path_alias_warning(alias)]));
+        }
+    }
+    Err(CodeLensError::MissingParam("path".to_owned()))
+}
+
+fn insert_response_annotations(
+    payload: &mut Value,
+    unknown_args: &[String],
+    deprecation_warnings: &[Value],
+) {
+    let Some(map) = payload.as_object_mut() else {
+        return;
+    };
+    if !unknown_args.is_empty() {
+        map.insert("unknown_args".to_owned(), json!(unknown_args));
+    }
+    if !deprecation_warnings.is_empty() {
+        map.insert(
+            "deprecation_warnings".to_owned(),
+            json!(deprecation_warnings),
+        );
+    }
+}
 
 fn compact_text_references(
     references: Vec<codelens_engine::TextReference>,
@@ -107,8 +156,9 @@ pub fn find_referencing_symbols(state: &AppState, arguments: &serde_json::Value)
     // P1-B — limit/top_k aliases + unknown_args.
     // See docs/design/arg-validation-policy.md.
     const KNOWN_ARGS: &[&str] = &[
-        "file_path",
         "path",
+        "file_path",
+        "relative_path",
         "symbol_name",
         "max_results",
         "limit",
@@ -119,8 +169,11 @@ pub fn find_referencing_symbols(state: &AppState, arguments: &serde_json::Value)
         "sample_limit",
         "line",
         "column",
+        "command",
+        "args",
     ];
-    let file_path = required_string(arguments, "file_path")?.to_owned();
+    let (file_path_arg, deprecation_warnings) = resolve_path_argument(arguments)?;
+    let file_path = file_path_arg.to_owned();
     let symbol_name_param = optional_string(arguments, "symbol_name");
     let max_results = crate::tool_runtime::optional_usize_with_aliases(
         arguments,
@@ -179,9 +232,13 @@ pub fn find_referencing_symbols(state: &AppState, arguments: &serde_json::Value)
                     "evidence": evidence,
                 });
                 if !unknown_args.is_empty()
-                    && let Some(map) = payload.as_object_mut()
+                    || !deprecation_warnings.is_empty()
                 {
-                    map.insert("unknown_args".to_owned(), json!(unknown_args));
+                    insert_response_annotations(
+                        &mut payload,
+                        &unknown_args,
+                        &deprecation_warnings,
+                    );
                 }
                 return Ok((payload, meta));
             }
@@ -233,9 +290,13 @@ pub fn find_referencing_symbols(state: &AppState, arguments: &serde_json::Value)
                         "evidence": evidence,
                     });
                     if !unknown_args.is_empty()
-                        && let Some(map) = payload.as_object_mut()
+                        || !deprecation_warnings.is_empty()
                     {
-                        map.insert("unknown_args".to_owned(), json!(unknown_args));
+                        insert_response_annotations(
+                            &mut payload,
+                            &unknown_args,
+                            &deprecation_warnings,
+                        );
                     }
                     return Ok((payload, meta));
                 }
@@ -272,11 +333,7 @@ pub fn find_referencing_symbols(state: &AppState, arguments: &serde_json::Value)
                 "include_context": include_context,
                 "evidence": evidence,
             });
-            if !unknown_args.is_empty()
-                && let Some(map) = payload.as_object_mut()
-            {
-                map.insert("unknown_args".to_owned(), json!(unknown_args));
-            }
+            insert_response_annotations(&mut payload, &unknown_args, &deprecation_warnings);
             (payload, meta)
         })?);
     }
@@ -340,9 +397,13 @@ pub fn find_referencing_symbols(state: &AppState, arguments: &serde_json::Value)
                     "evidence": evidence,
                 });
                 if !unknown_args.is_empty()
-                    && let Some(map) = payload.as_object_mut()
+                    || !deprecation_warnings.is_empty()
                 {
-                    map.insert("unknown_args".to_owned(), json!(unknown_args));
+                    insert_response_annotations(
+                        &mut payload,
+                        &unknown_args,
+                        &deprecation_warnings,
+                    );
                 }
                 return Ok((payload, meta));
             }
@@ -376,17 +437,16 @@ pub fn find_referencing_symbols(state: &AppState, arguments: &serde_json::Value)
                     0,
                 ),
             );
-            (
-                json!({
-                    "references": references,
-                    "count": total_count,
-                    "returned_count": references.len(),
-                    "sampled": sampled,
-                    "include_context": include_context,
-                    "evidence": evidence,
-                }),
-                meta,
-            )
+            let mut payload = json!({
+                "references": references,
+                "count": total_count,
+                "returned_count": references.len(),
+                "sampled": sampled,
+                "include_context": include_context,
+                "evidence": evidence,
+            });
+            insert_response_annotations(&mut payload, &unknown_args, &deprecation_warnings);
+            (payload, meta)
         })?,
     )
 }
@@ -405,8 +465,18 @@ fn resolve_symbol_position(
 }
 
 pub fn get_file_diagnostics(state: &AppState, arguments: &serde_json::Value) -> ToolResult {
-    let file_path = required_string(arguments, "file_path")?.to_owned();
+    const KNOWN_ARGS: &[&str] = &[
+        "path",
+        "file_path",
+        "relative_path",
+        "command",
+        "args",
+        "max_results",
+    ];
+    let (file_path_arg, deprecation_warnings) = resolve_path_argument(arguments)?;
+    let file_path = file_path_arg.to_owned();
     let max_results = optional_usize(arguments, "max_results", 200);
+    let unknown_args = crate::tool_runtime::collect_unknown_args(arguments, KNOWN_ARGS);
 
     // Try SCIP diagnostics first (if available).
     #[cfg(feature = "scip-backend")]
@@ -431,10 +501,13 @@ pub fn get_file_diagnostics(state: &AppState, arguments: &serde_json::Value) -> 
                     })
                 })
                 .collect();
-            return Ok((
-                json!({ "diagnostics": diags_json, "count": count, "backend": "scip" }),
-                success_meta(BackendKind::Scip, 0.95),
-            ));
+            let mut payload = json!({
+                "diagnostics": diags_json,
+                "count": count,
+                "backend": "scip",
+            });
+            insert_response_annotations(&mut payload, &unknown_args, &deprecation_warnings);
+            return Ok((payload, success_meta(BackendKind::Scip, 0.95)));
         }
     }
 
@@ -456,8 +529,10 @@ pub fn get_file_diagnostics(state: &AppState, arguments: &serde_json::Value) -> 
         })
         .map_err(|e| enhance_lsp_error(e, &command_ref))
         .map(|value| {
+            let mut payload = json!({ "diagnostics": value, "count": value.len() });
+            insert_response_annotations(&mut payload, &unknown_args, &deprecation_warnings);
             (
-                json!({ "diagnostics": value, "count": value.len() }),
+                payload,
                 success_meta(BackendKind::Lsp, 0.9),
             )
         })

--- a/crates/codelens-mcp/src/tools/symbols/handlers.rs
+++ b/crates/codelens-mcp/src/tools/symbols/handlers.rs
@@ -18,8 +18,70 @@ use crate::symbol_retrieval::{ScoredSymbol, search_symbols_bm25f, unique_query_t
 use codelens_engine::{SymbolInfo, SymbolKind, read_file, search_symbols_hybrid_with_semantic};
 use serde_json::{Value, json};
 
+const HEURISTIC_BODY_LINES: usize = 50;
+const PATH_ALIAS_DEPRECATION: &str =
+    "DEPRECATED v1.13.23 — use `path`. Soft alias maintained until v1.14.0.";
+
+fn path_alias_warning(alias: &str) -> Value {
+    json!({
+        "param": alias,
+        "replacement": "path",
+        "message": PATH_ALIAS_DEPRECATION,
+    })
+}
+
+fn resolve_path_argument(arguments: &Value) -> Result<(&str, Vec<Value>), CodeLensError> {
+    if let Some(path) = optional_string(arguments, "path") {
+        if let Some(alias @ ("file_path" | "relative_path")) =
+            optional_string(arguments, "_path_alias_source")
+        {
+            return Ok((path, vec![path_alias_warning(alias)]));
+        }
+        return Ok((path, Vec::new()));
+    }
+    for alias in ["file_path", "relative_path"] {
+        if let Some(path) = optional_string(arguments, alias) {
+            return Ok((path, vec![path_alias_warning(alias)]));
+        }
+    }
+    Err(CodeLensError::MissingParam("path".to_owned()))
+}
+
+fn insert_response_annotations(
+    payload: &mut Value,
+    unknown_args: &[String],
+    deprecation_warnings: &[Value],
+) {
+    let Some(map) = payload.as_object_mut() else {
+        return;
+    };
+    if !unknown_args.is_empty() {
+        map.insert("unknown_args".to_owned(), json!(unknown_args));
+    }
+    if !deprecation_warnings.is_empty() {
+        map.insert(
+            "deprecation_warnings".to_owned(),
+            json!(deprecation_warnings),
+        );
+    }
+}
+
+fn heuristic_body_slice(state: &AppState, file_path: &str, line: usize) -> Option<String> {
+    read_file(
+        &state.project(),
+        file_path,
+        Some(line),
+        Some(line.saturating_add(HEURISTIC_BODY_LINES)),
+    )
+    .ok()
+    .map(|file| file.content)
+    .filter(|body| !body.is_empty())
+}
+
 pub fn get_symbols_overview(state: &AppState, arguments: &Value) -> ToolResult {
-    let path = required_string(arguments, "path")?;
+    const KNOWN_ARGS: &[&str] = &["path", "file_path", "relative_path", "depth"];
+    let (path, deprecation_warnings) = resolve_path_argument(arguments)?;
+    let unknown_args = crate::tool_runtime::collect_unknown_args(arguments, KNOWN_ARGS);
     let explicit_depth = arguments.get("depth").and_then(|v| v.as_u64());
     let depth = explicit_depth.unwrap_or(1) as usize;
     let session = crate::session_context::SessionRequestContext::from_json(arguments);
@@ -52,15 +114,15 @@ pub fn get_symbols_overview(state: &AppState, arguments: &Value) -> ToolResult {
         symbols.truncate(max_symbols);
     }
 
-    Ok((
-        json!({
-            "symbols": symbols,
-            "count": symbols.len(),
-            "truncated": truncated,
-            "auto_summarized": stripped,
-        }),
-        success_meta(BackendKind::TreeSitter, 0.93),
-    ))
+    let mut payload = json!({
+        "symbols": symbols,
+        "count": symbols.len(),
+        "truncated": truncated,
+        "auto_summarized": stripped,
+    });
+    insert_response_annotations(&mut payload, &unknown_args, &deprecation_warnings);
+
+    Ok((payload, success_meta(BackendKind::TreeSitter, 0.93)))
 }
 
 pub fn find_symbol(state: &AppState, arguments: &Value) -> ToolResult {
@@ -146,6 +208,14 @@ pub fn find_symbol(state: &AppState, arguments: &Value) -> ToolResult {
                     if !doc.is_empty() {
                         sym["documentation"] = serde_json::Value::String(doc);
                     }
+                    if include_body
+                        && let Some(body) = heuristic_body_slice(state, &d.file_path, d.line)
+                    {
+                        sym["body"] = Value::String(body);
+                        sym["body_source"] = Value::String("scip_line_range_slice".to_owned());
+                        sym["body_truncation"] =
+                            Value::String("heuristic_50_lines".to_owned());
+                    }
                     sym
                 })
                 .collect();
@@ -153,7 +223,7 @@ pub fn find_symbol(state: &AppState, arguments: &Value) -> ToolResult {
                 "symbols": syms,
                 "count": count,
                 "body_truncated_count": 0,
-                "body_preview": false,
+                "body_preview": include_body,
                 "backend": "scip",
                 "evidence": evidence,
             });

--- a/crates/codelens-mcp/tools.toml
+++ b/crates/codelens-mcp/tools.toml
@@ -148,7 +148,7 @@ output_schema = "symbol_output_schema"
 [tool.input_schema]
 type = "object"
 required = ["path"]
-properties = { path = { type = "string" }, depth = { type = "integer" } }
+properties = { path = { type = "string" }, file_path = { type = "string", description = "DEPRECATED v1.13.23 — use `path`. Soft alias maintained until v1.14.0." }, relative_path = { type = "string", description = "DEPRECATED v1.13.23 — use `path`. Soft alias maintained until v1.14.0." }, depth = { type = "integer" } }
 
 # ─────
 
@@ -276,9 +276,11 @@ output_schema = "references_output_schema"
 
 [tool.input_schema]
 type = "object"
-required = ["file_path"]
+required = ["path"]
 [tool.input_schema.properties]
-file_path = { type = "string", description = "File containing or declaring the symbol" }
+path = { type = "string", description = "File containing or declaring the symbol" }
+file_path = { type = "string", description = "DEPRECATED v1.13.23 — use `path`. Soft alias maintained until v1.14.0." }
+relative_path = { type = "string", description = "DEPRECATED v1.13.23 — use `path`. Soft alias maintained until v1.14.0." }
 symbol_name = { type = "string", description = "Symbol name (default: tree-sitter search)" }
 line = { type = "integer", description = "Line number (triggers LSP path)" }
 column = { type = "integer", description = "Column number (triggers LSP path)" }
@@ -298,9 +300,11 @@ output_schema = "diagnostics_output_schema"
 
 [tool.input_schema]
 type = "object"
-required = ["file_path"]
+required = ["path"]
 [tool.input_schema.properties]
-file_path = { type = "string" }
+path = { type = "string" }
+file_path = { type = "string", description = "DEPRECATED v1.13.23 — use `path`. Soft alias maintained until v1.14.0." }
+relative_path = { type = "string", description = "DEPRECATED v1.13.23 — use `path`. Soft alias maintained until v1.14.0." }
 command = { type = "string" }
 args = { type = "array", items = { type = "string" } }
 max_results = { type = "integer" }


### PR DESCRIPTION
Resolves part of #172 + addresses #175 D. Two follow-up issues filed for the precise fixes.

## Summary

### #172 — find_symbol SCIP backend body filling (heuristic)

`find_symbol(include_body=true)` previously hardcoded `body_preview: false` and never returned a body in the SCIP backend. Now reads the source file at the definition's `file_path` and slices 50 lines from `line`. Response carries `body`, `body_source` (`"scip_line_range_slice"`), and `body_truncation` (`"heuristic_50_lines"`).

**Limitation**: SCIP `Definition` struct exposes only `line`, not `end_line`. The 50-line cap is a heuristic. Precise fix (extending `Definition` struct + revising 5 callers) deferred to follow-up issue.

### #175 D — path / file_path / relative_path schema unification (3 tools)

Three tools migrated to canonical `path` with backward-compatible aliases (mirrors #170 `name_path → name` pattern):

- `get_symbols_overview` 
- `find_referencing_symbols`
- LSP-family handlers (lsp.rs)

Pattern:
- `tools.toml`: `path` is canonical, legacy alias kept with DEPRECATED v1.13.23 note
- handler: `resolve_path_argument` helper checks `path` → `file_path` → `relative_path`; legacy match emits `deprecation_warnings`
- `KNOWN_ARGS` extended; legacy 변수 unknown_args 에서 빠짐
- 1 integration test per tool

Remaining 8 path-family tools deferred to a follow-up #175 D continuation issue.

## Test plan

- [x] `cargo test -p codelens-mcp` — 558 passed, 0 failed, 4 ignored
- [x] `cargo clippy -p codelens-mcp -- -W clippy::all` — 0 new warnings (2 needless_lifetimes auto-fixed)
- [ ] Visual: re-call `find_symbol(name="X", include_body=true)` against SCIP-indexed repo and confirm `body` appears
- [ ] Visual: legacy `file_path=...` callers still work with deprecation warning surfaced

## Follow-ups

- SCIP precise body extraction (Definition.end_line) — see new issue
- Path soft alias for remaining 8 tools — see new issue