### PR TITLE
fix(#240): extend SCIP staleness detection to find_referencing_symbols + get_callers

### DIFF
--- a/crates/codelens-mcp/src/tools/graph.rs
+++ b/crates/codelens-mcp/src/tools/graph.rs
@@ -411,8 +411,32 @@ pub fn get_callers_tool(state: &AppState, arguments: &serde_json::Value) -> Tool
             }
         }
 
-        let (resolution_summary, confidence_basis, meta) =
+        let (resolution_summary, computed_basis, computed_meta) =
             call_graph_analysis(value.iter().map(|entry| entry.resolution));
+        // Issue #240: when a SCIP-resolved caller line points at a file
+        // that's been edited since the index was built, the precise-tier
+        // confidence (≥ 0.95) lies the same way `find_symbol` did
+        // pre-#236. Probe staleness against every caller file (cheap —
+        // mtime per file) and degrade meta + emit warning when any is
+        // newer than the index.
+        #[cfg(feature = "scip-backend")]
+        let scip_staleness = {
+            let candidate_files: Vec<String> = value.iter().map(|c| c.file.clone()).collect();
+            crate::tools::scip_health::detect_scip_staleness(
+                state.project().as_path(),
+                &candidate_files,
+            )
+        };
+        #[cfg(not(feature = "scip-backend"))]
+        let scip_staleness: Option<()> = None;
+        let (confidence_basis, meta) = if scip_staleness.is_some() {
+            (
+                "scip_precise_stale_index",
+                crate::tool_evidence::meta_degraded("scip", 0.55, "scip_index_stale_vs_source"),
+            )
+        } else {
+            (computed_basis, computed_meta)
+        };
         let evidence = crate::tool_evidence::tool_evidence(
             "call_graph",
             &meta,
@@ -429,6 +453,15 @@ pub fn get_callers_tool(state: &AppState, arguments: &serde_json::Value) -> Tool
             "resolution_summary": resolution_summary,
             "evidence": evidence,
         });
