### PR TITLE
fix(#199-B-4, #207-C-2): set_preset/profile host_action + diagnose_issues directory reject

### DIFF
--- a/crates/codelens-mcp/src/integration_tests/session_mutation.rs
+++ b/crates/codelens-mcp/src/integration_tests/session_mutation.rs
@@ -125,6 +125,46 @@ fn set_profile_changes_tools_list() {
 }
 
 #[test]
+fn surface_mutation_responses_emit_host_action_hint() {
+    // #199-B-4: Some MCP hosts cache the visible tool surface and need an
+    // explicit reload signal after set_preset / set_profile, otherwise the
+    // newly-available tools never appear in the host's deferred pool. The
+    // nested `host_action` shape keeps both the programmatic
+    // `required` field and the human-readable `hint` under a single key
+    // so the response stays under the text-channel field cap.
+    let project = project_root();
+    let state = crate::AppState::new(project, crate::tool_defs::ToolPreset::Full);
+
+    let preset_resp = call_tool(&state, "set_preset", json!({"preset": "balanced"}));
+    assert_eq!(
+        preset_resp["data"]["host_action"]["required"],
+        json!("reload_tools_list"),
+        "set_preset must emit host_action.required so cached-surface hosts know to refresh"
+    );
+    let preset_hint = preset_resp["data"]["host_action"]["hint"]
+        .as_str()
+        .unwrap_or("");
+    assert!(
+        preset_hint.contains("tools/list"),
+        "set_preset host_action.hint should mention tools/list refresh: {preset_hint}"
+    );
+
+    let profile_resp = call_tool(&state, "set_profile", json!({"profile": "refactor-full"}));
+    assert_eq!(
+        profile_resp["data"]["host_action"]["required"],
+        json!("reload_tools_list"),
+        "set_profile must emit host_action.required so cached-surface hosts know to refresh"
+    );
+    let profile_hint = profile_resp["data"]["host_action"]["hint"]
+        .as_str()
+        .unwrap_or("");
+    assert!(
+        profile_hint.contains("tools/list"),
+        "set_profile host_action.hint should mention tools/list refresh: {profile_hint}"
+    );
+}
+
+#[test]
 fn refactor_profile_limits_surface_to_approved_mutations() {
     let project = project_root();
     let state = crate::AppState::new(project, crate::tool_defs::ToolPreset::Full);

--- a/crates/codelens-mcp/src/integration_tests/workflow/schema.rs
+++ b/crates/codelens-mcp/src/integration_tests/workflow/schema.rs
@@ -409,6 +409,36 @@ fn diagnose_issues_returns_structured_content() {
 }
 
 #[test]
+fn diagnose_issues_rejects_directory_path_with_actionable_error() {
+    // #207-C-2: passing a directory where get_file_diagnostics expects a
+    // file path used to surface as the misleading "no default LSP mapping
+    // for file" error. The handler now rejects directory inputs up front
+    // and the error message points to list_dir / get_changed_files for
+    // fan-out.
+    let project = project_root();
+    let dir_name = "diag_subdir_test";
+    fs::create_dir_all(project.as_path().join(dir_name))
+        .expect("mkdir directory fixture for diagnose_issues test");
+    let state = make_state(&project);
+
+    let payload = call_tool(&state, "diagnose_issues", json!({"path": dir_name}));
+    assert_eq!(
+        payload["success"],
+        json!(false),
+        "directory path must be rejected, payload: {payload}"
+    );
+    let err = payload["error"].as_str().unwrap_or_default();
+    assert!(
+        err.contains("directory"),
+        "error message should mention 'directory' explicitly: {err}"
+    );
+    assert!(
+        err.contains("list_dir") || err.contains("get_changed_files"),
+        "error message should suggest expand mechanism (list_dir / get_changed_files): {err}"
+    );
+}
+
+#[test]
 fn cleanup_duplicate_logic_returns_structured_content() {
     // cleanup_duplicate_logic without the semantic feature delegates to
     // dead_code_report (no required args).

--- a/crates/codelens-mcp/src/tools/session/surface_mutation.rs
+++ b/crates/codelens-mcp/src/tools/session/surface_mutation.rs
@@ -61,7 +61,11 @@ pub fn set_preset(state: &AppState, arguments: &serde_json::Value) -> ToolResult
             "active_surface": ToolSurface::Preset(new_preset).as_label(),
             "token_budget": budget,
             "effort_level": state.effort_level().as_str(),
-            "note": "Preset changed. Next tools/list call will reflect the new tool set."
+            "note": "Preset changed. Next tools/list call will reflect the new tool set.",
+            "host_action": {
+                "required": "reload_tools_list",
+                "hint": "Hosts may cache the tool surface; reissue tools/list or reconnect to see the new tools."
+            }
         }),
         success_meta(BackendKind::Session, 1.0),
     ))
