### PR TITLE
fix(#184): distinguish indexed-empty from file_not_indexed (Codex P2)

### DIFF
--- a/crates/codelens-engine/src/symbols/reader.rs
+++ b/crates/codelens-engine/src/symbols/reader.rs
@@ -157,6 +157,21 @@ impl SymbolIndex {
         Self::rows_to_symbol_infos(&self.project, &db, db_rows, include_body)
     }
 
+    /// Returns `true` when the on-disk symbol DB has a row for `path` (i.e.
+    /// the file has been indexed at least once), even if the file currently
+    /// has zero symbols. Used by `get_symbols_overview` callers to
+    /// distinguish "file is genuinely empty / comments only" from
+    /// "file has not been indexed yet". (#183 / #184 follow-up)
+    pub fn file_is_indexed(&self, path: &str) -> Result<bool> {
+        let db = self.reader()?;
+        let resolved = self.project.resolve(path)?;
+        if resolved.is_dir() {
+            return Ok(false);
+        }
+        let relative = self.project.to_relative(&resolved);
+        Ok(db.get_file(&relative)?.is_some())
+    }
+
     /// Get symbols overview from DB without lazy indexing.
     pub fn get_symbols_overview_cached(
         &self,

--- a/crates/codelens-mcp/src/integration_tests/readonly.rs
+++ b/crates/codelens-mcp/src/integration_tests/readonly.rs
@@ -198,6 +198,41 @@ fn get_symbols_overview_emits_degraded_reason_when_file_not_indexed() {
     // is the silent-empty path, not the eager-index optimization.
 }
 
+// #184 follow-up (Codex P2): a legitimately empty file that *is* indexed
+// must report `degraded_reason: "indexed_no_symbols"` (not
+// `file_not_indexed`) so callers do not run a useless refresh loop.
+#[test]
+fn get_symbols_overview_emits_indexed_no_symbols_for_genuinely_empty_file() {
+    let project = project_root();
+    fs::write(
+        project.as_path().join("blank.py"),
+        "# only a comment, no declarations\n",
+    )
+    .unwrap();
+    // Make state *after* the write so make_state's eager indexer adds the
+    // file row to the DB. The file row exists but has zero symbol rows.
+    let state = make_state(&project);
+
+    let payload = call_tool(
+        &state,
+        "get_symbols_overview",
+        json!({ "path": "blank.py" }),
+    );
+
+    assert_eq!(payload["success"], json!(true));
+    assert_eq!(payload["data"]["count"], json!(0));
+    assert_eq!(
+        payload["data"]["degraded_reason"],
+        json!("indexed_no_symbols"),
+        "indexed file with zero symbols must NOT report file_not_indexed; \
+         that would push callers into needless refresh_symbol_index loops"
+    );
+    assert!(
+        payload["data"].get("fallback_hint").is_none(),
+        "indexed_no_symbols branch must not advertise a recovery action"
+    );
+}
+
 // #180: extend the path soft-alias contract to read_file, list_dir, and
 // get_type_hierarchy. Each test asserts both the canonical `path` form
 // (no warning) and the legacy `relative_path` form (single

--- a/crates/codelens-mcp/src/tools/symbols/handlers.rs
+++ b/crates/codelens-mcp/src/tools/symbols/handlers.rs
@@ -122,12 +122,23 @@ pub fn get_symbols_overview(state: &AppState, arguments: &Value) -> ToolResult {
         "truncated": truncated,
         "auto_summarized": stripped,
     });
-    // #183: distinguish "file legitimately has 0 symbols" from "result is
-    // empty because the on-disk index has not caught up yet". The
-    // _cached path returns Vec::new() silently when the file row is
-    // absent from the symbol DB; without this signal a freshly-modified
-    // file looks indistinguishable from a true empty file and callers
-    // (humans + agents) fall back to grep, defeating CodeLens.
+    // #183 + #184 follow-up: distinguish three empty-result cases so
+    // callers (humans + agents) can act on the right signal:
+    //
+    //   - "file_not_indexed"        — file is on disk + supported extension
+    //                                 but no row in the symbol DB yet
+    //                                 (watcher lag / .gitignore / project
+    //                                 root mismatch)
+    //   - "indexed_no_symbols"      — file is on disk, supported, AND the
+    //                                 DB has a row for it; the empty list
+    //                                 is the truth (empty file, comments
+    //                                 only, type-alias-only module, …)
+    //                                 Callers should NOT trigger refresh.
+    //   - "unsupported_extension"   — extension is not in lang_registry
+    //
+    // The previous version conflated the first two and pushed clients into
+    // unnecessary `refresh_symbol_index` loops on legitimately empty
+    // files (Codex P2 on PR #184).
     if symbols.is_empty() {
         let resolved = state.project().resolve(path).ok();
         let on_disk = resolved
@@ -144,13 +155,23 @@ pub fn get_symbols_overview(state: &AppState, arguments: &Value) -> ToolResult {
             .map(codelens_engine::lang_registry::supports_symbols)
             .unwrap_or(false);
         if on_disk && supported {
-            payload["degraded_reason"] = json!("file_not_indexed");
-            payload["fallback_hint"] = json!(["refresh_symbol_index", "find_symbol",]);
-            payload["recovery_message"] = json!(
-                "Result is empty because this file is not in the on-disk index yet \
-                 (watcher lag, .gitignore, or project root mismatch). \
-                 Call `refresh_symbol_index` with this path, or wait ~1-2s after a recent edit."
-            );
+            let already_indexed = state.symbol_index().file_is_indexed(path).unwrap_or(false);
+            if already_indexed {
+                payload["degraded_reason"] = json!("indexed_no_symbols");
+                payload["recovery_message"] = json!(
+                    "File is indexed but has no top-level symbols (empty file, comments only, \
+                     or no declarations the active backend recognises). This is not an error; \
+                     no recovery action is required."
+                );
+            } else {
+                payload["degraded_reason"] = json!("file_not_indexed");
+                payload["fallback_hint"] = json!(["refresh_symbol_index", "find_symbol"]);
+                payload["recovery_message"] = json!(
+                    "Result is empty because this file is not in the on-disk index yet \
+                     (watcher lag, .gitignore, or project root mismatch). \
+                     Call `refresh_symbol_index` with this path, or wait ~1-2s after a recent edit."
+                );
+            }
         } else if on_disk {
             payload["degraded_reason"] = json!("unsupported_extension");
         }


### PR DESCRIPTION
## Summary

Codex P2 on PR #184: \`degraded_reason: \"file_not_indexed\"\` was emitted for **any** supported on-disk file whose symbol list was empty. But \`get_symbols_overview_cached\` also returns an empty Vec when the file *is* indexed and simply has no top-level symbols (empty file, comments-only file, type-alias-only module). The false degradation signal pushed clients into unnecessary \`refresh_symbol_index\` recovery loops on legitimately empty files.

Engine side adds a small public accessor:

- \`SymbolIndex::file_is_indexed(&self, path: &str) -> Result<bool>\` — thin wrapper around \`db.get_file(...)\` returning true iff the file has a row in the symbol DB, regardless of how many symbols are attached.

Handler now branches three-way:

| Condition | \`degraded_reason\` | \`fallback_hint\` |
|---|---|---|
| on disk + supported + DB has no row | \`file_not_indexed\` | \`[\"refresh_symbol_index\", \"find_symbol\"]\` |
| on disk + supported + DB has the row | \`indexed_no_symbols\` | (none) |
| on disk + unsupported extension | \`unsupported_extension\` | (none) |

The \`indexed_no_symbols\` branch carries a recovery_message clarifying \"no recovery action is required\".

Resolves Codex review comment on #184.

## Test plan

- [x] new integration test \`get_symbols_overview_emits_indexed_no_symbols_for_genuinely_empty_file\` — comments-only \`.py\` file written *before* \`make_state\` so eager indexer adds the file row, asserts \`indexed_no_symbols\` and absence of \`fallback_hint\`
- [x] existing \`file_not_indexed\` and \`unsupported_extension\` tests still pass
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --workspace --no-default-features -- -D warnings\` clean
- [ ] Codex re-review

🤖 Generated with [Claude Code](https://claude.com/claude-code)