### PR TITLE
fix(#214): surface oxc_semantic cross-file limitation in find_referencing_symbols

### DIFF
--- a/crates/codelens-mcp/src/integration_tests/lsp.rs
+++ b/crates/codelens-mcp/src/integration_tests/lsp.rs
@@ -665,3 +665,83 @@ fn lsp_refactor_without_concrete_workspace_edit_fails_closed() {
         "{payload}"
     );
 }
+
+/// Issue #214 regression: when `find_referencing_symbols` runs on a
+/// JS/TS file via the oxc_semantic backend, the response must surface
+/// the cross-file limitation so callers do not mistake "no callers in
+/// this file" for "no callers exist anywhere". The hint must point at
+/// `get_callers` (import_graph backend) for the cross-file case.
+#[test]
+fn find_referencing_symbols_oxc_response_carries_cross_file_hint() {
+    let project = project_root();
+    fs::write(
+        project.as_path().join("ref_target.ts"),
+        "export function refreshEpisodeDonationCaches(seasonId: string) {\n    return seasonId;\n}\n",
+    )
+    .unwrap();
+    let state = make_state(&project);
+    let payload = call_tool(
+        &state,
+        "find_referencing_symbols",
+        json!({
+            "file_path": "ref_target.ts",
+            "symbol_name": "refreshEpisodeDonationCaches",
+        }),
+    );
+    assert_eq!(payload["success"], json!(true), "{payload}");
+    assert_eq!(payload["data"]["backend"], json!("oxc_semantic"));
+
+    // The hint block must be present on every oxc_semantic response —
+    // not just when count == 1 — so callers always know cross-file
+    // callers require a separate tool.
+    assert!(
+        payload["data"]["precision_note"]
+            .as_str()
+            .unwrap_or("")
+            .contains("oxc_semantic"),
+        "precision_note must explain the oxc_semantic scope: {payload}"
+    );
+    assert_eq!(
+        payload["data"]["cross_file_callers_hint"]["tool"],
+        json!("get_callers"),
+        "{payload}"
+    );
+}
+
+/// Issue #214 regression: when oxc_semantic returns only the symbol's
+/// own definition row (the prime symptom of the cross-file gap for an
+/// exported function), the response must additionally carry a
+/// `self_only_warning` so the caller is unambiguously told to follow
+/// up with `get_callers`.
+#[test]
+fn find_referencing_symbols_oxc_definition_only_emits_self_only_warning() {
+    let project = project_root();
+    // Exported, never called within the file → oxc returns just the
+    // definition row.
+    fs::write(
+        project.as_path().join("isolated_export.ts"),
+        "export function refreshEpisodeDonationCaches(seasonId: string) {\n    return seasonId;\n}\n",
+    )
+    .unwrap();
+    let state = make_state(&project);
+    let payload = call_tool(
+        &state,
+        "find_referencing_symbols",
+        json!({
+            "file_path": "isolated_export.ts",
+            "symbol_name": "refreshEpisodeDonationCaches",
+        }),
+    );
+    assert_eq!(payload["success"], json!(true), "{payload}");
+    assert_eq!(payload["data"]["count"], json!(1), "{payload}");
+    assert_eq!(
+        payload["data"]["self_only_warning"]["code"],
+        json!("definition_only"),
+        "self_only_warning must be emitted when count == 1 and the row is the definition: {payload}"
+    );
+    assert_eq!(
+        payload["data"]["self_only_warning"]["recommended_action"],
+        json!("call_get_callers"),
+        "{payload}"
+    );
+}

--- a/crates/codelens-mcp/src/tools/lsp.rs
+++ b/crates/codelens-mcp/src/tools/lsp.rs
@@ -223,6 +223,14 @@ pub fn find_referencing_symbols(state: &AppState, arguments: &serde_json::Value)
                         count,
                     ),
                 );
+                // Issue #214: oxc_semantic resolves references within the
+                // file it was given — it does not cross file boundaries to
+                // chase `import { foo } from '...'` callers in sibling
+                // modules. Surface that limitation in every response so a
+                // caller that sees only a self-definition row knows there
+                // may be cross-file callers reachable via `get_callers`
+                // (import_graph backend) or `find_scoped_references` /
+                // `use_lsp=true`.
                 let mut payload = json!({
                     "references": refs_limited,
                     "count": count,
@@ -230,7 +238,38 @@ pub fn find_referencing_symbols(state: &AppState, arguments: &serde_json::Value)
                     "sampled": false,
                     "backend": "oxc_semantic",
                     "evidence": evidence,
+                    "precision_note": "oxc_semantic resolves references within the requested file; import-statement-based callers across files are not in scope.",
+                    "cross_file_callers_hint": {
+                        "tool": "get_callers",
+                        "rationale": "import_graph backend follows `import { name } from '...'` to upstream callers across files",
+                    },
                 });
