### PR TITLE
fix(#224, #226): preset+profile normalize + hint diagnostics not blocking

### DIFF
--- a/crates/codelens-mcp/src/tools/report_verifier.rs
+++ b/crates/codelens-mcp/src/tools/report_verifier.rs
@@ -105,6 +105,41 @@ fn browser_or_ssr_sensitive(
     .any(|needle| combined.contains(needle))
 }
 
+/// Issue #226: classify a single LSP diagnostic for the
+/// readiness-blocking decision. `hint` and `information` severities
+/// — and rust-analyzer's `inactive-code` in particular — are
+/// expected, advisory metadata for cfg-gated branches and similar
+/// situations; treating them as blockers trains agents to distrust
+/// the readiness signal.
+///
+/// Returns `true` only when the diagnostic represents an actual
+/// problem the caller should resolve before mutating: i.e. severity
+/// is `error` or `warning`, or the severity label is missing
+/// (defensive default for unknown LSP servers).
+fn is_blocking_diagnostic(diag: &Value) -> bool {
+    // rust-analyzer emits cfg-gated branches as `inactive-code` hints —
+    // explicit downgrade so the verdict is not driven by feature gate
+    // bookkeeping.
+    if diag
+        .get("code")
+        .and_then(|v| v.as_str())
+        .is_some_and(|c| c.eq_ignore_ascii_case("inactive-code"))
+    {
+        return false;
+    }
+    let label = diag
+        .get("severity_label")
+        .and_then(|v| v.as_str())
+        .map(str::to_ascii_lowercase);
+    match label.as_deref() {
+        Some("hint") | Some("information") | Some("info") => false,
+        Some("warning") | Some("warn") | Some("error") | Some("err") => true,
+        // No severity label at all → treat as blocking (defensive
+        // default; unknown LSP servers should not silently be ignored).
+        Some(_) | None => true,
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn build_verifier_contract(
     state: &AppState,
@@ -122,6 +157,8 @@ pub(crate) fn build_verifier_contract(
     let mut diagnostic_rows = Vec::new();
     let mut diagnostic_errors = Vec::new();
     let mut diagnostic_count = 0usize;
+    let mut blocking_diagnostic_count = 0usize;
+    let mut informational_diagnostic_count = 0usize;
     for file in touched_files.iter().take(3) {
         match super::lsp::get_file_diagnostics(
             state,
@@ -133,10 +170,34 @@ pub(crate) fn build_verifier_contract(
                     .and_then(|value| value.as_u64())
                     .unwrap_or_default() as usize;
                 diagnostic_count += count;
+                let diagnostics_array = payload
+                    .get("diagnostics")
+                    .cloned()
+                    .unwrap_or_else(|| json!([]));
+                // Issue #226: rust-analyzer emits `inactive-code` etc.
+                // as `severity_label: "hint"` for cfg-gated branches,
+                // which is informational metadata, not a blocker.
+                // Partition diagnostics so the readiness verdict is
+                // driven by warning/error severities only.
+                let mut file_blocking = 0usize;
+                let mut file_informational = 0usize;
+                if let Some(items) = diagnostics_array.as_array() {
+                    for diag in items {
+                        if is_blocking_diagnostic(diag) {
+                            file_blocking += 1;
+                        } else {
+                            file_informational += 1;
+                        }
+                    }
+                }
+                blocking_diagnostic_count += file_blocking;
+                informational_diagnostic_count += file_informational;
                 diagnostic_rows.push(json!({
                     "file_path": file,
                     "count": count,
-                    "diagnostics": payload.get("diagnostics").cloned().unwrap_or_else(|| json!([])),
+                    "blocking_count": file_blocking,
+                    "informational_count": file_informational,
+                    "diagnostics": diagnostics_array,
                 }));
             }
             Err(error) => diagnostic_errors.push(json!({
@@ -151,13 +212,15 @@ pub(crate) fn build_verifier_contract(
             json!({
                 "files": diagnostic_rows,
                 "errors": diagnostic_errors,
+                "blocking_count": blocking_diagnostic_count,
+                "informational_count": informational_diagnostic_count,
             }),
         );
         Some("verifier_diagnostics")
     } else {
         None
     };
-    let diagnostics_status = if diagnostic_count > 0 {
+    let diagnostics_status = if blocking_diagnostic_count > 0 {
         crate::util::push_unique_string(
             &mut contract.blockers,
             "Resolve reported diagnostics before mutating the touched files",
@@ -169,8 +232,14 @@ pub(crate) fn build_verifier_contract(
         VERIFIER_READY
     };
     contract.readiness.diagnostics_ready = diagnostics_status.to_owned();
-    let diagnostics_summary = if diagnostic_count > 0 {
-        format!("{diagnostic_count} diagnostic(s) reported across touched files.")
+    let diagnostics_summary = if blocking_diagnostic_count > 0 {
+        format!(
+            "{blocking_diagnostic_count} blocking diagnostic(s) reported across touched files (plus {informational_diagnostic_count} informational hint(s)).",
+        )
+    } else if informational_diagnostic_count > 0 {
+        format!(
+            "No blocking diagnostics; {informational_diagnostic_count} informational hint(s) (cfg-gated inactive-code, deprecation notes, etc.) surfaced for context only.",
+        )
     } else if !touched_files.is_empty() && diagnostics_section.is_none() {
         "Diagnostics unavailable for touched files; treat edits as provisional.".to_owned()
     } else if touched_files.is_empty() {
@@ -181,6 +250,7 @@ pub(crate) fn build_verifier_contract(
             touched_files.len()
         )
     };
+    let _ = diagnostic_count; // currently retained only for the rows summary
     push_verifier_check(
         &mut contract.verifier_checks,
         "diagnostic_verifier",
@@ -522,5 +592,72 @@ mod tests {
             "affected_files": 10,
         })];
         assert!(is_high_impact(&impacts));
+    }
+
+    /// Issue #226 regression: rust-analyzer `inactive-code` hints
+    /// (cfg-gated branches under default test/check builds) must not
+    /// be classified as blockers, otherwise `review_changes` flips
+    /// to `mutation_ready: blocked` on a perfectly clean diff.
+    #[test]
+    fn inactive_code_hint_is_not_blocking() {
+        let diag = json!({
+            "severity_label": "hint",
+            "code": "inactive-code",
+            "source": "rust-analyzer",
+            "message": "code is inactive due to #[cfg] directives: feature = \"http\" is disabled",
+        });
+        assert!(
+            !super::is_blocking_diagnostic(&diag),
+            "rust-analyzer inactive-code hint must not be a readiness blocker"
+        );
+    }
+
+    /// `severity_label: \"hint\"` from any source is informational —
+    /// even when the code is something other than `inactive-code`.
+    #[test]
+    fn generic_hint_severity_is_not_blocking() {
+        for label in ["hint", "Hint", "HINT", "information", "info"] {
+            let diag = json!({
+                "severity_label": label,
+                "code": "deprecated_signature",
+                "source": "tsserver",
+                "message": "deprecated overload",
+            });
+            assert!(
+                !super::is_blocking_diagnostic(&diag),
+                "severity_label `{label}` must downgrade to informational"
+            );
+        }
+    }
+
+    /// Real warnings and errors must still drive readiness to blocked
+    /// — the relaxation for hints must not silence genuine problems.
+    #[test]
+    fn warning_and_error_severities_remain_blocking() {
+        for label in ["warning", "warn", "error", "err"] {
+            let diag = json!({
+                "severity_label": label,
+                "code": "E0061",
+                "source": "rustc",
+                "message": "type mismatch",
+            });
+            assert!(
+                super::is_blocking_diagnostic(&diag),
+                "severity_label `{label}` must remain a blocker"
+            );
+        }
+    }
+
+    /// Defensive default: an LSP that omits `severity_label` is
+    /// treated as a blocker — silent acceptance would let unknown
+    /// servers slip past the readiness verdict.
+    #[test]
+    fn missing_severity_label_treated_as_blocking() {
+        let diag = json!({
+            "code": "U0001",
+            "source": "unknown-lsp",
+            "message": "unknown problem",
+        });
+        assert!(super::is_blocking_diagnostic(&diag));
     }
 }

--- a/crates/codelens-mcp/src/tools/session/project_ops.rs
+++ b/crates/codelens-mcp/src/tools/session/project_ops.rs
@@ -392,13 +392,40 @@ pub fn activate_project(state: &AppState, arguments: &serde_json::Value) -> Tool
 }
 
 pub fn prepare_harness_session(state: &AppState, arguments: &serde_json::Value) -> ToolResult {
-    if arguments.get("preset").and_then(|v| v.as_str()).is_some()
-        && arguments.get("profile").and_then(|v| v.as_str()).is_some()
-    {
-        return Err(crate::error::CodeLensError::Validation(
-            "prepare_harness_session accepts either `preset` or `profile`, not both".to_owned(),
-        ));
-    }
+    // Issue #224: previously this rejected callers that supplied both
+    // `preset` and `profile`, but the schema documented both as
+    // independent optional fields and routing docs frequently pair
+    // them ("profile=builder-minimal" + "preset=minimal"). The
+    // rejection burned a bootstrap round trip.
+    //
+    // New contract: `profile` wins (it carries the semantic role that
+    // determines tool surface + executor bias), `preset` is dropped
+    // when both are supplied, and the dropped value is surfaced via
+    // `surface_resolution` + a non-blocking warning so the caller
+    // can adjust on the next call.
+    let requested_profile = arguments
+        .get("profile")
+        .and_then(|v| v.as_str())
+        .map(str::to_owned);
+    let requested_preset = arguments
+        .get("preset")
+        .and_then(|v| v.as_str())
+        .map(str::to_owned);
+    let preset_dropped_for_profile = requested_profile.is_some() && requested_preset.is_some();
+    // Drop `preset` for the downstream `activate_project` call so
+    // the existing single-knob path runs unchanged. Working on a
+    // clone keeps the caller's original arguments intact for logging
+    // / response echo.
+    let adjusted_arguments_owner: Option<serde_json::Value> =
+        preset_dropped_for_profile.then(|| {
+            let mut cloned = arguments.clone();
+            if let Some(map) = cloned.as_object_mut() {
+                map.remove("preset");
+            }
+            cloned
+        });
+    let effective_arguments: &serde_json::Value =
+        adjusted_arguments_owner.as_ref().unwrap_or(arguments);
 
     // Preserve existing surface when caller does not explicitly request a
     // profile/preset change. `activate_project` auto-selects a surface based
@@ -406,10 +433,9 @@ pub fn prepare_harness_session(state: &AppState, arguments: &serde_json::Value) 
     // bootstrap call. We snapshot before activation and restore unless the
     // user provided a new profile/preset.
     let prior_surface = *state.surface();
-    let explicit_surface_request = arguments.get("profile").and_then(|v| v.as_str()).is_some()
-        || arguments.get("preset").and_then(|v| v.as_str()).is_some();
+    let explicit_surface_request = requested_profile.is_some() || requested_preset.is_some();
 
-    let (activate_payload, _) = activate_project(state, arguments)?;
+    let (activate_payload, _) = activate_project(state, effective_arguments)?;
 
     // Restore surface if the caller did not explicitly ask for a new one.
     if !explicit_surface_request {
@@ -601,6 +627,31 @@ pub fn prepare_harness_session(state: &AppState, arguments: &serde_json::Value) 
                 false,
                 "use_documented_task_overlay",
                 "bootstrap_routing",
+            );
+        }
+        // Issue #224: when caller supplied both `profile` and `preset`,
+        // surface a non-blocking warning naming the dropped value so the
+        // next call can drop the redundant arg explicitly. Profile wins
+        // because it carries the semantic role + executor bias.
+        if preset_dropped_for_profile {
+            let profile_str = requested_profile.as_deref().unwrap_or("?");
+            let preset_str = requested_preset.as_deref().unwrap_or("?");
+            push_prepare_harness_warning_with_extras(
+                &mut warnings,
+                &mut warning_codes,
+                "preset_dropped_for_profile",
+                &format!(
+                    "both `profile` and `preset` supplied; using profile=`{profile_str}` and dropping preset=`{preset_str}` (profile wins)",
+                ),
+                false,
+                "drop_redundant_argument",
+                "preset",
+                json!({
+                    "winner_field": "profile",
+                    "winner_value": requested_profile,
+                    "dropped_field": "preset",
+                    "dropped_value": requested_preset,
+                }),
             );
         }
         warnings


### PR DESCRIPTION
## Summary

- **#224** \`prepare_harness_session\` 가 \`profile\` + \`preset\` 둘 다 받으면 reject 하던 동작을 normalize 로 변경. \`profile\` win, \`preset\` drop, warning \`preset_dropped_for_profile\` 로 dropped value 노출
- **#226** \`review_changes\` 가 rust-analyzer \`inactive-code\` 같은 \`hint\` severity 를 blocker 로 분류해 깨끗한 diff 가 \`mutation_ready: blocked\` 로 표시되던 문제 fix

## Detail

### \`crates/codelens-mcp/src/tools/session/project_ops.rs\` (#224)

이전: \`preset\` + \`profile\` 둘 다 supplied → 즉시 \`Validation\` error → bootstrap round trip 낭비.

신규: \`profile\` 우선 적용 (semantic role + executor bias), \`preset\` drop. cloned arguments 로 downstream \`activate_project\` 호출 — 기존 single-knob path 변경 없음. warning 추가:

\`\`\`json
{
  \"code\": \"preset_dropped_for_profile\",
  \"message\": \"both \`profile\` and \`preset\` supplied; using profile=\`builder-minimal\` and dropping preset=\`minimal\` (profile wins)\",
  \"recommended_action\": \"drop_redundant_argument\",
  \"action_target\": \"preset\",
  \"winner_field\": \"profile\",
  \"winner_value\": \"builder-minimal\",
  \"dropped_field\": \"preset\",
  \"dropped_value\": \"minimal\"
}
\`\`\`

backward compatible: 한쪽만 보내는 기존 호출은 영향 없음.

### \`crates/codelens-mcp/src/tools/report_verifier.rs\` (#226)

새 helper \`is_blocking_diagnostic\`:
- \`code == \"inactive-code\"\` (rust-analyzer cfg-gated branch) 명시적 downgrade
- \`severity_label\` in \`{hint, information, info}\` → not blocking
- \`severity_label\` in \`{warning, warn, error, err}\` → blocking
- 누락 / 알 수 없는 label → defensive blocking (unknown LSP 묵인 회피)

\`build_verifier_contract\` 의 diagnostic 집계가 \`blocking_diagnostic_count\` / \`informational_diagnostic_count\` 분리:
- readiness verdict 는 \`blocking_count > 0\` 일 때만 \`blocked\`
- 응답 \`verifier_diagnostics\` section 에 두 카운트 모두 노출
- summary 메시지가 informational hint 만 있을 때 \"No blocking diagnostics; N informational hint(s) ...\" 로 명확히

이슈에서 cargo check / cargo test / cargo clippy 모두 통과한 diff 가 본 fix 후 \`diagnostics_ready: ready\` 로 정정.

## Test plan

- [x] \`cargo fmt --all -- --check\` (clean)
- [x] \`cargo clippy --workspace --features http,semantic --all-targets -- -D warnings\` (0 warnings)
- [x] \`cargo nextest run --workspace --features http,semantic\` — **1108 passed / 10 skipped / 0 failed**
- [x] 신규 unit tests 4 개:
  - \`inactive_code_hint_is_not_blocking\` (#226 primary)
  - \`generic_hint_severity_is_not_blocking\` — hint/info/information 모두 downgrade
  - \`warning_and_error_severities_remain_blocking\` — 회귀 가드 (relaxation 이 진짜 blocker 묵살 X)
  - \`missing_severity_label_treated_as_blocking\` — defensive default

## Closes

- Closes #224
- Closes #226

## Adjacent

- 머지 후 다음 사이클: #225 (review_changes cache key with diff digest), #227 (--version build_time stale)

## Notes

- 응답 schema 추가만 — 기존 호출자 영향 없음
- option 1 (profile wins + warning) 채택. option 2 (oneOf schema) / option 3 (combination normalize lookup) 은 별도 enhancement 후보
- \`is_blocking_diagnostic\` 는 향후 다른 LSP-known noise (deprecated_signature 등) 도 case-by-case 추가 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)