### PR TITLE
fix(#225): include per-file digest in diff_aware_references cache key

### DIFF
--- a/crates/codelens-mcp/src/tools/report_utils.rs
+++ b/crates/codelens-mcp/src/tools/report_utils.rs
@@ -30,6 +30,21 @@ pub(super) fn stable_cache_key(
     arguments: &Value,
     keys: &[&str],
 ) -> Option<String> {
+    stable_cache_key_with_extras(tool_name, arguments, keys, &BTreeMap::new())
+}
+
+/// Issue #225: variant of [`stable_cache_key`] that accepts caller-supplied
+/// `extras` merged into the keyed fields. Tools that work over file
+/// content (e.g. `diff_aware_references`) need to invalidate the cache
+/// when the underlying file content changes, not only when the
+/// `changed_files` argument string changes — `extras` carries the
+/// per-file mtime / hash digest that captures that.
+pub(super) fn stable_cache_key_with_extras(
+    tool_name: &str,
+    arguments: &Value,
+    keys: &[&str],
+    extras: &BTreeMap<String, Value>,
+) -> Option<String> {
     let mut fields = BTreeMap::new();
     for key in keys {
         if let Some(value) = arguments.get(*key)
@@ -37,6 +52,9 @@ pub(super) fn stable_cache_key(
         {
             fields.insert((*key).to_owned(), value.clone());
         }
+    }
+    for (key, value) in extras {
+        fields.insert(key.clone(), value.clone());
     }
     if fields.is_empty() {
         None
@@ -49,6 +67,35 @@ pub(super) fn stable_cache_key(
             .to_string(),
         )
     }
+}
+
+/// Issue #225 helper: collect per-file mtime digests for a list of
+/// changed files so the cache key invalidates when the file content
+/// changes on disk. Files that cannot be stat'd contribute `0` so a
+/// missing-file → present-file transition still flips the digest.
+pub(super) fn collect_file_mtime_digests(
+    project_root: &std::path::Path,
+    changed_files: &[String],
+) -> BTreeMap<String, Value> {
+    changed_files
+        .iter()
+        .map(|path| {
+            let resolved = project_root.join(path);
+            let mtime_secs = std::fs::metadata(&resolved)
+                .and_then(|meta| meta.modified())
+                .ok()
+                .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|dur| dur.as_secs())
+                .unwrap_or(0);
+            let len = std::fs::metadata(&resolved)
+                .map(|meta| meta.len())
+                .unwrap_or(0);
+            (
+                path.clone(),
+                json!({"mtime_secs": mtime_secs, "len_bytes": len}),
+            )
+        })
+        .collect()
 }
 
 pub(super) fn extract_handle_fields(payload: &Value) -> (Option<String>, Vec<String>) {
@@ -67,4 +114,114 @@ pub(super) fn extract_handle_fields(payload: &Value) -> (Option<String>, Vec<Str
         })
         .unwrap_or_default();
     (analysis_id, estimated_sections)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Issue #225 regression: same arguments + same changed_files but
+    /// different per-file digest must produce different cache keys so
+    /// `diff_aware_references` does not reuse a stale analysis after
+    /// the file content materially changed on disk.
+    #[test]
+    fn cache_key_changes_when_file_digest_changes() {
+        let arguments = json!({"changed_files": ["a.rs", "b.rs"]});
+        let mut extras_v1 = BTreeMap::new();
+        extras_v1.insert(
+            "file_digests".to_owned(),
+            json!({
+                "a.rs": {"mtime_secs": 1000, "len_bytes": 256},
+                "b.rs": {"mtime_secs": 1001, "len_bytes": 128},
+            }),
+        );
+        let mut extras_v2 = BTreeMap::new();
+        // Same files but a.rs got rewritten — mtime + len shifted.
+        extras_v2.insert(
+            "file_digests".to_owned(),
+            json!({
+                "a.rs": {"mtime_secs": 2500, "len_bytes": 320},
+                "b.rs": {"mtime_secs": 1001, "len_bytes": 128},
+            }),
+        );
+
+        let key_v1 = stable_cache_key_with_extras(
+            "diff_aware_references",
+            &arguments,
+            &["changed_files"],
+            &extras_v1,
+        );
+        let key_v2 = stable_cache_key_with_extras(
+            "diff_aware_references",
+            &arguments,
+            &["changed_files"],
+            &extras_v2,
+        );
+
+        assert_ne!(
+            key_v1, key_v2,
+            "different file digests must produce distinct cache keys"
+        );
+    }
+
+    /// Backward compat: same arguments + same digests must produce the
+    /// same key (cache hit semantics preserved when nothing changed).
+    #[test]
+    fn cache_key_stable_when_inputs_repeat() {
+        let arguments = json!({"changed_files": ["a.rs"]});
+        let mut extras = BTreeMap::new();
+        extras.insert(
+            "file_digests".to_owned(),
+            json!({"a.rs": {"mtime_secs": 1000, "len_bytes": 256}}),
+        );
+
+        let key_a = stable_cache_key_with_extras(
+            "diff_aware_references",
+            &arguments,
+            &["changed_files"],
+            &extras,
+        );
+        let key_b = stable_cache_key_with_extras(
+            "diff_aware_references",
+            &arguments,
+            &["changed_files"],
+            &extras,
+        );
+
+        assert_eq!(key_a, key_b);
+    }
+
+    /// `stable_cache_key` (the no-extras alias) must keep emitting the
+    /// same result as before — only callers that opt into the extras
+    /// variant pick up content invalidation.
+    #[test]
+    fn stable_cache_key_unchanged_for_existing_callers() {
+        let arguments = json!({"path": "src/lib.rs", "max_nodes": 50});
+        let key = stable_cache_key("mermaid_module_graph", &arguments, &["path", "max_nodes"]);
+        assert!(key.is_some());
+        let parsed: Value = serde_json::from_str(&key.unwrap()).expect("valid json");
+        assert_eq!(parsed["tool"], json!("mermaid_module_graph"));
+        assert_eq!(parsed["fields"]["path"], json!("src/lib.rs"));
+        assert_eq!(parsed["fields"]["max_nodes"], json!(50));
+        // No leak from extras map — backward compat invariant.
+        assert!(parsed["fields"].get("file_digests").is_none());
+    }
+
+    /// `collect_file_mtime_digests` returns a stable, sorted-by-key
+    /// map and falls back to zero values for missing files (so a
+    /// file's appearance/disappearance still flips the digest).
+    #[test]
+    fn file_mtime_digests_handles_missing_files() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let existing = tempdir.path().join("present.rs");
+        std::fs::write(&existing, b"fn main() {}").expect("write file");
+        let files = vec!["present.rs".to_owned(), "absent.rs".to_owned()];
+        let digests = collect_file_mtime_digests(tempdir.path(), &files);
+        assert!(digests.contains_key("present.rs"));
+        assert!(digests.contains_key("absent.rs"));
+        // Present file has non-zero len_bytes; absent file is zero/zero.
+        assert!(digests["present.rs"]["len_bytes"].as_u64().unwrap() > 0);
+        assert_eq!(digests["absent.rs"]["mtime_secs"], json!(0));
+        assert_eq!(digests["absent.rs"]["len_bytes"], json!(0));
+    }
 }

