### PR TITLE
fix(#198, #199-B-2): daemon HEAD git_sha drift + workspace dedup

### DIFF
--- a/crates/codelens-engine/src/project.rs
+++ b/crates/codelens-engine/src/project.rs
@@ -521,6 +521,19 @@ pub fn detect_workspace_packages(project: &Path) -> Vec<WorkspacePackage> {
         }
     }
 
+    // Cargo.toml is parsed line-by-line for `crates/*` mentions, which
+    // double-counts paths listed in both `[workspace] members` and
+    // `[workspace] default-members`. Sort + dedup on the (path, name,
+    // package_type) tuple so callers receive each workspace package
+    // once regardless of how many sections reference it.
+    packages.sort_by(|a, b| {
+        a.path
+            .cmp(&b.path)
+            .then_with(|| a.name.cmp(&b.name))
+            .then_with(|| a.package_type.cmp(&b.package_type))
+    });
+    packages
+        .dedup_by(|a, b| a.path == b.path && a.name == b.name && a.package_type == b.package_type);
     packages
 }
 
@@ -546,6 +559,39 @@ mod tests {
         path::Path,
         sync::{Mutex, OnceLock},
     };
+
+    #[test]
+    fn workspace_packages_dedup_when_members_and_default_members_share_paths() {
+        use super::detect_workspace_packages;
+        let temp = tempfile_dir();
+        let crate_dir = temp.join("crates/foo");
+        fs::create_dir_all(&crate_dir).expect("mkdir crate");
+        fs::write(
+            crate_dir.join("Cargo.toml"),
+            "[package]\nname = \"foo\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        )
+        .expect("write crate cargo");
+        // Multi-line TOML array form mirrors how Cargo formats workspace
+        // members in real repos and is what the line-grep heuristic in
+        // `detect_workspace_packages` recognizes today. Same path appears
+        // in both `members` and `default-members` so dedup is the only
+        // thing under test.
+        fs::write(
+            temp.join("Cargo.toml"),
+            "[workspace]\nmembers = [\n    \"crates/foo\",\n]\ndefault-members = [\n    \"crates/foo\",\n]\n",
+        )
+        .expect("write root cargo");
+
+        let pkgs = detect_workspace_packages(&temp);
+        assert_eq!(
+            pkgs.len(),
+            1,
+            "members + default-members listing the same path should dedup, got {pkgs:?}"
+        );
+        assert_eq!(pkgs[0].name, "foo");
+        assert_eq!(pkgs[0].path, "crates/foo");
+        assert_eq!(pkgs[0].package_type, "cargo");
+    }
 
     #[test]
     fn excludes_agent_worktree_directories() {

--- a/crates/codelens-mcp/src/build_info.rs
+++ b/crates/codelens-mcp/src/build_info.rs
@@ -131,14 +131,94 @@ fn current_executable_path() -> Result<std::path::PathBuf, String> {
     std::env::current_exe().map_err(|err| format!("current_exe unavailable: {err}"))
 }
 
-/// Runtime check for the Phase 4a failure mode: the daemon is still
-/// serving requests from an older in-memory binary while the
-/// executable on disk has been replaced with a newer build.
+/// Run `git -C <root> rev-parse --short=7 HEAD` to read the project's
+/// current short SHA. Returns `None` when git is unavailable, the
+/// project is not a git checkout, or the override env var is set to
+/// an empty string. Tests can short-circuit the subprocess call by
+/// setting `CODELENS_HEAD_GIT_SHA_OVERRIDE`.
+fn current_head_git_sha(project_root: &std::path::Path) -> Option<String> {
+    if let Some(override_value) = std::env::var_os("CODELENS_HEAD_GIT_SHA_OVERRIDE") {
+        let value = override_value.into_string().ok()?;
+        return if value.is_empty() { None } else { Some(value) };
+    }
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .arg("rev-parse")
+        .arg("--short=7")
+        .arg("HEAD")
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let trimmed = String::from_utf8(output.stdout).ok()?.trim().to_string();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed)
+    }
+}
+
+/// Combine mtime-staleness and HEAD git_sha mismatch into a single
+/// drift verdict. Two independent signals trigger `stale = true`:
 ///
