### PR TITLE
docs: refresh symbol_query architecture notes after PR-F/G/H (PR-I)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,14 +21,36 @@ Three concepts that show up across files and require reading several to understa
 
 `get_ranked_context`, `find_symbol`, and `get_symbols_overview` all dispatch through a single deep module: `crates/codelens-mcp/src/tools/symbol_query/`. Each tool's `pub fn` in `tools/symbols/handlers.rs` is a 3-line entry that constructs a `SymbolQueryRequest` variant and calls `SymbolQueryPipeline::run`. The orchestration body (query analysis → retrieval → rank fusion → SCIP enrichment → payload shaping) lives **inside** the pipeline module, not in `handlers.rs`.
 
+Module layout (post-PR-F/G/H):
+
+```
+crates/codelens-mcp/src/tools/
+├── semantic_retriever.rs           ← cross-cutting (pipeline + impact reports)
+├── symbol_query/
+│   ├── mod.rs                       ← SymbolQueryPipeline + SymbolQueryRequest
+│   ├── find_symbol.rs               ← stage body for find_symbol
+│   ├── ranked_context.rs            ← stage body for get_ranked_context
+│   ├── symbols_overview.rs          ← stage body for get_symbols_overview
+│   ├── sparse_retriever.rs          ← BM25F + context-window-adaptive budget + flatten_symbols
+│   └── rank_fusion.rs               ← stage-4 helpers (5 fn + RankFusionPolicy, all pub(super))
+└── symbols/
+    ├── handlers.rs                  ← 31 LOC: 3 thin pipeline stubs only
+    ├── bm25_search.rs               ← bm25_symbol_search + suggested_follow_up + confidence_tier
+    ├── fuzzy_search.rs              ← search_symbols_fuzzy (hybrid + semantic boost)
+    ├── inventory.rs                 ← refresh_symbol_index + get_complexity + get_project_structure
+    ├── formatter.rs                 ← compact_symbol_bodies (used by pipeline)
+    └── analyzer.rs                  ← semantic_scores_for_query
+```
+
 When changing symbol-query semantics:
 - Body of `run_ranked_context` / `run_find_symbol` / `run_symbols_overview` is in `tools/symbol_query/<tool>.rs`.
 - Cross-cutting retrieval seams owned by the pipeline:
   - `tools/semantic_retriever.rs` (dense ONNX semantic results) — used by the pipeline **and** the impact-report family.
-  - `tools/symbol_query/sparse_retriever.rs` (BM25F sparse hits, context-window-adaptive budget, `flatten_symbols` utility) — used by the pipeline **and** `symbols::handlers::{bm25_symbol_search, get_complexity}`.
-- Stage helpers (rank-fusion, SCIP signature/body slicing, body Jaccard, …) are file-private inside their `symbol_query/<tool>.rs` — do not promote to `pub(super)` casually; the seam exists so the pipeline owns these.
+  - `tools/symbol_query/sparse_retriever.rs` (BM25F sparse hits, context-window-adaptive budget, `flatten_symbols` utility) — used by the pipeline **and** `symbols::{bm25_search, inventory}`.
+- Rank-fusion stage (PR-H): the 5 helpers + `RankFusionPolicy` are `pub(super)` in `symbol_query/rank_fusion.rs`. `ranked_context.rs` is the only legitimate caller — the seam exists so the pipeline owns stage-4 entirely. Do not export rank-fusion items out of `symbol_query/`.
+- Other stage helpers (SCIP signature/body slicing in `find_symbol.rs`, body Jaccard, query analysis) are file-private inside their `symbol_query/<tool>.rs` — do not promote to `pub(super)` casually.
 
-Dependency direction is one-way: `symbols::handlers` → `symbol_query::*`. Never reach upward from the pipeline back into `symbols::handlers` — that was the cycle PR-F removed (`review_architecture` reported a 3-node loop `mod.rs → ranked_context.rs → handlers.rs`). If new sparse/retrieval helpers are needed, add them to `symbol_query/sparse_retriever.rs` (or a sibling sub-module).
+Dependency direction is one-way: `symbols::*` → `symbol_query::*`. Never reach upward from the pipeline back into `symbols::*` — that was the cycle PR-F removed (`review_architecture` reported a 3-node loop `mod.rs → ranked_context.rs → handlers.rs`). If new sparse/retrieval helpers are needed, add them to `symbol_query/sparse_retriever.rs` (or a sibling sub-module).
 
 ## Feature Flag Matrix (build-time)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -344,7 +344,9 @@ codelens-mcp-plugin/
                             │
               ┌─────────────▼─────────────┐
               │      Tool Handler         │
-              │  tools/symbols.rs         │
+              │  tools/symbol_query/*     │  ← deep pipeline (PR-A/B/C/D/E/F/G/H)
+              │  tools/symbols/*          │  ← BM25/fuzzy/inventory + 3 stubs
+              │  tools/semantic_retriever │  ← cross-cutting seam
               │  tools/lsp.rs             │
               │  tools/graph.rs           │
               │  tools/mutation.rs        │


### PR DESCRIPTION
## Summary

Final docs catch-up for the dogfood-driven deepening sequence (PR-F #324, PR-G #325, PR-H #326).

### CLAUDE.md
- Add an explicit module-tree block for `tools/symbol_query/` and `tools/symbols/` showing all 11 files in the deep package.
- Note PR-G's 4-way split of the old `handlers.rs` god-module: `bm25_search` / `fuzzy_search` / `inventory` / `handlers` (3 thin pipeline stubs at 31 LOC).
- Note PR-H's `rank_fusion.rs` sub-module — 5 helpers + `RankFusionPolicy` are `pub(super)`, `ranked_context.rs` is the only legitimate caller.
- Generalize the one-way dependency rule from `symbols::handlers` to `symbols::*` since the four new files all sit at the same boundary.

### docs/architecture.md
- Replace the legacy `tools/symbols.rs` single-file line in the high-level tool-handler diagram with three rows showing the deep pipeline, the BM25/fuzzy/inventory split, and the cross-cutting `semantic_retriever` seam.

### Verified (live daemon, post-merge-of-all-3 + symbol-index refresh)
- `get_symbols_overview rank_fusion.rs` → 6 symbols (RankFusionPolicy class @ line 25 + 5 helper fn).
- `review_architecture symbol_query/`: cycle hits = 0, importer 7, impacted file 12.
- `#318` envelope still working: stale-session POST and GET SSE both return JSON + `x-codelens-session-rotate: 1`.

No code changes; documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)