--- a/crates/codelens-mcp/src/tools/reports/impact_reports/impact.rs
+++ b/crates/codelens-mcp/src/tools/reports/impact_reports/impact.rs
@@ -1,7 +1,9 @@
 use crate::AppState;
 use crate::tool_runtime::ToolResult;
 use crate::tools::report_contract::make_handle_response;
-use crate::tools::report_utils::{stable_cache_key, strings_from_array};
+use crate::tools::report_utils::{
+    collect_file_mtime_digests, stable_cache_key, stable_cache_key_with_extras, strings_from_array,
+};
 use crate::tools::symbols::{semantic_results_for_query, semantic_status};
 use codelens_engine::search::SEMANTIC_COUPLING_THRESHOLD;
 use serde_json::{Value, json};
@@ -390,10 +392,29 @@ pub fn diff_aware_references(state: &AppState, arguments: &Value) -> ToolResult 
         "diff_references".to_owned(),
         json!({"changed_files": changed_files, "rows": rows}),
     );
+    // Issue #225: include per-file mtime/length digest in the cache
+    // key. Without this, two calls with the same `changed_files` set
+    // and same `task` reuse the prior analysis even after the file
+    // content materially changed on disk — a reviewer trusting the
+    // green readiness signal is then looking at a pre-fix snapshot.
+    let mut extras = BTreeMap::new();
+    extras.insert(
+        "file_digests".to_owned(),
+        json!(collect_file_mtime_digests(
+            state.project().as_path(),
+            &changed_files,
+        )),
+    );
+    let cache_key = stable_cache_key_with_extras(
+        "diff_aware_references",
+        arguments,
+        &["changed_files"],
+        &extras,
+    );
     make_handle_response(
         state,
         "diff_aware_references",
-        stable_cache_key("diff_aware_references", arguments, &["changed_files"]),
+        cache_key,
         "Diff-aware reference compression for reviewer and CI flows.".to_owned(),
         top_findings.into_iter().take(5).collect(),
         0.86,


### PR DESCRIPTION
## Summary

\`review_changes\` (→ \`diff_aware_references\`) 가 같은 \`changed_files\` set 으로 다시 호출되면 prior analysis 를 reuse 하던 문제 fix. 두 번째 호출이 file 내용이 materially 바뀐 후라도 같은 \`analysis_id\` 와 \`reused: true\` 를 반환 → reviewer 가 pre-fix snapshot 을 신뢰하게 됨. cache key 에 per-file mtime/length digest 포함.

## Background

이슈 #225 — 사용자가 첫 번째 \`review_changes\` 호출 후 helper 동작을 변경하고 같은 5 files set 으로 재호출했더니 같은 \`analysis_id: analysis-1777879759070-2\`, \`reused: true\`. 변경된 코드에 대한 평가가 아닌 옛 snapshot 그대로.

## Detail

### \`crates/codelens-mcp/src/tools/report_utils.rs\`

새 \`stable_cache_key_with_extras(tool, arguments, keys, extras)\` — caller-supplied extras 가 keyed fields 에 merge. \`stable_cache_key\` 는 thin wrapper (extras 빈 \`BTreeMap\`) 로 보존 — 기존 callers 변경 없음.

새 \`collect_file_mtime_digests(project_root, changed_files)\` — 각 파일의 \`{mtime_secs, len_bytes}\` 수집:

\`\`\`rust
{
  \"a.rs\": { \"mtime_secs\": 2500, \"len_bytes\": 320 },
  \"b.rs\": { \"mtime_secs\": 1001, \"len_bytes\": 128 }
}
\`\`\`

부재 파일은 \`{0, 0}\` → 파일 appearance/disappearance 도 cache invalidation.

### \`crates/codelens-mcp/src/tools/reports/impact_reports/impact.rs\`

\`diff_aware_references\` 가 \`stable_cache_key_with_extras\` 로 전환:

\`\`\`rust
let mut extras = BTreeMap::new();
extras.insert(\"file_digests\".to_owned(), json!(collect_file_mtime_digests(
    state.project().as_path(),
    &changed_files,
)));
let cache_key = stable_cache_key_with_extras(
    \"diff_aware_references\",
    arguments,
    &[\"changed_files\"],
    &extras,
);
\`\`\`

같은 \`changed_files\` 라도 mtime 또는 len 이 바뀌면 cache key 분리 → reuse 불가 → reviewer 가 항상 최신 snapshot 평가.

## Test plan

- [x] \`cargo fmt --all -- --check\` (clean)
- [x] \`cargo clippy --workspace --features http,semantic --all-targets -- -D warnings\` (0 warnings)
- [x] \`cargo nextest run --workspace --features http,semantic\` — **1112 passed / 10 skipped / 0 failed**
- [x] 신규 unit tests 4 개:
  - \`cache_key_changes_when_file_digest_changes\` (#225 primary)
  - \`cache_key_stable_when_inputs_repeat\` — backward-compat (digest 같으면 같은 key)
  - \`stable_cache_key_unchanged_for_existing_callers\` — extras-less wrapper 회귀 가드
  - \`file_mtime_digests_handles_missing_files\` — 부재 파일 처리

## Closes

- Closes #225

## Adjacent

- #213 (verify_change_readiness 도 동일 패턴: cache_key 에 active_project_root 추가)
- 후속: \`impact_report\` / 다른 diff-related tool 도 같은 patternization 후보 (별도 PR)

## Notes

- backward compatible: \`stable_cache_key\` 시그너처 그대로 유지, 기존 호출자 변경 없음
- mtime 은 git checkout/touch 로도 변할 수 있지만 file content 변경 의도가 명백한 dogfood 케이스에 충분
- 더 견고한 옵션 (sha256 hash) 은 cost trade-off — 큰 changed_files 세트에서 매 호출마다 hash 계산 비용. 현재 fix 는 작고 빠른 default

🤖 Generated with [Claude Code](https://claude.com/claude-code)