### PR TITLE
feat(scip): propagate end_line for precise body slicing (#179)

### DIFF
--- a/crates/codelens-engine/src/ir.rs
+++ b/crates/codelens-engine/src/ir.rs
@@ -248,6 +248,13 @@ pub struct SearchCandidate {
     pub kind: String,
     pub file_path: String,
     pub line: usize,
+    /// Inclusive end line for the underlying definition occurrence, when the
+    /// backend has it. Populated by the SCIP backend from the occurrence
+    /// range so `tools/symbols/handlers.rs` can slice the body exactly
+    /// instead of falling back to the 50-line heuristic. Other backends
+    /// (tree-sitter, embedding) leave this `None`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end_line: Option<usize>,
     pub signature: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name_path: Option<String>,
@@ -264,6 +271,7 @@ impl From<crate::search::SearchResult> for SearchCandidate {
             kind: r.kind,
             file_path: r.file,
             line: r.line,
+            end_line: None,
             signature: r.signature,
             name_path: Some(r.name_path),
             body: None,
@@ -280,6 +288,7 @@ impl From<crate::embedding_store::ScoredChunk> for SearchCandidate {
             kind: c.kind,
             file_path: c.file_path,
             line: c.line,
+            end_line: None,
             signature: c.signature,
             name_path: Some(c.name_path),
             body: None,

--- a/crates/codelens-engine/src/scip_backend.rs
+++ b/crates/codelens-engine/src/scip_backend.rs
@@ -113,6 +113,40 @@ impl ScipBackend {
         }
     }
 
+    /// Estimate the inclusive last line of a definition's body.
+    ///
+    /// SCIP records occurrence ranges that cover the symbol identifier
+    /// (e.g. the function name), not the body. Most indexers emit a
+    /// single-line range there, so we use the same enclosing-scope
+    /// heuristic as `find_callees`: the body extends until just before
+    /// the next definition occurrence in the same document. If no
+    /// following definition exists, returns `None` — the MCP layer falls
+    /// back to its 50-line slice. If the occurrence itself already spans
+    /// multiple lines (rare; rust-analyzer's macro-expanded items can do
+    /// this), we honor that span when it exceeds the next-def estimate.
+    fn body_end_line(
+        doc: &scip_types::Document,
+        start_line: usize,
+        occ_end_line: usize,
+    ) -> Option<usize> {
+        let mut sibling_starts: Vec<usize> = doc
+            .occurrences
+            .iter()
+            .filter(|occ| Self::is_definition(occ))
+            .map(|occ| Self::parse_range(occ).0)
+            .filter(|line| *line > start_line)
+            .collect();
+        sibling_starts.sort_unstable();
+        let next_def = sibling_starts.first().copied();
+        let sibling_estimate = next_def.map(|n| n.saturating_sub(1));
+        match (sibling_estimate, occ_end_line) {
+            (Some(est), occ) if occ > est => Some(occ),
+            (Some(est), _) if est > start_line => Some(est),
+            (None, occ) if occ > start_line => Some(occ),
+            _ => None,
+        }
+    }
+
     /// Find callees of `function_name` defined in `file_path` using SCIP occurrences.
     ///
     /// Strategy: SCIP does not directly model "function body extent", so we
@@ -335,7 +369,7 @@ impl PreciseBackend for ScipBackend {
             for (path, doc) in &self.documents {
                 for occ in &doc.occurrences {
                     if &occ.symbol == target && Self::is_definition(occ) {
-                        let (line, _, _, _) = Self::parse_range(occ);
+                        let (line, _, occ_end_line, _) = Self::parse_range(occ);
                         let short = Self::short_name(&occ.symbol);
                         // Issue #245: previously `signature` was filled
                         // from `SymbolInformation.documentation.first()`,
@@ -351,6 +385,7 @@ impl PreciseBackend for ScipBackend {
                             kind: "symbol".to_owned(),
                             file_path: path.clone(),
                             line,
+                            end_line: Self::body_end_line(doc, line, occ_end_line),
                             signature: String::new(),
                             name_path: Some(occ.symbol.clone()),
                             body: None,
@@ -367,12 +402,13 @@ impl PreciseBackend for ScipBackend {
             for (path, doc) in &self.documents {
                 for occ in &doc.occurrences {
                     if Self::is_definition(occ) && Self::short_name(&occ.symbol) == symbol {
-                        let (line, _, _, _) = Self::parse_range(occ);
+                        let (line, _, occ_end_line, _) = Self::parse_range(occ);
                         results.push(SearchCandidate {
                             name: symbol.to_owned(),
                             kind: "symbol".to_owned(),
                             file_path: path.clone(),
                             line,
+                            end_line: Self::body_end_line(doc, line, occ_end_line),
                             signature: String::new(),
                             name_path: Some(occ.symbol.clone()),
                             body: None,
@@ -411,6 +447,7 @@ impl PreciseBackend for ScipBackend {
                             },
                             file_path: path.clone(),
                             line,
+                            end_line: None,
                             signature: String::new(),
                             name_path: Some(occ.symbol.clone()),
                             body: None,
@@ -433,6 +470,7 @@ impl PreciseBackend for ScipBackend {
                             kind: "reference".to_owned(),
                             file_path: path.clone(),
                             line,
+                            end_line: None,
                             signature: String::new(),
                             name_path: Some(occ.symbol.clone()),
                             body: None,
@@ -647,7 +685,36 @@ mod tests {
         assert_eq!(defs[0].name, "MyStruct");
         assert_eq!(defs[0].file_path, "src/main.rs");
         assert_eq!(defs[0].line, 10);
+        // No sibling definition follows in src/main.rs and the
+        // occurrence range is single-line, so end_line stays None.
+        // Issue #179: the MCP layer must fall back to the 50-line
+        // heuristic in that case.
+        assert_eq!(defs[0].end_line, None);
         assert!(matches!(defs[0].source, IntelligenceSource::Scip));
+    }
+
+    /// Issue #179: when a same-document sibling definition follows the
+    /// queried symbol, `find_definitions` reports an `end_line` so the
+    /// MCP layer can slice the body precisely instead of falling back
+    /// to the 50-line heuristic.
+    #[test]
+    fn test_find_definitions_end_line_from_sibling() {
+        let idx = build_callees_fixture();
+        let file = write_index_to_file(&idx);
+        let backend = ScipBackend::load(file.path()).unwrap();
+
+        let defs = backend
+            .find_definitions(
+                "handle_request",
+                "crates/codelens-mcp/src/server/router.rs",
+                10,
+            )
+            .unwrap();
+        assert_eq!(defs.len(), 1);
+        assert_eq!(defs[0].line, 10);
+        // Next definition (`other_fn`) starts at line 25, so the body
+        // body extends through line 24 inclusive.
+        assert_eq!(defs[0].end_line, Some(24));
     }
 
     #[test]

--- a/crates/codelens-mcp/src/integration_tests/readonly.rs
+++ b/crates/codelens-mcp/src/integration_tests/readonly.rs
@@ -126,7 +126,14 @@ fn find_symbol_with_include_body_returns_body_via_scip_heuristic() {
         "SCIP heuristic should populate body content"
     );
     assert_eq!(first["body_source"], json!("scip_line_range_slice"));
-    assert_eq!(first["body_truncation"], json!("heuristic_50_lines"));
+    // #179: when the SCIP backend can pin the end line (next sibling
+    // definition exists in the same document), the slice is precise.
+    // Otherwise the 50-line heuristic still applies.
+    let truncation = first["body_truncation"].as_str().expect("body_truncation");
+    assert!(
+        matches!(truncation, "scip_precise_range" | "heuristic_50_lines"),
+        "body_truncation must be scip_precise_range or heuristic_50_lines, got {truncation:?}"
+    );
 }
 
 // #183: distinguish "file is empty" from "file not in index" so callers

--- a/crates/codelens-mcp/src/tools/symbols/handlers.rs
+++ b/crates/codelens-mcp/src/tools/symbols/handlers.rs
@@ -70,6 +70,38 @@ fn heuristic_body_slice(state: &AppState, file_path: &str, line: usize) -> Optio
     .filter(|body| !body.is_empty())
 }
 
+/// Issue #179: when the SCIP backend resolved an enclosing-scope end
+/// (the next sibling definition in the same document), slice exactly
+/// that range. `end_line` is inclusive; `read_file` slices
+/// `lines[start..end]` so we add 1. Falls back to the 50-line
+/// heuristic when no end was reported or when the slice came back
+/// empty.
+#[cfg(feature = "scip-backend")]
+fn scip_body_slice(
+    state: &AppState,
+    file_path: &str,
+    start_line: usize,
+    end_line: Option<usize>,
+) -> Option<(String, &'static str)> {
+    if let Some(end) = end_line
+        && end > start_line
+    {
+        let body = read_file(
+            &state.project(),
+            file_path,
+            Some(start_line),
+            Some(end.saturating_add(1)),
+        )
+        .ok()
+        .map(|file| file.content)
+        .filter(|body| !body.is_empty());
+        if let Some(body) = body {
+            return Some((body, "scip_precise_range"));
+        }
+    }
+    heuristic_body_slice(state, file_path, start_line).map(|body| (body, "heuristic_50_lines"))
+}
+
 /// Issue #235 (sub-fix B): when SCIP returns a definition occurrence with
 /// neither `d.signature` nor a usable hover string, fall back to reading
 /// the single source line at the SCIP-reported position. Empty trimmed
@@ -480,11 +512,12 @@ pub fn find_symbol(state: &AppState, arguments: &Value) -> ToolResult {
                         sym["documentation"] = serde_json::Value::String(doc);
                     }
                     if include_body
-                        && let Some(body) = heuristic_body_slice(state, &d.file_path, d.line)
+                        && let Some((body, truncation)) =
+                            scip_body_slice(state, &d.file_path, d.line, d.end_line)
                     {
                         sym["body"] = Value::String(body);
                         sym["body_source"] = Value::String("scip_line_range_slice".to_owned());
-                        sym["body_truncation"] = Value::String("heuristic_50_lines".to_owned());
+                        sym["body_truncation"] = Value::String(truncation.to_owned());
                     }
                     sym
                 })


### PR DESCRIPTION
## Summary

#172 후속. SCIP backend가 occurrence range + same-document next-def heuristic으로 `end_line` 추정 → MCP layer가 50줄 heuristic 대신 정확한 body slice.

## 변경

| 계층 | 변경 |
| ---- | ---- |
| engine `SearchCandidate` | `end_line: Option<usize>` 필드 추가 (None일 때 serde skip) |
| engine `ScipBackend::body_end_line` | next-def 패턴 (mirrors `find_callees`) + occurrence end_line fallback |
| engine `find_definitions` 4 callsites | end_line 채움 |
| engine 2× `From` impl | None 초기화 |
| mcp `scip_body_slice` | `d.end_line` 사용, fallback to heuristic |
| mcp `body_truncation` 메타 | `\"scip_precise_range\"` 또는 `\"heuristic_50_lines\"` |

## body_end_line 우선순위

1. same-document 내 next-sibling def 가 있으면 → `next.start - 1`
2. occurrence range가 multi-line이면 (예: macro-expanded items) → `occ.end_line`
3. 둘 다 단일 라인이면 → `None` (caller가 heuristic으로 폴백)

## Test plan

- [x] `test_find_definitions_end_line_from_sibling` — build_callees_fixture의 handle_request@10 + other_fn@25 ⇒ `end_line == Some(24)`
- [x] `test_find_definitions` — 기존 single-def fixture ⇒ `end_line == None` (회귀 가드)
- [x] `find_symbol_with_include_body_returns_body_via_scip_heuristic` — assertion 완화 (\`scip_precise_range\` | \`heuristic_50_lines\` 둘 다 허용, ignored 테스트지만 fixture 갱신 시 활용)
- [x] `cargo clippy --workspace --features scip-backend -- -D warnings` clean
- [x] `cargo clippy --workspace --no-default-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

## Diff stats

```
crates/codelens-engine/src/ir.rs                   |   9 +++
crates/codelens-engine/src/scip_backend.rs         |  71 +++++++++++++++++++++-
crates/codelens-mcp/src/integration_tests/readonly.rs |   9 ++-
crates/codelens-mcp/src/tools/symbols/handlers.rs  |  37 ++++++++++-
4 files changed, 121 insertions(+), 5 deletions(-)
```

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)