### PR TITLE
fix(#207-C-3, #207-C-1): single-line TOML workspace + callers unique_count

### DIFF
--- a/crates/codelens-engine/src/project.rs
+++ b/crates/codelens-engine/src/project.rs
@@ -428,8 +428,30 @@ pub fn detect_workspace_packages(project: &Path) -> Vec<WorkspacePackage> {
     {
         for line in content.lines() {
             let trimmed = line.trim().trim_matches('"').trim_matches(',');
-            if trimmed.contains("crates/") || trimmed.contains("packages/") {
-                let pattern = trimmed.trim_matches('"').trim_matches(',').trim();
+            if !trimmed.contains("crates/") && !trimmed.contains("packages/") {
+                continue;
+            }
+            // Multi-line TOML arrays put one path per line and the existing
+            // contains() guard handles them. Single-line forms like
+            // `members = ["crates/foo", "crates/bar"]` collapse the whole
+            // array into one line, so split on `,` between the brackets and
+            // process each path independently.
+            let mut candidates: Vec<&str> = Vec::new();
+            if let (Some(start), Some(end)) = (trimmed.find('['), trimmed.rfind(']'))
+                && start < end
+            {
+                candidates.extend(trimmed[start + 1..end].split(','));
+            }
+            if candidates.is_empty() {
+                candidates.push(trimmed);
+            }
+            for raw in candidates {
+                let pattern = raw.trim().trim_matches('"').trim_matches(',').trim();
+                if pattern.is_empty()
+                    || (!pattern.contains("crates/") && !pattern.contains("packages/"))
+                {
+                    continue;
+                }
                 if let Some(stripped) = pattern.strip_suffix("/*") {
                     // Glob pattern: "crates/*" → scan directory
                     let dir = project.join(stripped);
@@ -591,6 +613,66 @@ mod tests {
         assert_eq!(pkgs[0].name, "foo");
         assert_eq!(pkgs[0].path, "crates/foo");
         assert_eq!(pkgs[0].package_type, "cargo");
+    }
+
+    #[test]
+    fn workspace_packages_recognizes_single_line_toml_array() {
+        use super::detect_workspace_packages;
+        let temp = tempfile_dir();
+        let crate_dir = temp.join("crates/foo");
+        fs::create_dir_all(&crate_dir).expect("mkdir crate");
+        fs::write(
+            crate_dir.join("Cargo.toml"),
+            "[package]\nname = \"foo\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        )
+        .expect("write crate cargo");
+        // Single-line TOML array form (`members = ["crates/foo"]`) — what
+        // single-crate workspaces in small repos tend to use.
+        fs::write(
+            temp.join("Cargo.toml"),
+            "[workspace]\nmembers = [\"crates/foo\"]\n",
+        )
+        .expect("write root cargo");
+
+        let pkgs = detect_workspace_packages(&temp);
+        assert_eq!(
+            pkgs.len(),
+            1,
+            "single-line members array should be recognized, got {pkgs:?}"
+        );
+        assert_eq!(pkgs[0].name, "foo");
+        assert_eq!(pkgs[0].path, "crates/foo");
+        assert_eq!(pkgs[0].package_type, "cargo");
+    }
+
+    #[test]
+    fn workspace_packages_handles_single_line_array_with_multiple_paths() {
+        use super::detect_workspace_packages;
+        let temp = tempfile_dir();
+        for name in &["foo", "bar"] {
+            let crate_dir = temp.join("crates").join(name);
+            fs::create_dir_all(&crate_dir).expect("mkdir crate");
+            fs::write(
+                crate_dir.join("Cargo.toml"),
+                format!("[package]\nname = \"{name}\"\nversion = \"0.1.0\"\nedition = \"2021\"\n"),
+            )
+            .expect("write crate cargo");
+        }
+        fs::write(
+            temp.join("Cargo.toml"),
+            "[workspace]\nmembers = [\"crates/foo\", \"crates/bar\"]\n",
+        )
+        .expect("write root cargo");
+
+        let mut pkgs = detect_workspace_packages(&temp);
+        pkgs.sort_by(|a, b| a.path.cmp(&b.path));
+        assert_eq!(
+            pkgs.len(),
+            2,
+            "single-line array with two paths, got {pkgs:?}"
+        );
+        assert_eq!(pkgs[0].name, "bar");
+        assert_eq!(pkgs[1].name, "foo");
     }
 
     #[test]

--- a/crates/codelens-mcp/src/tools/graph.rs
+++ b/crates/codelens-mcp/src/tools/graph.rs
@@ -322,6 +322,34 @@ pub fn find_scoped_references_tool(state: &AppState, arguments: &serde_json::Val
     )
 }
 
+/// Count callers grouped by `(file, function)` so a SCIP entry that
+/// attributes a call to the caller-function start line and a tree-sitter
+/// entry that attributes the same logical caller to the call-expression
+/// line collapse into a single distinct caller.
+///
+/// The raw `count` field still reports `value.len()` for backwards
+/// compatibility; callers that need a deduped tally read
+/// `unique_caller_count` from the response.
+fn count_distinct_callers(callers: &[codelens_engine::CallerEntry]) -> usize {
+    let mut seen: std::collections::HashSet<(&str, &str)> = std::collections::HashSet::new();
+    for entry in callers {
+        seen.insert((entry.file.as_str(), entry.function.as_str()));
+    }
+    seen.len()
+}
+
+/// Count callees grouped by `(name, resolved_file)` so a SCIP entry and a
+/// tree-sitter entry referring to the same callee collapse into one
+/// distinct callee even when the per-call-site `line` numbers differ.
+fn count_distinct_callees(callees: &[codelens_engine::CalleeEntry]) -> usize {
+    let mut seen: std::collections::HashSet<(&str, Option<&str>)> =
+        std::collections::HashSet::new();
+    for entry in callees {
+        seen.insert((entry.name.as_str(), entry.resolved_file.as_deref()));
+    }
+    seen.len()
+}
+
 pub fn get_callers_tool(state: &AppState, arguments: &serde_json::Value) -> ToolResult {
     // P1-B — accept `limit`/`top_k` aliases for `max_results` and surface
     // unknown top-level keys so an agent that passes (e.g.) `threshold:
@@ -391,10 +419,12 @@ pub fn get_callers_tool(state: &AppState, arguments: &serde_json::Value) -> Tool
             confidence_basis,
             call_graph_evidence_signals(&resolution_summary),
         );
+        let unique_caller_count = count_distinct_callers(&value);
         let mut payload = json!({
             "function": function_name,
             "callers": value,
             "count": value.len(),
+            "unique_caller_count": unique_caller_count,
             "confidence_basis": confidence_basis,
             "resolution_summary": resolution_summary,
             "evidence": evidence,
@@ -476,10 +506,12 @@ pub fn get_callees_tool(state: &AppState, arguments: &serde_json::Value) -> Tool
             confidence_basis,
             call_graph_evidence_signals(&resolution_summary),
         );
+        let unique_callee_count = count_distinct_callees(&value);
         let mut payload = json!({
             "function": function_name,
             "callees": value,
             "count": value.len(),
+            "unique_callee_count": unique_callee_count,
             "confidence_basis": confidence_basis,
             "resolution_summary": resolution_summary,
             "evidence": evidence,
@@ -531,4 +563,84 @@ pub fn get_change_coupling_tool(state: &AppState, arguments: &serde_json::Value)
             success_meta(BackendKind::Git, 0.85),
         )
     })?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{count_distinct_callees, count_distinct_callers};
+    use codelens_engine::{CalleeEntry, CallerEntry};
+
+    fn caller(file: &str, function: &str, line: usize, resolution: &'static str) -> CallerEntry {
+        CallerEntry {
+            file: file.to_string(),
+            function: function.to_string(),
+            line,
+            confidence: 0.9,
+            resolution: Some(resolution),
+        }
+    }
+
+    fn callee(
+        name: &str,
+        line: usize,
+        resolved_file: Option<&str>,
+        resolution: &'static str,
+    ) -> CalleeEntry {
+        CalleeEntry {
+            name: name.to_string(),
+            line,
+            resolved_file: resolved_file.map(str::to_owned),
+            confidence: 0.9,
+            resolution: Some(resolution),
+        }
+    }
+
+    #[test]
+    fn count_distinct_callers_collapses_scip_and_tree_sitter_for_same_caller_function() {
+        // Mirrors the #207-C-1 dogfood observation: the same caller appears
+        // once with line attributed by SCIP (caller-fn start) and again with
+        // line attributed by tree-sitter (call-expression site), differing
+        // by +/-1. The existing (file, function, line) dedup misses these
+        // pairs; (file, function) collapses them into a single distinct
+        // caller.
+        let callers = vec![
+            caller("filesystem.rs", "get_current_config", 36, "scip"),
+            caller("filesystem.rs", "get_current_config", 37, "unique_name"),
+            caller("resources.rs", "read_resource", 137, "scip"),
+            caller("resources.rs", "read_resource", 136, "unique_name"),
+        ];
+        assert_eq!(count_distinct_callers(&callers), 2);
+    }
+
+    #[test]
+    fn count_distinct_callers_keeps_separate_caller_functions() {
+        let callers = vec![
+            caller("a.rs", "foo", 1, "scip"),
+            caller("a.rs", "bar", 1, "scip"),
+            caller("b.rs", "foo", 1, "scip"),
+        ];
+        assert_eq!(count_distinct_callers(&callers), 3);
+    }
+
+    #[test]
+    fn count_distinct_callees_collapses_same_name_resolved_file_pairs() {
+        let callees = vec![
+            callee("bar", 5, Some("b.rs"), "scip"),
+            callee("bar", 6, Some("b.rs"), "scip"),
+            callee("bar", 7, Some("b.rs"), "unique_name"),
+        ];
+        assert_eq!(count_distinct_callees(&callees), 1);
+    }
+
+    #[test]
+    fn count_distinct_callees_separates_unresolved_and_resolved_callees_with_same_name() {
+        let callees = vec![
+            callee("bar", 5, Some("b.rs"), "scip"),
+            callee("bar", 5, None, "unique_name"),
+        ];
+        // (bar, Some("b.rs")) and (bar, None) are distinct buckets so a
+        // resolved callee and an unresolved callee with the same identifier
+        // remain countable separately.
+        assert_eq!(count_distinct_callees(&callees), 2);
+    }
 }


### PR DESCRIPTION
## Summary

- **#207-C-3 fix**: `detect_workspace_packages` 가 이제 `members = ["crates/foo"]` 형태의 single-line TOML 배열도 인식. 작은 single-crate workspace 에서 `workspace_packages` 가 0 으로 보고되던 silent miss 차단.
- **#207-C-1 fix**: `get_callers` / `get_callees` 응답에 `unique_caller_count` / `unique_callee_count` 필드 추가. SCIP + tree-sitter 가 같은 caller 를 ±1 라인 차이로 양쪽 다 보고할 때 호출자가 deduped 카운트를 사용 가능. 기존 `count` 의미는 그대로.

## Detail

### #207-C-3 (single-line TOML array)

`crates/codelens-engine/src/project.rs` 의 `detect_workspace_packages` cargo workspace 분기에서, 매칭된 라인이 `[` 와 `]` 를 모두 포함하면 그 사이를 `,` 로 split 하여 각 path 를 독립 처리. multi-line array 형태는 영향 없음 (path 가 들어 있는 라인엔 `[` 가 없어서 fallthrough → `vec![trimmed]`).

신규 regression test 2 건:

- `workspace_packages_recognizes_single_line_toml_array` — 단일 path
- `workspace_packages_handles_single_line_array_with_multiple_paths` — 두 path

### #207-C-1 (callers/callees unique count)

`crates/codelens-mcp/src/tools/graph.rs` 에 두 helper 추가:

- `count_distinct_callers(callers) -> usize` — `(file, function)` 쌍으로 dedup
- `count_distinct_callees(callees) -> usize` — `(name, resolved_file)` 쌍으로 dedup

`get_callers_tool` / `get_callees_tool` 응답 payload 에 각각 `unique_caller_count` / `unique_callee_count` 필드 추가. 기존 `count` 는 raw `value.len()` 그대로 — backward compatible.

배경: graph.rs 의 in-handler dedup (line 370-377) 은 이미 `(file, function, line)` 키로 SCIP + tree-sitter merge 처리하고 있으나, SCIP 가 caller-function start line 을 잡고 tree-sitter 가 call-expression line 을 잡으면 ±1 라인 차이로 dedup miss → caller 1 인데 entry 2 개. dedup key 자체를 바꾸면 같은 caller 의 multi-line 호출 정보를 잃을 수 있어, 응답에 unique count 만 추가하는 conservative fix 채택.

신규 unit test 4 건:

- `count_distinct_callers_collapses_scip_and_tree_sitter_for_same_caller_function` — #207 이 보고한 패턴 그대로
- `count_distinct_callers_keeps_separate_caller_functions`
- `count_distinct_callees_collapses_same_name_resolved_file_pairs`
- `count_distinct_callees_separates_unresolved_and_resolved_callees_with_same_name`

## Test plan

- [x] `cargo check --workspace --features http,semantic` (worktree, 2.02s incremental)
- [x] `cargo clippy --workspace --features http,semantic --all-targets -- -D warnings` (0 warnings)
- [x] `cargo fmt --all -- --check` (clean)
- [x] `cargo nextest run --workspace --features http,semantic` (1079 passed / 10 skipped / 0 failed, 34s)
- [x] `cargo test --doc --workspace --features http,semantic` (1 passed / 1 ignored)
- [x] `cargo nextest run -p codelens-engine --lib 'project::tests::workspace_packages'` — 2 신규 PASS
- [x] `cargo nextest run -p codelens-mcp --bin codelens-mcp -E 'test(tools::graph::tests::)'` — 4 신규 PASS

## Closes

- Closes part of #207 (C-1 + C-3 만)
- C-2 (`diagnose_issues(path=<directory>)` error 메시지 + directory fan-out) 는 별도 PR 후속

## Adjacent

- #208 (이전 PR) — `daemon_binary_drift` git_sha + `workspace_packages` dedup. 머지되면 C-3 fix 가 dedup 과 자연스럽게 결합.
- #199 (B-1 `prepare_harness_session(detail=compact)` `*_omitted_count` 누락, B-3 SCIP function ref routing, B-4 `set_profile` host hint) — 별도 PR 후속

## Notes

- C-1 fix 는 응답에 필드만 추가하는 backward-compat 변경. 호출자 코드 변경 불필요.
- C-3 fix 는 cargo workspace 만 다룸. npm / go workspace 분기는 dir scan 패턴 (single-line TOML 무관) 이라 영향 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