+                // The "self-only" case (only the definition row itself)
+                // is the prime symptom of the cross-file gap — flag it
+                // explicitly so the caller does not mistake it for "no
+                // callers exist".
+                if count == 1
+                    && refs_limited
+                        .first()
+                        .and_then(|r| serde_json::to_value(r).ok())
+                        .and_then(|v| {
+                            v.get("kind")
+                                .and_then(|k| k.as_str())
+                                .map(|k| k.eq_ignore_ascii_case("definition"))
+                        })
+                        .unwrap_or(false)
+                    && let Some(map) = payload.as_object_mut()
+                {
+                    map.insert(
+                        "self_only_warning".to_owned(),
+                        json!({
+                            "code": "definition_only",
+                            "message": "Only the symbol's own definition row was returned. For exported symbols this almost always means cross-file callers exist but are not visible to oxc_semantic.",
+                            "recommended_action": "call_get_callers",
+                            "action_target": "cross_file_callers",
+                        }),
+                    );
+                }
                 if !unknown_args.is_empty() || !deprecation_warnings.is_empty() {
                     insert_response_annotations(&mut payload, &unknown_args, &deprecation_warnings);
                 }


### PR DESCRIPTION
## Summary

\`find_referencing_symbols(path, symbol_name)\` 가 JS/TS 파일에 대해 oxc_semantic backend 로 라우팅될 때 단일 파일 scope 내 reference 만 잡는 한계를 응답에 명시. export 함수의 경우 self-definition 만 반환되어 \"caller 0 건\" 으로 오인되던 케이스에서 \`self_only_warning\` + \`cross_file_callers_hint\` 로 즉시 \`get_callers\` (import_graph backend) 호출 안내.

## Background

이슈 #214 — Next.js \`'use server'\` action 함수 \`refreshEpisodeDonationCaches\` 의 caller 가 \`admin/donation-data/page.tsx\` line 20 (import) + line 341 (call) 에 존재하지만, \`find_referencing_symbols\` 가 self-definition 1 건만 반환:

\`\`\`json
{
  \"references\": [
    {\"symbol_name\":\"refreshEpisodeDonationCaches\",\"kind\":\"definition\",\"line\":30,\"column\":8}
  ],
  \"count\": 1,
  \"backend\": \"oxc_semantic\",
  \"confidence\": 0.95
}
\`\`\`

같은 세션의 \`get_callers\` 는 import_graph 로 caller 를 정상 발견. → 두 도구 정확도 격차를 호출자가 응답에서 즉시 인지하도록 명시.

## Detail

### \`crates/codelens-mcp/src/tools/lsp.rs\`

\`find_referencing_symbols\` oxc_semantic 응답에 항상 추가:

\`\`\`json
{ \"precision_note\": \"oxc_semantic resolves references within the requested file; import-statement-based callers across files are not in scope.\",
  \"cross_file_callers_hint\": {
    \"tool\": \"get_callers\",
    \"rationale\": \"import_graph backend follows \`import { name } from '...'\` to upstream callers across files\"
  } }
\`\`\`

\`count == 1\` + 그 1 건이 \`kind == \"definition\"\` 인 경우 (cross-file 갭의 prime symptom) 추가:

\`\`\`json
{ \"self_only_warning\": {
    \"code\": \"definition_only\",
    \"message\": \"Only the symbol's own definition row was returned. For exported symbols this almost always means cross-file callers exist but are not visible to oxc_semantic.\",
    \"recommended_action\": \"call_get_callers\",
    \"action_target\": \"cross_file_callers\"
  } }
\`\`\`

기존 \`references\` / \`count\` / \`backend\` / \`evidence\` 필드는 그대로 — backward compatible.

## Scope

본 PR 은 **응답 명시화** 에 집중. 두 가지 후속 enhancement 는 별도 PR:
- (A) oxc 결과가 self-only 일 때 자동으로 \`get_callers\` 호출해서 \`cross_file_callers\` section 으로 merge — 의미론 차이 (oxc=scope reference, import_graph=caller) 를 정확히 표현해야 해서 review 분리 필요
- (B) \`oxc_analysis::find_references_precise\` 자체에 cross-file 모델 추가 — 단일 파일 oxc Semantic 만으로는 불가능, project-wide module graph 필요

## Test plan

- [x] \`cargo check --workspace --features http,semantic\` (clean)
- [x] \`cargo clippy --workspace --features http,semantic --all-targets -- -D warnings\` (0 warnings)
- [x] \`cargo fmt --all -- --check\` (clean)
- [x] \`cargo nextest run --workspace --features http,semantic\` — **1076 passed / 10 skipped / 0 failed**
- [x] 신규 integration tests 2 개:
  - \`find_referencing_symbols_oxc_response_carries_cross_file_hint\` — 모든 oxc 응답에 hint 발행
  - \`find_referencing_symbols_oxc_definition_only_emits_self_only_warning\` — count==1+definition 시 명시적 warning

## Closes

- Closes #214

## Adjacent

- #208 / #209 / #210 / #212 / #216 / #217 / #219 (이번 dogfood 사이클 PR queue)
- 후속: oxc + get_callers 자동 merge / oxc_analysis cross-file 모델 — 별도 enhancement issue 등록 후보

## Notes

- backward compatible: 새 필드만 추가
- SCIP 백엔드 + tree-sitter fallback 응답은 별도 path — 본 PR 은 oxc_semantic primary 케이스만 다룸 (이슈 repro 대상)
- CLAUDE.md 의 \"Known accuracy limits\" 섹션 (Python tree-sitter 가 imports/type annotations 누락) 과 동일 클래스 문제 — JS/TS 의 oxc 버전. 같은 패턴으로 응답에서 명시.

🤖 Generated with [Claude Code](https://claude.com/claude-code)