### PR TITLE
style: cargo fmt — unblock CI for #174/176/177/178

### DIFF
--- a/crates/codelens-engine/src/phantom_modules.rs
+++ b/crates/codelens-engine/src/phantom_modules.rs
@@ -10,7 +10,7 @@
 //! useful, but a private `mod foo;` with no `use` references on the
 //! parent symbol path is almost always cleanup-eligible.
 
-use crate::project::{collect_files, ProjectRoot};
+use crate::project::{ProjectRoot, collect_files};
 use anyhow::Result;
 use regex::Regex;
 use serde::Serialize;
@@ -344,11 +344,7 @@ fn extract_leading_type_ident(segment: &str) -> Option<&str> {
         .find(|c: char| !c.is_alphanumeric() && c != '_')
         .unwrap_or(last.len());
     let name = &last[..end];
-    if name.is_empty() {
-        None
-    } else {
-        Some(name)
-    }
+    if name.is_empty() { None } else { Some(name) }
 }
 
 /// If the line is a top-level type declaration in this file (`struct X`,

--- a/crates/codelens-engine/src/phantom_modules.rs
+++ b/crates/codelens-engine/src/phantom_modules.rs
@@ -295,7 +295,7 @@ fn is_impl_extension_or_reexport(project_root: &Path, decl: &PhantomModuleEntry)
     // any unreferenced module that happens to contain a local helper
     // struct + its impl would be filtered out forever.
     let local_types: Vec<&str> = source.lines().filter_map(extract_local_type_name).collect();
