### PR TITLE
fix(#221): false-positive head_git_sha drift on length mismatch

### DIFF
--- a/crates/codelens-mcp/build.rs
+++ b/crates/codelens-mcp/build.rs
@@ -65,9 +65,15 @@ fn main() {
     );
     println!("cargo:rerun-if-changed={}", schema_src.display());
 
-    // 1. Git SHA (short, 7-char)
+    // 1. Git SHA (short, 7-char). Pin `--short=7` so the build-time
+    // value matches what `current_head_git_sha` reads at runtime
+    // (`git rev-parse --short=7 HEAD`); without the explicit width,
+    // git widens to 8+ chars whenever the current SHA collides with
+    // any other object prefix, which would silently flip
+    // `daemon_binary_drift` into a false-positive `head_git_sha_mismatch`
+    // even when the binary was just built from HEAD. See issue #221.
     let git_sha = Command::new("git")
-        .args(["rev-parse", "--short", "HEAD"])
+        .args(["rev-parse", "--short=7", "HEAD"])
         .output()
         .ok()
         .and_then(|out| {

--- a/crates/codelens-mcp/src/build_info.rs
+++ b/crates/codelens-mcp/src/build_info.rs
@@ -172,6 +172,21 @@ fn current_head_git_sha(project_root: &std::path::Path) -> Option<String> {
 /// `mtime_stale` takes precedence in `reason_code` so existing
 /// consumers keep their semantics. The `"unknown"` sentinel emitted
 /// by `build.rs` for non-git builds is treated as "no signal".
+/// Issue #221: even when both sides come from `git rev-parse --short`
+/// they can disagree in width (git widens to 8+ chars on prefix
+/// collisions), so the strict `==` comparison previously used here
+/// raised a false-positive `head_git_sha_mismatch` for the same
+/// commit. Compare by common prefix instead — two SHAs match when
+/// one is a prefix of the other (subject to a 4-char minimum so we
+/// don't treat trivially-short strings as a wildcard).
+fn shas_share_prefix(a: &str, b: &str) -> bool {
+    const MIN_PREFIX_LEN: usize = 4;
+    if a.len() < MIN_PREFIX_LEN || b.len() < MIN_PREFIX_LEN {
+        return false;
+    }
+    a.starts_with(b) || b.starts_with(a)
+}
+
 fn classify_drift(
     mtime_stale: bool,
     head_git_sha: Option<&str>,
@@ -183,7 +198,7 @@ fn classify_drift(
             if !head.is_empty()
                 && head != "unknown"
                 && binary_git_sha != "unknown"
-                && head != binary_git_sha
+                && !shas_share_prefix(head, binary_git_sha)
     );
     let stale = mtime_stale || head_mismatch;
     let reason_code = match (mtime_stale, head_mismatch) {
@@ -366,5 +381,45 @@ mod tests {
         let (stale, code, _) = classify_drift(false, Some(""), "f7885f9b");
         assert!(!stale);
         assert_eq!(code, None);
+    }
+
+    /// Issue #221 regression: same commit but with two different git
+    /// `--short` widths (build script captured 8 chars; runtime
+    /// `current_head_git_sha` returns 7) must not trigger a
+    /// false-positive `head_git_sha_mismatch`. Common-prefix match
+    /// is the new contract.
+    #[test]
+    fn classify_drift_treats_unequal_length_shas_with_common_prefix_as_match() {
+        // 7 chars (HEAD via --short=7) vs 8 chars (build via --short
+        // widened by git collision-avoidance). Same commit.
+        let (stale, code, reason) = classify_drift(false, Some("f28620a"), "f28620a5");
+        assert!(
+            !stale,
+            "common-prefix shas must not trigger head_git_sha_mismatch"
+        );
+        assert_eq!(code, None);
+        assert_eq!(reason, None);
+
+        // Symmetric: 8 chars (HEAD) vs 7 chars (binary).
+        let (stale, code, _) = classify_drift(false, Some("f28620a5"), "f28620a");
+        assert!(!stale);
+        assert_eq!(code, None);
+    }
+
+    /// Real mismatch (different commit) must still be detected — the
+    /// prefix relaxation must not silence genuine drift.
+    #[test]
+    fn classify_drift_still_detects_real_mismatch_with_different_prefix() {
+        // Different commits, different first chars.
+        let (stale, code, _) = classify_drift(false, Some("f28620a"), "abcd1234");
+        assert!(stale, "different prefixes must still trigger mismatch");
+        assert_eq!(code, Some("head_git_sha_mismatch"));
+
+        // Same first 3 chars but diverging by char 4 — below the 4-char
+        // minimum we still treat as mismatch (the rule requires at least
+        // 4 matching chars to be considered a prefix relationship).
+        let (stale, code, _) = classify_drift(false, Some("f28000a"), "f28620a5");
+        assert!(stale);
+        assert_eq!(code, Some("head_git_sha_mismatch"));
     }
 }


### PR DESCRIPTION
## Summary

PR #208 (#198 fix) 가 binary 와 HEAD 의 git_sha 를 strict \`==\` 으로 비교했지만, build script (\`git rev-parse --short HEAD\` — git default) 와 runtime helper (\`git rev-parse --short=7 HEAD\` — 명시) 가 git collision-avoidance 휴리스틱으로 다른 길이 (8 vs 7 chars) 의 short hash 를 반환할 수 있어 같은 commit 도 drift 로 오판하던 문제 fix.

## Repro

방금 머지된 main HEAD (\`f28620a5\`) 기준 daemon 재시작 후 \`prepare_harness_session\` 호출:

\`\`\`json
{
  \"daemon_binary_drift\": {
    \"status\": \"stale\",
    \"reason_code\": \"head_git_sha_mismatch\",
    \"binary_git_sha\": \"f28620a5\",   // 8 chars (build script)
    \"head_git_sha\": \"f28620a\",      // 7 chars (runtime --short=7)
    \"reason\": \"daemon binary git_sha does not match project HEAD; rebuild and restart to pick up newer commits\"
  }
}
\`\`\`

→ 같은 commit 인데도 \`status: stale\`, \`health_summary.status: warn\` 으로 표시.

## Detail

### \`crates/codelens-mcp/build.rs\`

\`git rev-parse --short HEAD\` → \`--short=7\` 로 명시. git default 는 \"가장 짧으면서 unique\" 를 자동 결정하는데 collision 가능성이 있는 commit 에서 8+ chars 로 widen → mismatch. \`--short=7\` 고정 시 runtime helper 와 width 통일.

### \`crates/codelens-mcp/src/build_info.rs\`

- 새 \`shas_share_prefix(a: &str, b: &str) -> bool\` — 둘 다 ≥ 4 chars 일 때 한쪽이 다른 쪽의 prefix 면 match. min-length 4 는 \"공허하게 짧은 string 이 wildcard 처럼 동작\" 회피.
- \`classify_drift\` 가 \`head != binary_git_sha\` 대신 \`!shas_share_prefix(head, binary_git_sha)\` 로 비교.

build.rs 의 \`--short=7\` 만으로도 즉시 fix 가능하지만, defensive 로 \`shas_share_prefix\` 도 추가 — 미래에 어느 한쪽이 widen 되어도 회귀 방지.

## Test plan

- [x] \`cargo check --workspace --features http,semantic\` (clean)
- [x] \`cargo clippy --workspace --features http,semantic --all-targets -- -D warnings\` (0 warnings)
- [x] \`cargo fmt --all -- --check\` (clean)
- [x] \`cargo nextest run --workspace --features http,semantic\` — **1104 passed / 10 skipped / 0 failed**
- [x] 신규 unit tests 2 개:
  - \`classify_drift_treats_unequal_length_shas_with_common_prefix_as_match\` — primary case (8 vs 7)
  - \`classify_drift_still_detects_real_mismatch_with_different_prefix\` — 회귀 가드 (진짜 mismatch 는 여전히 감지)

## Closes

- Closes #221

## Adjacent

- #208 (regression source — \`current_head_git_sha\` 를 \`--short=7\` 로 도입했으나 build.rs 는 그대로)
- #198 (origin issue — daemon_binary_drift git_sha 비교 도입)

## Notes

- backward compatible: 응답 필드 변경 없음 — 다만 false-positive 가 사라져 \`health_summary.status\` 가 stale 이 아닌 \`ok\` 로 surface
- \`MIN_PREFIX_LEN = 4\` 는 git short 권장 minimum (4 chars) 과 일치
- daemon 재빌드 필요: 새 binary 가 \`--short=7\` 로 capture 한 SHA 를 가져야 즉시 fix 가시화. \`shas_share_prefix\` 만으로도 기존 binary 가 보고하던 false-positive 는 사라짐 (runtime classify_drift 에서 prefix 비교).

🤖 Generated with [Claude Code](https://claude.com/claude-code)