@@ -111,7 +115,11 @@ pub fn set_profile(state: &AppState, arguments: &serde_json::Value) -> ToolResul
             "current_profile": profile.as_str(),
             "active_surface": ToolSurface::Profile(profile).as_label(),
             "token_budget": budget,
-            "note": "Profile changed. Next tools/list call will reflect the role-specific tool surface."
+            "note": "Profile changed. Next tools/list call will reflect the role-specific tool surface.",
+            "host_action": {
+                "required": "reload_tools_list",
+                "hint": "Hosts may cache the tool surface; reissue tools/list or reconnect to see the new tools."
+            }
         }),
         success_meta(BackendKind::Session, 1.0),
     ))

--- a/crates/codelens-mcp/src/tools/workflows.rs
+++ b/crates/codelens-mcp/src/tools/workflows.rs
@@ -198,21 +198,28 @@ pub fn review_changes(state: &AppState, arguments: &Value) -> ToolResult {
 }
 
 pub fn diagnose_issues(state: &AppState, arguments: &Value) -> ToolResult {
-    if arguments
+    if let Some(path_str) = arguments
         .get("path")
         .or_else(|| arguments.get("file_path"))
         .and_then(|v| v.as_str())
-        .is_some()
     {
+        // diagnose_issues delegates to get_file_diagnostics, which routes
+        // through the LSP recipe table keyed by file extension. A directory
+        // path bypasses recipe selection and surfaces as the misleading
+        // "no default LSP mapping for file" error (see #207-C-2). Detect a
+        // directory up front and return an actionable Validation error so
+        // callers know to expand the path before retry.
+        let project_relative = state.project().as_path().join(path_str);
+        if project_relative.is_dir() || std::path::Path::new(path_str).is_dir() {
+            return Err(crate::error::CodeLensError::Validation(format!(
+                "diagnose_issues received a directory path `{path_str}`; pass a single file path instead. Directory-scope diagnostics are not yet supported — expand the directory via list_dir or get_changed_files and call diagnose_issues per file."
+            )));
+        }
         return delegate_workflow(
             state,
             "diagnose_issues",
             "get_file_diagnostics",
-            json!({
-                "file_path": arguments.get("file_path")
-                    .or_else(|| arguments.get("path"))
-                    .and_then(|v| v.as_str()),
-            }),
+            json!({ "file_path": path_str }),
             crate::tools::lsp::get_file_diagnostics,
         );
     }


### PR DESCRIPTION
## Summary

- **#199-B-4 fix**: `set_preset` / `set_profile` 응답에 `host_action: { required, hint }` 필드 추가. surface 변경 후 host (Claude Code 등) 가 cached tool surface 를 reload 해야 새 tools 가 보인다는 actionable signal 을 노출.
- **#207-C-2 fix**: `diagnose_issues` 가 directory path 를 받았을 때 "LSP error: no default LSP mapping for file" 라는 misleading 메시지 대신 directory 임을 명시적으로 reject + `list_dir` / `get_changed_files` fan-out 제안.

## Detail

### #199-B-4 (host_action hint)

`crates/codelens-mcp/src/tools/session/surface_mutation.rs` 의 `set_preset` / `set_profile` 응답에 nested object 추가:

```jsonc
"host_action": {
    "required": "reload_tools_list",
    "hint": "Hosts may cache the tool surface; reissue tools/list or reconnect to see the new tools."
}
```

**왜 nested object 인가**: 처음에는 `host_action_required` + `host_hint` 를 top-level 두 키로 추가했으나 `set_preset` 응답이 9 keys (effort_level 포함) 가 되어 `dispatch/response_support.rs:572` 의 `summarize_text_object` 가 `MAX_OBJECT_ITEMS = 8` cap 으로 9 번째 키 (`host_hint`) 를 silently drop 했다. nested 1 key 로 묶으면 cap 안에 들어간다. **이 cap 동작은 별도 dogfood follow-up 으로 추적** (작은 payload 인데 trim 됨).

신규 integration test: `surface_mutation_responses_emit_host_action_hint` — set_preset + set_profile 둘 다 `host_action.required = "reload_tools_list"` + `host_action.hint` 가 `tools/list` 를 언급하는지 검증.

### #207-C-2 (diagnose_issues directory reject)

`crates/codelens-mcp/src/tools/workflows.rs` 의 `diagnose_issues` 가 path/file_path 인자를 받았을 때 directory 인지 먼저 판정. `state.project().as_path().join(path_str).is_dir()` 또는 literal `Path::new(path_str).is_dir()` 인 경우 명확한 Validation error 반환:

```
diagnose_issues received a directory path `<path>`; pass a single file path instead. Directory-scope diagnostics are not yet supported — expand the directory via list_dir or get_changed_files and call diagnose_issues per file.
```

이전: 같은 입력이 `get_file_diagnostics` 로 그대로 전달 → LSP recipe table 이 extension 매핑 못 찾아 "no default LSP mapping for **file**" 라는 잘못된 메시지 (실제로는 directory).

신규 integration test: `diagnose_issues_rejects_directory_path_with_actionable_error` — fixture 안에 디렉터리 만들고 그 path 로 `diagnose_issues` 호출 후 error message 가 "directory" + "list_dir"/"get_changed_files" 포함하는지 검증.

## Test plan

- [x] `cargo check --workspace --features http,semantic` (1.41s incremental)
- [x] `cargo clippy --workspace --features http,semantic --all-targets -- -D warnings` (0 warnings)
- [x] `cargo fmt --all -- --check` (clean)
- [x] `cargo nextest run --workspace --features http,semantic` (1075 passed / 10 skipped / 0 failed, 62s)
- [x] 신규 2 tests `surface_mutation_responses_emit_host_action_hint` + `diagnose_issues_rejects_directory_path_with_actionable_error` PASS
- [x] 기존 `set_preset_changes_tools_list` / `set_profile_changes_tools_list` / `diagnose_issues_returns_structured_content` 회귀 없음

## Closes

- Closes #199-B-4 (set_profile host hint)
- Closes #207-C-2 (diagnose_issues directory error msg)

## Adjacent / Follow-up

- **새 dogfood finding (별도 추적)**: `dispatch/response_support.rs:572` `summarize_text_object` 의 `MAX_OBJECT_ITEMS = 8` cap 이 작은 payload (예: set_preset 9 keys, 116 token / 8000 budget) 에서도 trim 발동. Stage 1 (<75% budget) pass-through 라고 문서화돼 있지만 field-count cap 은 별도. 새 dogfood 이슈로 등록 예정.
- #208 (이전 PR): #198 daemon git_sha + #199-B-2 workspace_packages dedup
- #209 (이전 PR): #207-C-3 single-line TOML + #207-C-1 callers unique_count
- 남은 후속: #199-B-1 (prepare_harness_session compact omit_count), #199-B-3 (SCIP function ref routing), #200 (preset codegen)

## Notes

- 두 fix 모두 backward-compat: `host_action` 은 신규 nested key (호출자 코드 변경 불필요), directory reject 는 기존 success path 가 file 입력만 사용하면 영향 없음.
- diagnose_issues 의 path resolution 은 project-root-relative + literal path 둘 다 시도 → 절대 path 와 상대 path 모두 정확히 처리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