+        #[cfg(feature = "scip-backend")]
+        if let Some(stale) = scip_staleness.as_ref()
+            && let Some(map) = payload.as_object_mut()
+        {
+            map.insert(
+                "scip_index_stale_warning".to_owned(),
+                crate::tools::scip_health::scip_stale_warning_payload(stale),
+            );
+        }
         if !unknown_args.is_empty()
             && let Some(map) = payload.as_object_mut()
         {

--- a/crates/codelens-mcp/src/tools/lsp.rs
+++ b/crates/codelens-mcp/src/tools/lsp.rs
@@ -310,11 +310,33 @@ pub fn find_referencing_symbols(state: &AppState, arguments: &serde_json::Value)
                 {
                     let limited: Vec<_> = refs.into_iter().take(max_results).collect();
                     let count = limited.len();
-                    let meta = success_meta(BackendKind::Scip, 0.98);
+                    // Issue #240: same SCIP staleness probe as
+                    // `find_symbol` — if the index pre-dates any
+                    // resolved file, swap to a degraded meta + emit
+                    // `scip_index_stale_warning` so reviewers can't
+                    // mistake stale call sites for current ones.
+                    let scip_candidate_files: Vec<String> =
+                        limited.iter().map(|r| r.file_path.clone()).collect();
+                    let scip_staleness = crate::tools::scip_health::detect_scip_staleness(
+                        state.project().as_path(),
+                        &scip_candidate_files,
+                    );
+                    let (meta, confidence_basis) = if scip_staleness.is_some() {
+                        (
+                            crate::tool_evidence::meta_degraded(
+                                "scip",
+                                0.55,
+                                "scip_index_stale_vs_source",
+                            ),
+                            "scip_precise_stale_index",
+                        )
+                    } else {
+                        (success_meta(BackendKind::Scip, 0.98), "scip_precise")
+                    };
                     let evidence = crate::tool_evidence::tool_evidence(
                         "references",
                         &meta,
-                        "scip_precise",
+                        confidence_basis,
                         crate::tool_evidence::precision_signals(
                             true,
                             true,
@@ -343,6 +365,14 @@ pub fn find_referencing_symbols(state: &AppState, arguments: &serde_json::Value)
                         "backend": "scip",
                         "evidence": evidence,
                     });
+                    if let Some(stale) = scip_staleness.as_ref()
+                        && let Some(map) = payload.as_object_mut()
+                    {
+                        map.insert(
+                            "scip_index_stale_warning".to_owned(),
+                            crate::tools::scip_health::scip_stale_warning_payload(stale),
+                        );
+                    }
                     if !unknown_args.is_empty() || !deprecation_warnings.is_empty() {
                         insert_response_annotations(
                             &mut payload,

--- a/crates/codelens-mcp/src/tools/mod.rs
+++ b/crates/codelens-mcp/src/tools/mod.rs
@@ -13,6 +13,7 @@ mod report_utils;
 mod report_verifier;
 pub mod reports;
 pub mod rules;
+mod scip_health;
 pub(crate) mod semantic_edit;
 pub(crate) mod semantic_edit_args;
 pub mod session;

--- a/crates/codelens-mcp/src/tools/scip_health.rs
+++ b/crates/codelens-mcp/src/tools/scip_health.rs
@@ -1,0 +1,158 @@
+//! SCIP backend freshness helpers shared by every tool that resolves
+//! through `codelens_engine::ScipBackend`.
+//!
+//! Issue #235 / #236 introduced per-call staleness detection on
+//! `find_symbol` so its precise-tier 0.98 confidence wouldn't lie when
+//! the on-disk `index.scip` pre-dated the resolved source files. Issue
+//! #240 extends the same probe to `find_referencing_symbols` and
+//! `get_callers`, which exhibit the identical silent-miss shape.
+//!
+//! The helper is a best-effort I/O probe: any missing file, unreadable
+//! mtime, or absent index returns `None` so the caller never fabricates
+//! a stale-evidence claim from missing data.
+
+#[cfg(feature = "scip-backend")]
+use serde_json::json;
+
+#[cfg(feature = "scip-backend")]
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub(crate) struct ScipStaleness {
+    pub(crate) index_path: String,
+    pub(crate) stale_files: Vec<(String, u64)>,
+}
+
+#[cfg(feature = "scip-backend")]
+pub(crate) fn detect_scip_staleness(
+    project_root: &std::path::Path,
+    candidate_files: &[String],
+) -> Option<ScipStaleness> {
+    let index_path = codelens_engine::ScipBackend::detect(project_root)?;
+    let index_mtime = std::fs::metadata(&index_path).ok()?.modified().ok()?;
+    let mut stale = Vec::new();
+    for rel in candidate_files {
+        let abs = project_root.join(rel);
+        let Ok(meta) = std::fs::metadata(&abs) else {
+            continue;
+        };
+        let Ok(file_mtime) = meta.modified() else {
+            continue;
+        };
+        if file_mtime > index_mtime {
+            let age_secs = file_mtime
+                .duration_since(index_mtime)
+                .map(|d| d.as_secs())
+                .unwrap_or(0);
+            stale.push((rel.clone(), age_secs));
+        }
+    }
+    (!stale.is_empty()).then(|| ScipStaleness {
+        index_path: index_path.display().to_string(),
+        stale_files: stale,
+    })
+}
+
+/// Build the `scip_index_stale_warning` payload that every SCIP-resolved
+/// tool surfaces when `detect_scip_staleness` flags one or more files.
+/// Centralised here so the message + recommended action stay identical
+/// across `find_symbol`, `find_referencing_symbols`, and `get_callers` —
+/// callers can branch on a single `code: scip_index_stale` signal.
+#[cfg(feature = "scip-backend")]
+pub(crate) fn scip_stale_warning_payload(stale: &ScipStaleness) -> serde_json::Value {
+    let stale_files_payload: Vec<serde_json::Value> = stale
+        .stale_files
+        .iter()
+        .map(|(file, age)| json!({"file_path": file, "newer_than_index_by_seconds": age}))
+        .collect();
+    json!({
+        "code": "scip_index_stale",
+        "message": "SCIP index pre-dates one or more resolved source files; reported line / body / signature may not match current source. Regenerate the index before trusting precise-tier results.",
+        "recommended_action": "regenerate_scip_index",
+        "action_target": "scip_backend",
+        "index_path": stale.index_path,
+        "stale_files": stale_files_payload,
+    })
+}
+
+#[cfg(all(test, feature = "scip-backend"))]
+mod tests {
+    use super::{ScipStaleness, detect_scip_staleness, scip_stale_warning_payload};
+    use std::time::{Duration, SystemTime};
+
+    fn build_fixture(
+        index_age_secs: u64,
+        source_age_secs: u64,
+        sources: &[&str],
+    ) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        let now = SystemTime::now();
+        let index_mtime = now - Duration::from_secs(index_age_secs);
+        let source_mtime = now - Duration::from_secs(source_age_secs);
+        let index_path = root.join("index.scip");
+        std::fs::write(&index_path, b"stub").expect("write index");
+        filetime::set_file_mtime(
+            &index_path,
+            filetime::FileTime::from_system_time(index_mtime),
+        )
+        .expect("backdate index");
+        for rel in sources {
+            let abs = root.join(rel);
+            if let Some(parent) = abs.parent() {
+                std::fs::create_dir_all(parent).expect("mkdirs");
+            }
+            std::fs::write(&abs, b"// placeholder\n").expect("write source");
+            filetime::set_file_mtime(&abs, filetime::FileTime::from_system_time(source_mtime))
+                .expect("backdate source");
+        }
+        dir
+    }
+
+    #[test]
+    fn staleness_detected_when_source_is_newer_than_index() {
+        let dir = build_fixture(600, 60, &["src/lib.rs"]);
+        let staleness = detect_scip_staleness(dir.path(), &["src/lib.rs".to_owned()])
+            .expect("source newer than index → staleness Some");
+        assert_eq!(staleness.stale_files.len(), 1);
+        assert_eq!(staleness.stale_files[0].0, "src/lib.rs");
+        assert!(staleness.stale_files[0].1 >= 300);
+        assert!(staleness.index_path.ends_with("index.scip"));
+    }
+
+    #[test]
+    fn no_staleness_when_index_is_newer_than_source() {
+        let dir = build_fixture(60, 600, &["src/lib.rs"]);
+        let staleness = detect_scip_staleness(dir.path(), &["src/lib.rs".to_owned()]);
+        assert!(staleness.is_none(), "got {staleness:?}");
+    }
+
+    #[test]
+    fn missing_index_returns_none_silently() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("src.rs"), b"x").expect("source");
+        assert!(detect_scip_staleness(dir.path(), &["src.rs".to_owned()]).is_none());
+    }
+
+    #[test]
+    fn missing_source_file_is_skipped_not_failed() {
+        let dir = build_fixture(600, 60, &[]);
+        assert!(detect_scip_staleness(dir.path(), &["src/does_not_exist.rs".to_owned()]).is_none());
+    }
+
+    #[test]
+    fn warning_payload_carries_required_fields() {
+        let stale = ScipStaleness {
+            index_path: "/tmp/index.scip".to_owned(),
+            stale_files: vec![("src/a.rs".to_owned(), 1234)],
+        };
+        let payload = scip_stale_warning_payload(&stale);
+        assert_eq!(payload["code"], "scip_index_stale");
+        assert_eq!(payload["recommended_action"], "regenerate_scip_index");
+        assert_eq!(payload["action_target"], "scip_backend");
+        assert_eq!(payload["index_path"], "/tmp/index.scip");
+        assert_eq!(payload["stale_files"][0]["file_path"], "src/a.rs");
+        assert_eq!(
+            payload["stale_files"][0]["newer_than_index_by_seconds"],
+            1234
+        );
+    }
+}

--- a/crates/codelens-mcp/src/tools/symbols/handlers.rs
+++ b/crates/codelens-mcp/src/tools/symbols/handlers.rs
@@ -114,51 +114,11 @@ pub(super) fn read_signature_line(
     Some(trimmed.to_owned())
 }
 
+// Issue #240: SCIP staleness detection promoted to `tools/scip_health.rs`
+// so `find_referencing_symbols` and `get_callers` can reuse the same
+// probe + warning shape.
 #[cfg(feature = "scip-backend")]
-#[derive(Debug, PartialEq, Eq)]
-pub(super) struct ScipStaleness {
-    pub(super) index_path: String,
-    pub(super) stale_files: Vec<(String, u64)>,
-}
-
-/// Issue #235: detect when SCIP-backed answers are reading from an
-/// `index.scip` that pre-dates one or more of the resolved source files.
-/// Returns `Some(_)` only if at least one file in `candidate_files` has a
-/// modified time strictly newer than the index's modified time, in which
-/// case the SCIP-reported line/body for that file is suspect even though
-/// the precise-tier confidence (0.98) would otherwise read as high trust.
-///
-/// Best-effort: any I/O failure (missing index, unreadable mtime) skips
-/// the file silently rather than fabricating a stale-evidence claim.
-#[cfg(feature = "scip-backend")]
-pub(super) fn detect_scip_staleness(
-    project_root: &std::path::Path,
-    candidate_files: &[String],
-) -> Option<ScipStaleness> {
-    let index_path = codelens_engine::ScipBackend::detect(project_root)?;
-    let index_mtime = std::fs::metadata(&index_path).ok()?.modified().ok()?;
-    let mut stale = Vec::new();
-    for rel in candidate_files {
-        let abs = project_root.join(rel);
-        let Ok(meta) = std::fs::metadata(&abs) else {
-            continue;
-        };
-        let Ok(file_mtime) = meta.modified() else {
-            continue;
-        };
-        if file_mtime > index_mtime {
-            let age_secs = file_mtime
-                .duration_since(index_mtime)
-                .map(|d| d.as_secs())
-                .unwrap_or(0);
-            stale.push((rel.clone(), age_secs));
-        }
-    }
-    (!stale.is_empty()).then(|| ScipStaleness {
-        index_path: index_path.display().to_string(),
-        stale_files: stale,
-    })
-}
+use crate::tools::scip_health::{detect_scip_staleness, scip_stale_warning_payload};
 
 pub fn get_symbols_overview(state: &AppState, arguments: &Value) -> ToolResult {
     const KNOWN_ARGS: &[&str] = &["path", "file_path", "relative_path", "depth"];
@@ -433,23 +393,9 @@ pub fn find_symbol(state: &AppState, arguments: &Value) -> ToolResult {
                     json!(deprecation_warnings),
                 );
                 if let Some(stale) = scip_staleness.as_ref() {
-                    let stale_files_payload: Vec<serde_json::Value> = stale
-                        .stale_files
-                        .iter()
-                        .map(|(file, age)| {
-                            json!({"file_path": file, "newer_than_index_by_seconds": age})
-                        })
-                        .collect();
                     map.insert(
                         "scip_index_stale_warning".to_owned(),
-                        json!({
-                            "code": "scip_index_stale",
-                            "message": "SCIP index pre-dates one or more resolved source files; reported line / body / signature may not match current source. Regenerate the index before trusting precise-tier results.",
-                            "recommended_action": "regenerate_scip_index",
-                            "action_target": "scip_backend",
-                            "index_path": stale.index_path,
-                            "stale_files": stale_files_payload,
-                        }),
+                        scip_stale_warning_payload(stale),
                     );
                 }
                 if !unknown_args.is_empty() {
@@ -1384,95 +1330,6 @@ mod confidence_tier_tests {
             confidence_tier(&matched, 0, "dispatch_tool", "dispatch::dispatch_tool"),
             "low"
         );
-    }
-}
-
-#[cfg(all(test, feature = "scip-backend"))]
-mod scip_staleness_tests {
-    use super::detect_scip_staleness;
-    use std::time::{Duration, SystemTime};
-
-    /// Build a temp project root with an `index.scip` placeholder file
-    /// dated `index_age_secs` ago, plus the named source files dated
-    /// `source_age_secs` ago. Returns the project root path.
-    fn build_fixture(
-        index_age_secs: u64,
-        source_age_secs: u64,
-        sources: &[&str],
-    ) -> tempfile::TempDir {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let root = dir.path();
-        let now = SystemTime::now();
-        let index_mtime = now - Duration::from_secs(index_age_secs);
-        let source_mtime = now - Duration::from_secs(source_age_secs);
-        let index_path = root.join("index.scip");
-        std::fs::write(&index_path, b"stub").expect("write index");
-        filetime::set_file_mtime(
-            &index_path,
-            filetime::FileTime::from_system_time(index_mtime),
-        )
-        .expect("backdate index");
-        for rel in sources {
-            let abs = root.join(rel);
-            if let Some(parent) = abs.parent() {
-                std::fs::create_dir_all(parent).expect("mkdirs");
-            }
-            std::fs::write(&abs, b"// placeholder\n").expect("write source");
-            filetime::set_file_mtime(&abs, filetime::FileTime::from_system_time(source_mtime))
-                .expect("backdate source");
-        }
-        dir
-    }
-
-    #[test]
-    fn staleness_detected_when_source_is_newer_than_index() {
-        let dir = build_fixture(
-            /* index_age */ 600,
-            /* source_age */ 60,
-            &["src/lib.rs"],
-        );
-        let staleness = detect_scip_staleness(dir.path(), &["src/lib.rs".to_owned()])
-            .expect("source newer than index → staleness Some");
-        assert_eq!(staleness.stale_files.len(), 1);
-        assert_eq!(staleness.stale_files[0].0, "src/lib.rs");
-        // Allow a generous window — the test only asserts the delta is
-        // strictly positive and within the same order of magnitude as the
-        // configured backdate gap (≥ 5 minutes).
-        assert!(
-            staleness.stale_files[0].1 >= 300,
-            "stale-by-seconds delta must reflect the backdate, got {}",
-            staleness.stale_files[0].1
-        );
-        assert!(staleness.index_path.ends_with("index.scip"));
-    }
-
-    #[test]
-    fn no_staleness_when_index_is_newer_than_source() {
-        let dir = build_fixture(
-            /* index_age */ 60,
-            /* source_age */ 600,
-            &["src/lib.rs"],
-        );
-        let staleness = detect_scip_staleness(dir.path(), &["src/lib.rs".to_owned()]);
-        assert!(staleness.is_none(), "got {staleness:?}");
-    }
-
-    #[test]
-    fn missing_index_returns_none_silently() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        std::fs::write(dir.path().join("src.rs"), b"x").expect("source");
-        let staleness = detect_scip_staleness(dir.path(), &["src.rs".to_owned()]);
-        assert!(
-            staleness.is_none(),
-            "no index.scip → must be None, not a fabricated staleness claim: {staleness:?}"
-        );
-    }
-
-    #[test]
-    fn missing_source_file_is_skipped_not_failed() {
-        let dir = build_fixture(/* index_age */ 600, 60, &[]);
-        let staleness = detect_scip_staleness(dir.path(), &["src/does_not_exist.rs".to_owned()]);
-        assert!(staleness.is_none());
     }
 }
 


### PR DESCRIPTION
## Summary
- PR #236 only wired SCIP staleness detection into `find_symbol`. Live dogfood today confirmed `get_callers` and `find_referencing_symbols` still surface stale precise-tier 0.95+ confidence on the same 8-day-old index — same silent-miss class.
- Promote `detect_scip_staleness` + `ScipStaleness` to a new shared `tools/scip_health.rs` module, plus `scip_stale_warning_payload` so the warning shape stays identical across all three tools (callers can branch on a single `code: scip_index_stale`).
- Both new call sites swap to degraded meta (`confidence: 0.55`, `degraded_reason: scip_index_stale_vs_source`, `confidence_basis: scip_precise_stale_index`) when staleness is detected.

## Test plan
- [x] 5 new unit tests in `tools::scip_health::tests` (4 staleness shapes + 1 warning-payload check)
- [x] 3 existing `read_signature_line_tests` continue to pass
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --features http,semantic --all-targets -- -D warnings`
- [x] `cargo clippy --workspace --no-default-features --all-targets -- -D warnings`
- [x] `cargo nextest run -p codelens-mcp --features http,semantic --bin codelens-mcp` (729 pass / 8 skip)

Closes #240.

🤖 Generated with [Claude Code](https://claude.com/claude-code)