-/// `stale_daemon = true` means the executable path currently visible on
-/// disk has an mtime newer than `daemon_started_at`, so restarting the
-/// daemon is recommended before trusting version-sensitive behavior.
-pub(crate) fn daemon_binary_drift_payload(daemon_started_at: &str) -> serde_json::Value {
+/// - `mtime_stale`: on-disk executable mtime is newer than daemon
+///   start time (Phase 4a — daemon outlived its own binary)
+/// - HEAD git_sha mismatch: daemon's compile-time `BUILD_GIT_SHA`
+///   differs from the project's current HEAD short SHA, so a fix
+///   merged after the binary was built is silently absent
+///
+/// `mtime_stale` takes precedence in `reason_code` so existing
+/// consumers keep their semantics. The `"unknown"` sentinel emitted
+/// by `build.rs` for non-git builds is treated as "no signal".
+fn classify_drift(
+    mtime_stale: bool,
+    head_git_sha: Option<&str>,
+    binary_git_sha: &str,
+) -> (bool, Option<&'static str>, Option<&'static str>) {
+    let head_mismatch = matches!(
+        head_git_sha,
+        Some(head)
+            if !head.is_empty()
+                && head != "unknown"
+                && binary_git_sha != "unknown"
+                && head != binary_git_sha
+    );
+    let stale = mtime_stale || head_mismatch;
+    let reason_code = match (mtime_stale, head_mismatch) {
+        (true, _) => Some("stale_daemon_binary"),
+        (false, true) => Some("head_git_sha_mismatch"),
+        _ => None,
+    };
+    let reason = match (mtime_stale, head_mismatch) {
+        (true, _) => Some(
+            "disk executable is newer than the running daemon; restart the MCP server to pick up the latest build",
+        ),
+        (false, true) => Some(
+            "daemon binary git_sha does not match project HEAD; rebuild and restart to pick up newer commits",
+        ),
+        _ => None,
+    };
+    (stale, reason_code, reason)
+}
+
+/// Runtime check for two independent daemon-staleness failure modes:
+///
+/// 1. Phase 4a: the on-disk executable mtime is newer than the daemon
+///    start time (binary was rebuilt while the long-running daemon
+///    kept serving the older in-memory copy).
+/// 2. HEAD git_sha mismatch: the project's current HEAD differs from
+///    `BUILD_GIT_SHA`, so a fix merged after the binary was compiled
+///    is silently absent. Detected when `project_root` is supplied
+///    and `git rev-parse --short=7 HEAD` succeeds.
+///
+/// Either signal sets `stale_daemon = true`; the mtime signal takes
+/// precedence in `reason_code` so existing consumers keep semantics.
+pub(crate) fn daemon_binary_drift_payload(
+    daemon_started_at: &str,
+    project_root: Option<&std::path::Path>,
+) -> serde_json::Value {
     let daemon_started_seconds = match parse_rfc3339_utc_seconds(daemon_started_at) {
         Some(value) => value,
         None => {
@@ -191,13 +271,11 @@ pub(crate) fn daemon_binary_drift_payload(daemon_started_at: &str) -> serde_json
             });
         }
     };
-    let stale_daemon = modified_seconds > daemon_started_seconds;
+    let mtime_stale = modified_seconds > daemon_started_seconds;
+    let head_git_sha = project_root.and_then(current_head_git_sha);
+    let (stale_daemon, reason_code, reason) =
+        classify_drift(mtime_stale, head_git_sha.as_deref(), BUILD_GIT_SHA);
     let status = if stale_daemon { "stale" } else { "ok" };
