### PR TITLE
fix(#211): summarize_text_object exposes _omitted_keys for cap-driven drops

### DIFF
--- a/crates/codelens-mcp/src/dispatch/response_support.rs
+++ b/crates/codelens-mcp/src/dispatch/response_support.rs
@@ -573,10 +573,16 @@ fn summarize_text_object(source: &Map<String, Value>, depth: usize) -> Value {
 
     let mut summarized = Map::new();
     let mut array_shrunk = false;
+    // #211: previously the loop broke on the first cap hit and only
+    // marked `truncated: true`, leaving callers with no way to know
+    // which keys had been dropped. Collect every dropped key so the
+    // response carries a `_omitted_keys` list and downstream agents
+    // can request the missing fields explicitly.
+    let mut omitted_keys: Vec<String> = Vec::new();
     for (index, (key, value)) in source.iter().enumerate() {
         if index >= MAX_OBJECT_ITEMS {
-            summarized.insert("truncated".to_owned(), Value::Bool(true));
-            break;
+            omitted_keys.push(key.clone());
+            continue;
         }
         if let Value::Array(items) = value
             && items.len() > TEXT_CHANNEL_MAX_ARRAY_ITEMS
@@ -584,6 +590,10 @@ fn summarize_text_object(source: &Map<String, Value>, depth: usize) -> Value {
             array_shrunk = true;
         }
         summarized.insert(key.clone(), summarize_text_value(value, depth + 1));
+    }
+    if !omitted_keys.is_empty() {
+        summarized.insert("truncated".to_owned(), Value::Bool(true));
+        summarized.insert("_omitted_keys".to_owned(), json!(omitted_keys));
     }
     if source.contains_key("truncated") || array_shrunk {
         summarized.insert("truncated".to_owned(), Value::Bool(true));
@@ -898,6 +908,61 @@ fn summarize_structured_content(value: &Value, depth: usize) -> Value {
 mod text_channel_tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn summarize_text_object_records_omitted_keys_when_capped() {
+        // #211: a 12-key payload with the cap at 8 used to silently lose
+        // the trailing 4 keys with only `truncated: true` as a signal.
+        // The new contract surfaces each dropped key by name so the
+        // caller can either widen the request (detail=full) or request
+        // the missing fields directly.
+        let mut map = Map::new();
+        for i in 0..12u32 {
+            map.insert(format!("key{i:02}"), json!(i));
+        }
+        let result = summarize_text_object(&map, 0);
+        let obj = result.as_object().expect("object");
+        assert_eq!(
+            obj.get("truncated").and_then(Value::as_bool),
+            Some(true),
+            "cap-driven drop must mark truncated=true"
+        );
+        let omitted = obj
+            .get("_omitted_keys")
+            .and_then(Value::as_array)
+            .expect("_omitted_keys array present after cap drop");
+        assert_eq!(
+            omitted.len(),
+            4,
+            "12 keys - 8 cap = 4 dropped, got {omitted:?}"
+        );
+        let omitted_names: Vec<&str> = omitted.iter().filter_map(Value::as_str).collect();
+        assert_eq!(
+            omitted_names,
+            vec!["key08", "key09", "key10", "key11"],
+            "omitted_keys must list the trailing keys in iteration order"
+        );
+    }
+
+    #[test]
+    fn summarize_text_object_no_omitted_keys_when_under_cap() {
+        // Stage 1 / under-cap behavior must stay clean — no `truncated`
+        // flag and no `_omitted_keys` entry when nothing was dropped.
+        let mut map = Map::new();
+        for i in 0..5u32 {
+            map.insert(format!("key{i}"), json!(i));
+        }
+        let result = summarize_text_object(&map, 0);
+        let obj = result.as_object().expect("object");
+        assert!(
+            obj.get("_omitted_keys").is_none(),
+            "no _omitted_keys when under cap, got {obj:?}"
+        );
+        assert!(
+            obj.get("truncated").is_none(),
+            "no truncated when under cap"
+        );
+    }
 
     #[test]
     fn shrinking_array_child_flags_parent_truncated() {


### PR DESCRIPTION
## Summary

`#211` fix — `summarize_text_object` 가 `MAX_OBJECT_ITEMS = 8` cap 으로 키를 drop 할 때 `_omitted_keys` array 를 응답에 노출. 호출자가 어떤 필드가 잘렸는지 즉시 인지하여 후속 호출 (`detail=full`, 별도 query) 결정 가능.

## Background

이번 dogfood 사이클 (#208 / #209 / #210) 의 PR #210 작업 중 `set_preset` 응답이 9 keys 로 늘어나면서 9 번째 (`host_hint`) 가 silently dropped 된 케이스 발견. 본 fix 는 cap 자체는 유지하되 drop event 의 visibility 를 보강.

## Detail

`crates/codelens-mcp/src/dispatch/response_support.rs:571-602` `summarize_text_object`:

기존: cap 도달 시 `summarized.insert("truncated", true); break;` — drop 된 키 정보 없음.

신규:

```rust
let mut omitted_keys: Vec<String> = Vec::new();
for (index, (key, value)) in source.iter().enumerate() {
    if index >= MAX_OBJECT_ITEMS {
        omitted_keys.push(key.clone());
        continue;
    }
    // ... existing array-shrunk + insert ...
}
if !omitted_keys.is_empty() {
    summarized.insert("truncated".to_owned(), Value::Bool(true));
    summarized.insert("_omitted_keys".to_owned(), json!(omitted_keys));
}
```

- `continue` 로 break 대체 → 모든 drop 된 키 수집 (이전엔 첫 cap hit 에서 break)
- `_omitted_keys` 는 iteration order (trailing keys first) → 호출자가 정확한 source slice 재구성 가능
- under-cap 응답은 영향 없음 (omitted_keys 비어 있으면 marker 없음)

기존 `<key>_omitted_count` 패턴 (`summarize_structured_content` line 877-879) 과 일관 — array shrink 와 같은 visibility 정책을 object cap 에도 적용.

## Test plan

- [x] `cargo check --workspace --features http,semantic` (4.26s)
- [x] `cargo clippy --workspace --features http,semantic --all-targets -- -D warnings` (0 warnings)
- [x] `cargo fmt --all -- --check` (clean)
- [x] `cargo nextest run --workspace --features http,semantic` (1075 passed / 10 skipped / 0 failed, 39s)
- [x] 신규 unit tests 2 개 (`summarize_text_object_records_omitted_keys_when_capped` + `summarize_text_object_no_omitted_keys_when_under_cap`) PASS
- [x] 기존 `shrinking_array_child_flags_parent_truncated` / `short_array_leaves_parent_untruncated` / `nested_object_array_shrink_flags_inner_parent` / `bounded_payload_passthrough_returns_no_truncation_info` 등 회귀 없음

## Closes

- Closes #211 (omitted_keys 노출 — 옵션 1 채택)

## Adjacent

- #208 (이전 PR) — daemon git_sha + workspace dedup
- #209 (이전 PR) — single-line TOML + callers unique_count
- #210 (이전 PR) — host_action + diagnose_issues directory (본 fix 의 발견 계기)
- #211 의 다른 옵션 (budget-aware cap, cap 수치 보강, schema 검증) 은 별도 후속

## Notes

- **MCP spec cross-check** (context7 `/websites/modelcontextprotocol_io_specification_2025-11-25`): `CallToolResult._meta` (top-level Result metadata) 가 truncation 정보의 spec-aligned 슬롯이지만, CodeLens 의 응답 envelope 이 `success/data/...` 한 단계 더 깊이 wrap 하므로 본 fix 는 `data` envelope 안에 — 기존 per-tool truncation marker 들과 일관된 위치. 향후 envelope refactor 시 `_meta` 로 migrate 후보 (별도 enhancement).
- backward compatible: 기존 호출자가 `_omitted_keys` 무시해도 영향 없음. 새 호출자는 drop 된 필드를 명시적으로 따라갈 수 있음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
