### PR TITLE
fix(#238): ad-hoc codesign http daemon binary on macOS to prevent silent OS_REASON_CODESIGNING kill

### DIFF
--- a/scripts/install-http-daemons-launchd.sh
+++ b/scripts/install-http-daemons-launchd.sh
@@ -216,6 +216,22 @@ elif [[ ! -x "$BIN_PATH" ]]; then
 	exit 1
 fi
 
+# Issue #238: macOS launchd silently kills freshly-rebuilt binaries with
+# `OS_REASON_CODESIGNING` (Hardened Runtime / Gatekeeper enforcement),
+# leaving the daemons in `state = spawn scheduled` with no live process
+# and no signal at the CodeLens MCP layer. Ad-hoc sign here so every
+# redeploy from the dogfood loop comes back up cleanly. Best-effort:
+# `codesign` failure is logged but not fatal so non-Apple-tooled hosts
+# still complete the install.
+if [[ "$(uname)" == "Darwin" ]] && command -v codesign >/dev/null 2>&1; then
+	echo "==> Ad-hoc signing http binary (macOS Hardened Runtime)"
+	codesign -s - --force \
+		--preserve-metadata=identifier,entitlements,flags,runtime \
+		"$BIN_PATH" || {
+		echo "warning: codesign failed; daemons may be killed by Gatekeeper" >&2
+	}
+fi
+
 readonly_label="${LABEL_PREFIX}-readonly"
 mutation_label="${LABEL_PREFIX}-mutation"
 readonly_plist="$LAUNCH_AGENTS_DIR/${readonly_label}.plist"


### PR DESCRIPTION
## Summary
- macOS launchd silently kills the redeployed http binary with `OS_REASON_CODESIGNING` after every dogfood-loop rebuild — `pgrep` returns empty, CodeLens MCP clients report only `MCP server disconnected`, and `mcp-doctor.sh --strict` doesn't surface a Gatekeeper signal.
- Add an idempotent ad-hoc codesign step (`codesign -s - --force --preserve-metadata=identifier,entitlements,flags,runtime`) immediately after the binary lands at `$BIN_PATH`.
- Gated on `uname == Darwin` + `command -v codesign`; logs a warning but doesn't abort if the sign fails (broken sign chain never blocks the install).

## Test plan
- [x] `bash -n scripts/install-http-daemons-launchd.sh` (syntax)
- [x] Verified the workaround live earlier today: ad-hoc codesign → kickstart → both daemons spawn cleanly, `curl initialize` succeeds (PR #237 verify cycle).

Closes #238.

🤖 Generated with [Claude Code](https://claude.com/claude-code)