-    let reason_code = if stale_daemon {
-        Some("stale_daemon_binary")
-    } else {
-        None
-    };
     let recommended_action = if stale_daemon {
         Some("restart_mcp_server")
     } else {
@@ -215,17 +293,14 @@ pub(crate) fn daemon_binary_drift_payload(daemon_started_at: &str) -> serde_json
         "daemon_started_at": daemon_started_at,
         "binary_build_time": BUILD_TIME,
         "binary_git_sha": BUILD_GIT_SHA,
-        "reason": if stale_daemon {
-            Some("disk executable is newer than the running daemon; restart the MCP server to pick up the latest build")
-        } else {
-            None
-        },
+        "head_git_sha": head_git_sha,
+        "reason": reason,
     })
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{format_rfc3339_utc, parse_rfc3339_utc_seconds};
+    use super::{classify_drift, format_rfc3339_utc, parse_rfc3339_utc_seconds};
 
     #[test]
     fn rfc3339_utc_round_trips_known_epoch_values() {
@@ -238,5 +313,58 @@ mod tests {
             assert_eq!(format_rfc3339_utc(unix_seconds), expected);
             assert_eq!(parse_rfc3339_utc_seconds(expected), Some(unix_seconds));
         }
+    }
+
+    #[test]
+    fn classify_drift_reports_head_mismatch_when_binary_sha_lags_head() {
+        let (stale, code, reason) = classify_drift(false, Some("237e4465"), "f7885f9b");
+        assert!(stale, "head mismatch must trigger stale=true");
+        assert_eq!(code, Some("head_git_sha_mismatch"));
+        assert!(reason.unwrap().contains("does not match project HEAD"));
+    }
+
+    #[test]
+    fn classify_drift_clears_when_head_matches_binary() {
+        let (stale, code, reason) = classify_drift(false, Some("237e4465"), "237e4465");
+        assert!(!stale);
+        assert_eq!(code, None);
+        assert_eq!(reason, None);
+    }
+
+    #[test]
+    fn classify_drift_prefers_mtime_stale_signal_over_head_mismatch() {
+        let (stale, code, reason) = classify_drift(true, Some("237e4465"), "f7885f9b");
+        assert!(stale);
+        assert_eq!(
+            code,
+            Some("stale_daemon_binary"),
+            "mtime stale must take precedence in reason_code"
+        );
+        assert!(reason.unwrap().contains("disk executable is newer"));
+    }
+
+    #[test]
+    fn classify_drift_treats_unknown_sentinel_as_no_signal() {
+        let (stale, code, _) = classify_drift(false, Some("unknown"), "f7885f9b");
+        assert!(!stale, "unknown HEAD must not trigger mismatch");
+        assert_eq!(code, None);
+
+        let (stale, code, _) = classify_drift(false, Some("237e4465"), "unknown");
+        assert!(!stale, "unknown binary SHA must not trigger mismatch");
+        assert_eq!(code, None);
+    }
+
+    #[test]
+    fn classify_drift_skips_when_head_unavailable() {
+        let (stale, code, _) = classify_drift(false, None, "f7885f9b");
+        assert!(!stale);
+        assert_eq!(code, None);
+    }
+
+    #[test]
+    fn classify_drift_skips_when_head_string_is_empty() {
+        let (stale, code, _) = classify_drift(false, Some(""), "f7885f9b");
+        assert!(!stale);
+        assert_eq!(code, None);
     }
 }