-    
+
     source.lines().any(|l| {
         if !(l.starts_with("impl ") || l.starts_with("impl<")) {
             return false;

--- a/crates/codelens-engine/src/phantom_modules.rs
+++ b/crates/codelens-engine/src/phantom_modules.rs
@@ -295,16 +295,16 @@ fn is_impl_extension_or_reexport(project_root: &Path, decl: &PhantomModuleEntry)
     // any unreferenced module that happens to contain a local helper
     // struct + its impl would be filtered out forever.
     let local_types: Vec<&str> = source.lines().filter_map(extract_local_type_name).collect();
-    let has_parent_extending_impl = source.lines().any(|l| {
+    
+    source.lines().any(|l| {
         if !(l.starts_with("impl ") || l.starts_with("impl<")) {
             return false;
         }
         match extract_impl_target_type(l) {
-            Some(target) => !local_types.iter().any(|name| *name == target),
+            Some(target) => !local_types.contains(&target),
             None => false,
         }
-    });
-    has_parent_extending_impl
+    })
 }
 
 /// Extracts the type name on the right-hand side of an `impl` line.

--- a/crates/codelens-engine/src/redundant_definitions.rs
+++ b/crates/codelens-engine/src/redundant_definitions.rs
@@ -8,7 +8,7 @@
 //! be flagged by `find_dead_code_v2` only AFTER the wrappers were removed,
 //! so this complement helps surface the cluster pre-deletion.
 
-use crate::project::{collect_files, ProjectRoot};
+use crate::project::{ProjectRoot, collect_files};
 use anyhow::Result;
 use regex::Regex;
 use serde::Serialize;

--- a/crates/codelens-engine/src/search.rs
+++ b/crates/codelens-engine/src/search.rs
@@ -217,10 +217,7 @@ fn apply_pagerank_boost(
     pagerank_scores: &std::collections::HashMap<String, f64>,
     max_boost: f64,
 ) {
-    let max_pr = pagerank_scores
-        .values()
-        .copied()
-        .fold(0.0_f64, f64::max);
+    let max_pr = pagerank_scores.values().copied().fold(0.0_f64, f64::max);
     if max_pr <= 0.0 {
         return;
     }

--- a/crates/codelens-engine/src/symbols/parser.rs
+++ b/crates/codelens-engine/src/symbols/parser.rs
@@ -1,5 +1,5 @@
-use super::types::{make_symbol_id, ParsedSymbol, SymbolInfo, SymbolKind, SymbolProvenance};
 use super::LanguageConfig;
+use super::types::{ParsedSymbol, SymbolInfo, SymbolKind, SymbolProvenance, make_symbol_id};
 use anyhow::{Context, Result};
 use std::collections::{HashSet, VecDeque};
 use std::sync::{Arc, LazyLock, Mutex};

--- a/crates/codelens-engine/src/symbols/reader.rs
+++ b/crates/codelens-engine/src/symbols/reader.rs
@@ -1,9 +1,9 @@
-use super::parser::{flatten_symbol_infos, slice_source};
-use super::ranking::{self, prune_to_budget, rank_symbols, RankingContext};
-use super::types::{
-    make_symbol_id, parse_symbol_id, RankedContextResult, SymbolInfo, SymbolKind, SymbolProvenance,
-};
 use super::SymbolIndex;
+use super::parser::{flatten_symbol_infos, slice_source};
+use super::ranking::{self, RankingContext, prune_to_budget, rank_symbols};
+use super::types::{
+    RankedContextResult, SymbolInfo, SymbolKind, SymbolProvenance, make_symbol_id, parse_symbol_id,
+};
 use crate::db::IndexDb;
 use crate::project::ProjectRoot;
 use anyhow::Result;

--- a/crates/codelens-engine/tests/ranking_pagerank_effect.rs
+++ b/crates/codelens-engine/tests/ranking_pagerank_effect.rs
@@ -20,7 +20,7 @@
 //! function still works in isolation — exactly the kind of bug a
 //! signal-level CI gate should catch.
 
-use codelens_engine::{search_symbols_hybrid_with_semantic, ProjectRoot};
+use codelens_engine::{ProjectRoot, search_symbols_hybrid_with_semantic};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -38,7 +38,7 @@ fn temp_project(prefix: &str) -> (PathBuf, ProjectRoot) {
 }
 
 fn seed_two_file_index(project: &ProjectRoot) {
-    use codelens_engine::db::{index_db_path, IndexDb, NewSymbol};
+    use codelens_engine::db::{IndexDb, NewSymbol, index_db_path};
     let db = IndexDb::open(&index_db_path(project.as_path())).unwrap();
     let popular = db
         .upsert_file("popular.py", 100, "h1", 10, Some("py"))

--- a/crates/codelens-mcp/src/over_visible.rs
+++ b/crates/codelens-mcp/src/over_visible.rs
@@ -121,10 +121,16 @@ pub(crate) fn find_over_visible_apis(project_root: &Path) -> Result<Vec<OverVisi
         let other_file_count = rs.files.iter().filter(|f| **f != decl.file).count();
         let other_crate_count = rs.crates.iter().filter(|c| **c != decl.crate_name).count();
 
-        let suggestion = match (decl.visibility.as_str(), other_file_count, other_crate_count) {
+        let suggestion = match (
+            decl.visibility.as_str(),
+            other_file_count,
+            other_crate_count,
+        ) {
             ("pub", 0, _) => Some(("private", "no caller in any file")),
             ("pub", _, 0) => Some(("pub(crate)", "no caller outside the declaring crate")),
-            ("pub(crate)", 0, _) => Some(("private", "no caller in any other file inside this crate")),
+            ("pub(crate)", 0, _) => {
+                Some(("private", "no caller in any other file inside this crate"))
+            }
             _ => None,
         };
 
@@ -308,12 +314,12 @@ mod tests {
         ));
         let src = dir.join("crates/sample/src");
         std::fs::create_dir_all(&src).unwrap();
+        std::fs::write(src.join("lib.rs"), "pub fn intra_caller() {}\n").unwrap();
         std::fs::write(
-            src.join("lib.rs"),
-            "pub fn intra_caller() {}\n",
+            src.join("other.rs"),
+            "fn use_it() { super::intra_caller(); }\n",
         )
         .unwrap();
-        std::fs::write(src.join("other.rs"), "fn use_it() { super::intra_caller(); }\n").unwrap();
 
         let entries = find_over_visible_apis(&dir).expect("scan ok");
         let hit = entries
@@ -370,15 +376,19 @@ mod tests {
             })
             .into();
         let entries = find_over_visible_apis(&repo).expect("find_over_visible_apis");
-        eprintln!(
-            "\n=== {} over-visible declarations ===\n",
-            entries.len()
-        );
+        eprintln!("\n=== {} over-visible declarations ===\n", entries.len());
         // Print the first 30 to keep output bounded during dogfood runs.
         for e in entries.iter().take(30) {
             eprintln!(
                 "  {} {} {} ({} → {}; {}) at {}:{}",
-                e.current_visibility, e.kind, e.name, e.current_visibility, e.suggested_visibility, e.reason, e.file, e.line
+                e.current_visibility,
+                e.kind,
+                e.name,
+                e.current_visibility,
+                e.suggested_visibility,
+                e.reason,
+                e.file,
+                e.line
             );
         }
     }

--- a/crates/codelens-mcp/src/resource_context.rs
+++ b/crates/codelens-mcp/src/resource_context.rs
@@ -1,13 +1,13 @@
+use crate::AppState;
 use crate::client_profile::ClientProfile;
 use crate::protocol::{Tool, ToolPhase};
 use crate::tool_defs::{
-    is_deferred_control_tool, preferred_bootstrap_tools, preferred_namespaces,
-    preferred_tier_labels, tool_deprecation, tool_namespace, tool_phase_label, tool_tier_label,
-    visible_namespaces, visible_tiers, visible_tools, ToolProfile, ToolSurface,
+    ToolProfile, ToolSurface, is_deferred_control_tool, preferred_bootstrap_tools,
+    preferred_namespaces, preferred_tier_labels, tool_deprecation, tool_namespace,
+    tool_phase_label, tool_tier_label, visible_namespaces, visible_tiers, visible_tools,
 };
 use crate::tools::session::metrics_config::collect_runtime_health_snapshot;
-use crate::AppState;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::collections::{BTreeMap, BTreeSet};
 
 // Default surface for hosts that fetch `tools/list` without a phase filter

--- a/crates/codelens-mcp/src/surface_audit.rs
+++ b/crates/codelens-mcp/src/surface_audit.rs
@@ -111,11 +111,7 @@ fn strip_line_comments(source: &str) -> String {
         .lines()
         .map(|line| {
             let trimmed = line.trim_start();
-            if trimmed.starts_with("//") {
-                ""
-            } else {
-                line
-            }
+            if trimmed.starts_with("//") { "" } else { line }
         })
         .collect::<Vec<_>>()
         .join("\n")

--- a/crates/codelens-mcp/src/surface_manifest.rs
+++ b/crates/codelens-mcp/src/surface_manifest.rs
@@ -11,8 +11,8 @@ use std::collections::{BTreeMap, BTreeSet};
 mod exports;
 mod harness;
 mod host_adapters;
-use exports::{build_agent_experience, build_harness_artifacts_summary};
 pub(crate) use exports::handoff_artifact_schema_json;
+use exports::{build_agent_experience, build_harness_artifacts_summary};
 use harness::{build_harness_modes, build_harness_spec};
 use host_adapters::{build_host_adapters, build_host_adapters_for_project};
 pub(crate) use host_adapters::{

--- a/crates/codelens-mcp/src/surface_manifest/exports.rs
+++ b/crates/codelens-mcp/src/surface_manifest/exports.rs
@@ -9,7 +9,7 @@
 //! external docs and resource URIs.
 
 use super::HOST_ADAPTER_HOSTS;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 pub(crate) const AGENT_EXPERIENCE_SCHEMA_VERSION: &str = "codelens-agent-experience-v1";
 pub(crate) const AGENT_EXPERIENCE_DOC_PATH: &str = "docs/design/symbiote-ux-flows-v1.md";

--- a/crates/codelens-mcp/src/surface_manifest/tests.rs
+++ b/crates/codelens-mcp/src/surface_manifest/tests.rs
@@ -32,10 +32,12 @@ fn manifest_matches_registry_counts() {
     );
     assert_eq!(
         manifest["tool_registry"]["output_schema_count"],
-        json!(tools()
-            .iter()
-            .filter(|tool| tool.output_schema.is_some())
-            .count())
+        json!(
+            tools()
+                .iter()
+                .filter(|tool| tool.output_schema.is_some())
+                .count()
+        )
     );
     assert_eq!(
         manifest["runtime"]["visible_tool_count"],
@@ -59,21 +61,28 @@ fn manifest_matches_registry_counts() {
         manifest["harness_spec"]["schema_version"],
         json!(HARNESS_SPEC_SCHEMA_VERSION)
     );
-    assert!(manifest["harness_modes"]["modes"]
-        .as_array()
-        .is_some_and(|modes| modes
-            .iter()
-            .any(|mode| mode["name"] == json!("planner-builder"))));
-    assert!(manifest["harness_spec"]["contracts"]
-        .as_array()
-        .is_some_and(|contracts| contracts
-            .iter()
-            .any(|contract| contract["name"] == json!("planner-builder-handoff"))));
-    assert!(manifest["harness_artifacts"]["schemas"]
-        .as_array()
-        .is_some_and(|schemas| schemas.iter().any(
-            |schema| schema["runtime_resource"] == json!(HANDOFF_ARTIFACT_SCHEMA_RESOURCE_URI)
-        )));
+    assert!(
+        manifest["harness_modes"]["modes"]
+            .as_array()
+            .is_some_and(|modes| modes
+                .iter()
+                .any(|mode| mode["name"] == json!("planner-builder")))
+    );
+    assert!(
+        manifest["harness_spec"]["contracts"]
+            .as_array()
+            .is_some_and(|contracts| contracts
+                .iter()
+                .any(|contract| contract["name"] == json!("planner-builder-handoff")))
+    );
+    assert!(
+        manifest["harness_artifacts"]["schemas"]
+            .as_array()
+            .is_some_and(|schemas| schemas
+                .iter()
+                .any(|schema| schema["runtime_resource"]
+                    == json!(HANDOFF_ARTIFACT_SCHEMA_RESOURCE_URI)))
+    );
 
     let manifest_profiles = manifest["surfaces"]["profiles"]
         .as_array()

--- a/crates/codelens-mcp/src/tool_defs/generated/build_generated.rs
+++ b/crates/codelens-mcp/src/tool_defs/generated/build_generated.rs
@@ -44,6 +44,31 @@ pub fn analysis_tools(ro_a: &ToolAnnotations, ro_p: &ToolAnnotations) -> Vec<Too
             json!({"type":"object","properties":{"max_results":{"type":"integer"}}}),
         ).with_annotations(ro_a.clone()),
         Tool::new(
+            "find_redundant_definitions",
+            "[CodeLens:Analysis] Find Rust thin-wrapper functions whose body is a single call to another function with one literal default. Output groups by target so multi-wrapper substrates surface as cleanup clusters.",
+            json!({"type":"object","properties":{"max_results":{"type":"integer"}}}),
+        ).with_annotations(ro_a.clone()),
+        Tool::new(
+            "audit_tool_surface_consistency",
+            "[CodeLens:Analysis] Cross-check `tools.toml` entries against `dispatch_table()` macro arms and report drift. `missing_in_dispatch` = registered in toml but no handler arm; `missing_in_toml` = dispatched but missing schema entry. Catches deletion-cascade asymmetry that would otherwise surface as runtime `tool not found` or schema validation failures.",
+            json!({"type":"object","properties":{}}),
+        ).with_annotations(ro_a.clone()),
+        Tool::new(
+            "find_orphan_handlers",
+            "[CodeLens:Analysis] Find ToolHandler-shaped functions in `crates/codelens-mcp/src/tools/` that are neither registered in dispatch tables (`tools/mod.rs` macro arms or `dispatch/table.rs` Arc::new inserts) nor referenced from any other workspace .rs file. v2 added the cross-file reference check so handler-shaped helpers (a `*_tool` calling another via path) no longer surface as false orphans.",
+            json!({"type":"object","properties":{}}),
+        ).with_annotations(ro_a.clone()),
+        Tool::new(
+            "find_over_visible_apis",
+            "[CodeLens:Analysis] Find `pub` / `pub(crate)` declarations whose references all stay inside a narrower scope than they advertise. `pub` with no cross-crate caller → suggest `pub(crate)`. `pub(crate)` with no other-file caller → suggest dropping visibility. Complements find_phantom_modules / find_redundant_definitions: those find dead surface, this one finds too-wide surface that compiler warnings cannot catch because the items are still in use, just not by anyone outside the declaring boundary.",
+            json!({"type":"object","properties":{}}),
+        ).with_annotations(ro_a.clone()),
+        Tool::new(
+            "find_phantom_modules",
+            "[CodeLens:Analysis] Find `mod NAME;` declarations whose name is never referenced as a path segment elsewhere in the workspace. Reports both private and public mods; visibility is included so callers can filter. Known limitation: impl-extension pattern (file split where the module only adds `impl X { ... }` to a parent type) is reported but is not actually phantom — manual review required.",
+            json!({"type":"object","properties":{"max_results":{"type":"integer"}}}),
+        ).with_annotations(ro_a.clone()),
+        Tool::new(
             "get_change_coupling",
             "[CodeLens:Analysis] Files that frequently change together in git history.",
             json!({"type":"object","properties":{"months":{"type":"integer"},"min_strength":{"type":"number"},"min_commits":{"type":"integer"},"max_results":{"type":"integer"}}}),

--- a/crates/codelens-mcp/src/tool_defs/presets.rs
+++ b/crates/codelens-mcp/src/tool_defs/presets.rs
@@ -1398,9 +1398,10 @@ mod overlay_tests {
         let plan = compile_surface_overlay(full_surface(), Some(HostContext::ClaudeCode), None);
         assert!(plan.applied());
         assert_eq!(plan.preferred_executor_bias, Some("claude"));
-        assert!(plan
-            .preferred_entrypoints
-            .contains(&"analyze_change_request"));
+        assert!(
+            plan.preferred_entrypoints
+                .contains(&"analyze_change_request")
+        );
         assert!(!plan.routing_notes.is_empty());
     }
 
@@ -1425,9 +1426,10 @@ mod overlay_tests {
                 "planning overlay should avoid {mutation}"
             );
         }
-        assert!(plan
-            .preferred_entrypoints
-            .contains(&"analyze_change_request"));
+        assert!(
+            plan.preferred_entrypoints
+                .contains(&"analyze_change_request")
+        );
     }
 
     #[test]
@@ -1444,9 +1446,10 @@ mod overlay_tests {
                 "editing overlay should emphasize {mutation}"
             );
         }
-        assert!(plan
-            .preferred_entrypoints
-            .contains(&"verify_change_readiness"));
+        assert!(
+            plan.preferred_entrypoints
+                .contains(&"verify_change_readiness")
+        );
         assert!(plan.avoid_tools.is_empty());
     }
 
@@ -1507,9 +1510,11 @@ mod overlay_tests {
             Some(HostContext::ClaudeCode),
             None,
         );
-        assert!(!plan
-            .preferred_entrypoints
-            .contains(&"analyze_change_request"));
+        assert!(
+            !plan
+                .preferred_entrypoints
+                .contains(&"analyze_change_request")
+        );
     }
 
     #[test]

