### PR TITLE
refactor(tools): extract semantic_retriever as cross-cutting seam (arch PR A)

### DIFF
--- a/crates/codelens-mcp/src/dispatch/table.rs
+++ b/crates/codelens-mcp/src/dispatch/table.rs
@@ -90,8 +90,12 @@ fn semantic_search_handler(state: &AppState, arguments: &serde_json::Value) -> T
         .iter()
         .map(|result| format!("{}:{}", result.file, result.name))
         .collect();
-    let mut results =
-        crate::tools::symbols::semantic_results_for_query(state, query, candidate_limit, false);
+    let mut results = crate::tools::semantic_retriever::semantic_results_for_query(
+        state,
+        query,
+        candidate_limit,
+        false,
+    );
 
     // Apply structural boost: +0.06 for results that also appear in structural candidates
     for result in &mut results {

--- a/crates/codelens-mcp/src/tools/mod.rs
+++ b/crates/codelens-mcp/src/tools/mod.rs
@@ -16,6 +16,7 @@ pub mod reports;
 mod scip_health;
 pub(crate) mod semantic_edit;
 pub(crate) mod semantic_edit_args;
+pub(crate) mod semantic_retriever;
 pub mod session;
 mod suggestions;
 pub mod symbols;

--- a/crates/codelens-mcp/src/tools/reports/impact_reports/boundary.rs
+++ b/crates/codelens-mcp/src/tools/reports/impact_reports/boundary.rs
@@ -2,7 +2,7 @@ use crate::AppState;
 use crate::tool_runtime::{ToolResult, required_string};
 use crate::tools::report_contract::make_handle_response;
 use crate::tools::report_utils::{stable_cache_key, strings_from_array};
-use crate::tools::symbols::{semantic_results_for_query, semantic_status};
+use crate::tools::semantic_retriever::{semantic_results_for_query, semantic_status};
 use codelens_engine::search::{SEMANTIC_COUPLING_THRESHOLD, SEMANTIC_NEW_RESULT_THRESHOLD};
 use codelens_engine::{find_circular_dependencies, get_change_coupling};
 use serde_json::{Value, json};

--- a/crates/codelens-mcp/src/tools/reports/impact_reports/impact.rs
+++ b/crates/codelens-mcp/src/tools/reports/impact_reports/impact.rs
@@ -4,7 +4,7 @@ use crate::tools::report_contract::make_handle_response;
 use crate::tools::report_utils::{
     collect_file_mtime_digests, stable_cache_key, stable_cache_key_with_extras, strings_from_array,
 };
-use crate::tools::symbols::{semantic_results_for_query, semantic_status};
+use crate::tools::semantic_retriever::{semantic_results_for_query, semantic_status};
 use codelens_engine::search::SEMANTIC_COUPLING_THRESHOLD;
 use serde_json::{Value, json};
 use std::collections::BTreeMap;

--- a/crates/codelens-mcp/src/tools/reports/impact_reports/refactor.rs
+++ b/crates/codelens-mcp/src/tools/reports/impact_reports/refactor.rs
@@ -2,7 +2,7 @@ use crate::AppState;
 use crate::tool_runtime::ToolResult;
 use crate::tools::report_contract::make_handle_response;
 use crate::tools::report_utils::{stable_cache_key, strings_from_array};
-use crate::tools::symbols::{semantic_results_for_query, semantic_status};
+use crate::tools::semantic_retriever::{semantic_results_for_query, semantic_status};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
 

--- a/crates/codelens-mcp/src/tools/semantic_retriever.rs
+++ b/crates/codelens-mcp/src/tools/semantic_retriever.rs
@@ -1,0 +1,148 @@
+//! Semantic retrieval seam — the deep module behind every tool that
+//! asks the embedding index for symbol matches.
+//!
+//! Two responsibilities live here:
+//!   - `semantic_status` reports whether the embedding engine is
+//!     loaded, indexed, and aligned with the configured model.
+//!   - `semantic_results_for_query` runs a single retrieval pass
+//!     (analyse + embed + rerank) and returns the top-N matches.
+//!
+//! Both functions are consumed by the symbol-query path inside
+//! `tools/symbols/` and by the impact-report family in
+//! `tools/reports/impact_reports/`, so they cannot live inside
+//! either module. Pulling them up to `tools::semantic_retriever`
+//! establishes the seam where future callers compose semantic
+//! retrieval without re-exporting a symbol-shaped facade.
+//!
+//! Behaviour is feature-gated on `semantic`; when the feature is
+//! disabled both entry points degrade gracefully (status reports
+//! `not_compiled`, retrieval returns an empty `Vec`). The handler
+//! signature stays stable so callers do not branch on the cfg flag.
+
+use super::AppState;
+use codelens_engine::SemanticMatch;
+use serde_json::{Value, json};
+
+#[cfg(feature = "semantic")]
+use super::query_analysis::{analyze_retrieval_query, semantic_query_for_embedding_search};
+
+#[cfg(feature = "semantic")]
+pub(crate) fn semantic_status(state: &AppState) -> Value {
+    let configured_model = codelens_engine::configured_embedding_model_name();
+    let guard = state.embedding_ref();
+    if let Some(engine) = guard.as_ref() {
+        let info = engine.index_info();
+        return if info.indexed_symbols > 0 {
+            json!({
+                "status": "ready",
+                "model": info.model_name,
+                "indexed_symbols": info.indexed_symbols,
+                "loaded": true,
+            })
+        } else {
+            json!({
+                "status": "unavailable",
+                "model": info.model_name,
+                "indexed_symbols": info.indexed_symbols,
+                "loaded": true,
+                "reason": "embedding index is empty; call index_embeddings",
+            })
+        };
+    }
+    drop(guard);
+
+    match codelens_engine::EmbeddingEngine::inspect_existing_index(&state.project())
+        .ok()
+        .flatten()
+    {
+        Some(info) if info.model_name == configured_model && info.indexed_symbols > 0 => json!({
+            "status": "ready",
+            "model": info.model_name,
+            "indexed_symbols": info.indexed_symbols,
+            "loaded": false,
+        }),
+        Some(info) if info.model_name != configured_model => json!({
+            "status": "unavailable",
+            "model": info.model_name,
+            "expected_model": configured_model,
+            "indexed_symbols": info.indexed_symbols,
+            "loaded": false,
+            "reason": "embedding index model mismatch; call index_embeddings to rebuild",
+        }),
+        Some(info) => json!({
+            "status": "unavailable",
+            "model": info.model_name,
+            "indexed_symbols": info.indexed_symbols,
+            "loaded": false,
+            "reason": "embedding index is empty; call index_embeddings",
+        }),
+        None => json!({
+            "status": "unavailable",
+            "model": configured_model,
+            "loaded": false,
+            "reason": "embedding index missing; call index_embeddings",
+        }),
+    }
+}
+
+#[cfg(not(feature = "semantic"))]
+pub(crate) fn semantic_status(_state: &AppState) -> Value {
+    json!({
+        "status": "not_compiled",
+        "model": "disabled",
+        "indexed_symbols": 0,
+        "loaded": false,
+        "reason": "semantic feature not compiled into this binary",
+    })
+}
+
+#[cfg(feature = "semantic")]
+pub(crate) fn semantic_results_for_query(
+    state: &AppState,
+    query: &str,
+    limit: usize,
+    disable_semantic: bool,
+) -> Vec<SemanticMatch> {
+    if disable_semantic {
+        return Vec::new();
+    }
+
+    let query_analysis = analyze_retrieval_query(query);
+
+    // Skip embedding lookup for short single-word identifiers where FTS is more accurate
+    if query_analysis.prefer_lexical_only && query_analysis.original_query.len() <= 40 {
+        return Vec::new();
+    }
+
+    if query_analysis.semantic_query.is_empty() {
+        return Vec::new();
+    }
+
+    let guard = state.embedding_engine();
+    if let Some(engine) = guard.as_ref()
+        && engine.is_indexed()
+    {
+        let candidate_limit = limit.saturating_mul(4).clamp(limit, 80);
+        let search_query =
+            semantic_query_for_embedding_search(&query_analysis, Some(state.project().as_path()));
+        let results = engine
+            .search(&search_query, candidate_limit)
+            .unwrap_or_default();
+        return super::query_analysis::rerank_semantic_matches(
+            &query_analysis.semantic_query,
+            results,
+            limit,
+        );
+    }
+    Vec::new()
+}
+
+#[cfg(not(feature = "semantic"))]
+pub(crate) fn semantic_results_for_query(
+    _state: &AppState,
+    _query: &str,
+    _limit: usize,
+    _disable_semantic: bool,
+) -> Vec<SemanticMatch> {
+    Vec::new()
+}

--- a/crates/codelens-mcp/src/tools/symbols/analyzer.rs
+++ b/crates/codelens-mcp/src/tools/symbols/analyzer.rs
@@ -1,133 +1,13 @@
 use super::super::AppState;
-#[cfg(feature = "semantic")]
-use super::super::query_analysis::analyze_retrieval_query;
 use super::fusion::rank_fusion_policy;
 use crate::symbol_retrieval::ScoredSymbol;
 use codelens_engine::{RankedContextResult, SemanticMatch};
 use serde_json::{Value, json};
 
-#[cfg(feature = "semantic")]
-use super::super::query_analysis::semantic_query_for_embedding_search;
-
-#[cfg(feature = "semantic")]
-pub(crate) fn semantic_status(state: &AppState) -> Value {
-    let configured_model = codelens_engine::configured_embedding_model_name();
-    let guard = state.embedding_ref();
-    if let Some(engine) = guard.as_ref() {
-        let info = engine.index_info();
-        return if info.indexed_symbols > 0 {
-            json!({
-                "status": "ready",
-                "model": info.model_name,
-                "indexed_symbols": info.indexed_symbols,
-                "loaded": true,
-            })
-        } else {
-            json!({
-                "status": "unavailable",
-                "model": info.model_name,
-                "indexed_symbols": info.indexed_symbols,
-                "loaded": true,
-                "reason": "embedding index is empty; call index_embeddings",
-            })
-        };
-    }
-    drop(guard);
-
-    match codelens_engine::EmbeddingEngine::inspect_existing_index(&state.project())
-        .ok()
-        .flatten()
-    {
-        Some(info) if info.model_name == configured_model && info.indexed_symbols > 0 => json!({
-            "status": "ready",
-            "model": info.model_name,
-            "indexed_symbols": info.indexed_symbols,
-            "loaded": false,
-        }),
-        Some(info) if info.model_name != configured_model => json!({
-            "status": "unavailable",
-            "model": info.model_name,
-            "expected_model": configured_model,
-            "indexed_symbols": info.indexed_symbols,
-            "loaded": false,
-            "reason": "embedding index model mismatch; call index_embeddings to rebuild",
-        }),
-        Some(info) => json!({
-            "status": "unavailable",
-            "model": info.model_name,
-            "indexed_symbols": info.indexed_symbols,
-            "loaded": false,
-            "reason": "embedding index is empty; call index_embeddings",
-        }),
-        None => json!({
-            "status": "unavailable",
-            "model": configured_model,
-            "loaded": false,
-            "reason": "embedding index missing; call index_embeddings",
-        }),
-    }
-}
-
-#[cfg(not(feature = "semantic"))]
-pub(crate) fn semantic_status(_state: &AppState) -> Value {
-    json!({
-        "status": "not_compiled",
-        "model": "disabled",
-        "indexed_symbols": 0,
-        "loaded": false,
-        "reason": "semantic feature not compiled into this binary",
-    })
-}
-#[cfg(feature = "semantic")]
-pub(crate) fn semantic_results_for_query(
-    state: &AppState,
-    query: &str,
-    limit: usize,
-    disable_semantic: bool,
-) -> Vec<SemanticMatch> {
-    if disable_semantic {
-        return Vec::new();
-    }
-
-    let query_analysis = analyze_retrieval_query(query);
-
-    // Skip embedding lookup for short single-word identifiers where FTS is more accurate
-    if query_analysis.prefer_lexical_only && query_analysis.original_query.len() <= 40 {
-        return Vec::new();
-    }
-
-    if query_analysis.semantic_query.is_empty() {
-        return Vec::new();
-    }
-
-    let guard = state.embedding_engine();
-    if let Some(engine) = guard.as_ref()
-        && engine.is_indexed()
-    {
-        let candidate_limit = limit.saturating_mul(4).clamp(limit, 80);
-        let search_query =
-            semantic_query_for_embedding_search(&query_analysis, Some(state.project().as_path()));
-        let results = engine
-            .search(&search_query, candidate_limit)
-            .unwrap_or_default();
-        return crate::tools::query_analysis::rerank_semantic_matches(
-            &query_analysis.semantic_query,
-            results,
-            limit,
-        );
-    }
-    Vec::new()
-}
-
-#[cfg(not(feature = "semantic"))]
-pub(crate) fn semantic_results_for_query(
-    _state: &AppState,
-    _query: &str,
-    _limit: usize,
-    _disable_semantic: bool,
-) -> Vec<SemanticMatch> {
-    Vec::new()
-}
+// PR-A (#200/#268 follow-up architecture refactor): `semantic_status`
+// and `semantic_results_for_query` moved to `crate::tools::semantic_retriever`
+// so the impact-report family and dispatch table can consume the seam
+// without re-exporting a symbol-shaped facade.
 
 pub(super) fn semantic_scores_for_query(
     state: &AppState,
@@ -136,7 +16,12 @@ pub(super) fn semantic_scores_for_query(
     disable_semantic: bool,
 ) -> std::collections::HashMap<String, f64> {
     let mut scores = std::collections::HashMap::new();
-    for r in semantic_results_for_query(state, query, limit, disable_semantic) {
+    for r in crate::tools::semantic_retriever::semantic_results_for_query(
+        state,
+        query,
+        limit,
+        disable_semantic,
+    ) {
         if r.score > 0.05 {
             let key = format!("{}:{}", r.file_path, r.symbol_name);
             scores.insert(key, r.score);

--- a/crates/codelens-mcp/src/tools/symbols/handlers.rs
+++ b/crates/codelens-mcp/src/tools/symbols/handlers.rs
@@ -6,8 +6,7 @@ use super::super::{
 use super::{
     analyzer::{
         annotate_ranked_context_provenance, compact_semantic_evidence, compact_sparse_evidence,
-        merge_semantic_ranked_entries, merge_sparse_ranked_entries, semantic_results_for_query,
-        semantic_scores_for_query,
+        merge_semantic_ranked_entries, merge_sparse_ranked_entries, semantic_scores_for_query,
     },
     formatter::{compact_symbol_bodies, count_branches},
 };
@@ -15,6 +14,7 @@ use crate::error::CodeLensError;
 use crate::protocol::BackendKind;
 use crate::symbol_corpus::build_symbol_corpus;
 use crate::symbol_retrieval::{ScoredSymbol, search_symbols_bm25f, unique_query_terms};
+use crate::tools::semantic_retriever::semantic_results_for_query;
 use codelens_engine::{SymbolInfo, SymbolKind, read_file, search_symbols_hybrid_with_semantic};
 use serde_json::{Value, json};
 

--- a/crates/codelens-mcp/src/tools/symbols/mod.rs
+++ b/crates/codelens-mcp/src/tools/symbols/mod.rs
@@ -3,7 +3,6 @@ mod formatter;
 mod fusion;
 mod handlers;
 
-pub(crate) use analyzer::{semantic_results_for_query, semantic_status};
 pub use handlers::{
     bm25_symbol_search, find_symbol, flatten_symbols, get_complexity, get_ranked_context,
     get_symbols_overview, refresh_symbol_index, search_symbols_fuzzy,


### PR DESCRIPTION
## Summary

PR-A 시리즈 (5 PR 예정) 의 첫 단계. \`tools/symbols/analyzer.rs\` 안에 있던 두 함수 (\`semantic_status\`, \`semantic_results_for_query\`) 를 새 모듈 \`tools/semantic_retriever\` 로 추출. 행동 변경 없음 — pure 위치 이동.

## 동기

architectural friction 스캔 결과 (Candidate 5, SymbolQuery pipeline) 의 prep. \`semantic_results_for_query\` / \`semantic_status\` 는 두 부류 caller 가 사용 중:

1. \`tools/symbols/handlers.rs\` (symbol query 경로)
2. \`tools/reports/impact_reports/{boundary,impact,refactor}.rs\` + \`dispatch/table.rs\` (cross-cutting 직접 호출)

두 adapter 가 있다는 건 진정한 seam — 한 곳 (symbols/) 안에 두면 다른 caller 가 \`tools::symbols::*\` re-export 를 통해 incidental facade를 거쳐야 함. \`tools/scip_health\` 와 같은 cross-cutting 패턴으로 통일.

## 변경

| 파일 | 변경 |
| ---- | ---- |
| \`tools/semantic_retriever.rs\` | 신규. 두 함수 + cfg branches |
| \`tools/mod.rs\` | \`pub(crate) mod semantic_retriever;\` |
| \`tools/symbols/analyzer.rs\` | 두 함수 제거 (-130 LOC). 내부 \`semantic_scores_for_query\` 는 새 module 경유 |
| \`tools/symbols/mod.rs\` | \`pub(crate) use analyzer::{semantic_results_for_query, semantic_status};\` 제거 |
| \`tools/symbols/handlers.rs\` | use 경로 갱신 (\`super::analyzer\` → \`crate::tools::semantic_retriever\`) |
| \`tools/reports/impact_reports/{boundary,impact,refactor}.rs\` | use 경로 갱신 |
| \`dispatch/table.rs\` | 호출 경로 갱신 |

총 9 file, +170 / -133 LOC.

## Stage chain (planned)

- **PR-A (이 PR)** — semantic_retriever 추출 (seam 확립)
- PR-B — SymbolQueryPipeline skeleton + get_ranked_context
- PR-C — find_symbol pipeline 통과
- PR-D — get_symbols_overview pipeline 통과
- PR-E — stage visibility narrow + docs/architecture.md 갱신

각 PR self-contained + reversible.

## Test plan

- [x] \`cargo check --workspace --features semantic\` clean
- [x] \`cargo check --workspace --no-default-features\` clean
- [x] \`cargo clippy --workspace --features semantic -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean
- [x] 기존 7 symbols::tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)