### PR TITLE
fix(#204, #205): actionable stale_index/index_recovery warnings

### DIFF
--- a/crates/codelens-mcp/src/tools/session/metrics_config/capabilities.rs
+++ b/crates/codelens-mcp/src/tools/session/metrics_config/capabilities.rs
@@ -2,7 +2,7 @@ use crate::AppState;
 use crate::protocol::BackendKind;
 use crate::tool_defs::ToolSurface;
 use crate::tool_runtime::{ToolResult, success_meta};
-use serde_json::json;
+use serde_json::{Value, json};
 use std::path::Path;
 
 #[cfg(feature = "semantic")]
@@ -387,23 +387,31 @@ pub(crate) fn build_health_summary(
     let stale_files = index_stats.map(|s| s.stale_files).unwrap_or(0);
     let mut warnings = Vec::new();
 
-    let mut push_warning = |code: &str,
-                            message: String,
-                            recommended_action: Option<&str>,
-                            action_target: Option<&str>| {
-        warnings.push(json!({
-            "code": code,
-            "severity": "warn",
-            "message": message,
-            "recommended_action": recommended_action,
-            "action_target": action_target,
-        }));
-    };
+    let mut push_warning =
+        |code: &str,
+         message: String,
+         recommended_action: Option<&str>,
+         action_target: Option<&str>,
+         extras: Option<serde_json::Map<String, Value>>| {
+            let mut warning = serde_json::Map::new();
+            warning.insert("code".to_owned(), json!(code));
+            warning.insert("severity".to_owned(), json!("warn"));
+            warning.insert("message".to_owned(), json!(message));
+            warning.insert("recommended_action".to_owned(), json!(recommended_action));
+            warning.insert("action_target".to_owned(), json!(action_target));
+            if let Some(extras) = extras {
+                for (key, value) in extras {
+                    warning.insert(key, value);
+                }
+            }
+            warnings.push(Value::Object(warning));
+        };
 
     if supported_files == 0 {
         push_warning(
             "no_supported_files",
             "no supported source files detected".to_string(),
+            None,
             None,
             None,
         );
@@ -414,22 +422,36 @@ pub(crate) fn build_health_summary(
             "symbol index is empty".to_string(),
             Some("refresh_symbol_index"),
             Some("symbol_index"),
+            None,
         );
     }
     if supported_files > 0 && indexed_files < supported_files {
+        let unindexed = supported_files.saturating_sub(indexed_files);
+        let breakdown = json!({
+            "indexed_files": indexed_files,
+            "supported_files": supported_files,
+            "unindexed_files": unindexed,
+        });
         push_warning(
             "partial_index_coverage",
             format!("index coverage incomplete ({indexed_files}/{supported_files})"),
             Some("refresh_symbol_index"),
             Some("symbol_index"),
+            breakdown.as_object().cloned(),
         );
     }
     if stale_files > 0 {
+        let breakdown = json!({
+            "stale_files": stale_files,
+            "indexed_files": indexed_files,
+            "supported_files": supported_files,
+        });
         push_warning(
             "stale_index",
             format!("{stale_files} indexed files are stale"),
             Some("refresh_symbol_index"),
             Some("symbol_index"),
+            breakdown.as_object().cloned(),
         );
     }
 
@@ -446,6 +468,7 @@ pub(crate) fn build_health_summary(
                     .to_string(),
                 semantic_status.recommended_action(),
                 semantic_status.action_target(),
+                None,
             );
         }
         _ => {}
@@ -463,6 +486,7 @@ pub(crate) fn build_health_summary(
                 .to_string(),
             semantic_status.recommended_action(),
             semantic_status.action_target(),
+            None,
         );
     }
 
@@ -487,6 +511,7 @@ pub(crate) fn build_health_summary(
             daemon_binary_drift
                 .get("action_target")
                 .and_then(|v| v.as_str()),
+            None,
         );
     }
 
@@ -1181,5 +1206,71 @@ mod tests {
             CapabilitiesDetail::from_value(&json!({"detail": 42})),
             CapabilitiesDetail::Full
         );
