### PR TITLE
fix(#180): path soft alias for read_file, list_dir, get_type_hierarchy

### DIFF
--- a/crates/codelens-mcp/src/dispatch/envelope.rs
+++ b/crates/codelens-mcp/src/dispatch/envelope.rs
@@ -135,7 +135,12 @@ fn apply_path_alias_normalisation(tool_name: &str, arguments: &mut serde_json::V
     let has_relative_path = obj.contains_key("relative_path");
     let supports_relative_path_alias = matches!(
         tool_name,
-        "get_symbols_overview" | "find_referencing_symbols" | "get_file_diagnostics"
+        "get_symbols_overview"
+            | "find_referencing_symbols"
+            | "get_file_diagnostics"
+            | "read_file"
+            | "list_dir"
+            | "get_type_hierarchy"
     );
     match (has_file_path, has_path) {
         (true, false) => {

--- a/crates/codelens-mcp/src/integration_tests/readonly.rs
+++ b/crates/codelens-mcp/src/integration_tests/readonly.rs
@@ -198,6 +198,109 @@ fn get_symbols_overview_emits_degraded_reason_when_file_not_indexed() {
     // is the silent-empty path, not the eager-index optimization.
 }
 
+// #180: extend the path soft-alias contract to read_file, list_dir, and
+// get_type_hierarchy. Each test asserts both the canonical `path` form
+// (no warning) and the legacy `relative_path` form (single
+// deprecation_warnings entry) so a future regression that drops the alias
+// will fail with a precise diff.
+#[test]
+fn read_file_accepts_legacy_relative_path_with_deprecation_warning() {
+    let project = project_root();
+    fs::write(project.as_path().join("legacy_read.txt"), "hello\n").unwrap();
+    let state = make_state(&project);
+
+    let payload = call_tool(
+        &state,
+        "read_file",
+        json!({ "relative_path": "legacy_read.txt" }),
+    );
+    assert_eq!(payload["success"], json!(true));
+    let warnings = payload["data"]["deprecation_warnings"]
+        .as_array()
+        .expect("deprecation_warnings array on legacy call");
+    assert_eq!(warnings.len(), 1);
+    assert_eq!(warnings[0]["param"], json!("relative_path"));
+    assert_eq!(warnings[0]["replacement"], json!("path"));
+
+    let payload = call_tool(&state, "read_file", json!({ "path": "legacy_read.txt" }));
+    assert_eq!(payload["success"], json!(true));
+    assert!(
+        payload["data"].get("deprecation_warnings").is_none(),
+        "canonical `path` call must not emit deprecation_warnings"
+    );
+}
+
+#[test]
+fn list_dir_accepts_legacy_relative_path_with_deprecation_warning() {
+    let project = project_root();
+    fs::create_dir_all(project.as_path().join("legacy_dir/nested")).unwrap();
+    fs::write(project.as_path().join("legacy_dir/x.txt"), "x\n").unwrap();
+    let state = make_state(&project);
+
+    let payload = call_tool(&state, "list_dir", json!({ "relative_path": "legacy_dir" }));
+    assert_eq!(payload["success"], json!(true));
+    assert_eq!(
+        payload["data"]["deprecation_warnings"]
+            .as_array()
+            .expect("deprecation_warnings array")
+            .len(),
+        1
+    );
+    assert_eq!(
+        payload["data"]["deprecation_warnings"][0]["param"],
+        json!("relative_path")
+    );
+
+    let payload = call_tool(&state, "list_dir", json!({ "path": "legacy_dir" }));
+    assert_eq!(payload["success"], json!(true));
+    assert!(payload["data"].get("deprecation_warnings").is_none());
+}
+
+#[test]
+fn get_type_hierarchy_accepts_legacy_relative_path_with_deprecation_warning() {
+    let project = project_root();
+    fs::write(
+        project.as_path().join("legacy_hierarchy.py"),
+        "class Base:\n    pass\n\nclass Child(Base):\n    pass\n",
+    )
+    .unwrap();
+    let state = make_state(&project);
+
+    let payload = call_tool(
+        &state,
+        "get_type_hierarchy",
+        json!({
+            "name_path": "Base",
+            "relative_path": "legacy_hierarchy.py",
+            "hierarchy_type": "sub",
+        }),
+    );
+    assert_eq!(payload["success"], json!(true));
+    assert_eq!(
+        payload["data"]["deprecation_warnings"]
+            .as_array()
+            .expect("deprecation_warnings array")
+            .len(),
+        1
+    );
+    assert_eq!(
+        payload["data"]["deprecation_warnings"][0]["param"],
+        json!("relative_path")
+    );
+
+    let payload = call_tool(
+        &state,
+        "get_type_hierarchy",
+        json!({
+            "name_path": "Base",
+            "path": "legacy_hierarchy.py",
+            "hierarchy_type": "sub",
+        }),
+    );
+    assert_eq!(payload["success"], json!(true));
+    assert!(payload["data"].get("deprecation_warnings").is_none());
+}
+
 // P1-B contract: every read-only tool in the second wave must
 // 1) honor `limit` / `top_k` aliases for whatever its canonical
 //    limit field is (or skip the alias if it has no limit field),

--- a/crates/codelens-mcp/src/tool_defs/generated/build_generated.rs
+++ b/crates/codelens-mcp/src/tool_defs/generated/build_generated.rs
@@ -306,13 +306,13 @@ pub fn file_io_tools(ro_p: &ToolAnnotations) -> Vec<Tool> {
         ).with_output_schema(get_current_config_output_schema()).with_annotations(ro_p.clone()),
         Tool::new(
             "read_file",
-            "[CodeLens:File] Read file contents with optional line range.",
-            json!({"type":"object","required":["relative_path"],"properties":{"relative_path":{"type":"string"},"start_line":{"type":"integer"},"end_line":{"type":"integer"}}}),
+            "[CodeLens:File] Read file contents with optional line range. Use `path` (canonical). Legacy `relative_path` is accepted for one release with a deprecation warning.",
+            json!({"type":"object","required":["path"],"properties":{"path":{"type":"string"},"relative_path":{"type":"string","description":"DEPRECATED v1.13.23 — use `path`. Soft alias maintained until v1.14.0."},"start_line":{"type":"integer"},"end_line":{"type":"integer"}}}),
         ).with_output_schema(file_content_output_schema()).with_annotations(ro_p.clone()),
         Tool::new(
             "list_dir",
-            "[CodeLens:File] List directory contents, optionally recursive.",
-            json!({"type":"object","required":["relative_path"],"properties":{"relative_path":{"type":"string"},"recursive":{"type":"boolean"}}}),
+            "[CodeLens:File] List directory contents, optionally recursive. Use `path` (canonical). Legacy `relative_path` is accepted for one release with a deprecation warning.",
+            json!({"type":"object","required":["path"],"properties":{"path":{"type":"string"},"relative_path":{"type":"string","description":"DEPRECATED v1.13.23 — use `path`. Soft alias maintained until v1.14.0."},"recursive":{"type":"boolean"}}}),
         ).with_annotations(ro_p.clone()),
         Tool::new(
             "find_file",
@@ -356,8 +356,8 @@ pub fn lsp_tools(ro_a: &ToolAnnotations, ro_p: &ToolAnnotations) -> Vec<Tool> {
         ).with_annotations(ro_p.clone()),
         Tool::new(
             "get_type_hierarchy",
-            "[CodeLens:Symbol] Inheritance hierarchy — supertypes and subtypes of a class/interface.",
-            json!({"type":"object","properties":{"name_path":{"type":"string"},"fully_qualified_name":{"type":"string"},"relative_path":{"type":"string"},"hierarchy_type":{"type":"string","enum":["super","sub","both"]},"depth":{"type":"integer"},"command":{"type":"string"},"args":{"type":"array","items":{"type":"string"}}}}),
+            "[CodeLens:Symbol] Inheritance hierarchy — supertypes and subtypes of a class/interface. Use `path` (canonical). Legacy `relative_path` is accepted for one release with a deprecation warning.",
+            json!({"type":"object","properties":{"name_path":{"type":"string"},"fully_qualified_name":{"type":"string"},"path":{"type":"string"},"relative_path":{"type":"string","description":"DEPRECATED v1.13.23 — use `path`. Soft alias maintained until v1.14.0."},"hierarchy_type":{"type":"string","enum":["super","sub","both"]},"depth":{"type":"integer"},"command":{"type":"string"},"args":{"type":"array","items":{"type":"string"}}}}),
         ).with_output_schema(get_type_hierarchy_output_schema()).with_annotations(ro_a.clone()),
         Tool::new(
             "resolve_symbol_target",

--- a/crates/codelens-mcp/src/tools/filesystem.rs
+++ b/crates/codelens-mcp/src/tools/filesystem.rs
@@ -59,8 +59,34 @@ pub fn get_current_config(state: &AppState, arguments: &serde_json::Value) -> To
     ))
 }
 
+/// #180: emit a deprecation_warnings entry if the caller passed `relative_path`
+/// instead of the canonical `path`. The dispatch envelope normalises
+/// `relative_path → path` for the read_file/list_dir/get_type_hierarchy
+/// allow-listed tools, so handler code only needs to read `path` and check
+/// the `_path_alias_source` marker injected by the envelope.
+fn relative_path_deprecation(arguments: &serde_json::Value) -> Vec<Value> {
+    if optional_string(arguments, "_path_alias_source") == Some("relative_path") {
+        vec![json!({
+            "param": "relative_path",
+            "replacement": "path",
+            "message": "DEPRECATED v1.13.23 — use `path`. Soft alias maintained until v1.14.0.",
+        })]
+    } else {
+        Vec::new()
+    }
+}
+
+fn attach_deprecation_warnings(value: &mut Value, warnings: Vec<Value>) {
+    if warnings.is_empty() {
+        return;
+    }
+    if let Some(map) = value.as_object_mut() {
+        map.insert("deprecation_warnings".to_owned(), Value::Array(warnings));
+    }
+}
+
 pub fn read_file_tool(state: &AppState, arguments: &serde_json::Value) -> ToolResult {
-    let path = required_string(arguments, "relative_path")?;
+    let path = required_string(arguments, "path")?;
     let start_line = arguments
         .get("start_line")
         .and_then(|v| v.as_u64())
@@ -69,18 +95,24 @@ pub fn read_file_tool(state: &AppState, arguments: &serde_json::Value) -> ToolRe
         .get("end_line")
         .and_then(|v| v.as_u64())
         .map(|v| v as usize);
-    Ok(read_file(&state.project(), path, start_line, end_line)
-        .map(|value| (json!(value), success_meta(BackendKind::Filesystem, 1.0)))?)
+    let warnings = relative_path_deprecation(arguments);
+    Ok(
+        read_file(&state.project(), path, start_line, end_line).map(|value| {
+            let mut payload = json!(value);
+            attach_deprecation_warnings(&mut payload, warnings);
+            (payload, success_meta(BackendKind::Filesystem, 1.0))
+        })?,
+    )
 }
 
 pub fn list_dir_tool(state: &AppState, arguments: &serde_json::Value) -> ToolResult {
-    let path = required_string(arguments, "relative_path")?;
+    let path = required_string(arguments, "path")?;
     let recursive = optional_bool(arguments, "recursive", false);
+    let warnings = relative_path_deprecation(arguments);
     Ok(list_dir(&state.project(), path, recursive).map(|value| {
-        (
-            json!({ "entries": value, "count": value.len() }),
-            success_meta(BackendKind::Filesystem, 1.0),
-        )
+        let mut payload = json!({ "entries": value, "count": value.len() });
+        attach_deprecation_warnings(&mut payload, warnings);
+        (payload, success_meta(BackendKind::Filesystem, 1.0))
     })?)
 }
 

--- a/crates/codelens-mcp/src/tools/lsp.rs
+++ b/crates/codelens-mcp/src/tools/lsp.rs
@@ -562,7 +562,20 @@ pub fn get_type_hierarchy(state: &AppState, arguments: &serde_json::Value) -> To
         .and_then(|v| v.as_str())
         .ok_or_else(|| CodeLensError::MissingParam("name_path or fully_qualified_name".into()))?
         .to_owned();
-    let relative_path = optional_string(arguments, "relative_path").map(ToOwned::to_owned);
+    // #180: prefer canonical `path`; envelope normalises `relative_path → path`
+    // for this tool, so reading `path` first picks up either input shape.
+    let relative_path = optional_string(arguments, "path")
+        .or_else(|| optional_string(arguments, "relative_path"))
+        .map(ToOwned::to_owned);
+    let alias_used = optional_string(arguments, "_path_alias_source")
+        .filter(|s| *s == "relative_path")
+        .map(|_| {
+            json!({
+                "param": "relative_path",
+                "replacement": "path",
+                "message": "DEPRECATED v1.13.23 — use `path`. Soft alias maintained until v1.14.0.",
+            })
+        });
     let hierarchy_type = optional_string(arguments, "hierarchy_type")
         .unwrap_or("both")
         .to_owned();
@@ -589,7 +602,10 @@ pub fn get_type_hierarchy(state: &AppState, arguments: &serde_json::Value) -> To
             });
 
         match lsp_result {
-            Ok(value) => Ok((json!(value), meta_for_backend("lsp_pooled", 0.82))),
+            Ok(value) => Ok((
+                attach_alias_warning(json!(value), alias_used.clone()),
+                meta_for_backend("lsp_pooled", 0.82),
+            )),
             Err(_) => Ok(get_type_hierarchy_native(
                 &state.project(),
                 &query,
@@ -599,7 +615,7 @@ pub fn get_type_hierarchy(state: &AppState, arguments: &serde_json::Value) -> To
             )
             .map(|value| {
                 (
-                    json!(value),
+                    attach_alias_warning(json!(value), alias_used.clone()),
                     meta_degraded(
                         "tree-sitter-native",
                         0.80,
@@ -618,11 +634,26 @@ pub fn get_type_hierarchy(state: &AppState, arguments: &serde_json::Value) -> To
         )
         .map(|value| {
             (
-                json!(value),
+                attach_alias_warning(json!(value), alias_used),
                 meta_degraded("tree-sitter-native", 0.80, "no LSP command available"),
             )
         })?)
     }
+}
+
+/// #180: append a single deprecation_warnings entry to a payload when the
+/// caller used a legacy path alias. Mirrors the per-file helper in
+/// filesystem.rs so all path-aliased tools emit the same shape.
+fn attach_alias_warning(mut payload: Value, warning: Option<Value>) -> Value {
+    if let Some(warning) = warning
+        && let Some(map) = payload.as_object_mut()
+    {
+        map.insert(
+            "deprecation_warnings".to_owned(),
+            Value::Array(vec![warning]),
+        );
+    }
+    payload
 }
 
 pub fn plan_symbol_rename(state: &AppState, arguments: &serde_json::Value) -> ToolResult {

--- a/crates/codelens-mcp/tools.toml
+++ b/crates/codelens-mcp/tools.toml
@@ -54,27 +54,27 @@ properties = {}
 [[tool]]
 name = "read_file"
 category = "file_io"
-description = "[CodeLens:File] Read file contents with optional line range."
+description = "[CodeLens:File] Read file contents with optional line range. Use `path` (canonical). Legacy `relative_path` is accepted for one release with a deprecation warning."
 annotations = "ro_p"
 output_schema = "file_content_output_schema"
 
 [tool.input_schema]
 type = "object"
-required = ["relative_path"]
-properties = { relative_path = { type = "string" }, start_line = { type = "integer" }, end_line = { type = "integer" } }
+required = ["path"]
+properties = { path = { type = "string" }, relative_path = { type = "string", description = "DEPRECATED v1.13.23 — use `path`. Soft alias maintained until v1.14.0." }, start_line = { type = "integer" }, end_line = { type = "integer" } }
 
 # ─────
 
 [[tool]]
 name = "list_dir"
 category = "file_io"
-description = "[CodeLens:File] List directory contents, optionally recursive."
+description = "[CodeLens:File] List directory contents, optionally recursive. Use `path` (canonical). Legacy `relative_path` is accepted for one release with a deprecation warning."
 annotations = "ro_p"
 
 [tool.input_schema]
 type = "object"
-required = ["relative_path"]
-properties = { relative_path = { type = "string" }, recursive = { type = "boolean" } }
+required = ["path"]
+properties = { path = { type = "string" }, relative_path = { type = "string", description = "DEPRECATED v1.13.23 — use `path`. Soft alias maintained until v1.14.0." }, recursive = { type = "boolean" } }
 
 # ─────
 
@@ -332,7 +332,7 @@ max_results = { type = "integer" }
 [[tool]]
 name = "get_type_hierarchy"
 category = "lsp"
-description = "[CodeLens:Symbol] Inheritance hierarchy — supertypes and subtypes of a class/interface."
+description = "[CodeLens:Symbol] Inheritance hierarchy — supertypes and subtypes of a class/interface. Use `path` (canonical). Legacy `relative_path` is accepted for one release with a deprecation warning."
 annotations = "ro_a"
 output_schema = "get_type_hierarchy_output_schema"
 
@@ -341,7 +341,8 @@ type = "object"
 [tool.input_schema.properties]
 name_path = { type = "string" }
 fully_qualified_name = { type = "string" }
-relative_path = { type = "string" }
+path = { type = "string" }
+relative_path = { type = "string", description = "DEPRECATED v1.13.23 — use `path`. Soft alias maintained until v1.14.0." }
 hierarchy_type = { type = "string", enum = ["super", "sub", "both"] }
 depth = { type = "integer" }
 command = { type = "string" }


### PR DESCRIPTION
## Summary

First batch of the #180 follow-up to #170. Three more read-only tools accept the canonical \`path\` argument with a deprecation warning when the legacy \`relative_path\` is used:

- \`read_file\`
- \`list_dir\`
- \`get_type_hierarchy\`

For each tool: \`tools.toml\` schema gains \`path\` (canonical, required) plus a deprecated \`relative_path\` description; the dispatch envelope's \`apply_path_alias_normalisation\` allow-list is extended so \`relative_path → path\` normalisation runs for these names; handlers read \`path\` and emit a single \`deprecation_warnings\` entry of shape \`{param, replacement, message}\` when the legacy form was used.

Each tool gains a paired integration test (canonical → no warning, legacy → exactly one warning with correct \`param\` / \`replacement\`). 567 existing tests continue to pass; \`cargo clippy --no-default-features -- -D warnings\` clean.

Resolves part of #180 (3 of ~38 audited tools).

## Out of scope (tracked under #180 for follow-up)

- **Mutation primitives** — \`rename_symbol\`, \`replace_*\`, \`insert_*\`, \`delete_lines\`, \`refactor_*\`. Schema change has stronger compatibility implications and benefits from a separate review.
- **Optional-scope tools** — \`get_callers\`, \`get_callees\`, \`find_scoped_references\` use \`file_path\` as an optional scope rather than a target file; semantics differ.
- **Workflow-first tools** — \`plan_safe_refactor\`, \`refactor_safety_report\`, \`diagnose_issues\`, \`prepare_harness_session\` have multi-arg path surfaces and warrant their own audit.

## Test plan

- [x] \`cargo test -p codelens-mcp --bin codelens-mcp accepts_legacy_relative_path\` — 4 passed (3 new + the existing find_referencing_symbols guard)
- [x] full \`cargo test -p codelens-mcp --bin codelens-mcp\` — 563 passed, 4 ignored
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --workspace --no-default-features -- -D warnings\` clean
- [x] \`python3 scripts/regen-tool-defs.py --check\` clean
- [ ] Codex review

## Cross-refs

- #170 (find_symbol \`name_path\` soft alias precedent)
- #176 (path canonicalisation strategy)
- #178 (3-tool batch from the dogfood session)
- dogfood session 2026-05-03

🤖 Generated with [Claude Code](https://claude.com/claude-code)