### PR TITLE
fix(#203-C-3): reject directory file_path on find_symbol with actionable error

### DIFF
--- a/crates/codelens-mcp/src/integration_tests/readonly.rs
+++ b/crates/codelens-mcp/src/integration_tests/readonly.rs
@@ -901,3 +901,49 @@ fn returns_changed_files_via_tool_call() {
     let payload = call_tool(&state, "get_changed_files", json!({}));
     assert_eq!(payload["success"], json!(true));
 }
+
+// Issue #203 (3): historically `find_symbol({ name, file_path: "<dir>" })`
+// silently returned `{ symbols: [], count: 0 }` with a fuzzy-search
+// fallback hint, masking the wrong-input-shape as "no such symbol".
+// The handler now rejects directory `file_path` values up front with an
+// actionable Validation error so the caller can switch to either
+// `get_symbols_overview` (single-file scan) or `bm25_symbol_search`
+// (project-wide query).
+#[test]
+fn find_symbol_rejects_directory_file_path_with_actionable_error() {
+    let project = project_root();
+    let dir_name = "find_symbol_dir_fixture";
+    fs::create_dir_all(project.as_path().join(dir_name))
+        .expect("mkdir directory fixture for find_symbol test");
+    fs::write(
+        project.as_path().join(dir_name).join("a.py"),
+        "def reset():\n    return 1\n",
+    )
+    .unwrap();
+    fs::write(
+        project.as_path().join(dir_name).join("b.py"),
+        "def reset():\n    return 2\n",
+    )
+    .unwrap();
+    let state = make_state(&project);
+
+    let payload = call_tool(
+        &state,
+        "find_symbol",
+        json!({ "name": "reset", "file_path": dir_name }),
+    );
+    assert_eq!(
+        payload["success"],
+        json!(false),
+        "directory file_path must be rejected, payload: {payload}"
+    );
+    let err = payload["error"].as_str().unwrap_or_default();
+    assert!(
+        err.contains("directory"),
+        "error message should mention 'directory' explicitly: {err}"
+    );
+    assert!(
+        err.contains("get_symbols_overview") || err.contains("bm25_symbol_search"),
+        "error message should suggest a directory-aware alternative tool: {err}"
+    );
+}

--- a/crates/codelens-mcp/src/tools/symbols/handlers.rs
+++ b/crates/codelens-mcp/src/tools/symbols/handlers.rs
@@ -215,6 +215,19 @@ pub fn find_symbol(state: &AppState, arguments: &Value) -> ToolResult {
         .or(name_path_alias)
         .ok_or_else(|| CodeLensError::MissingParam("symbol_id or name".into()))?;
     let file_path = optional_string(arguments, "file_path");
+    // Issue #203 (3): historically a directory `file_path` slipped through and
+    // returned `{ symbols: [], count: 0 }` with the no-exact-match fallback
+    // hint, which reads as "the symbol doesn't exist" rather than "you gave
+    // me the wrong input shape". Reject directory inputs up front and steer
+    // the caller to an alternative whose schema actually accepts a directory.
+    if let Some(path_str) = file_path {
+        let project_relative = state.project().as_path().join(path_str);
+        if project_relative.is_dir() || std::path::Path::new(path_str).is_dir() {
+            return Err(crate::error::CodeLensError::Validation(format!(
+                "find_symbol received a directory `file_path` `{path_str}`; pass a single file path instead. For directory-scope symbol scans use `get_symbols_overview(path: \"{path_str}\")` for an AST tree, or `bm25_symbol_search(query: \"{name}\")` for a project-wide name search."
+            )));
+        }
+    }
     let include_body = optional_bool(arguments, "include_body", false);
     let exact_match = optional_bool(arguments, "exact_match", false);
     let max_matches = crate::tool_runtime::optional_usize_with_aliases(


### PR DESCRIPTION
## Summary
- `find_symbol({ name, file_path: '<dir>' })` historically returned `{ symbols: [], count: 0 }` with the no-exact-match fallback hint, masking a wrong-input-shape as "no such symbol".
- The handler now rejects directory `file_path` values up front with an actionable Validation error that names the path and points to `get_symbols_overview(path: ...)` (single-file AST tree) or `bm25_symbol_search(query: ...)` (project-wide identifier search).
- Mirrors the existing `#207-C-2` directory check on `diagnose_issues`.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --features http,semantic --all-targets -- -D warnings`
- [x] `cargo nextest run -p codelens-mcp --features http,semantic --bin codelens-mcp` (720 pass / 8 skip)
- [x] New regression test: `find_symbol_rejects_directory_file_path_with_actionable_error`

Closes #203 (sub-task 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)