+    }
+
+    /// `partial_index_coverage` previously emitted only a one-line
+    /// message ("index coverage incomplete (12/30)"). Issue #204 asked
+    /// for a structured `breakdown` object so callers can act without
+    /// re-parsing the message string.
+    #[test]
+    fn partial_index_coverage_warning_carries_breakdown() {
+        let stats = codelens_engine::IndexStats {
+            indexed_files: 12,
+            supported_files: 30,
+            stale_files: 0,
+        };
+        // SemanticSearchStatus::Available keeps the focus on
+        // partial_index_coverage by avoiding any semantic warnings.
+        #[cfg(feature = "semantic")]
+        let status = SemanticSearchStatus::Available;
+        #[cfg(not(feature = "semantic"))]
+        let status = SemanticSearchStatus::FeatureDisabled;
+        let summary = build_health_summary(Some(&stats), &status, &json!({}));
+
+        let warnings = summary
+            .get("warnings")
+            .and_then(|v| v.as_array())
+            .expect("warnings array");
+        let warning = warnings
+            .iter()
+            .find(|w| w.get("code") == Some(&json!("partial_index_coverage")))
+            .expect("partial_index_coverage warning emitted");
+        assert_eq!(warning["recommended_action"], json!("refresh_symbol_index"));
+        assert_eq!(warning["action_target"], json!("symbol_index"));
+        assert_eq!(warning["indexed_files"], json!(12));
+        assert_eq!(warning["supported_files"], json!(30));
+        assert_eq!(warning["unindexed_files"], json!(18));
+    }
+
+    /// `stale_index` previously surfaced a count without context. After
+    /// the followup4 fix it carries a `breakdown` of
+    /// stale/indexed/supported so the caller can decide whether to
+    /// trigger a full or stale-only refresh.
+    #[test]
+    fn stale_index_warning_carries_breakdown() {
+        let stats = codelens_engine::IndexStats {
+            indexed_files: 30,
+            supported_files: 30,
+            stale_files: 5,
+        };
+        #[cfg(feature = "semantic")]
+        let status = SemanticSearchStatus::Available;
+        #[cfg(not(feature = "semantic"))]
+        let status = SemanticSearchStatus::FeatureDisabled;
+        let summary = build_health_summary(Some(&stats), &status, &json!({}));
+
+        let warnings = summary
+            .get("warnings")
+            .and_then(|v| v.as_array())
+            .expect("warnings array");
+        let warning = warnings
+            .iter()
+            .find(|w| w.get("code") == Some(&json!("stale_index")))
+            .expect("stale_index warning emitted");
+        assert_eq!(warning["recommended_action"], json!("refresh_symbol_index"));
+        assert_eq!(warning["action_target"], json!("symbol_index"));
+        assert_eq!(warning["stale_files"], json!(5));
+        assert_eq!(warning["indexed_files"], json!(30));
+        assert_eq!(warning["supported_files"], json!(30));
     }
 }

--- a/crates/codelens-mcp/src/tools/session/project_ops.rs
+++ b/crates/codelens-mcp/src/tools/session/project_ops.rs
@@ -35,6 +35,43 @@ fn push_prepare_harness_warning(
     }
 }
 
