### PR TITLE
refactor(inspect): collapse text/JSON variant pairs in cli/host/inspect/text_policy

### DIFF
--- a/crates/codelens-mcp/src/cli/host/inspect/text_policy.rs
+++ b/crates/codelens-mcp/src/cli/host/inspect/text_policy.rs
@@ -24,217 +24,132 @@ fn extract_managed_text_block(text: &str) -> Option<String> {
     Some(text[start..end].to_owned())
 }
 
-pub(super) fn inspect_json_config_entry(path: &Path, template: &Value) -> String {
-    let display = path.display();
+/// Single source of truth for `inspect_*` results — `(status_slug, message)`.
+/// The text and JSON wrappers below format this tuple differently but never
+/// disagree on the underlying classification.
+type InspectVerdict = (&'static str, &'static str);
+
+fn classify_json_config_entry(path: &Path, template: &Value) -> InspectVerdict {
     let Ok(content) = fs::read_to_string(path) else {
-        return format!("- {display} [json]: missing");
+        return ("missing", "missing");
     };
     let Ok(payload) = serde_json::from_str::<Value>(&content) else {
-        return format!("- {display} [json]: present but invalid JSON");
+        return ("invalid_json", "present but invalid JSON");
     };
     let Some((parent_path, key)) = parse_json_route_from_template(template) else {
-        return format!("- {display} [json]: present but manual review required");
+        return (
+            "manual_review_required",
+            "present but manual review required",
+        );
     };
     let Some(actual) = get_json_key(&payload, &parent_path, &key) else {
-        return format!("- {display} [json]: present but missing CodeLens entry");
+        return (
+            "missing_codelens_entry",
+            "present but missing CodeLens entry",
+        );
     };
     let expected = get_json_key(template, &parent_path, &key);
     if expected.is_some_and(|value| value == actual) {
-        format!("- {display} [json]: attached (exact CodeLens entry)")
+        ("attached_exact", "attached (exact CodeLens entry)")
     } else {
-        format!("- {display} [json]: attached (customized CodeLens entry)")
+        (
+            "attached_customized",
+            "attached (customized CodeLens entry)",
+        )
     }
 }
 
+pub(super) fn inspect_json_config_entry(path: &Path, template: &Value) -> String {
+    let (_, message) = classify_json_config_entry(path, template);
+    format!("- {} [json]: {}", path.display(), message)
+}
+
 pub(super) fn inspect_json_config_entry_json(path: &Path, template: &Value) -> Value {
-    let path_text = path.display().to_string();
+    let (status, message) = classify_json_config_entry(path, template);
+    json!({
+        "path": path.display().to_string(),
+        "format": "json",
+        "status": status,
+        "message": message,
+    })
+}
+
+fn classify_toml_section(path: &Path, template: &str) -> InspectVerdict {
     let Ok(content) = fs::read_to_string(path) else {
-        return json!({
-            "path": path_text,
-            "format": "json",
-            "status": "missing",
-            "message": "missing",
-        });
+        return ("missing", "missing");
     };
-    let Ok(payload) = serde_json::from_str::<Value>(&content) else {
-        return json!({
-            "path": path_text,
-            "format": "json",
-            "status": "invalid_json",
-            "message": "present but invalid JSON",
-        });
+    let Some(section) = extract_toml_section_name(template) else {
+        return (
+            "manual_review_required",
+            "present but manual review required",
+        );
     };
-    let Some((parent_path, key)) = parse_json_route_from_template(template) else {
-        return json!({
-            "path": path_text,
-            "format": "json",
-            "status": "manual_review_required",
-            "message": "present but manual review required",
-        });
-    };
-    let Some(actual) = get_json_key(&payload, &parent_path, &key) else {
-        return json!({
-            "path": path_text,
-            "format": "json",
-            "status": "missing_codelens_entry",
-            "message": "present but missing CodeLens entry",
-        });
-    };
-    let expected = get_json_key(template, &parent_path, &key);
-    if expected.is_some_and(|value| value == actual) {
-        json!({
-            "path": path_text,
-            "format": "json",
-            "status": "attached_exact",
-            "message": "attached (exact CodeLens entry)",
-        })
+    if !has_toml_section(&content, &section) {
+        return (
+            "missing_codelens_section",
+            "present but missing CodeLens section",
+        );
+    }
+    let actual_section =
+        extract_toml_section_block(&content, &section).unwrap_or_else(|| content.clone());
+    if normalize_text_for_compare(&actual_section) == normalize_text_for_compare(template) {
+        ("attached_exact", "attached (exact generated file)")
     } else {
-        json!({
-            "path": path_text,
-            "format": "json",
-            "status": "attached_customized",
-            "message": "attached (customized CodeLens entry)",
-        })
+        ("attached_customized", "attached (CodeLens section present)")
     }
 }
 
 pub(super) fn inspect_toml_section(path: &Path, template: &str) -> String {
-    let display = path.display();
-    let Ok(content) = fs::read_to_string(path) else {
-        return format!("- {display} [toml]: missing");
-    };
-    let Some(section) = extract_toml_section_name(template) else {
-        return format!("- {display} [toml]: present but manual review required");
-    };
-    if !has_toml_section(&content, &section) {
-        return format!("- {display} [toml]: present but missing CodeLens section");
-    }
-    let actual_section =
-        extract_toml_section_block(&content, &section).unwrap_or_else(|| content.clone());
-    if normalize_text_for_compare(&actual_section) == normalize_text_for_compare(template) {
-        format!("- {display} [toml]: attached (exact generated file)")
-    } else {
-        format!("- {display} [toml]: attached (CodeLens section present)")
-    }
+    let (_, message) = classify_toml_section(path, template);
+    format!("- {} [toml]: {}", path.display(), message)
 }
 
 pub(super) fn inspect_toml_section_json(path: &Path, template: &str) -> Value {
-    let path_text = path.display().to_string();
+    let (status, message) = classify_toml_section(path, template);
+    json!({
+        "path": path.display().to_string(),
+        "format": "toml",
+        "status": status,
+        "message": message,
+    })
+}
+
+fn classify_text_policy_file(path: &Path, expected: &str) -> InspectVerdict {
     let Ok(content) = fs::read_to_string(path) else {
-        return json!({
-            "path": path_text,
-            "format": "toml",
-            "status": "missing",
-            "message": "missing",
-        });
+        return ("missing", "missing");
     };
-    let Some(section) = extract_toml_section_name(template) else {
-        return json!({
-            "path": path_text,
-            "format": "toml",
-            "status": "manual_review_required",
-            "message": "present but manual review required",
-        });
-    };
-    if !has_toml_section(&content, &section) {
-        return json!({
-            "path": path_text,
-            "format": "toml",
-            "status": "missing_codelens_section",
-            "message": "present but missing CodeLens section",
-        });
+    if normalize_text_for_compare(&content) == normalize_text_for_compare(expected) {
+        return ("present_exact", "present (exact generated file)");
     }
-    let actual_section =
-        extract_toml_section_block(&content, &section).unwrap_or_else(|| content.clone());
-    if normalize_text_for_compare(&actual_section) == normalize_text_for_compare(template) {
-        json!({
-            "path": path_text,
-            "format": "toml",
-            "status": "attached_exact",
-            "message": "attached (exact generated file)",
-        })
-    } else {
-        json!({
-            "path": path_text,
-            "format": "toml",
-            "status": "attached_customized",
-            "message": "attached (CodeLens section present)",
-        })
+    if let Some(expected_block) = extract_managed_text_block(expected)
+        && let Some(actual_block) = extract_managed_text_block(&content)
+    {
+        if normalize_text_for_compare(&actual_block) == normalize_text_for_compare(&expected_block)
+        {
+            return ("present_exact", "present (exact managed block)");
+        }
+        return ("present_customized", "present (customized managed block)");
     }
+    if first_significant_template_line(expected).is_some_and(|line| content.contains(line)) {
+        return ("present_customized", "present (customized)");
+    }
+    (
+        "manual_review_required",
+        "present but manual review required",
+    )
 }
 
 pub(crate) fn inspect_text_policy_file(path: &Path, expected: &str, format: &str) -> String {
-    let display = path.display();
-    let Ok(content) = fs::read_to_string(path) else {
-        return format!("- {display} [{format}]: missing");
-    };
-    if normalize_text_for_compare(&content) == normalize_text_for_compare(expected) {
-        return format!("- {display} [{format}]: present (exact generated file)");
-    }
-    if let Some(expected_block) = extract_managed_text_block(expected)
-        && let Some(actual_block) = extract_managed_text_block(&content)
-    {
-        if normalize_text_for_compare(&actual_block) == normalize_text_for_compare(&expected_block)
-        {
-            return format!("- {display} [{format}]: present (exact managed block)");
-        }
-        return format!("- {display} [{format}]: present (customized managed block)");
-    }
-    if first_significant_template_line(expected).is_some_and(|line| content.contains(line)) {
-        return format!("- {display} [{format}]: present (customized)");
-    }
-    format!("- {display} [{format}]: present but manual review required")
+    let (_, message) = classify_text_policy_file(path, expected);
+    format!("- {} [{format}]: {}", path.display(), message)
 }
 
 pub(crate) fn inspect_text_policy_file_json(path: &Path, expected: &str, format: &str) -> Value {
-    let path_text = path.display().to_string();
-    let Ok(content) = fs::read_to_string(path) else {
-        return json!({
-            "path": path_text,
-            "format": format,
-            "status": "missing",
-            "message": "missing",
-        });
-    };
-    if normalize_text_for_compare(&content) == normalize_text_for_compare(expected) {
-        return json!({
-            "path": path_text,
-            "format": format,
-            "status": "present_exact",
-            "message": "present (exact generated file)",
-        });
-    }
-    if let Some(expected_block) = extract_managed_text_block(expected)
-        && let Some(actual_block) = extract_managed_text_block(&content)
-    {
-        if normalize_text_for_compare(&actual_block) == normalize_text_for_compare(&expected_block)
-        {
-            return json!({
-                "path": path_text,
-                "format": format,
-                "status": "present_exact",
-                "message": "present (exact managed block)",
-            });
-        }
-        return json!({
-            "path": path_text,
-            "format": format,
-            "status": "present_customized",
-            "message": "present (customized managed block)",
-        });
-    }
-    if first_significant_template_line(expected).is_some_and(|line| content.contains(line)) {
-        return json!({
-            "path": path_text,
-            "format": format,
-            "status": "present_customized",
-            "message": "present (customized)",
-        });
-    }
+    let (status, message) = classify_text_policy_file(path, expected);
     json!({
-        "path": path_text,
+        "path": path.display().to_string(),
         "format": format,
-        "status": "manual_review_required",
-        "message": "present but manual review required",
+        "status": status,
+        "message": message,
     })
 }


### PR DESCRIPTION
## Summary

Three pairs of \`inspect_*\` helpers (\`json_config_entry\`, \`toml_section\`, \`text_policy_file\`) duplicated the entire classification flow with output formatting as the only meaningful difference. Extract the classification into a single source of truth (\`classify_*\` returning \`(status_slug, message)\` tuple) and reduce the wrappers to format adapters.

## Result

- **Net: -85 LOC** (240 → 155, ~35% smaller)
- 3 \`classify_*\` helpers (single source of truth per inspect kind)
- 6 wrappers (3 text, 3 JSON) — pure format adapters
- One \`InspectVerdict = (&'static str, &'static str)\` type alias documents the contract

## Detected by + verified by

- \`mcp__codelens__cleanup_duplicate_logic\` flagged 5 pairs at similarity ≥ 0.94. Of those, \`extract_toml_section_name\` ↔ \`extract_toml_section_block\` was a false-positive (parser vs extractor). The remaining 3 inner inspect pairs are addressed here. The outer \`inspect_host_file\` ↔ \`inspect_host_file_json\` dispatcher pair (similarity 0.95) is intentionally left as a dispatcher in \`inspect.rs\` — collapsing it would coalesce a clean format-dispatch with the inner classification logic.
- \`mcp__codelens__verify_change_readiness\` (\`profile_hint=refactor-full\`) reported readiness: \`ready\` across all four verifiers (diagnostics / reference / test / mutation), 0 blockers, 20 related test targets near the change.

## Test plan

- [x] \`cargo check -p codelens-mcp\`
- [x] \`cargo test -p codelens-mcp --bin codelens-mcp\` — 677 passed
- [x] \`cargo test -p codelens-mcp --bin codelens-mcp inspect\` — \`inspect_text_policy_file_treats_exact_managed_block_as_present_exact\` and \`inspect_text_policy_file_treats_modified_managed_block_as_present_customized\` both PASS
- [x] \`cargo clippy --workspace -- -D warnings\`
- [x] \`cargo fmt --all -- --check\`

## Closes

#278

🤖 Generated with [Claude Code](https://claude.com/claude-code)