### PR TITLE
fix(#218): expose remediation tool/args on stale-index warnings

### DIFF
--- a/crates/codelens-mcp/src/tools/session/metrics_config/capabilities.rs
+++ b/crates/codelens-mcp/src/tools/session/metrics_config/capabilities.rs
@@ -442,31 +442,47 @@ pub(crate) fn build_health_summary(
     }
     if supported_files > 0 && indexed_files < supported_files {
         let unindexed = supported_files.saturating_sub(indexed_files);
-        let breakdown = json!({
+        // Issue #218: callers (Claude Code agents) need to know not just
+        // *that* a refresh is recommended, but exactly which tool to call.
+        // `recommended_action` is a verb; `remediation` is the trigger
+        // recipe — co-located so the agent does not have to guess at the
+        // tool name (refresh_symbol_index vs onboard_project vs
+        // activate_project) or its argument shape.
+        let extras = json!({
             "indexed_files": indexed_files,
             "supported_files": supported_files,
             "unindexed_files": unindexed,
+            "remediation": {
+                "method": "tool_call",
+                "tool": "refresh_symbol_index",
+                "args": {},
+            },
         });
         push_warning(
             "partial_index_coverage",
             format!("index coverage incomplete ({indexed_files}/{supported_files})"),
             Some("refresh_symbol_index"),
             Some("symbol_index"),
-            breakdown.as_object().cloned(),
+            extras.as_object().cloned(),
         );
     }
     if stale_files > 0 {
-        let breakdown = json!({
+        let extras = json!({
             "stale_files": stale_files,
             "indexed_files": indexed_files,
             "supported_files": supported_files,
+            "remediation": {
+                "method": "tool_call",
+                "tool": "refresh_symbol_index",
+                "args": {},
+            },
         });
         push_warning(
             "stale_index",
             format!("{stale_files} indexed files are stale"),
             Some("refresh_symbol_index"),
             Some("symbol_index"),
-            breakdown.as_object().cloned(),
+            extras.as_object().cloned(),
         );
     }
 
@@ -1257,6 +1273,18 @@ mod tests {
         assert_eq!(warning["indexed_files"], json!(12));
         assert_eq!(warning["supported_files"], json!(30));
         assert_eq!(warning["unindexed_files"], json!(18));
+        // Issue #218: callers must not have to guess which tool / args to
+        // call — `remediation` is the executable trigger recipe.
+        assert_eq!(
+            warning["remediation"]["tool"],
+            json!("refresh_symbol_index"),
+            "remediation must name the exact tool to call"
+        );
+        assert_eq!(warning["remediation"]["method"], json!("tool_call"));
+        assert!(
+            warning["remediation"]["args"].is_object(),
+            "remediation.args must be an object (even if empty)"
+        );
     }
 
     /// `stale_index` previously surfaced a count without context. After
@@ -1289,5 +1317,14 @@ mod tests {
         assert_eq!(warning["stale_files"], json!(5));
         assert_eq!(warning["indexed_files"], json!(30));
         assert_eq!(warning["supported_files"], json!(30));
+        // Issue #218: same actionable trigger pattern as
+        // partial_index_coverage — the warning must point at a concrete
+        // tool name plus an argument shape, not just a verb.
+        assert_eq!(
+            warning["remediation"]["tool"],
+            json!("refresh_symbol_index")
+        );
+        assert_eq!(warning["remediation"]["method"], json!("tool_call"));
+        assert!(warning["remediation"]["args"].is_object());
     }
 }


### PR DESCRIPTION
## Summary

\`prepare_harness_session\` 의 \`partial_index_coverage\` 와 \`stale_index\` warning 이 \`recommended_action: refresh_symbol_index\` 만 노출하고 호출자가 실제 어떤 tool 을 어떤 args 로 호출해야 하는지는 추측해야 하던 문제 fix. 이미 \`index_refresh_skipped\` 가 PR #216 에서 도입한 \`remediation\` 블록 패턴을 두 warning 에도 동일 적용.

## Background

이슈 #218 — Signature Studio 사용자가 4 PR 머지 후 \`prepare_harness_session(detail=compact)\` 호출 시 다음 응답 받음:

\`\`\`json
{
  \"warnings\": [
    { \"code\": \"partial_index_coverage\", \"message\": \"index coverage incomplete (622/681)\", \"recommended_action\": \"refresh_symbol_index\" },
    { \"code\": \"stale_index\", \"message\": \"112 indexed files are stale\", \"recommended_action\": \"refresh_symbol_index\" }
  ]
}
\`\`\`

→ \`refresh_symbol_index\` 는 verb 일 뿐, 어떤 tool 을 어떤 args 로 호출해야 하는지 호출자가 추측. LLM agent 는 \`refresh_symbol_index\` / \`activate_project\` / \`onboard_project\` 등 여러 candidate 중 매번 결정해야 함.

## Detail

\`crates/codelens-mcp/src/tools/session/metrics_config/capabilities.rs\` — \`partial_index_coverage\` 와 \`stale_index\` 두 warning 에 \`remediation\` 블록 추가:

\`\`\`json
{
  \"code\": \"stale_index\",
  \"message\": \"112 indexed files are stale\",
  \"recommended_action\": \"refresh_symbol_index\",
  \"action_target\": \"symbol_index\",
  \"stale_files\": 112,
  \"indexed_files\": 622,
  \"supported_files\": 681,
  \"remediation\": {
    \"method\": \"tool_call\",
    \"tool\": \"refresh_symbol_index\",
    \"args\": {}
  }
}
\`\`\`

\`refresh_symbol_index\` 는 input_schema 가 비어있는 (no params) tool 이므로 \`args: {}\`. 동일 패턴이 PR #216 의 \`index_refresh_skipped\` warning 과 일치.

## Test plan

- [x] \`cargo check --workspace --features http,semantic\` (clean)
- [x] \`cargo clippy --workspace --features http,semantic --all-targets -- -D warnings\` (0 warnings)
- [x] \`cargo fmt --all -- --check\` (clean)
- [x] \`cargo nextest run --workspace --features http,semantic\` — **1104 passed / 10 skipped / 0 failed**
- [x] 기존 unit tests 2 개 확장 — \`remediation.tool / method / args\` 검증 assertion 추가:
  - \`partial_index_coverage_warning_carries_breakdown\`
  - \`stale_index_warning_carries_breakdown\`

## Closes

- Closes #218

## Adjacent

- #216 (\`index_refresh_skipped\` 가 \`remediation\` 패턴 도입)
- #208~#220, #222 (이번 dogfood 사이클)

## Notes

- backward compatible: 기존 호출자가 새 \`remediation\` 필드 무시 시 영향 없음
- remediation 패턴이 이제 모든 stale-index 계열 warning 에 일관 적용 — health_summary 의 두 warning + project_ops 의 두 warning 총 4 개
- 이슈 옵션 (B) \`force_refresh_stale: true\` flag, (C) \`stale_index_active: true\` in-band 경고, (D) threshold 자동 상향 은 별도 PR 후보

🤖 Generated with [Claude Code](https://claude.com/claude-code)