+/// Variant of `push_prepare_harness_warning` that merges `extras` into
+/// the warning object, used when a warning carries actionable
+/// follow-up data (e.g. `remediation`, `auto_refresh_threshold`,
+/// per-file breakdown). Existing callers can stay on the simpler
+/// helper; only warnings that need to surface concrete next steps
+/// or freshness breakdowns reach for this variant.
+///
+/// `extras` is expected to be a `Value::Object`. Non-object values are
+/// ignored so the warning shape stays consistent.
+#[allow(clippy::too_many_arguments)]
+fn push_prepare_harness_warning_with_extras(
+    warnings: &mut Vec<Value>,
+    warning_codes: &mut HashSet<String>,
+    code: &str,
+    message: &str,
+    restart_recommended: bool,
+    recommended_action: &str,
+    action_target: &str,
+    extras: Value,
+) {
+    if !warning_codes.insert(code.to_owned()) {
+        return;
+    }
+    let mut warning = serde_json::Map::new();
+    warning.insert("code".to_owned(), json!(code));
+    warning.insert("message".to_owned(), json!(message));
+    warning.insert("restart_recommended".to_owned(), json!(restart_recommended));
+    warning.insert("recommended_action".to_owned(), json!(recommended_action));
+    warning.insert("action_target".to_owned(), json!(action_target));
+    if let Value::Object(map) = extras {
+        for (key, value) in map {
+            warning.insert(key, value);
+        }
+    }
+    warnings.push(Value::Object(warning));
+}
+
 fn append_prepare_harness_warning_from_guidance(
     warnings: &mut Vec<Value>,
     warning_codes: &mut HashSet<String>,
@@ -483,27 +520,65 @@ pub fn prepare_harness_session(state: &AppState, arguments: &serde_json::Value) 
             .and_then(|value| value.as_str())
             .unwrap_or("unknown")
         {
-            "failed" => push_prepare_harness_warning(
-                &mut warnings,
-                &mut warning_codes,
-                "index_refresh_failed",
-                index_recovery
-                    .get("error")
-                    .and_then(|value| value.as_str())
-                    .unwrap_or("failed to refresh stale index during bootstrap"),
-                false,
-                "refresh_symbol_index",
-                "symbol_index",
-            ),
-            "skipped" => push_prepare_harness_warning(
-                &mut warnings,
-                &mut warning_codes,
-                "index_refresh_skipped",
-                "stale index detected but auto-refresh threshold was exceeded",
-                false,
-                "refresh_symbol_index",
-                "symbol_index",
-            ),
+            "failed" => {
+                let stale_files = index_recovery
+                    .get("before")
+                    .and_then(|before| before.get("stale_files"))
+                    .and_then(|value| value.as_u64())
+                    .unwrap_or(0);
+                push_prepare_harness_warning_with_extras(
+                    &mut warnings,
+                    &mut warning_codes,
+                    "index_refresh_failed",
+                    index_recovery
+                        .get("error")
+                        .and_then(|value| value.as_str())
+                        .unwrap_or("failed to refresh stale index during bootstrap"),
+                    false,
+                    "refresh_symbol_index",
+                    "symbol_index",
+                    json!({
+                        "remediation": {
+                            "method": "tool_call",
+                            "tool": "refresh_symbol_index",
+                            "alternative_command": "codelens reindex --force",
+                        },
+                        "stale_files": stale_files,
+                    }),
+                )
+            }
+            "skipped" => {
+                let stale_files = index_recovery
+                    .get("before")
+                    .and_then(|before| before.get("stale_files"))
+                    .and_then(|value| value.as_u64())
+                    .unwrap_or(0);
+                let threshold = index_recovery
+                    .get("threshold")
+                    .and_then(|value| value.as_u64())
+                    .unwrap_or(DEFAULT_AUTO_REFRESH_STALE_THRESHOLD as u64);
+                push_prepare_harness_warning_with_extras(
+                    &mut warnings,
+                    &mut warning_codes,
+                    "index_refresh_skipped",
+                    "stale index detected but auto-refresh threshold was exceeded",
+                    false,
+                    "refresh_symbol_index",
+                    "symbol_index",
+                    json!({
+                        "remediation": {
+                            "method": "tool_call",
+                            "tool": "refresh_symbol_index",
+                            "args": { "scope": "stale_only" },
+                            "alternative_command": "codelens reindex --stale-only",
+                        },
+                        "auto_refresh_threshold": {
+                            "max_stale_files": threshold,
+                            "current_stale_files": stale_files,
+                        },
+                    }),
+                )
+            }
             _ => {}
         }
         if requested_host_context.is_some() && host_context.is_none() {
@@ -819,5 +894,96 @@ pub fn auto_set_embed_hint_lang(project_path: &std::path::Path) {
     // threads that read env, so the concurrent-read hazard does not apply.
     unsafe {
         std::env::set_var("CODELENS_EMBED_HINT_AUTO_LANG", lang);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extras_warning_merges_object_keys_and_dedupes_by_code() {
+        let mut warnings: Vec<Value> = Vec::new();
+        let mut codes: HashSet<String> = HashSet::new();
+
+        push_prepare_harness_warning_with_extras(
+            &mut warnings,
+            &mut codes,
+            "index_refresh_skipped",
+            "stale index detected but auto-refresh threshold was exceeded",
+            false,
+            "refresh_symbol_index",
+            "symbol_index",
+            json!({
+                "remediation": {
+                    "method": "tool_call",
+                    "tool": "refresh_symbol_index",
+                    "args": { "scope": "stale_only" },
+                    "alternative_command": "codelens reindex --stale-only",
+                },
+                "auto_refresh_threshold": {
+                    "max_stale_files": 32,
+                    "current_stale_files": 47,
+                },
+            }),
+        );
+
+        // Same code is dropped on the second call — no duplicate warnings.
+        push_prepare_harness_warning_with_extras(
+            &mut warnings,
+            &mut codes,
+            "index_refresh_skipped",
+            "second emission must be ignored",
+            false,
+            "refresh_symbol_index",
+            "symbol_index",
+            json!({ "remediation": { "tool": "ignored" } }),
+        );
+
+        assert_eq!(warnings.len(), 1, "duplicate code must be deduped");
+        let warning = warnings[0].as_object().expect("warning is object");
+        assert_eq!(warning["code"], json!("index_refresh_skipped"));
+        assert_eq!(warning["recommended_action"], json!("refresh_symbol_index"));
+        assert_eq!(warning["action_target"], json!("symbol_index"));
+        assert_eq!(warning["restart_recommended"], json!(false));
+        let remediation = warning["remediation"].as_object().expect("remediation");
+        assert_eq!(remediation["tool"], json!("refresh_symbol_index"));
+        assert_eq!(remediation["args"]["scope"], json!("stale_only"));
+        assert_eq!(
+            remediation["alternative_command"],
+            json!("codelens reindex --stale-only")
+        );
+        let threshold = warning["auto_refresh_threshold"]
+            .as_object()
+            .expect("threshold");
+        assert_eq!(threshold["max_stale_files"], json!(32));
+        assert_eq!(threshold["current_stale_files"], json!(47));
+    }
+
+    #[test]
+    fn extras_warning_ignores_non_object_extras() {
+        let mut warnings: Vec<Value> = Vec::new();
+        let mut codes: HashSet<String> = HashSet::new();
+
+        push_prepare_harness_warning_with_extras(
+            &mut warnings,
+            &mut codes,
+            "index_refresh_failed",
+            "failed to refresh stale index during bootstrap",
+            false,
+            "refresh_symbol_index",
+            "symbol_index",
+            // Non-object extras must be dropped silently so the warning shape
+            // stays consistent — callers should not have to validate `extras`
+            // construction.
+            json!("not-an-object"),
+        );
+
+        assert_eq!(warnings.len(), 1);
+        let warning = warnings[0].as_object().expect("warning is object");
+        assert_eq!(warning["code"], json!("index_refresh_failed"));
+        // No spurious key inserted from the string extras.
+        assert!(warning.get("remediation").is_none());
+        assert!(warning.get("auto_refresh_threshold").is_none());
     }
 }


### PR DESCRIPTION
## Summary

`prepare_harness_session` / `get_session_state` 의 두 stale-detection warning 가족 (`stale_index`, `index_refresh_failed/skipped`, `partial_index_coverage`) 이 message 문자열 외에는 actionable payload 가 없어 호출자가 (1) 어느 도구를 호출해야 하는지, (2) 임계값을 얼마나 초과했는지 추가 RTT 없이 결정할 수 없던 문제를 fix.

기존:
\`\`\`json
{ \"code\": \"stale_index\", \"message\": \"5 indexed files are stale\", \"recommended_action\": \"refresh_symbol_index\" }
\`\`\`

신규:
\`\`\`json
{ \"code\": \"stale_index\", \"message\": \"5 indexed files are stale\",
  \"recommended_action\": \"refresh_symbol_index\", \"action_target\": \"symbol_index\",
  \"stale_files\": 5, \"indexed_files\": 30, \"supported_files\": 30 }
\`\`\`

## Detail

### `crates/codelens-mcp/src/tools/session/metrics_config/capabilities.rs`

\`build_health_summary\` 의 \`push_warning\` 클로저를 5-arg 로 확장 — \`extras: Option<serde_json::Map<String, Value>>\`. 7 개 호출자 중 \`partial_index_coverage\` 와 \`stale_index\` 두 분기만 breakdown 객체를 전달, 나머지 5 개는 \`None\` 으로 noop.

- \`partial_index_coverage\` → \`{ indexed_files, supported_files, unindexed_files }\` — 호출자가 진행률을 즉시 계산 가능
- \`stale_index\` → \`{ stale_files, indexed_files, supported_files }\` — refresh scope 결정용 데이터 (전체 vs stale-only)

### \`crates/codelens-mcp/src/tools/session/project_ops.rs\`

새 헬퍼 \`push_prepare_harness_warning_with_extras\` (8-arg, \`#[allow(clippy::too_many_arguments)]\`) 추가. 기존 \`push_prepare_harness_warning\` 은 그대로 — 5 개 호출자 모두 변경 없음. \`index_recovery\` 두 분기만 새 헬퍼로 라우팅:

**\"failed\" 분기** — refresh 가 실제로 실패한 경우:
\`\`\`json
{ \"code\": \"index_refresh_failed\",
  \"remediation\": { \"method\": \"tool_call\", \"tool\": \"refresh_symbol_index\",
                    \"alternative_command\": \"codelens reindex --force\" },
  \"stale_files\": <count> }
\`\`\`

**\"skipped\" 분기** — auto-refresh 가 임계값 초과로 건너뛴 경우:
\`\`\`json
{ \"code\": \"index_refresh_skipped\",
  \"remediation\": { \"tool\": \"refresh_symbol_index\", \"args\": {\"scope\": \"stale_only\"},
                    \"alternative_command\": \"codelens reindex --stale-only\" },
  \"auto_refresh_threshold\": { \"max_stale_files\": 32, \"current_stale_files\": 47 } }
\`\`\`

호출자는 \`auto_refresh_threshold\` 만 보고도 (1) 임계값 자체를 올릴지, (2) 명시적 refresh 를 즉시 트리거할지 결정 가능.

## Test plan

- [x] 신규 unit tests 4개 추가 — `extras_warning_merges_object_keys_and_dedupes_by_code`, `extras_warning_ignores_non_object_extras`, `partial_index_coverage_warning_carries_breakdown`, `stale_index_warning_carries_breakdown`
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --features http,semantic --all-targets -- -D warnings` 0 warnings
- [x] `cargo nextest run --workspace --features http,semantic` — **1077 passed / 10 skipped / 0 failed** (이전 1073 → +4 신규, 0 회귀)

## Closes

- Closes #204 (stale_index actionable)
- Closes #205 (index_recovery remediation/threshold visibility)

## Adjacent

- #208 / #209 / #210 / #212 (이번 dogfood 사이클 PR queue)
- 후속 옵션: #205 의 다른 측면 (stale state mtime/version 노출 in `current_config`) 은 별도 PR — 본 PR 은 warning payload 만 다룸

## Notes

- backward compatible: 기존 호출자가 새 필드 무시 시 영향 없음
- \`#[allow(clippy::too_many_arguments)]\` 은 8-arg helper 1 곳에만 적용 — 다른 헬퍼는 그대로
- \`push_prepare_harness_warning\` 과 \`push_prepare_harness_warning_with_extras\` 분리는 의도적 — extras 가 필요 없는 단순 warning 은 기존 헬퍼로 깔끔하게 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)