--- a/crates/codelens-mcp/src/tools/session/metrics_config/capabilities.rs
+++ b/crates/codelens-mcp/src/tools/session/metrics_config/capabilities.rs
@@ -541,8 +541,10 @@ pub(crate) fn collect_runtime_health_snapshot(
 ) -> RuntimeHealthSnapshot {
     let index_stats = state.symbol_index().stats().ok();
     let semantic_status = determine_semantic_search_status(state, surface);
-    let daemon_binary_drift =
-        crate::build_info::daemon_binary_drift_payload(state.daemon_started_at());
+    let daemon_binary_drift = crate::build_info::daemon_binary_drift_payload(
+        state.daemon_started_at(),
+        Some(state.project().as_path()),
+    );
     let health_summary =
         build_health_summary(index_stats.as_ref(), &semantic_status, &daemon_binary_drift);
     RuntimeHealthSnapshot {


### PR DESCRIPTION
## Summary

- **#198 fix**: `daemon_binary_drift_payload` 가 이제 `BUILD_GIT_SHA` 와 프로젝트 HEAD short SHA (`git rev-parse --short=7`) 를 비교한다. 더 오래된 commit 으로 빌드된 daemon 도 executable mtime 이 변하지 않은 상태에서 `stale_daemon=true` (`reason_code="head_git_sha_mismatch"`) 를 보고 → fix 가 retroactively 적용 안 된 것처럼 보이던 silent false-negative 차단.
- **#199-B-2 fix**: `detect_workspace_packages` 가 이제 모든 collector 가 실행된 뒤 결과를 sort + dedup. `[workspace] members` 와 `[workspace] default-members` 가 같은 path 를 명시하면 패키지가 두 번 push 되던 문제 해소 (이 리포: 3 packages → 6 entries 관찰).

## Detail

### #198

`crates/codelens-mcp/src/build_info.rs` 에 두 개의 helper 추가:

- `current_head_git_sha(project_root: &Path) -> Option<String>` — `git -C <root> rev-parse --short=7 HEAD` 호출. `CODELENS_HEAD_GIT_SHA_OVERRIDE` env 로 테스트에서 subprocess 우회 가능.
- `classify_drift(mtime_stale, head_git_sha, binary_git_sha) -> (stale, reason_code, reason)` — 두 신호를 결합. mtime-stale 이 `reason_code` 에서 우선해서 기존 consumer semantics 유지. `"unknown"` 센티넬은 양쪽 모두에서 no-signal.

`daemon_binary_drift_payload` signature 에 `project_root: Option<&Path>` 추가 (`pub(crate)`, 외부 API 영향 없음). caller `crates/codelens-mcp/src/tools/session/metrics_config/capabilities.rs:545` 한 곳 함께 수정. 응답에 `head_git_sha` 필드 새로 노출.

신규 unit test 6 건:

- `classify_drift_reports_head_mismatch_when_binary_sha_lags_head`
- `classify_drift_clears_when_head_matches_binary`
- `classify_drift_prefers_mtime_stale_signal_over_head_mismatch`
- `classify_drift_treats_unknown_sentinel_as_no_signal`
- `classify_drift_skips_when_head_unavailable`
- `classify_drift_skips_when_head_string_is_empty`

### #199-B-2

`crates/codelens-engine/src/project.rs` 의 `detect_workspace_packages` 마지막에 sort + `dedup_by` 추가. 키는 `(path, name, package_type)` 튜플. cargo / npm / go workspace 모두에 동일 적용.

신규 regression test 1 건: `workspace_packages_dedup_when_members_and_default_members_share_paths` — multi-line TOML array 형태로 같은 path 가 두 섹션에 나오는 케이스.

> **Note**: 같은 함수의 single-line TOML array form (`members = ["crates/foo"]`) 미지원은 별도 추적 (#207 C-3).

## Test plan

- [x] `cargo check --workspace --features http,semantic` (1.61s)
- [x] `cargo clippy --workspace --features http,semantic --all-targets -- -D warnings` (0 warnings)
- [x] `cargo fmt --all -- --check` (clean)
- [x] `cargo nextest run --workspace --features http,semantic` (1080 passed / 10 skipped / 0 failed, 38s)
- [x] `cargo test --doc --workspace --features http,semantic` (1 passed / 1 ignored)
- [x] `cargo nextest run -p codelens-mcp --bin codelens-mcp -E 'test(build_info::tests::)'` — 7 신규 + 기존 cases 모두 PASS
- [x] `cargo nextest run -p codelens-engine --lib 'project::tests::workspace_packages_dedup'` — PASS
- [ ] 머지 후 사용자 환경: `cargo build --release --features http,semantic` → `launchctl kickstart -k "gui/$(id -u)/dev.codelens.mcp-readonly"` → `prepare_harness_session` 응답의 `daemon_binary_drift.head_git_sha` 등장 + drift 시 `status="stale"`, `reason_code="head_git_sha_mismatch"` 확인.

## Closes

- Closes #198
- Partially addresses #199 (B-2 만; B-1 prepare_harness_session compact omit_count, B-3 SCIP function ref routing, B-4 set_profile host hint 는 후속 PR)

## Adjacent

- #207 — 본 PR fix 검증 중 발견된 dogfood follow-up (get_callers SCIP+unique_name dup, diagnose_issues directory error msg, detect_workspace_packages single-line TOML)
- #200 — `tool_defs/presets.rs` codegen 제안 (별도 PR)

## Notes

- 첫 번째 fix 가 적용되면 사용자가 PR 머지 후 daemon 재빌드 안 했을 때 `prepare_harness_session` 한 호출만으로 "fix 가 미반영 상태" 를 즉시 인지 → #195-style retroactive 혼란 차단 (이번 dogfood 세션에서도 동일 증상 재현됨).
- helper 함수 `current_head_git_sha` 는 macOS / Linux / Windows 모두에서 `git` binary 가 PATH 에 있을 때 동작. 빌드 환경이 git 없을 때 (`cargo install codelens-mcp` 직접 다운로드 사용자) 는 `BUILD_GIT_SHA = "unknown"` 으로 빌드되어 양쪽 모두 quiet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
