### PR TITLE
fix(#213): scope verify_change_readiness by active project root

### DIFF
--- a/crates/codelens-mcp/src/state/project_accessors.rs
+++ b/crates/codelens-mcp/src/state/project_accessors.rs
@@ -14,6 +14,19 @@ impl AppState {
             .unwrap_or_else(|| self.default_project.clone())
     }
 
+    /// `true` if the caller has explicitly activated a project (via
+    /// `activate_project` or session-scoped routing). When `false`,
+    /// `project()` falls back to the daemon's startup default — which
+    /// is rarely the caller's actual cwd in HTTP/launchd setups.
+    ///
+    /// Workflows that surface project-scoped findings (rankings,
+    /// blockers, prior analyses) should warn when this returns `false`,
+    /// otherwise stale state from prior sessions may leak into the
+    /// response. See issue #213.
+    pub(crate) fn has_explicit_active_project(&self) -> bool {
+        self.active_project_context().is_some()
+    }
+
     /// Get the active symbol index.
     pub(crate) fn symbol_index(&self) -> Arc<SymbolIndex> {
         self.active_project_context()

--- a/crates/codelens-mcp/src/state/session_host.rs
+++ b/crates/codelens-mcp/src/state/session_host.rs
@@ -30,7 +30,7 @@ impl AppState {
         self.project_scope_for_session(&session)
     }
 
-    pub(super) fn default_project_scope(&self) -> String {
+    pub(crate) fn default_project_scope(&self) -> String {
         self.default_project.as_path().to_string_lossy().to_string()
     }
 

--- a/crates/codelens-mcp/src/tools/reports/verifier_reports.rs
+++ b/crates/codelens-mcp/src/tools/reports/verifier_reports.rs
@@ -9,9 +9,16 @@ fn verify_change_readiness_cache_key(
     arguments: &Value,
     task: &str,
     overlapping_claims: &[crate::state::FileClaimEntry],
+    active_project_root: &str,
 ) -> String {
     let mut fields = Map::new();
     fields.insert("task".to_owned(), json!(task));
+    // Issue #213: scope the cache key by active project root so
+    // artifacts produced for project A never satisfy a verify call
+    // from project B running against the same daemon. Without this,
+    // top_findings / prior_analyses leak across projects whenever the
+    // task string and changed_files happen to coincide.
+    fields.insert("active_project_root".to_owned(), json!(active_project_root));
     if let Some(profile_hint) = arguments.get("profile_hint").cloned() {
         fields.insert("profile_hint".to_owned(), profile_hint);
     }
@@ -121,6 +128,32 @@ pub fn verify_change_readiness(state: &AppState, arguments: &Value) -> ToolResul
             }),
         );
     }
+    // Issue #213: surface the project root the response is scoped to,
+    // and warn when the caller has not explicitly activated a project.
+    // In HTTP/launchd setups the daemon's startup default rarely
+    // matches the caller's actual cwd, and prior-session findings
+    // leak through the ranked-context layer when the active project
+    // has not been pinned.
+    let active_project_root = state.current_project_scope();
+    let active_project_explicit = state.has_explicit_active_project();
+    let active_project_section = json!({
+        "path": active_project_root,
+        "source": if active_project_explicit { "explicit_activation" } else { "daemon_default_fallback" },
+        "explicit": active_project_explicit,
+    });
+    sections.insert("active_project".to_owned(), active_project_section);
+    if !active_project_explicit {
+        sections.insert(
+            "active_project_warning".to_owned(),
+            json!({
+                "code": "no_explicit_active_project",
+                "message": "verify_change_readiness was called without an explicit active project; response uses the daemon's startup default and may surface findings from a prior session",
+                "recommended_action": "activate_project",
+                "action_target": "active_project",
+                "default_project_root": state.default_project_scope(),
+            }),
+        );
+    }
     let mut result = make_handle_response(
         state,
         "verify_change_readiness",
@@ -128,6 +161,7 @@ pub fn verify_change_readiness(state: &AppState, arguments: &Value) -> ToolResul
             arguments,
             task,
             &overlapping_claims,
+            &active_project_root,
         )),
         format!("Verifier-first readiness report for `{task}` with blockers and preflight cues."),
         top_findings,
@@ -352,4 +386,46 @@ pub fn unresolved_reference_check(state: &AppState, arguments: &Value) -> ToolRe
         symbol.map(ToOwned::to_owned),
         Some(arguments),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Issue #213 regression: the cache key must include the active
+    /// project root so verify-change-readiness artifacts produced for
+    /// project A never satisfy a verify call from project B against
+    /// the same daemon.
+    #[test]
+    fn cache_key_changes_with_active_project_root() {
+        let arguments = json!({"task": "audit auth"});
+        let task = "audit auth";
+        let claims = Vec::new();
+
+        let key_a = verify_change_readiness_cache_key(&arguments, task, &claims, "/repos/proj-a");
+        let key_b = verify_change_readiness_cache_key(&arguments, task, &claims, "/repos/proj-b");
+
+        assert_ne!(
+            key_a, key_b,
+            "different project roots must produce distinct cache keys"
+        );
+        assert!(
+            key_a.contains("/repos/proj-a"),
+            "active_project_root must be embedded in the cache key (got: {key_a})"
+        );
+    }
+
+    /// Backward-compat: same arguments + same project root must
+    /// produce the same key (cache hit semantics preserved).
+    #[test]
+    fn cache_key_stable_when_inputs_repeat() {
+        let arguments = json!({"task": "audit auth", "profile_hint": "reviewer-graph"});
+        let task = "audit auth";
+        let claims = Vec::new();
+
+        let key_a = verify_change_readiness_cache_key(&arguments, task, &claims, "/repos/proj-a");
+        let key_b = verify_change_readiness_cache_key(&arguments, task, &claims, "/repos/proj-a");
+
+        assert_eq!(key_a, key_b);
+    }
 }


