### PR TITLE
refactor(arch): break symbol_query ↔ symbols::handlers cycle (PR-F)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,10 +23,12 @@ Three concepts that show up across files and require reading several to understa
 
 When changing symbol-query semantics:
 - Body of `run_ranked_context` / `run_find_symbol` / `run_symbols_overview` is in `tools/symbol_query/<tool>.rs`.
-- Cross-cutting retrieval seam is `tools/semantic_retriever.rs` (used both by the pipeline and the impact-report family).
+- Cross-cutting retrieval seams owned by the pipeline:
+  - `tools/semantic_retriever.rs` (dense ONNX semantic results) — used by the pipeline **and** the impact-report family.
+  - `tools/symbol_query/sparse_retriever.rs` (BM25F sparse hits, context-window-adaptive budget, `flatten_symbols` utility) — used by the pipeline **and** `symbols::handlers::{bm25_symbol_search, get_complexity}`.
 - Stage helpers (rank-fusion, SCIP signature/body slicing, body Jaccard, …) are file-private inside their `symbol_query/<tool>.rs` — do not promote to `pub(super)` casually; the seam exists so the pipeline owns these.
 
-`pub(crate)` helpers that span the pipeline and a non-pipeline handler (today: `sparse_symbol_hits_for_query`, `adapt_budget_to_context_window` — used by the pipeline + `bm25_symbol_search`) stay in `tools/symbols/handlers.rs`. That visibility is intentional, not a tightening target.
+Dependency direction is one-way: `symbols::handlers` → `symbol_query::*`. Never reach upward from the pipeline back into `symbols::handlers` — that was the cycle PR-F removed (`review_architecture` reported a 3-node loop `mod.rs → ranked_context.rs → handlers.rs`). If new sparse/retrieval helpers are needed, add them to `symbol_query/sparse_retriever.rs` (or a sibling sub-module).
 
 ## Feature Flag Matrix (build-time)
 

--- a/crates/codelens-mcp/src/tools/symbol_query/mod.rs
+++ b/crates/codelens-mcp/src/tools/symbol_query/mod.rs
@@ -25,6 +25,7 @@ use serde_json::Value;
 
 mod find_symbol;
 mod ranked_context;
+pub(crate) mod sparse_retriever;
 mod symbols_overview;
 
 pub(crate) use find_symbol::run_find_symbol;

--- a/crates/codelens-mcp/src/tools/symbol_query/ranked_context.rs
+++ b/crates/codelens-mcp/src/tools/symbol_query/ranked_context.rs
@@ -28,6 +28,7 @@
 //! the cross-cutting `semantic_retriever` out; PR-B (this PR) moves
 //! the rest of the ranked-context stages into a single deep module.
 
+use super::sparse_retriever::{adapt_budget_to_context_window, sparse_symbol_hits_for_query};
 use crate::AppState;
 use crate::error::CodeLensError;
 use crate::protocol::BackendKind;
@@ -40,9 +41,6 @@ use crate::tool_runtime::{
 };
 use crate::tools::query_analysis::analyze_retrieval_query;
 use crate::tools::semantic_retriever::semantic_results_for_query;
-use crate::tools::symbols::handlers::{
-    adapt_budget_to_context_window, sparse_symbol_hits_for_query,
-};
 use codelens_engine::{RankedContextResult, SemanticMatch};
 use serde_json::{Value, json};
 

