### PR TITLE
chore(deps): pin codelens-engine via [workspace.dependencies] (PR-K)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,10 @@ keywords = ["mcp", "code-intelligence", "tree-sitter", "lsp", "ai"]
 categories = ["development-tools", "command-line-utilities"]
 
 [workspace.dependencies]
+# Internal workspace crate. Pinned to the current workspace version so
+# release-plz can bump it via the workspace `[workspace.package].version`
+# alone, instead of every member crate hand-editing the pin.
+codelens-engine = { path = "crates/codelens-engine", version = "=1.13.28", default-features = false }
 anyhow = "1.0"
 axum = "0.8"
 axum-server = { version = "0.8", features = ["tls-rustls"] }

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Pure Rust MCP server for multi-agent harnesses with hybrid retrieval (tree-sitte
 
 ## Surface Snapshot
 
-- Workspace version: `1.13.27`
+- Workspace version: `1.13.28`
 - Workspace members: `2` (`crates/codelens-engine`, `crates/codelens-mcp`)
 - Registered tool definitions: `72`
 - Tool output schemas: `52 / 72`

--- a/crates/codelens-mcp/Cargo.toml
+++ b/crates/codelens-mcp/Cargo.toml
@@ -37,7 +37,7 @@ regex.workspace = true
 rusqlite.workspace = true
 toml = "0.8"
 rustls = { workspace = true, optional = true }
-codelens-engine = { path = "../codelens-engine", version = "=1.13.28", default-features = false }
+codelens-engine = { workspace = true }
 thiserror.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,7 +7,7 @@
 
 <!-- SURFACE_MANIFEST_ARCHITECTURE_SNAPSHOT:BEGIN -->
 
-- Workspace version: `1.13.27`
+- Workspace version: `1.13.28`
 - Workspace members: `2` (`crates/codelens-engine`, `crates/codelens-mcp`)
 - Registered tool definitions in source: `72`
 - Tool output schemas in source: `52 / 72`

--- a/docs/generated/surface-manifest.json
+++ b/docs/generated/surface-manifest.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "codelens-surface-manifest-v2",
   "workspace": {
-    "version": "1.13.27",
+    "version": "1.13.28",
     "description": "Harness-native Rust MCP server for code intelligence with generated surface governance, hybrid retrieval, and mutation-gated workflows",
     "members": [
       "crates/codelens-engine",
@@ -2779,7 +2779,7 @@
   },
   "runtime": {
     "server_name": "codelens-mcp",
-    "version": "1.13.27",
+    "version": "1.13.28",
     "transport": [
       "stdio",
       "streamable-http"
@@ -2815,7 +2815,7 @@
     ]
   },
   "summary": {
-    "workspace_version": "1.13.27",
+    "workspace_version": "1.13.28",
     "workspace_member_count": 2,
     "registered_tool_definitions": 72,
     "tool_output_schemas": {

--- a/docs/platform-setup.md
+++ b/docs/platform-setup.md
@@ -590,7 +590,7 @@ agent = client.agents.create(
 
 <!-- SURFACE_MANIFEST_PLATFORM_SURFACES:BEGIN -->
 
-- Workspace version: `1.13.27`
+- Workspace version: `1.13.28`
 - Presets: `minimal` (21), `balanced` (59), `full` (72)
 - Profiles: `planner-readonly` (29), `builder-minimal` (29), `reviewer-graph` (34), `evaluator-compact` (29), `refactor-full` (29), `ci-audit` (34), `workflow-first` (29)
 - Canonical manifest: [`docs/generated/surface-manifest.json`](generated/surface-manifest.json)


### PR DESCRIPTION
## Summary

`crates/codelens-mcp/Cargo.toml` had `codelens-engine = "=1.13.27"` (then `"=1.13.28"`) hardcoded directly in its `[dependencies]` table, which forced every release bump to hand-edit two version pins (workspace package version + this member-level pin). release-plz cannot bump the member-level pin from the workspace-version side, so the PR-F/G/H series' release cut had to fix it manually mid-flight.

Move the pin into the workspace's `[workspace.dependencies]` table and reach it via `codelens-engine = { workspace = true }` from the member crate. Future releases bump a single version string at the workspace root.

This pairs with the workflow permission fix landed in repo settings (`default_workflow_permissions=write` + `can_approve_pull_request_reviews=true`) — release-plz can now create its release PR automatically on the next merge to `main`.

## Test plan
- [x] `cargo check -p codelens-mcp --bin codelens-mcp` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)