### PR TITLE
fix(#243): normalize SCIP-derived line numbers to 1-indexed at JSON serialization boundary

### DIFF
--- a/crates/codelens-mcp/src/tools/graph.rs
+++ b/crates/codelens-mcp/src/tools/graph.rs
@@ -395,16 +395,27 @@ pub fn get_callers_tool(state: &AppState, arguments: &serde_json::Value) -> Tool
         if let Some(backend) = state.scip() {
             let scip_entries = backend.find_callers(function_name);
             if !scip_entries.is_empty() {
+                // Issue #243: SCIP `parse_range` is 0-indexed per spec,
+                // but tree-sitter `value` entries already carry 1-indexed
+                // line numbers. Normalize the SCIP rows up front so the
+                // dedup key + the serialized output share one
+                // convention. Reviewers comparing `get_callers` to
+                // `read_file` / grep stop hitting a -1 fudge.
+                let mut scip_entries: Vec<_> = scip_entries
+                    .into_iter()
+                    .map(|mut c| {
+                        c.line = crate::tools::scip_health::scip_line_to_display(c.line);
+                        c
+                    })
+                    .collect();
                 let existing: std::collections::HashSet<(String, String, usize)> = value
                     .iter()
                     .map(|c| (c.file.clone(), c.function.clone(), c.line))
                     .collect();
-                let mut merged: Vec<_> = scip_entries
-                    .into_iter()
-                    .filter(|c| !existing.contains(&(c.file.clone(), c.function.clone(), c.line)))
-                    .collect();
-                merged.append(&mut value);
-                value = merged;
+                scip_entries
+                    .retain(|c| !existing.contains(&(c.file.clone(), c.function.clone(), c.line)));
+                scip_entries.append(&mut value);
+                value = scip_entries;
                 if value.len() > max_results {
                     value.truncate(max_results);
                 }

--- a/crates/codelens-mcp/src/tools/lsp.rs
+++ b/crates/codelens-mcp/src/tools/lsp.rs
@@ -348,11 +348,20 @@ pub fn find_referencing_symbols(state: &AppState, arguments: &serde_json::Value)
                     let refs_json: Vec<serde_json::Value> = limited
                         .iter()
                         .map(|r| {
+                            // Issue #243: SCIP `parse_range` is 0-indexed
+                            // per spec; tree-sitter / file-display /
+                            // grep are 1-indexed. Normalize at the JSON
+                            // serialization boundary so reviewers
+                            // comparing `find_referencing_symbols`
+                            // output to `read_file` / `Edit` line
+                            // numbers stop landing one row early.
+                            let display_line =
+                                crate::tools::scip_health::scip_line_to_display(r.line);
                             json!({
                                 "name": r.name,
                                 "kind": r.kind,
                                 "file_path": r.file_path,
-                                "line": r.line,
+                                "line": display_line,
                                 "score": r.score,
                             })
                         })

--- a/crates/codelens-mcp/src/tools/scip_health.rs
+++ b/crates/codelens-mcp/src/tools/scip_health.rs
@@ -51,6 +51,18 @@ pub(crate) fn detect_scip_staleness(
     })
 }
 
+/// Issue #243: convert a 0-indexed SCIP `parse_range` line to the
+/// 1-indexed convention every other CodeLens surface (tree-sitter,
+/// `read_file`, grep, IDE) uses. Single source of truth so the +1
+/// shift can't drift out of sync between `find_symbol`,
+/// `find_referencing_symbols`, and `get_callers`. Saturating add is
+/// a defence against `usize::MAX` sentinel rows we don't expect to
+/// see but shouldn't panic on either.
+#[cfg(feature = "scip-backend")]
+pub(crate) fn scip_line_to_display(scip_line: usize) -> usize {
+    scip_line.saturating_add(1)
+}
+
 /// Build the `scip_index_stale_warning` payload that every SCIP-resolved
 /// tool surfaces when `detect_scip_staleness` flags one or more files.
 /// Centralised here so the message + recommended action stay identical
@@ -75,7 +87,9 @@ pub(crate) fn scip_stale_warning_payload(stale: &ScipStaleness) -> serde_json::V
 
 #[cfg(all(test, feature = "scip-backend"))]
 mod tests {
-    use super::{ScipStaleness, detect_scip_staleness, scip_stale_warning_payload};
+    use super::{
+        ScipStaleness, detect_scip_staleness, scip_line_to_display, scip_stale_warning_payload,
+    };
     use std::time::{Duration, SystemTime};
 
     fn build_fixture(
@@ -154,5 +168,23 @@ mod tests {
             payload["stale_files"][0]["newer_than_index_by_seconds"],
             1234
         );
+    }
+
+    #[test]
+    fn scip_line_to_display_shifts_zero_indexed_to_one_indexed() {
+        // Issue #243 regression: SCIP `parse_range` returns 0-indexed
+        // line numbers per spec; the rest of the CodeLens surface
+        // (tree-sitter / read_file / grep / IDE) is 1-indexed. The
+        // helper must shift exactly one row.
+        assert_eq!(scip_line_to_display(0), 1);
+        assert_eq!(scip_line_to_display(93), 94);
+        assert_eq!(scip_line_to_display(413), 414);
+    }
+
+    #[test]
+    fn scip_line_to_display_saturates_on_max_sentinel() {
+        // `find_callees` uses `usize::MAX` as a synthetic
+        // next-definition sentinel — adding 1 must not panic.
+        assert_eq!(scip_line_to_display(usize::MAX), usize::MAX);
     }
 }

--- a/crates/codelens-mcp/src/tools/symbols/handlers.rs
+++ b/crates/codelens-mcp/src/tools/symbols/handlers.rs
@@ -118,7 +118,9 @@ pub(super) fn read_signature_line(
 // so `find_referencing_symbols` and `get_callers` can reuse the same
 // probe + warning shape.
 #[cfg(feature = "scip-backend")]
-use crate::tools::scip_health::{detect_scip_staleness, scip_stale_warning_payload};
+use crate::tools::scip_health::{
+    detect_scip_staleness, scip_line_to_display, scip_stale_warning_payload,
+};
 
 /// Issue #235 (sub-fix C): humanize raw SCIP descriptors (e.g.
 /// `"rust-analyzer cargo codelens-mcp 1.9.59 tools/session/project_ops/prepare_harness_session()."`)
@@ -401,11 +403,22 @@ pub fn find_symbol(state: &AppState, arguments: &Value) -> ToolResult {
                     // reverse-lookup callers don't lose information.
                     let scip_descriptor_raw = d.name_path.clone().unwrap_or_else(|| d.name.clone());
                     let humanized_name_path = humanize_scip_name_path(&scip_descriptor_raw);
+                    // Issue #243: SCIP `parse_range` returns 0-indexed line
+                    // numbers (per spec) but the rest of the CodeLens
+                    // surface (tree-sitter `get_symbols_overview`,
+                    // `read_file`, grep, IDE) is 1-indexed. Normalize at
+                    // the JSON serialization boundary so cross-tool
+                    // comparison stops needing a -1 fudge. The raw
+                    // 0-indexed `d.line` is still passed to
+                    // `read_signature_line` and `heuristic_body_slice`
+                    // since both slice file content using `Vec<&str>`
+                    // indices and need the original convention.
+                    let display_line = scip_line_to_display(d.line);
                     let mut sym = json!({
                         "name": d.name,
                         "kind": d.kind,
                         "file_path": d.file_path,
-                        "line": d.line,
+                        "line": display_line,
                         "signature": signature_value,
                         "signature_source": signature_source,
                         "name_path": humanized_name_path,


### PR DESCRIPTION
## Summary
- `find_symbol`, `find_referencing_symbols`, and `get_callers` SCIP paths returned 0-indexed line numbers per the SCIP spec, while every other CodeLens surface is 1-indexed. Reviewers comparing the two landed one row early on every SCIP-resolved entry.
- Add `scip_line_to_display(scip_line) -> scip_line + 1` (saturating) in `tools/scip_health.rs` as the single source of truth.
- Apply at the JSON serialization boundary in all three SCIP paths. Raw 0-indexed `d.line` is still passed to `read_signature_line` / `heuristic_body_slice` (file slicing needs the original convention).
- For `get_callers`, normalize SCIP entries up-front so the dedup against tree-sitter entries (already 1-indexed) doesn't double-count rows that differ only by indexing convention.

## Test plan
- [x] 2 new `scip_line_to_display_*` unit tests (canonical mapping + `usize::MAX` saturation)
- [x] 5 existing `scip_health::tests` continue to pass (4 staleness + warning payload)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --features http,semantic --all-targets -- -D warnings`
- [x] `cargo clippy --workspace --no-default-features --all-targets -- -D warnings`
- [x] `cargo nextest run -p codelens-mcp --features http,semantic --bin codelens-mcp` (736 pass / 8 skip)

Closes #243.

🤖 Generated with [Claude Code](https://claude.com/claude-code)