--- a/crates/codelens-mcp/src/tools/symbol_query/sparse_retriever.rs
+++ b/crates/codelens-mcp/src/tools/symbol_query/sparse_retriever.rs
@@ -1,0 +1,126 @@
+//! Sparse retrieval helpers shared between the symbol-query pipeline
+//! and the legacy `bm25_symbol_search` / `get_complexity` handlers.
+//!
+//! Moved here from `tools/symbols/handlers.rs` to break the
+//! `symbol_query ↔ symbols` cycle reported by `review_architecture`:
+//! the pipeline used to import these helpers upward from
+//! `handlers.rs`, while `handlers.rs` re-entered the pipeline through
+//! its 3-line tool entries. The dependency now flows one way —
+//! `symbols::handlers` → `symbol_query::sparse_retriever` — so the
+//! pipeline owns its retrieval primitives.
+
+use crate::AppState;
+use crate::error::CodeLensError;
+use crate::symbol_corpus::build_symbol_corpus;
+use crate::symbol_retrieval::{ScoredSymbol, search_symbols_bm25f};
+use crate::tools::query_analysis::RetrievalQueryAnalysis;
+use codelens_engine::SymbolInfo;
+
+pub(crate) fn sparse_symbol_hits_for_query(
+    state: &AppState,
+    query_analysis: &RetrievalQueryAnalysis,
+    max_results: usize,
+    include_tests: bool,
+    include_generated: bool,
+    session: &crate::session_context::SessionRequestContext,
+) -> Result<Vec<ScoredSymbol>, CodeLensError> {
+    let mut all_symbols = Vec::new();
+    for path in state.symbol_index().indexed_file_paths()? {
+        if let Ok(symbols) = state.symbol_index().get_symbols_overview_cached(&path, 3) {
+            all_symbols.extend(flatten_symbols(&symbols));
+        }
+    }
+
+    let corpus = build_symbol_corpus(&all_symbols);
+    let mut scored = search_symbols_bm25f(
+        &corpus,
+        &query_analysis.expanded_query,
+        max_results.saturating_mul(3).max(max_results),
+        include_tests,
+        include_generated,
+    );
+
+    let recent_files = state.recent_file_paths_for_session(session);
+    if !recent_files.is_empty() {
+        for hit in &mut scored {
+            if recent_files
+                .iter()
+                .any(|path| hit.document.file_path.starts_with(path))
+            {
+                hit.score *= 1.08;
+            }
+        }
+        scored.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+    }
+    scored.truncate(max_results);
+    Ok(scored)
+}
+
+/// Scale a base token budget to the host's advertised model context window.
+///
+/// Returns the smaller of (base × multiplier) and a per-tier ceiling so a
+/// 1M-context host doesn't end up with a budget larger than reasonably
+/// retrievable evidence, while a 32K host doesn't get pushed over its head.
+pub(crate) fn adapt_budget_to_context_window(base: usize, context_window: usize) -> usize {
+    let (multiplier, cap) = match context_window {
+        n if n >= 1_000_000 => (4.0_f64, 131_072_usize),
+        n if n >= 200_000 => (2.0_f64, 65_536_usize),
+        n if n >= 32_000 => (1.0_f64, 32_768_usize),
+        _ => (0.5_f64, 16_384_usize),
+    };
+    ((base as f64 * multiplier).round() as usize).min(cap)
+}
+
+pub fn flatten_symbols(symbols: &[SymbolInfo]) -> Vec<SymbolInfo> {
+    let mut flat = Vec::new();
+    let mut stack = symbols.to_vec();
+    while let Some(mut symbol) = stack.pop() {
+        let children = std::mem::take(&mut symbol.children);
+        flat.push(symbol);
+        stack.extend(children);
+    }
+    flat
+}
+
+#[cfg(test)]
+mod adapt_budget_tests {
+    use super::adapt_budget_to_context_window;
+
+    #[test]
+    fn small_window_halves_budget_capped_at_16k() {
+        assert_eq!(adapt_budget_to_context_window(32_768, 8_000), 16_384);
+        assert_eq!(adapt_budget_to_context_window(8_000, 16_000), 4_000);
+    }
+
+    #[test]
+    fn standard_window_passes_base_capped_at_32k() {
+        assert_eq!(adapt_budget_to_context_window(16_384, 64_000), 16_384);
+        assert_eq!(adapt_budget_to_context_window(40_000, 64_000), 32_768);
+    }
+
+    #[test]
+    fn large_window_doubles_budget_capped_at_64k() {
+        assert_eq!(adapt_budget_to_context_window(16_384, 200_000), 32_768);
+        assert_eq!(adapt_budget_to_context_window(50_000, 200_000), 65_536);
+    }
+
+    #[test]
+    fn xl_window_quadruples_budget_capped_at_128k() {
+        assert_eq!(adapt_budget_to_context_window(16_384, 1_000_000), 65_536);
+        assert_eq!(adapt_budget_to_context_window(40_000, 1_000_000), 131_072);
+    }
+
+    #[test]
+    fn boundary_at_32k_uses_standard_tier() {
+        assert_eq!(adapt_budget_to_context_window(16_384, 32_000), 16_384);
+    }
+
+    #[test]
+    fn boundary_at_200k_uses_large_tier() {
+        assert_eq!(adapt_budget_to_context_window(16_384, 200_000), 32_768);
+    }
+}

