### PR TITLE
fix(#247-A): extend SCIP staleness detection to get_callees

### DIFF
--- a/crates/codelens-mcp/src/tools/graph.rs
+++ b/crates/codelens-mcp/src/tools/graph.rs
@@ -542,8 +542,43 @@ pub fn get_callees_tool(state: &AppState, arguments: &serde_json::Value) -> Tool
             }
         }
 
-        let (resolution_summary, confidence_basis, meta) =
+        let (resolution_summary, computed_basis, computed_meta) =
             call_graph_analysis(value.iter().map(|entry| entry.resolution));
+        // Issue #247 (sub-fix A): get_callees was the last caller-graph
+        // surface still missing per-call SCIP staleness detection. When
+        // SCIP indexes the source file of `function_name` but the file
+        // (or any resolved callee file) has been edited since the index
+        // was built, the precise-tier confidence (≥ 0.95) lies the same
+        // way `find_symbol` did pre-#236 and `get_callers` did pre-#240.
+        // Probe staleness against the function's own source file plus
+        // every resolved callee file — same pattern as #241 in
+        // `get_callers`.
+        #[cfg(feature = "scip-backend")]
+        let scip_staleness = {
+            let mut candidate_files: Vec<String> = value
+                .iter()
+                .filter_map(|c| c.resolved_file.clone())
+                .collect();
+            if let Some(target) = file_path {
+                candidate_files.push(target.to_owned());
+            }
+            candidate_files.sort();
+            candidate_files.dedup();
+            crate::tools::scip_health::detect_scip_staleness(
+                state.project().as_path(),
+                &candidate_files,
+            )
+        };
+        #[cfg(not(feature = "scip-backend"))]
+        let scip_staleness: Option<()> = None;
+        let (confidence_basis, meta) = if scip_staleness.is_some() {
+            (
+                "scip_precise_stale_index",
+                crate::tool_evidence::meta_degraded("scip", 0.55, "scip_index_stale_vs_source"),
+            )
+        } else {
+            (computed_basis, computed_meta)
+        };
         let evidence = crate::tool_evidence::tool_evidence(
             "call_graph",
             &meta,
@@ -560,6 +595,15 @@ pub fn get_callees_tool(state: &AppState, arguments: &serde_json::Value) -> Tool
             "resolution_summary": resolution_summary,
             "evidence": evidence,
         });
+        #[cfg(feature = "scip-backend")]
+        if let Some(stale) = scip_staleness.as_ref()
+            && let Some(map) = payload.as_object_mut()
+        {
+            map.insert(
+                "scip_index_stale_warning".to_owned(),
+                crate::tools::scip_health::scip_stale_warning_payload(stale),
+            );
+        }
         if !unknown_args.is_empty()
             && let Some(map) = payload.as_object_mut()
         {


### PR DESCRIPTION
## Summary
- `get_callees` now probes `detect_scip_staleness` against the function's own source file plus every resolved callee file, mirroring the #241 pattern that landed for `get_callers`.
- When staleness is detected: `confidence_basis: \"scip_precise_stale_index\"`, meta degraded to 0.55, payload carries `scip_index_stale_warning` with `recommended_action: \"regenerate_scip_index\"`.
- Addresses sub-fix A from #247. Closure-local filter + path_proximity tightening (sub-fix B) is a separate engine-layer follow-up.

## Reproduction (issue #247)
\`\`\`
get_callees({
  file_path: \"crates/codelens-mcp/src/tools/symbols/handlers.rs\",
  function_name: \"looks_like_signature\"  // added in PR #246, not in current index.scip
})
\`\`\`
Before: \`precise_available: false\`, no warning, \`prefix\` (closure param) silently resolved via \`path_proximity\` to an unrelated Python file in \`benchmarks/\`.

After: \`scip_precise_stale_index\` + warning telling the user to regenerate the index.

## Test plan
- [x] \`cargo fmt --all\` clean
- [x] \`cargo clippy --workspace --features http,semantic --all-targets -- -D warnings\` clean
- [x] \`cargo clippy --workspace --no-default-features --all-targets -- -D warnings\` clean
- [x] \`cargo nextest run -p codelens-mcp --features http,semantic --bin codelens-mcp\` — 741 passed / 8 skipped
- [ ] Live verify after merge: re-query \`get_callees\` against \`looks_like_signature\` and confirm \`scip_index_stale_warning\` appears

Refs #247 (sub-fix A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)