### PR TITLE
docs(agents): elevate AGENTS.md to active cost-routing layer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 # CodeLens MCP — Codex Repo Notes
 
 <!-- CODELENS_HOST_ROUTING:BEGIN -->
+
 ## CodeLens Routing
 
 - Native first for point lookups and already-local single-file edits.
@@ -79,3 +80,36 @@ Two CodeLens HTTP daemons are the recommended local operational shape for this p
 Agents should attach by URL rather than spawning their own stdio subprocess. The daemons share this project's on-disk index; advisory `register_agent_work` + `claim_files` coordinates mutation collisions.
 
 See [docs/multi-agent-integration.md](docs/multi-agent-integration.md) for the full delegation pattern, coordination discipline (TTL/release), and brief templates.
+
+## Agent Cost Routing
+
+This document is not a passive note — it routes work to the cheapest agent that can do it correctly. Pick by **risk × evidence requirement**, not by reflex.
+
+| Task class                                                                   | Model / agent                                                                     | Why                                                                                                                                                                |
+| ---------------------------------------------------------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Read-only symbol/reference lookup, project bootstrap, single-file overview   | **Haiku 4.5** via `codelens-explorer` subagent                                    | Bounded mechanical tier, ≤6 lookups, no judgment. Cheap, fast, no merge risk.                                                                                      |
+| Multi-file code mutation under a confirmed plan, ≤5 sub-step / 400 net LOC   | **Sonnet 4.6** via `builder` subagent (worktree-isolated)                         | Implementation tier. Parent verifies (`cargo test`, `cargo clippy`) — `builder` self-report is not trusted.                                                        |
+| Bulk codegen / large refactor with high mutation count                       | **Sonnet 4.6 + Codex** via `codex-builder`                                        | Codex burns cheap implementation tokens; Claude stays as planner/reviewer. Use only after `verify_change_readiness` is `ready`.                                    |
+| Acceptance-criteria scoring, planner/builder review, judgment-heavy critique | **Opus 4.7 (xhigh effort)** via `evaluator` subagent                              | Critic role; spec violations cost more than the price delta. Wrap risky changes (schema migration, auth, payment, shared infra) with an additional evaluator loop. |
+| Plan/decompose/orchestrate, brainstorm, route work                           | **Opus 4.7 (xhigh effort)** in the active conversation (this Claude Code session) | Decisions stay where the user sees them; no asymmetric handoff for plans.                                                                                          |
+
+### Anti-routing
+
+- Do **not** dispatch a `builder` subagent in `isolation: "worktree"` mode for a small change that fits in `≤5 sub-step / ≤30 net LOC` — inline edits in the active session are faster and keep evidence visible. The builder's `status: completed` self-report has been observed to fire mid-Task with WIP-only commits; parent must verify with `cargo test/clippy/fmt` regardless. (See `~/.claude/projects/-Users-bagjaeseog/memory/feedback_inline_over_background_dispatch.md`.)
+- Do **not** chain a subagent to spawn another subagent — Claude Code subagents cannot create sub-subagents. Multi-step delegation chains run from the main conversation, not nested.
+- Do **not** swap models mid-session (Opus ↔ Haiku) — KV cache is model-specific, the cold write costs more than just staying on Opus.
+
+### Cost-safe defaults (env)
+
+This repo's session config relies on:
+
+- `ENABLE_PROMPT_CACHING_1H=1` — required to avoid the 5-minute TTL regression (`anthropics/claude-code#46829`). 60–90% cost reduction on multi-turn flows when properly cached.
+- `CLAUDE_CODE_FORK_SUBAGENT=1` — fork inherits parent prompt cache, ~10% first-turn cost vs a fresh subagent. Prefer fork (no `subagent_type`) for read-only research; reserve named subagents for context-bounded mutation work.
+- `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=65` — percentage-based compaction; tool-call absolute thresholds are deprecated as a hard-stop signal under 1M context.
+
+These belong in the host's `~/.claude/settings.json` (not this repo). Surface them here so contributors know what the routing assumes.
+
+### Surface response cache hygiene
+
+- The MCP server's `surface_generation` payload (returned by `tools/list`, `prepare_harness_session`, `get_current_config`) splits stable identity (`schema_version`, `binary_version`, `tool_schema_fingerprint`, `refresh_action`, `refresh_hint`) from volatile runtime (`runtime.binary_git_sha`, `runtime.binary_build_time`). Only the top-level fields are safe to embed in a cached system / tools prompt prefix; injecting `runtime.*` into a prefix breaks the prompt cache on every release.
+- Cache-hit envelope: when a CodeLens tool reuses an analysis artifact, the response carries `data.cache_hit_tier` (`"exact" | "warm" | "cold"`) and the routing hint distinguishes `CachedExact` / `CachedWarm` / `Cached` (legacy alias). Hosts should treat `CachedExact` and `CachedWarm` as zero-cost to call again; `Cached` and `Sync` may be re-evaluated by the host's own routing.


### PR DESCRIPTION
## Summary

AGENTS.md를 passive routing-overlay 노트에서 **active cost-routing layer**로 승격. 어떤 agent class가 어떤 task class를 담당하는지 (Haiku explorer / Sonnet builder / Opus evaluator) 명시하고, 이번 세션에서 관찰된 anti-routing 패턴 (mid-Task builder dispatch, model swap, nested subagents)과 cost-safe env 가정을 표면화.

P0-1 (#273)에서 ship된 `cache_hit_tier` envelope과 P0-2 (#274)에서 ship된 `surface_generation.runtime` split을 **Surface response cache hygiene** 섹션에서 참조 — 호스트가 어느 영역을 prompt prefix로 안전하게 흡수할 수 있는지 명시.

## Changes

- `AGENTS.md` 끝에 `## Agent Cost Routing` 섹션 추가
  - Task class × Model/agent × Why 매트릭스 (5개 룰)
  - Anti-routing (3개 — 인라인 우선, sub-subagent 금지, model swap 금지)
  - Cost-safe env 변수 (`ENABLE_PROMPT_CACHING_1H`, `CLAUDE_CODE_FORK_SUBAGENT`, `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`)
  - Surface response cache hygiene 참조

## Why

GitHub Codex bot 자동 review가 #273, #274의 backward-compat 주장을 정확히 검토했고 (P2 finding 2건 fix push 완료), 이 PR은 그 cache hygiene 정책의 **외부 호스트 컨트랙트 문서화**. 호스트가 prefix-stable 영역만 흡수하도록 의도를 명문화.

또한 2026-05 dogfood 분석에서 builder dispatch가 status:completed 거짓 보고로 통제 불능 발생 사례 (`feedback_inline_over_background_dispatch.md`)를 anti-routing 룰로 박아 동일 회귀 차단.

## Compatibility

문서-only 변경. 코드/API 영향 없음. CodeLens managed marker (`<!-- CODELENS_HOST_ROUTING:BEGIN/END -->`) 외부에 추가되어 `surface-manifest.py` round-trip 안전.

## Test plan

- [x] AGENTS.md repo-local convention 준수 (markers 외부 추가)
- [x] 코드 변경 없음 (cargo check 불필요)

## Related

- #273 — `cache_hit_tier` envelope (Surface response cache hygiene 참조 대상)
- #274 — `surface_generation.runtime` split (동상)

🤖 Generated with [Claude Code](https://claude.com/claude-code)