--- a/crates/codelens-mcp/src/tools/symbols/handlers.rs
+++ b/crates/codelens-mcp/src/tools/symbols/handlers.rs
@@ -1,15 +1,13 @@
 use super::super::{
     AppState, ToolResult, optional_bool, optional_string, optional_usize,
-    query_analysis::{RetrievalQueryAnalysis, analyze_retrieval_query},
-    required_string, success_meta,
+    query_analysis::analyze_retrieval_query, required_string, success_meta,
 };
 use super::{analyzer::semantic_scores_for_query, formatter::count_branches};
-use crate::error::CodeLensError;
 use crate::protocol::BackendKind;
-use crate::symbol_corpus::build_symbol_corpus;
-use crate::symbol_retrieval::{ScoredSymbol, search_symbols_bm25f, unique_query_terms};
+use crate::symbol_retrieval::unique_query_terms;
+use crate::tools::symbol_query::sparse_retriever::{flatten_symbols, sparse_symbol_hits_for_query};
 use crate::tools::symbol_query::{SymbolQueryPipeline, SymbolQueryRequest};
-use codelens_engine::{SymbolInfo, SymbolKind, read_file, search_symbols_hybrid_with_semantic};
+use codelens_engine::{SymbolKind, read_file, search_symbols_hybrid_with_semantic};
 use serde_json::{Value, json};
 
 pub fn get_symbols_overview(state: &AppState, arguments: &Value) -> ToolResult {
@@ -20,50 +18,6 @@ pub fn get_symbols_overview(state: &AppState, arguments: &Value) -> ToolResult {
 pub fn find_symbol(state: &AppState, arguments: &Value) -> ToolResult {
     crate::tools::symbol_query::SymbolQueryPipeline::new(state)
         .run(crate::tools::symbol_query::SymbolQueryRequest::FindSymbol { arguments })
-}
-
-pub(crate) fn sparse_symbol_hits_for_query(
-    state: &AppState,
-    query_analysis: &RetrievalQueryAnalysis,
-    max_results: usize,
-    include_tests: bool,
-    include_generated: bool,
-    session: &crate::session_context::SessionRequestContext,
-) -> Result<Vec<ScoredSymbol>, CodeLensError> {
-    let mut all_symbols = Vec::new();
-    for path in state.symbol_index().indexed_file_paths()? {
-        if let Ok(symbols) = state.symbol_index().get_symbols_overview_cached(&path, 3) {
-            all_symbols.extend(flatten_symbols(&symbols));
-        }
-    }
-
-    let corpus = build_symbol_corpus(&all_symbols);
-    let mut scored = search_symbols_bm25f(
-        &corpus,
-        &query_analysis.expanded_query,
-        max_results.saturating_mul(3).max(max_results),
-        include_tests,
-        include_generated,
-    );
-
-    let recent_files = state.recent_file_paths_for_session(session);
-    if !recent_files.is_empty() {
-        for hit in &mut scored {
-            if recent_files
-                .iter()
-                .any(|path| hit.document.file_path.starts_with(path))
-            {
-                hit.score *= 1.08;
-            }
-        }
-        scored.sort_by(|a, b| {
-            b.score
-                .partial_cmp(&a.score)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
-    }
-    scored.truncate(max_results);
-    Ok(scored)
 }
 
 pub fn bm25_symbol_search(state: &AppState, arguments: &Value) -> ToolResult {
@@ -166,25 +120,6 @@ pub fn bm25_symbol_search(state: &AppState, arguments: &Value) -> ToolResult {
         }),
         meta,
     ))
-}
-
-/// Scale a base token budget to the host's advertised model context window.
-///
-/// Returns the smaller of (base × multiplier) and a per-tier ceiling so a
-/// 1M-context host doesn't end up with a budget larger than reasonably
-/// retrievable evidence, while a 32K host doesn't get pushed over its head.
-///
-/// Tiers are conservative on purpose. The intent is to widen room when there
-/// is room, not to fill the host's window — the host still owns the response
-/// and may apply its own truncation downstream.
-pub(crate) fn adapt_budget_to_context_window(base: usize, context_window: usize) -> usize {
-    let (multiplier, cap) = match context_window {
-        n if n >= 1_000_000 => (4.0_f64, 131_072_usize),
-        n if n >= 200_000 => (2.0_f64, 65_536_usize),
-        n if n >= 32_000 => (1.0_f64, 32_768_usize),
-        _ => (0.5_f64, 16_384_usize),
-    };
-    ((base as f64 * multiplier).round() as usize).min(cap)
 }
 
 pub fn get_ranked_context(state: &AppState, arguments: &Value) -> ToolResult {
@@ -351,17 +286,6 @@ pub fn search_symbols_fuzzy(state: &AppState, arguments: &Value) -> ToolResult {
 
 // ── Helpers ──────────────────────────────────────────────────────────────
 
-pub fn flatten_symbols(symbols: &[SymbolInfo]) -> Vec<SymbolInfo> {
-    let mut flat = Vec::new();
-    let mut stack = symbols.to_vec();
-    while let Some(mut symbol) = stack.pop() {
-        let children = std::mem::take(&mut symbol.children);
-        flat.push(symbol);
-        stack.extend(children);
-    }
-    flat
-}
-
 /// Follow-up tool hints for a BM25 symbol card.
 ///
 /// Mirrors the `bm25-sparse-lane-spec` matrix. Frontier-model harnesses
@@ -387,52 +311,6 @@ fn suggested_follow_up(kind: &str, exported: bool) -> Vec<&'static str> {
         return with_refs;
     }
     base
-}
-
-#[cfg(test)]
-mod adapt_budget_tests {
-    use super::adapt_budget_to_context_window;
-
-    #[test]
-    fn small_window_halves_budget_capped_at_16k() {
-        // 8K context — base 32K halved to 16K, capped at 16K floor
-        assert_eq!(adapt_budget_to_context_window(32_768, 8_000), 16_384);
-        // base 8K halved to 4K — under cap
-        assert_eq!(adapt_budget_to_context_window(8_000, 16_000), 4_000);
-    }
-
-    #[test]
-    fn standard_window_passes_base_capped_at_32k() {
-        // 64K window → ×1, cap 32K
-        assert_eq!(adapt_budget_to_context_window(16_384, 64_000), 16_384);
-        assert_eq!(adapt_budget_to_context_window(40_000, 64_000), 32_768);
-    }
-
-    #[test]
-    fn large_window_doubles_budget_capped_at_64k() {
-        // 200K → ×2 cap 64K
-        assert_eq!(adapt_budget_to_context_window(16_384, 200_000), 32_768);
-        assert_eq!(adapt_budget_to_context_window(50_000, 200_000), 65_536);
-    }
-
-    #[test]
-    fn xl_window_quadruples_budget_capped_at_128k() {
-        // 1M → ×4 cap 128K
-        assert_eq!(adapt_budget_to_context_window(16_384, 1_000_000), 65_536);
-        assert_eq!(adapt_budget_to_context_window(40_000, 1_000_000), 131_072);
-    }
-
-    #[test]
-    fn boundary_at_32k_uses_standard_tier() {
-        // exactly 32K → standard tier (×1, cap 32K), not small tier
-        assert_eq!(adapt_budget_to_context_window(16_384, 32_000), 16_384);
-    }
-
-    #[test]
-    fn boundary_at_200k_uses_large_tier() {
-        // exactly 200K → large tier (×2, cap 64K)
-        assert_eq!(adapt_budget_to_context_window(16_384, 200_000), 32_768);
-    }
 }
 
 #[cfg(test)]

--- a/crates/codelens-mcp/src/tools/symbols/mod.rs
+++ b/crates/codelens-mcp/src/tools/symbols/mod.rs
@@ -6,16 +6,21 @@ mod analyzer;
 // here without re-implementing it). The seam stays at `pub(crate)`
 // — see CLAUDE.md "Symbol-query path lives behind one seam".
 pub(crate) mod formatter;
-// `handlers` is `pub(crate)` so the pipeline can reach
-// `sparse_symbol_hits_for_query` + `adapt_budget_to_context_window`,
-// both of which are also consumed by `bm25_symbol_search` inside
-// this module. Two callers → real seam; leave the visibility wide
-// rather than duplicating the helpers inside the pipeline.
+// `handlers` is `pub(crate)` so the legacy BM25 / fuzzy / complexity /
+// refresh tools can keep their existing seams while the new
+// `SymbolQueryPipeline` owns the three core symbol-shape tools
+// (`get_ranked_context`, `find_symbol`, `get_symbols_overview`).
+// After PR-F the dependency flow is one-way:
+// `symbols::handlers` → `symbol_query::sparse_retriever` — no more
+// `symbol_query → symbols::handlers` upward reach, which used to
+// create the `mod.rs → ranked_context.rs → handlers.rs` cycle
+// reported by `review_architecture`.
 pub(crate) mod handlers;
 
+pub use crate::tools::symbol_query::sparse_retriever::flatten_symbols;
 pub use handlers::{
-    bm25_symbol_search, find_symbol, flatten_symbols, get_complexity, get_ranked_context,
-    get_symbols_overview, refresh_symbol_index, search_symbols_fuzzy,
+    bm25_symbol_search, find_symbol, get_complexity, get_ranked_context, get_symbols_overview,
+    refresh_symbol_index, search_symbols_fuzzy,
 };
 
 // The rank-fusion + provenance + SCIP-enrichment + budget-guard unit


### PR DESCRIPTION
## Summary

Self-introspect dogfood follow-up: `review_architecture` on `crates/codelens-mcp/src/tools/symbol_query` reported a 3-node module cycle
```
symbol_query/mod.rs → symbol_query/ranked_context.rs → symbols/handlers.rs → (back via pipeline tool entries)
```
The upward edge was the pipeline importing `sparse_symbol_hits_for_query` + `adapt_budget_to_context_window` from `handlers.rs`. PR-F moves both helpers (plus the `flatten_symbols` utility they depend on, and the `adapt_budget_tests` block) into a new `tools/symbol_query/sparse_retriever.rs`. After this PR the dependency flows one way: `symbols::handlers` → `symbol_query::sparse_retriever`.

- handlers.rs: **-130 LOC** (from 570 → ~440)
- new file: `symbol_query/sparse_retriever.rs` (~125 LOC, 3 helpers + 6 tests)
- CLAUDE.md "Symbol-query path lives behind one seam": the previous *intentional, not a tightening target* note is replaced by the sparse_retriever seam description + a "never reach upward from the pipeline into symbols::handlers" rule.

## Why

The CLAUDE.md note had explicitly named the cycle as *intentional* (`Two callers → real seam; leave the visibility wide rather than duplicating the helpers inside the pipeline.`). It was a justified compromise at the time but `review_architecture`'s `risk_level: "high"` + the cycle hit made it the next clear deepening target. The cycle is no longer load-bearing once the helpers live inside the pipeline directory — the same two callers still reach them, just via a single seam owned by `symbol_query/`.

## Test plan
- [x] `cargo clippy --workspace --features http,semantic -- -D warnings`
- [x] `cargo clippy --workspace --no-default-features -- -D warnings`
- [x] `cargo clippy --workspace --features scip-backend -- -D warnings`
- [x] `cargo test -p codelens-mcp --bin codelens-mcp` — 593 passed / 0 failed
- [x] `adapt_budget_tests` (6 tests) pass at new location
- [x] `cargo fmt --all -- --check`
- [ ] Post-merge: rebuild binary + restart daemon, then re-run `review_architecture` to confirm cycle hits = 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)