### PR TITLE
refactor(coordination): single-source DEFAULT_COORDINATION_TTL_SECS

### DIFF
--- a/crates/codelens-mcp/src/agent_coordination.rs
+++ b/crates/codelens-mcp/src/agent_coordination.rs
@@ -1,16 +1,18 @@
 use anyhow::Context;
-use rusqlite::{Connection, OptionalExtension, params};
+use rusqlite::{params, Connection, OptionalExtension};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
 use crate::util::now_ms;
 
-const DEFAULT_COORDINATION_TTL_SECS: u64 = 5 * 60;
+/// Default TTL for coordination claims/leases when callers do not specify one.
+/// Single source of truth — shared with `state::coordination` to avoid drift.
+pub(crate) const DEFAULT_COORDINATION_TTL_SECS: u64 = 5 * 60;
 const MAX_COORDINATION_TTL_SECS: u64 = 60 * 60;
 const COORDINATION_DB_FILENAME: &str = "coordination.db";
 

--- a/crates/codelens-mcp/src/state/coordination.rs
+++ b/crates/codelens-mcp/src/state/coordination.rs
@@ -2,6 +2,7 @@ use serde_json::Value;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use crate::agent_coordination::DEFAULT_COORDINATION_TTL_SECS;
 use crate::error::CodeLensError;
 use crate::session_context::SessionRequestContext;
 
@@ -9,8 +10,6 @@ use super::{
     ActiveAgentEntry, AgentWorkEntry, AppState, CoordinationCounts, CoordinationLockStats,
     CoordinationSnapshot, FileClaimEntry,
 };
-
-const DEFAULT_COORDINATION_TTL_SECS: u64 = 5 * 60;
 
 fn resolve_coordination_session_id(
     session: &SessionRequestContext,


### PR DESCRIPTION
## Summary

Both `agent_coordination.rs` and `state/coordination.rs` independently defined `const DEFAULT_COORDINATION_TTL_SECS: u64 = 5 * 60`. A future change to TTL semantics in one would silently diverge from the other. This PR makes `agent_coordination` the single source of truth (`pub(crate)`) and imports the constant from `state::coordination`.

## Detected by

`mcp__codelens__cleanup_duplicate_logic` on `crates/codelens-mcp/src` (similarity 0.93). CodeLens-on-CodeLens dogfood. The same scan surfaced 4 more dedup candidates filed as #277, #278, #279, #280.

## Changes

- `crates/codelens-mcp/src/agent_coordination.rs:13` — promoted `DEFAULT_COORDINATION_TTL_SECS` to `pub(crate)` with a one-line invariant doc.
- `crates/codelens-mcp/src/state/coordination.rs:13` — replaced local `const` with `use crate::agent_coordination::DEFAULT_COORDINATION_TTL_SECS;`.

Net: +6 / -5.

## Out of scope (deliberate)

The `lock_stats` ↔ `coordination_lock_stats` pair (similarity 0.94) is left as a follow-up. The two functions live on different ownership boundaries (DB-direct vs `AppState` wrapper), so a clean merge needs a small refactor of the lock-stat aggregation contract — separate from this constant-dedup change.

## Test plan

- [x] `cargo test -p codelens-mcp --bin codelens-mcp` (668 passed)
- [x] `cargo check -p codelens-mcp`

## Closes

#276

🤖 Generated with [Claude Code](https://claude.com/claude-code)