--- a/crates/codelens-mcp/src/tools/graph.rs
+++ b/crates/codelens-mcp/src/tools/graph.rs
@@ -219,10 +219,7 @@ pub(crate) fn find_dead_code_v2_tool(
     )
 }
 
-pub fn find_orphan_handlers_tool(
-    state: &AppState,
-    _arguments: &serde_json::Value,
-) -> ToolResult {
+pub fn find_orphan_handlers_tool(state: &AppState, _arguments: &serde_json::Value) -> ToolResult {
     let entries = crate::orphan_handlers::find_orphan_handlers(state.project().as_path())?;
     Ok((
         json!({
@@ -233,16 +230,15 @@ pub fn find_orphan_handlers_tool(
     ))
 }
 
-pub fn find_over_visible_apis_tool(
-    state: &AppState,
-    _arguments: &serde_json::Value,
-) -> ToolResult {
+pub fn find_over_visible_apis_tool(state: &AppState, _arguments: &serde_json::Value) -> ToolResult {
     let entries = crate::over_visible::find_over_visible_apis(state.project().as_path())?;
     let by_kind: std::collections::BTreeMap<String, usize> =
-        entries.iter().fold(std::collections::BTreeMap::new(), |mut acc, e| {
-            *acc.entry(e.kind.clone()).or_insert(0) += 1;
-            acc
-        });
+        entries
+            .iter()
+            .fold(std::collections::BTreeMap::new(), |mut acc, e| {
+                *acc.entry(e.kind.clone()).or_insert(0) += 1;
+                acc
+            });
     Ok((
         json!({
             "over_visible_apis": entries,
@@ -268,10 +264,7 @@ pub fn audit_tool_surface_consistency_tool(
     ))
 }
 
-pub fn find_phantom_modules_tool(
-    state: &AppState,
-    arguments: &serde_json::Value,
-) -> ToolResult {
+pub fn find_phantom_modules_tool(state: &AppState, arguments: &serde_json::Value) -> ToolResult {
     let max_results = optional_usize(arguments, "max_results", 50);
     let entries = phantom_modules::find_phantom_modules(&state.project(), max_results)?;
     Ok((
@@ -288,8 +281,7 @@ pub fn find_redundant_definitions_tool(
     arguments: &serde_json::Value,
 ) -> ToolResult {
     let max_results = optional_usize(arguments, "max_results", 50);
-    let entries =
-        redundant_definitions::find_redundant_definitions(&state.project(), max_results)?;
+    let entries = redundant_definitions::find_redundant_definitions(&state.project(), max_results)?;
     let mut groups: std::collections::BTreeMap<String, Vec<&_>> = std::collections::BTreeMap::new();
     for entry in &entries {
         groups.entry(entry.target.clone()).or_default().push(entry);


### PR DESCRIPTION
Pre-existing rustfmt debt on main blocks \`cargo fmt --check\` in CI for every PR. This PR applies rustfmt without behavioural change.

## Why

PRs #174 #176 #177 #178 all show \`check (ubuntu-latest) FAILURE\` because main has fmt drift. None of those PRs touch the affected files. Applying fmt here unblocks all four.

## Test plan

- [x] cargo check -p codelens-engine — pass
- [x] cargo test -p codelens-engine — pass
- [ ] cargo fmt --check — should now pass on main after merge

After merge, retry CI on #174 #176 #177 #178 (or rebase them).