### PR TITLE
chore(install): strip xattrs + verify codesign for freshly built binary

### DIFF
--- a/scripts/install-http-daemons-launchd.sh
+++ b/scripts/install-http-daemons-launchd.sh
@@ -260,13 +260,29 @@ fi
 # redeploy from the dogfood loop comes back up cleanly. Best-effort:
 # `codesign` failure is logged but not fatal so non-Apple-tooled hosts
 # still complete the install.
-if [[ "$(uname)" == "Darwin" ]] && command -v codesign >/dev/null 2>&1; then
-	echo "==> Ad-hoc signing http binary (macOS Hardened Runtime)"
-	codesign -s - --force \
-		--preserve-metadata=identifier,entitlements,flags,runtime \
-		"$BIN_PATH" || {
-		echo "warning: codesign failed; daemons may be killed by Gatekeeper" >&2
-	}
+#
+# Issue #286: even after a clean ad-hoc sign, a `cp` from another volume
+# or a downloaded artifact can carry `com.apple.quarantine` xattrs that
+# trigger the same Gatekeeper rejection. Strip xattrs before signing so
+# this step is idempotent regardless of how the binary landed on disk.
+if [[ "$(uname)" == "Darwin" ]]; then
+	if command -v xattr >/dev/null 2>&1; then
+		xattr -cr "$BIN_PATH" 2>/dev/null || true
+	fi
+	if command -v codesign >/dev/null 2>&1; then
+		echo "==> Ad-hoc signing http binary (macOS Hardened Runtime)"
+		codesign -s - --force \
+			--preserve-metadata=identifier,entitlements,flags,runtime \
+			"$BIN_PATH" || {
+			echo "warning: codesign failed; daemons may be killed by Gatekeeper" >&2
+		}
+		# Verify the signature actually applied — a silent codesign failure
+		# (rare, but seen on partial Xcode installs) would still let the
+		# binary through to launchd where it dies with OS_REASON_CODESIGNING.
+		if ! codesign --verify --strict "$BIN_PATH" 2>/dev/null; then
+			echo "warning: codesign --verify failed for $BIN_PATH; daemons will likely fail to launch" >&2
+		fi
+	fi
 fi
 
 readonly_label="${LABEL_PREFIX}-readonly"


### PR DESCRIPTION
## Summary

Issue #238 added ad-hoc signing to fix \`OS_REASON_CODESIGNING\` daemon launch failures. Two edge cases still got past it:

1. \`com.apple.quarantine\` xattrs from \`cp\` across volumes survived the sign
2. \`codesign -s -\` could silently succeed but produce an unverifiable signature

Both would cause \`launchctl kickstart\` to leave the daemon in \`state = spawn scheduled\` with no live process — the exact symptom the dogfood cycle hit on 2026-05-10.

## Changes

\`scripts/install-http-daemons-launchd.sh\`:
- Add \`xattr -cr\` before \`codesign\` (best-effort, idempotent)
- Add \`codesign --verify --strict\` after, log a warning if verification fails

## Test plan

- [x] \`bash -n scripts/install-http-daemons-launchd.sh\` — syntax OK
- [x] \`bash scripts/install-http-daemons-launchd.sh . --no-build --print-only\` — successfully signs and prints plists, replacing existing signature
- [x] Manual reproduction of the original failure mode resolved by the same xattr + codesign sequence (verified during this dogfood cycle on 2026-05-10)

## Closes

#286

🤖 Generated with [Claude Code](https://claude.com/claude-code)