### PR TITLE
fix(#186): detect anonymized agent project name + remediation hint

### DIFF
--- a/crates/codelens-mcp/src/tools/session/project_ops.rs
+++ b/crates/codelens-mcp/src/tools/session/project_ops.rs
@@ -15,6 +15,26 @@ use std::collections::HashSet;
 
 const DEFAULT_AUTO_REFRESH_STALE_THRESHOLD: usize = 32;
 
+/// Issue #186: heuristic for spotting Claude/Codex internal workspace
+/// directories whose basename is itself an anonymized agent hash
+/// (e.g. `agent-a110134bd9c6e7440`). When `prepare_harness_session`
+/// resolves the active project to one of these instead of the
+/// daemon's CLI startup root, downstream tools see a near-empty
+/// index and emit false-positive `no_supported_files` warnings.
+///
+/// We treat any name that begins with `agent-` and whose suffix is
+/// strictly hex (≥ 12 chars of `[0-9a-fA-F]`) as anonymized — the
+/// shape that the harness itself produces. Limiting to hex avoids
+/// false-positives on real project directories like `agent-server/`
+/// or `agent-orchestrator/` where alphabetic chars like `r`/`s`/`t`
+/// rule out a hash interpretation.
+fn is_anonymized_agent_project_name(name: &str) -> bool {
+    let Some(suffix) = name.strip_prefix("agent-") else {
+        return false;
+    };
+    suffix.len() >= 12 && suffix.chars().all(|c| c.is_ascii_hexdigit())
+}
+
 fn push_prepare_harness_warning(
     warnings: &mut Vec<Value>,
     warning_codes: &mut HashSet<String>,
@@ -629,6 +649,43 @@ pub fn prepare_harness_session(state: &AppState, arguments: &serde_json::Value) 
                 "bootstrap_routing",
             );
         }
+        // Issue #186: detect when the active project resolved to an
+        // anonymized agent identifier (e.g. `agent-a110134bd9c6e7440`)
+        // instead of the daemon's CLI startup root. This happens when
+        // a session-bound switch lands on an internal Claude/Codex
+        // workspace path where the directory basename is itself a
+        // hash. The active project is then "shared on-disk index"
+        // material from a sibling daemon's view but the answer key is
+        // a different tree, surfacing as `indexed_files: 0` +
+        // false-positive `no_supported_files`. Surface the mismatch
+        // so the caller can re-issue with `project=<real path>`.
+        let active_project_name_for_check = activate_payload
+            .get("project_name")
+            .and_then(|value| value.as_str())
+            .unwrap_or_default();
+        if is_anonymized_agent_project_name(active_project_name_for_check) {
+            let daemon_default = state.default_project_scope();
+            push_prepare_harness_warning_with_extras(
+                &mut warnings,
+                &mut warning_codes,
+                "anonymized_project_name_detected",
+                &format!(
+                    "active project resolved to anonymized agent identifier `{active_project_name_for_check}`; this usually means a session-bound switch landed on an internal harness workspace and the on-disk index for the daemon's CLI default project is not loaded. Re-issue prepare_harness_session with `project=<absolute repo path>` to pin the intended project.",
+                ),
+                false,
+                "activate_explicit_project",
+                "active_project",
+                json!({
+                    "anonymized_project_name": active_project_name_for_check,
+                    "daemon_default_project_root": daemon_default,
+                    "remediation": {
+                        "method": "tool_call",
+                        "tool": "prepare_harness_session",
+                        "args": { "project": daemon_default },
+                    },
+                }),
+            );
+        }
         // Issue #224: when caller supplied both `profile` and `preset`,
         // surface a non-blocking warning naming the dropped value so the
         // next call can drop the redundant arg explicitly. Profile wins
@@ -1036,5 +1093,42 @@ mod tests {
         // No spurious key inserted from the string extras.
         assert!(warning.get("remediation").is_none());
         assert!(warning.get("auto_refresh_threshold").is_none());
+    }
+
+    /// Issue #186 detector: a `agent-<hash>` directory basename is the
+    /// telltale sign that the active project is an internal Claude/
+    /// Codex workspace, not the daemon's CLI startup root.
+    #[test]
+    fn anonymized_agent_project_name_detected_for_hash_pattern() {
+        // Real-world cases from the dogfood report.
+        assert!(is_anonymized_agent_project_name("agent-a110134bd9c6e7440"));
+        assert!(is_anonymized_agent_project_name(
+            "agent-0123456789abcdefABCDEF"
+        ));
+        // Minimum-length boundary (12 chars after prefix).
+        assert!(is_anonymized_agent_project_name("agent-aaaaaaaaaaaa"));
+    }
+
+    /// Real project directories that happen to start with `agent`
+    /// must not trip the detector. Only hash-shaped suffixes count.
+    #[test]
+    fn anonymized_agent_project_name_rejects_real_project_names() {
+        assert!(!is_anonymized_agent_project_name("agent-server")); // dash inside not hex
+        assert!(!is_anonymized_agent_project_name("agent-cli")); // too short
+        assert!(!is_anonymized_agent_project_name("codelens-mcp-plugin"));
+        assert!(!is_anonymized_agent_project_name("rg-family"));
+        assert!(!is_anonymized_agent_project_name("agent-orchestrator")); // dash inside
+        // A sub-12 hash-ish suffix is also rejected (too short to be the
+        // anonymizer the harness uses).
+        assert!(!is_anonymized_agent_project_name("agent-abc123"));
+    }
+
+    /// Edge cases: empty string, missing prefix, only the prefix.
+    #[test]
+    fn anonymized_agent_project_name_handles_edge_cases() {
+        assert!(!is_anonymized_agent_project_name(""));
+        assert!(!is_anonymized_agent_project_name("agent-"));
+        assert!(!is_anonymized_agent_project_name("foo-agent-aaaaaaaaaaaa"));
+        assert!(!is_anonymized_agent_project_name("AGENT-aaaaaaaaaaaa")); // case sensitive
     }
 }