### PR DESCRIPTION
## Summary

\`verify_change_readiness\` 가 호출자의 cwd 가 아닌 daemon startup default 프로젝트의 ranking / prior_analyses 를 응답에 노출하던 cross-project leak 문제 fix. cache key 에 active project root 포함 + 응답에 \`active_project\` 정보 항상 surface + explicit activation 이 없을 때 \`active_project_warning\` 발행.

## Background

이슈 #213 — HTTP/launchd 모드의 daemon 은 startup 시 default project 를 결정하고, \`active_project_context()\` 가 \`None\` 이면 그 default 로 fallback. 사용자가 cwd \`~/rg-family\` 에서 \`activate_project\` 명시 호출 없이 \`verify_change_readiness\` 를 호출하면 daemon 의 default (예: \`~/codelens-mcp-plugin\`) 의 ranking 이 \`top_findings\` 에 노출됨.

```json
{
  "top_findings": [
    "TOTAL_THEME_COUNT: verify app/page.tsx first",  // ← 다른 프로젝트
    "total: verify src/lib/gifStudioPlanTransforms.ts first"
  ],
  "risk_level": "high",
  "confidence": 0.91
}
```

\`risk_level: high\`, \`confidence: 0.91\` 로 표시되어 사용자가 신뢰하기 쉬움 → 잘못된 변경 트리거 위험. 추가로 \`prior_analyses\` 에 다른 프로젝트의 분석 ID 들이 mix → cache key 가 active project 를 무시하기 때문.

## Detail

### \`crates/codelens-mcp/src/state/project_accessors.rs\`

- 새 \`pub(crate) fn has_explicit_active_project(&self) -> bool\`. \`active_project_context().is_some()\` 노출. 외부 호출자가 daemon default fallback 여부를 직접 판별 가능.

### \`crates/codelens-mcp/src/state/session_host.rs\`

- \`default_project_scope\` 가시성 \`pub(super)\` → \`pub(crate)\`. warning 응답에 \`default_project_root\` 동봉 가능.

### \`crates/codelens-mcp/src/tools/reports/verifier_reports.rs\`

\`verify_change_readiness_cache_key\` 시그너처에 \`active_project_root: &str\` 추가:

\`\`\`json
{ \"tool\": \"verify_change_readiness\",
  \"fields\": { \"task\": \"...\", \"active_project_root\": \"/repos/proj-a\", \"profile_hint\": \"...\", \"changed_files\": [...] } }
\`\`\`

→ 동일 task / changed_files 라도 프로젝트가 다르면 cache key 가 분리되어 cross-project artifact reuse 불가.

핸들러가 응답 sections 에 추가:

\`\`\`json
{ \"active_project\": {
    \"path\": \"/Users/.../rg-family\",
    \"source\": \"daemon_default_fallback\",   // 또는 \"explicit_activation\"
    \"explicit\": false
  },
  \"active_project_warning\": {
    \"code\": \"no_explicit_active_project\",
    \"message\": \"... response uses the daemon's startup default and may surface findings from a prior session\",
    \"recommended_action\": \"activate_project\",
    \"action_target\": \"active_project\",
    \"default_project_root\": \"/Users/.../codelens-mcp-plugin\"
  } }
\`\`\`

- \`active_project\` 는 항상 surface — 호출자가 응답이 어떤 프로젝트 기반인지 즉시 검증
- \`active_project_warning\` 은 \`has_explicit_active_project() = false\` 일 때만 발행
- backward compatible: 새 필드만 추가, 기존 \`top_findings\` / \`readiness\` 등 그대로

## Test plan

- [x] \`cargo check --workspace --features http,semantic\` (clean)
- [x] \`cargo clippy --workspace --features http,semantic --all-targets -- -D warnings\` (0 warnings)
- [x] \`cargo fmt --all -- --check\` (clean)
- [x] \`cargo nextest run --workspace --features http,semantic\` — **1076 passed / 10 skipped / 0 failed**
- [x] 신규 unit tests 2 개:
  - \`cache_key_changes_with_active_project_root\` — cross-project key 분리 primary case
  - \`cache_key_stable_when_inputs_repeat\` — backward-compat 회귀 가드

## Closes

- Closes #213

## Adjacent

- #208 / #209 / #210 / #212 / #216 / #217 (이번 dogfood 사이클 PR queue)
- 후속: cache_key 에 project root 포함했지만 \`prior_analyses\` 자체의 cross-project filter 는 별도 PR (artifact_store 레벨)
- \`get_ranked_context\` 같은 다른 workflow 도 동일 패턴 적용 후보 — 별도 PR

## Notes

- backward compatible: 기존 호출자가 새 필드 무시 시 영향 없음
- explicit activation 한 호출자는 warning 미발행 — 정상 path
- daemon default 가 cwd 와 일치하는 stdio 모드는 영향 없음 (warning 만 발행, 결과 동일)

🤖 Generated with [Claude Code](https://claude.com/claude-code)