### PR TITLE
fix(#227): touch build.rs before release install to refresh BUILD_TIME

### DIFF
--- a/scripts/install-http-daemons-launchd.sh
+++ b/scripts/install-http-daemons-launchd.sh
@@ -190,6 +190,16 @@ mkdir -p "$LOG_DIR"
 
 if [[ "$NO_BUILD" == "0" ]]; then
 	echo "==> Building codelens-mcp with http feature from $REPO_ROOT"
+	# Issue #227: cargo caches build script output across incremental
+	# rebuilds, so source-only changes leave CODELENS_BUILD_TIME
+	# pointing at the previous build. Touch the build script before
+	# every release/install build so cargo re-runs it and embeds the
+	# current timestamp — daemon freshness verification then has a
+	# trustworthy `built` value in `--version` and capabilities output.
+	BUILD_RS="$REPO_ROOT/crates/codelens-mcp/build.rs"
+	if [[ -f "$BUILD_RS" ]]; then
+		touch "$BUILD_RS"
+	fi
 	(
 		cd "$REPO_ROOT"
 		cargo build -p codelens-mcp --release --features http


### PR DESCRIPTION
## Summary

\`scripts/install-http-daemons-launchd.sh\` 가 source-only 재빌드 시 cargo 가 build script 출력을 cache 해서 \`CODELENS_BUILD_TIME\` 이 이전 빌드 시각 그대로였던 문제 fix. \`--version\` 의 \`built <time>\` 이 daemon 신선도 검증 용도였는데 stale 값이 나와 dogfood 루프에서 misleading 했음.

## Background

이슈 #227 — 사용자가 \`bash scripts/install-http-daemons-launchd.sh . --load\` 두 번 실행했는데 두 번째 빌드 후에도 \`--version\` 이 첫 빌드 시각을 보고. binary mtime 은 갱신되었으나 embedded build_time 은 그대로 → 호출자가 새 patch 가 실제로 컴파일됐는지 확신 불가.

\`crates/codelens-mcp/build.rs\` 는 \`SystemTime::now()\` 를 \`CODELENS_BUILD_TIME\` 으로 export 하지만, cargo 가 build script 출력을 incremental cache 하므로 source 변경이 build.rs 영향 범위 밖이면 재실행 안 됨.

## Detail

\`scripts/install-http-daemons-launchd.sh\`:

\`\`\`bash
if [[ -f \"\$BUILD_RS\" ]]; then
    touch \"\$BUILD_RS\"
fi
(
    cd \"\$REPO_ROOT\"
    cargo build -p codelens-mcp --release --features http
)
\`\`\`

cargo 는 build.rs mtime 변경을 감지해 build script 를 재실행 → 새 \`SystemTime::now()\` 가 \`CODELENS_BUILD_TIME\` 으로 embed. \`--no-build\` 모드는 의도된 binary reuse 라서 touch 안 함.

## Test plan

- [x] script syntax (\`bash -n scripts/install-http-daemons-launchd.sh\`) 통과
- [x] 다른 \`cargo build\` 호출 (\`scripts/quality-gate.sh\` 등) 은 변경 없음 — release install 경로만 영향
- [x] \`--no-build\` 분기는 touch skip — 의도된 binary reuse 보존

## Closes

- Closes #227

## Adjacent

- 이슈 옵션 (B) \"--version 에 disk binary mtime 도 함께 노출\" 은 별도 enhancement (CLI output 변경 필요)
- 이슈 옵션 (C) docs 추가는 \`docs/dogfood/\` 또는 troubleshooting 문서에 별도 commit 후보

## Notes

- 가장 작은 surface 변경 — 1 script, 7 lines added
- 기존 build.rs 코드 변경 없음 (\`cargo:rerun-if-changed\` 지시어 그대로)
- semantic / scip-backend 등 다른 feature flag 와 무관

🤖 Generated with [Claude Code](https://claude.com/claude-code)