### PR DESCRIPTION
## Summary

\`prepare_harness_session\` 가 read-only daemon 에서 호출될 때 active project 가 daemon 의 CLI startup root 가 아닌 anonymized agent identifier (e.g. \`agent-a110134bd9c6e7440\`) 로 잡히면 downstream 가 \`indexed_files: 0\` + false-positive \`no_supported_files\` warning 으로 \"이 프로젝트는 비어있다\" 라는 잘못된 신호를 받던 문제 fix.

## Background

이슈 #186 — 두 daemon (port 7838 mutation, 7839 read-only) 동일 cwd 로 시작했는데 \`:7839\` 에서 \`prepare_harness_session\` 호출 시 \`project_name: \"agent-a110134bd9c6e7440\"\`, \`indexed_files: 0\`. 동일 daemon 의 다른 도구 (\`find_symbol\` 등) 는 정상 → 인덱스 자체는 공유, prepare_harness_session 의 project 식별만 다름.

근본 원인은 session-bound switch 가 internal Claude/Codex workspace path 로 빠지는 것. 응답에 명확히 surface 해서 caller 가 즉시 인지 + 정정 가능하도록 fix.

## Detail

### \`crates/codelens-mcp/src/tools/session/project_ops.rs\`

새 helper:

\`\`\`rust
fn is_anonymized_agent_project_name(name: &str) -> bool {
    let Some(suffix) = name.strip_prefix(\"agent-\") else { return false; };
    suffix.len() >= 12 && suffix.chars().all(|c| c.is_ascii_hexdigit())
}
\`\`\`

- \`agent-\` prefix + ≥12-char strict hex suffix 만 true
- hex-only 제약은 false-positive 회피용. \`agent-server\` (s, r, v non-hex), \`agent-orchestrator\` 등 real project 는 reject

\`prepare_harness_session\` warnings 블록에 추가:

\`\`\`json
{
  \"code\": \"anonymized_project_name_detected\",
  \"message\": \"active project resolved to anonymized agent identifier \`agent-a110134bd9c6e7440\`; ...\",
  \"recommended_action\": \"activate_explicit_project\",
  \"action_target\": \"active_project\",
  \"anonymized_project_name\": \"agent-a110134bd9c6e7440\",
  \"daemon_default_project_root\": \"/Users/.../codelens-mcp-plugin\",
  \"remediation\": {
    \"method\": \"tool_call\",
    \"tool\": \"prepare_harness_session\",
    \"args\": { \"project\": \"/Users/.../codelens-mcp-plugin\" }
  }
}
\`\`\`

호출자가 응답에서 바로 daemon CLI default 로 re-issue 가능.

## Test plan

- [x] \`cargo fmt --all -- --check\` (clean)
- [x] \`cargo clippy --workspace --features http,semantic --all-targets -- -D warnings\` (0 warnings)
- [x] \`cargo nextest run --workspace --features http,semantic\` — **1115 passed / 10 skipped / 0 failed**
- [x] 신규 unit tests 3 개:
  - \`anonymized_agent_project_name_detected_for_hash_pattern\` (primary)
  - \`anonymized_agent_project_name_rejects_real_project_names\` (false-positive 가드 — \`agent-server\`, \`agent-orchestrator\`, \`codelens-mcp-plugin\`, \`agent-cli\`, \`agent-abc123\` 등)
  - \`anonymized_agent_project_name_handles_edge_cases\` (empty / no-prefix / case sensitive)

## Closes

- Closes #186

## Adjacent

- 이슈 옵션 (1) detection + warning 채택. 옵션 (2) 자동 fallback 은 공격적이라 별도 enhancement 후보 — 현재는 caller 가 명시적으로 re-issue
- 옵션 (3) \"indexed_files: 0 인데 같은 daemon 다른 도구 정상\" 모순 health check 는 별도 PR 후보

## Notes

- backward compatible: 새 warning code 만 추가, 기존 응답 schema 영향 없음
- 옵션 (2) (자동 daemon CLI default 로 fallback) 은 호출자 의도를 무시할 수 있어 explicit caller-side re-issue 가 안전. remediation 블록이 정확히 그 path 제시

🤖 Generated with [Claude Code](https://claude.com/claude-code)