### PR TITLE
fix(#215): node_modules/.bin fallback for LSP binary lookup

### DIFF
--- a/crates/codelens-engine/src/lib.rs
+++ b/crates/codelens-engine/src/lib.rs
@@ -88,7 +88,7 @@ pub use lsp::{
     default_lsp_command_for_extension, default_lsp_command_for_path,
     find_referencing_symbols_via_lsp, get_diagnostics_via_lsp, get_lsp_recipe,
     get_rename_plan_via_lsp, get_type_hierarchy_via_lsp, lsp_binary_exists,
-    resolve_symbol_target_via_lsp, search_workspace_symbols_via_lsp,
+    lsp_binary_exists_with_hint, resolve_symbol_target_via_lsp, search_workspace_symbols_via_lsp,
 };
 pub use project::{
     ProjectRoot, WorkspacePackage, compute_dominant_language, detect_frameworks,

--- a/crates/codelens-engine/src/lsp/mod.rs
+++ b/crates/codelens-engine/src/lsp/mod.rs
@@ -16,7 +16,7 @@ pub(crate) mod workspace_edit;
 pub use registry::{
     LSP_RECIPES, LspRecipe, LspStatus, check_lsp_status, default_lsp_args_for_command,
     default_lsp_command_for_extension, default_lsp_command_for_path, get_lsp_recipe,
-    lsp_binary_exists,
+    lsp_binary_exists, lsp_binary_exists_with_hint,
 };
 pub use session::LspSessionPool;
 pub use types::{

--- a/crates/codelens-engine/src/lsp/registry.rs
+++ b/crates/codelens-engine/src/lsp/registry.rs
@@ -283,7 +283,46 @@ fn fallback_search_dirs() -> Vec<PathBuf> {
     dirs
 }
 
+/// Maximum number of parent directories to traverse when looking for a
+/// `node_modules/.bin/<command>` shim. The Next.js / pnpm monorepo layout
+/// rarely nests workspaces deeper than a few levels, so 8 is a generous
+/// upper bound that still avoids walking out of the project tree.
+const NODE_MODULES_TRAVERSE_DEPTH: usize = 8;
+
+/// Walk `start` and up to `depth` parents, returning the path of the first
+/// `node_modules/.bin/<command>` shim that exists. Used by the LSP resolver
+/// so a Next.js / TS project that installs `typescript-language-server`
+/// only as a devDependency does not have to globally install it.
+fn find_in_node_modules_bin(start: &Path, command: &str, depth: usize) -> Option<PathBuf> {
+    let mut current = Some(start);
+    let mut steps = 0;
+    while let Some(dir) = current {
+        if steps > depth {
+            break;
+        }
+        if let Some(path) = resolve_in_dir(&dir.join("node_modules").join(".bin"), command) {
+            return Some(path);
+        }
+        current = dir.parent();
+        steps += 1;
+    }
+    None
+}
+
 pub(crate) fn resolve_lsp_binary(command: &str) -> Option<PathBuf> {
+    resolve_lsp_binary_with_hint(command, None)
+}
+
+/// Resolve an LSP binary with an optional `hint_dir`. When `hint_dir` is
+/// `Some`, the resolver also walks up from that directory looking for a
+/// `node_modules/.bin/<command>` shim before reporting the binary as
+/// missing. This unblocks Node / TS projects that install LSP servers
+/// as devDependencies (the Next.js standard pattern), where the global
+/// PATH does not see the binary but the per-project shim does.
+pub(crate) fn resolve_lsp_binary_with_hint(
+    command: &str,
+    hint_dir: Option<&Path>,
+) -> Option<PathBuf> {
     let command_path = Path::new(command);
     if command_path.components().count() > 1 {
         return if command_path.is_file() {
@@ -317,6 +356,12 @@ pub(crate) fn resolve_lsp_binary(command: &str) -> Option<PathBuf> {
         }
     }
 
+    if let Some(start) = hint_dir
+        && let Some(path) = find_in_node_modules_bin(start, command, NODE_MODULES_TRAVERSE_DEPTH)
+    {
+        return Some(path);
+    }
+
     None
 }
 
@@ -326,6 +371,15 @@ pub(crate) fn resolve_lsp_binary(command: &str) -> Option<PathBuf> {
 /// aligned even when the daemon inherits a minimal launchd/systemd PATH.
 pub fn lsp_binary_exists(command: &str) -> bool {
     resolve_lsp_binary(command).is_some()
+}
+
+/// Like [`lsp_binary_exists`] but also walks up from `hint_dir` looking
+/// for `node_modules/.bin/<command>` shims. Callers that have a concrete
+/// project root or file path should prefer this — it lets capability
+/// reporting return `installed = true` for Node / TS projects that ship
+/// the LSP only as a devDependency.
+pub fn lsp_binary_exists_with_hint(command: &str, hint_dir: Option<&Path>) -> bool {
+    resolve_lsp_binary_with_hint(command, hint_dir).is_some()
 }
 
 /// Check which LSP servers are installed and which are missing.
@@ -373,4 +427,91 @@ pub fn default_lsp_args_for_command(command: &str) -> Option<&'static [&'static 
         .iter()
         .find(|recipe| recipe.binary_name == command)
         .map(|recipe| recipe.args)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Issue #215: a Next.js / TS project that installs
+    /// `typescript-language-server` only as a devDependency must still
+    /// be reachable via `node_modules/.bin/<command>`. The hint
+    /// directory points the resolver at the project root so the shim
+    /// is found even when the daemon's PATH does not include it.
+    #[test]
+    fn resolves_lsp_via_node_modules_bin_when_hint_dir_provided() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let bin_dir = tempdir.path().join("node_modules").join(".bin");
+        std::fs::create_dir_all(&bin_dir).expect("mkdir node_modules/.bin");
+        let unique = format!(
+            "phantom-lsp-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        );
+        let shim = bin_dir.join(&unique);
+        std::fs::write(&shim, b"#!/bin/sh\nexit 0\n").expect("write shim");
+
+        // Without the hint, resolution fails — the binary is not on PATH.
+        assert!(
+            resolve_lsp_binary(&unique).is_none(),
+            "binary must be invisible without the hint dir"
+        );
+
+        // With the hint, the project-local shim is discovered.
+        let resolved = resolve_lsp_binary_with_hint(&unique, Some(tempdir.path()))
+            .expect("hint dir resolves the project-local shim");
+        assert_eq!(resolved, shim);
+        assert!(lsp_binary_exists_with_hint(&unique, Some(tempdir.path())));
+    }
+
+    /// The resolver walks up to `NODE_MODULES_TRAVERSE_DEPTH` parents,
+    /// so a hint pointing at `<repo>/apps/web/src/lib/...` still finds
+    /// `<repo>/node_modules/.bin/<command>` (npm/pnpm hoisting layout).
+    #[test]
+    fn resolves_lsp_via_node_modules_bin_in_parent_directory() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let nested = tempdir.path().join("apps/web/src/lib");
+        std::fs::create_dir_all(&nested).expect("mkdir nested");
+        let bin_dir = tempdir.path().join("node_modules").join(".bin");
+        std::fs::create_dir_all(&bin_dir).expect("mkdir node_modules/.bin");
+        let unique = format!(
+            "phantom-lsp-parent-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        );
+        let shim = bin_dir.join(&unique);
+        std::fs::write(&shim, b"#!/bin/sh\nexit 0\n").expect("write shim");
+
+        let resolved = resolve_lsp_binary_with_hint(&unique, Some(&nested))
+            .expect("parent traversal must surface hoisted shim");
+        assert_eq!(resolved, shim);
+    }
+
+    /// `resolve_lsp_binary_with_hint(_, None)` must behave exactly like
+    /// `resolve_lsp_binary` — passing `None` does not enable any new
+    /// fallback path (and so does not regress callers that have no
+    /// project context).
+    #[test]
+    fn hint_none_does_not_enable_node_modules_fallback() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let bin_dir = tempdir.path().join("node_modules").join(".bin");
+        std::fs::create_dir_all(&bin_dir).expect("mkdir node_modules/.bin");
+        let unique = format!(
+            "phantom-lsp-no-hint-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        );
+        std::fs::write(bin_dir.join(&unique), b"#!/bin/sh\nexit 0\n").expect("write shim");
+
+        // No hint → resolver only consults PATH + standard fallback dirs.
+        // Since `tempdir` is not on PATH and is not a fallback dir, the
+        // binary remains undiscovered.
+        assert!(resolve_lsp_binary_with_hint(&unique, None).is_none());
+    }
 }

--- a/crates/codelens-engine/src/lsp/session.rs
+++ b/crates/codelens-engine/src/lsp/session.rs
@@ -11,7 +11,7 @@ use url::Url;
 
 use super::commands::is_allowed_lsp_command;
 use super::protocol::{language_id_for_path, poll_readable, read_message, send_message};
-use super::registry::resolve_lsp_binary;
+use super::registry::resolve_lsp_binary_with_hint;
 use super::types::{
     LspCodeActionRefactorPlan, LspCodeActionRefactorResult, LspCodeActionRequest, LspDiagnostic,
     LspDiagnosticRequest, LspReference, LspRenamePlan, LspRenamePlanRequest, LspRenameRequest,
@@ -243,7 +243,8 @@ impl LspSessionPool {
 
 impl LspSession {
     fn start(project: &ProjectRoot, command: &str, args: &[String]) -> Result<Self> {
-        let command_path = resolve_lsp_binary(command).unwrap_or_else(|| command.into());
+        let command_path = resolve_lsp_binary_with_hint(command, Some(project.as_path()))
+            .unwrap_or_else(|| command.into());
         let mut child = Command::new(&command_path)
             .args(args)
             .stdin(Stdio::piped())

--- a/crates/codelens-mcp/src/tools/session/metrics_config/capabilities.rs
+++ b/crates/codelens-mcp/src/tools/session/metrics_config/capabilities.rs
@@ -54,10 +54,25 @@ impl DiagnosticsGuidance {
             .as_deref()
             .and_then(codelens_engine::get_lsp_recipe);
 
+        // For LSP binary lookup, hint with the directory holding the
+        // requested file so per-project shims (e.g. Next.js installs
+        // `typescript-language-server` only as a devDependency, where
+        // `node_modules/.bin` is the only valid resolution path) are
+        // visible to capability reporting.
+        let hint_dir = file_path
+            .map(std::path::Path::new)
+            .and_then(|path| path.parent())
+            .map(|parent| parent.to_path_buf());
+
         let status = match (file_path, recipe) {
             (None, _) => DiagnosticsStatus::FilePathRequired,
             (Some(_), None) => DiagnosticsStatus::UnsupportedExtension,
-            (Some(_), Some(recipe)) if !codelens_engine::lsp_binary_exists(recipe.binary_name) => {
+            (Some(_), Some(recipe))
+                if !codelens_engine::lsp_binary_exists_with_hint(
+                    recipe.binary_name,
+                    hint_dir.as_deref(),
+                ) =>
+            {
                 DiagnosticsStatus::LspBinaryMissing
             }
             (Some(_), Some(_)) => DiagnosticsStatus::Available,


### PR DESCRIPTION
## Summary

`get_file_diagnostics` 가 \`typescript-language-server\` 같은 LSP 서버를 글로벌이 아닌 devDependency 로 설치한 Next.js / 모던 JS 프로젝트에서 즉시 실패하던 문제 fix. resolver 가 file 의 부모 디렉토리부터 위로 최대 8 단계 traverse 하면서 \`node_modules/.bin/<command>\` shim 을 자동 탐색.

## Background

이슈 #215 — Next.js / pnpm / npm workspaces 등 모던 JS 패턴은 LSP 서버를 글로벌 PATH 가 아닌 \`node_modules/.bin/\` shim 으로 install 하는 게 표준. CodeLens 의 LSP resolver 는 PATH + 고정 fallback dirs (\`/opt/homebrew/bin\`, \`~/.cargo/bin\` 등) 만 보고 있어 daemon 응답이 \`LSP not attached\` 로 종료.

```json
{
  "success": false,
  "error": "LSP not attached: LSP server 'typescript-language-server' not found. Install it:\n  npm i -g typescript-language-server typescript"
}
```

옵션 (A) (\`node_modules/.bin\` 자동 탐지) 채택. 옵션 (B) tsc fallback 과 (C) degraded 응답 은 별도 enhancement 로 분리.

## Detail

### \`crates/codelens-engine/src/lsp/registry.rs\`

- 새 \`resolve_lsp_binary_with_hint(command, hint_dir: Option<&Path>)\`:
  PATH / fallback dirs / \`CODELENS_LSP_PATH_EXTRA\` 모두 miss 시 hint dir 부터 parent 8 단계 까지 \`node_modules/.bin/<command>\` 탐색
- 기존 \`resolve_lsp_binary(command)\` 는 thin wrapper (\`hint=None\`) — 호출자 변경 없이 보존
- 새 public \`lsp_binary_exists_with_hint(command, hint_dir)\`

\`NODE_MODULES_TRAVERSE_DEPTH = 8\` — pnpm/npm workspaces hoisting layout (\`apps/web/src/lib/...\` → \`<repo>/node_modules/.bin/\`) 도 커버하면서 unrelated parent 까지 walk 하지 않는 균형값.

### \`crates/codelens-engine/src/lsp/session.rs\`

\`LspSession::start\` 가 \`project.as_path()\` 를 hint 로 전달 — 실제 spawn 경로가 자동으로 project-local shim 사용.

### \`crates/codelens-mcp/src/tools/session/metrics_config/capabilities.rs\`

\`DiagnosticsGuidance::for_file\` 가 file_path 의 부모 디렉토리를 hint 로 전달 — capability check 도 동일 fallback path 적용 (status: \"available\" 로 정정).

## Test plan

- [x] \`cargo check --workspace --features http,semantic\` (clean)
- [x] \`cargo clippy --workspace --features http,semantic --all-targets -- -D warnings\` (0 warnings)
- [x] \`cargo fmt --all -- --check\` (clean)
- [x] \`cargo nextest run --workspace --features http,semantic\` — **1077 passed / 10 skipped / 0 failed**
- [x] 신규 unit tests 3 개:
  - \`resolves_lsp_via_node_modules_bin_when_hint_dir_provided\` — primary case
  - \`resolves_lsp_via_node_modules_bin_in_parent_directory\` — pnpm/npm hoisted layout
  - \`hint_none_does_not_enable_node_modules_fallback\` — backward-compat 회귀 가드

## Closes

- Closes #215

## Adjacent

- #208 / #209 / #210 / #212 / #216 (이번 dogfood 사이클 PR queue)
- 후속: 옵션 (B) \`tsc --noEmit\` fallback / 옵션 (C) explicit \"degraded\" response — 별도 enhancement issue 로 분리

## Notes

- backward compatible: \`resolve_lsp_binary\` / \`lsp_binary_exists\` 시그너처 보존, hint 가 \`None\` 이면 기존 동작 그대로
- traversal depth 는 const — 추후 monorepo 실측 결과로 조정 가능
- \`NODE_MODULES_TRAVERSE_DEPTH=8\` 은 hint dir 자체부터 카운트 — 7 parent + 본인

🤖 Generated with [Claude Code](https://claude.com/claude-code)