### PR TITLE
fix(#201): degrade confidence + evidence on find_referencing_symbols self-only result

### DIFF
--- a/crates/codelens-mcp/src/integration_tests/lsp.rs
+++ b/crates/codelens-mcp/src/integration_tests/lsp.rs
@@ -745,3 +745,61 @@ fn find_referencing_symbols_oxc_definition_only_emits_self_only_warning() {
         "{payload}"
     );
 }
+
+/// Issue #201 regression: when `find_referencing_symbols` returns only
+/// the definition row, the response previously kept its precise-backend
+/// confidence at 0.95 — making the silent miss look like a high-trust
+/// "this symbol is unused" answer. Reviewers acting on that signal would
+/// drop refactors. Degrade `evidence.confidence` (and the top-level
+/// confidence mirror) when self-only is detected, and surface a
+/// `degraded_reason` so an evidence-first reader gets the same warning
+/// signal as the `self_only_warning` block carries.
+#[test]
+fn find_referencing_symbols_oxc_self_only_degrades_confidence_and_evidence() {
+    let project = project_root();
+    fs::write(
+        project.as_path().join("isolated_export_for_201.ts"),
+        "export function refreshEpisodeDonationCachesV2(seasonId: string) {\n    return seasonId;\n}\n",
+    )
+    .unwrap();
+    let state = make_state(&project);
+    let payload = call_tool(
+        &state,
+        "find_referencing_symbols",
+        json!({
+            "file_path": "isolated_export_for_201.ts",
+            "symbol_name": "refreshEpisodeDonationCachesV2",
+        }),
+    );
+    assert_eq!(payload["success"], json!(true), "{payload}");
+    assert_eq!(payload["data"]["count"], json!(1), "{payload}");
+
+    let evidence_conf = payload["data"]["evidence"]["confidence"]
+        .as_f64()
+        .expect("evidence.confidence numeric");
+    assert!(
+        evidence_conf < 0.9,
+        "self-only result must degrade evidence.confidence below the precise-path 0.95, got {evidence_conf}: {payload}"
+    );
+    let top_conf = payload["confidence"]
+        .as_f64()
+        .expect("top-level confidence numeric");
+    assert!(
+        (top_conf - evidence_conf).abs() < 1e-6,
+        "top-level confidence must mirror evidence.confidence (top {top_conf} vs evidence {evidence_conf}): {payload}"
+    );
+    let degraded = payload["data"]["evidence"]["degraded_reason"]
+        .as_str()
+        .unwrap_or_default();
+    assert!(
+        degraded.contains("single_definition") || degraded.contains("self_only"),
+        "evidence.degraded_reason must mark the self-only path, got `{degraded}`: {payload}"
+    );
+    assert_eq!(
+        payload["data"]["evidence"]["confidence_basis"]
+            .as_str()
+            .unwrap_or_default(),
+        "oxc_semantic_self_only",
+        "confidence_basis must shift to the self-only label so reviewers can branch on it: {payload}"
+    );
+}

--- a/crates/codelens-mcp/src/tools/lsp.rs
+++ b/crates/codelens-mcp/src/tools/lsp.rs
@@ -210,11 +210,43 @@ pub fn find_referencing_symbols(state: &AppState, arguments: &serde_json::Value)
             {
                 let refs_limited: Vec<_> = refs.into_iter().take(max_results).collect();
                 let count = refs_limited.len();
-                let meta = success_meta(BackendKind::Hybrid, 0.95);
+                // Issue #201: a self-only result (only the definition row
+                // itself) is the prime symptom of the oxc_semantic
+                // single-file scope gap. Historically the response kept the
+                // precise-path 0.95 confidence, which reads as a
+                // high-trust "this symbol is unused" answer — exactly the
+                // shape of result reviewers wrongly act on. Detect
+                // self-only up front so we can build a degraded meta and
+                // a `oxc_semantic_self_only` evidence basis instead.
+                let is_self_only = count == 1
+                    && refs_limited
+                        .first()
+                        .and_then(|r| serde_json::to_value(r).ok())
+                        .and_then(|v| {
+                            v.get("kind")
+                                .and_then(|k| k.as_str())
+                                .map(|k| k.eq_ignore_ascii_case("definition"))
+                        })
+                        .unwrap_or(false);
+                let (meta, confidence_basis) = if is_self_only {
+                    (
+                        crate::tool_evidence::meta_degraded(
+                            "hybrid",
+                            0.6,
+                            "single_definition_no_cross_file_visible",
+                        ),
+                        "oxc_semantic_self_only",
+                    )
+                } else {
+                    (
+                        success_meta(BackendKind::Hybrid, 0.95),
+                        "oxc_semantic_precise",
+                    )
+                };
                 let evidence = crate::tool_evidence::tool_evidence(
                     "references",
                     &meta,
-                    "oxc_semantic_precise",
+                    confidence_basis,
                     crate::tool_evidence::precision_signals(
                         true,
                         true,
@@ -248,18 +280,7 @@ pub fn find_referencing_symbols(state: &AppState, arguments: &serde_json::Value)
                 // is the prime symptom of the cross-file gap — flag it
                 // explicitly so the caller does not mistake it for "no
                 // callers exist".
-                if count == 1
-                    && refs_limited
-                        .first()
-                        .and_then(|r| serde_json::to_value(r).ok())
-                        .and_then(|v| {
-                            v.get("kind")
-                                .and_then(|k| k.as_str())
-                                .map(|k| k.eq_ignore_ascii_case("definition"))
-                        })
-                        .unwrap_or(false)
-                    && let Some(map) = payload.as_object_mut()
-                {
+                if is_self_only && let Some(map) = payload.as_object_mut() {
                     map.insert(
                         "self_only_warning".to_owned(),
                         json!({


### PR DESCRIPTION
## Summary
- `find_referencing_symbols` on the default `oxc_semantic` path used to keep `confidence: 0.95` + `precise_used: true` even when the only row returned was the symbol's own definition — exactly the silent-miss shape that makes reviewers drop refactors on exported symbols that have cross-file callers.
- Detect the self-only shape before building the meta; switch to a degraded meta (`confidence: 0.6`, `degraded_reason: single_definition_no_cross_file_visible`, `confidence_basis: oxc_semantic_self_only`). The existing `self_only_warning` block still fires.
- Locks the new invariant with a regression test alongside the #214 test (`..._oxc_self_only_degrades_confidence_and_evidence`).

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --features http,semantic --all-targets -- -D warnings`
- [x] `cargo nextest run -p codelens-mcp --features http,semantic --bin codelens-mcp` (721 pass / 8 skip)
- [x] Existing `find_referencing_symbols_oxc_definition_only_emits_self_only_warning` continues to pass

Closes #201.

🤖 Generated with [Claude Code](https://claude.com/claude-code)