### PR TITLE
feat(transparency): index_freshness hint on read-hot symbol tools (PR-J)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Pure Rust MCP server for multi-agent harnesses with hybrid retrieval (tree-sitte
 
 ## Surface Snapshot
 
-- Workspace version: `1.13.27`
+- Workspace version: `1.13.28`
 - Workspace members: `2` (`crates/codelens-engine`, `crates/codelens-mcp`)
 - Registered tool definitions: `72`
 - Tool output schemas: `52 / 72`

--- a/crates/codelens-engine/src/db/ops.rs
+++ b/crates/codelens-engine/src/db/ops.rs
@@ -326,6 +326,27 @@ impl IndexDb {
         Ok(count as usize)
     }
 
+    /// Newest `indexed_at` epoch (seconds) across all files in the index,
+    /// or `None` when the table is empty. Callers compare against the
+    /// current wall-clock to surface a freshness hint on responses.
+    pub fn max_files_indexed_at(&self) -> Result<Option<i64>> {
+        let row: Option<i64> = self
+            .conn
+            .query_row("SELECT MAX(indexed_at) FROM files", [], |row| row.get(0))
+            .optional()?;
+        Ok(row)
+    }
+
+    /// Oldest `indexed_at` epoch (seconds) across all files in the index,
+    /// or `None` when the table is empty.
+    pub fn min_files_indexed_at(&self) -> Result<Option<i64>> {
+        let row: Option<i64> = self
+            .conn
+            .query_row("SELECT MIN(indexed_at) FROM files", [], |row| row.get(0))
+            .optional()?;
+        Ok(row)
+    }
+
     /// Return all indexed file paths.
     pub fn all_file_paths(&self) -> Result<Vec<String>> {
         all_file_paths(&self.conn)

--- a/crates/codelens-engine/src/symbols/mod.rs
+++ b/crates/codelens-engine/src/symbols/mod.rs
@@ -101,6 +101,22 @@ impl SymbolIndex {
         }
     }
 
+    /// Newest `indexed_at` epoch (seconds) across the index, or `None`
+    /// when no files are indexed yet. Used by tool responses to attach
+    /// a freshness hint so callers can detect a stale daemon without
+    /// having to compare results against the working tree by hand.
+    pub fn max_indexed_at(&self) -> Result<Option<i64>> {
+        let db = self.reader()?;
+        db.max_files_indexed_at()
+    }
+
+    /// Oldest `indexed_at` epoch (seconds) across the index, or `None`
+    /// when no files are indexed yet.
+    pub fn min_indexed_at(&self) -> Result<Option<i64>> {
+        let db = self.reader()?;
+        db.min_files_indexed_at()
+    }
+
     pub fn stats(&self) -> Result<IndexStats> {
         let db = self.reader()?;
         let supported_files = collect_candidate_files(self.project.as_path())?;

--- a/crates/codelens-mcp/src/dispatch/response.rs
+++ b/crates/codelens-mcp/src/dispatch/response.rs
@@ -65,6 +65,20 @@ pub(crate) fn build_success_response(input: SuccessResponseInput<'_>) -> JsonRpc
     let effective_budget = effective_budget_for_tool(name, request_budget);
     let mut payload = payload;
 
+    // PR-J: attach `index_freshness` to the read-hot symbol tools so
+    // callers can detect a stale daemon without diffing results against
+    // the working tree. See `tool_runtime::index_freshness_hint` for
+    // the four-bucket staleness heuristic.
+    if matches!(
+        name,
+        "find_referencing_symbols" | "find_symbol" | "get_ranked_context" | "get_symbols_overview"
+    ) && let Some(obj) = payload.as_object_mut()
+        && !obj.contains_key("index_freshness")
+        && let Some(freshness) = crate::tool_runtime::index_freshness_hint(state)
+    {
+        obj.insert("index_freshness".to_owned(), freshness);
+    }
+
     if is_verifier_source_tool(name) {
         state.record_recent_preflight_from_payload(
             name,

--- a/crates/codelens-mcp/src/tool_runtime.rs
+++ b/crates/codelens-mcp/src/tool_runtime.rs
@@ -125,6 +125,44 @@ pub fn optional_usize_with_aliases(
 /// Returns an empty Vec for non-object values so non-object inputs
 /// fall through to the handler's existing argument parsing without
 /// spurious "unknown" claims.
+/// Freshness hint for tool responses that read from the on-disk symbol
+/// index. Compares the index's newest `indexed_at` against wall-clock
+/// time so callers can detect a stale daemon without having to diff
+/// results against the working tree.
+///
+/// Buckets:
+///   - `fresh`           — newest file indexed < 60s ago
+///   - `recent`          — 60s..600s
+///   - `possibly_stale`  — 600s..3600s
+///   - `stale`           — >= 3600s (sets `refresh_recommended: true`)
+///
+/// Returns `None` when the index is empty (callers omit the hint to
+/// avoid noise on a fresh project).
+pub fn index_freshness_hint(state: &AppState) -> Option<serde_json::Value> {
+    use serde_json::json;
+    let max_at = state.symbol_index().max_indexed_at().ok().flatten()?;
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()?
+        .as_secs() as i64;
+    let age_secs = (now - max_at).max(0);
+    let (hint, refresh_recommended) = if age_secs < 60 {
+        ("fresh", false)
+    } else if age_secs < 600 {
+        ("recent", false)
+    } else if age_secs < 3600 {
+        ("possibly_stale", false)
+    } else {
+        ("stale", true)
+    };
+    Some(json!({
+        "newest_indexed_at_epoch_secs": max_at,
+        "newest_indexed_age_secs": age_secs,
+        "staleness_hint": hint,
+        "refresh_recommended": refresh_recommended,
+    }))
+}
+
 pub fn collect_unknown_args(value: &serde_json::Value, known: &[&str]) -> Vec<String> {
     let Some(map) = value.as_object() else {
         return Vec::new();

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,7 +7,7 @@
 
 <!-- SURFACE_MANIFEST_ARCHITECTURE_SNAPSHOT:BEGIN -->
 
-- Workspace version: `1.13.27`
+- Workspace version: `1.13.28`
 - Workspace members: `2` (`crates/codelens-engine`, `crates/codelens-mcp`)
 - Registered tool definitions in source: `72`
 - Tool output schemas in source: `52 / 72`

--- a/docs/generated/surface-manifest.json
+++ b/docs/generated/surface-manifest.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "codelens-surface-manifest-v2",
   "workspace": {
-    "version": "1.13.27",
+    "version": "1.13.28",
     "description": "Harness-native Rust MCP server for code intelligence with generated surface governance, hybrid retrieval, and mutation-gated workflows",
     "members": [
       "crates/codelens-engine",
@@ -2779,7 +2779,7 @@
   },
   "runtime": {
     "server_name": "codelens-mcp",
-    "version": "1.13.27",
+    "version": "1.13.28",
     "transport": [
       "stdio",
       "streamable-http"
@@ -2815,7 +2815,7 @@
     ]
   },
   "summary": {
-    "workspace_version": "1.13.27",
+    "workspace_version": "1.13.28",
     "workspace_member_count": 2,
     "registered_tool_definitions": 72,
     "tool_output_schemas": {

--- a/docs/platform-setup.md
+++ b/docs/platform-setup.md
@@ -590,7 +590,7 @@ agent = client.agents.create(
 
 <!-- SURFACE_MANIFEST_PLATFORM_SURFACES:BEGIN -->
 
-- Workspace version: `1.13.27`
+- Workspace version: `1.13.28`
 - Presets: `minimal` (21), `balanced` (59), `full` (72)
 - Profiles: `planner-readonly` (29), `builder-minimal` (29), `reviewer-graph` (34), `evaluator-compact` (29), `refactor-full` (29), `ci-audit` (34), `workflow-first` (29)
 - Canonical manifest: [`docs/generated/surface-manifest.json`](generated/surface-manifest.json)


### PR DESCRIPTION
## Summary

Closes the staleness gap surfaced during the PR-F/G/H dogfood loop: after the rank_fusion helpers moved files, the live daemon's `find_referencing_symbols` returned empty for `merge_semantic_ranked_entries` because its SymbolIndex was stale. The response carried no signal that the index was stale — callers had to guess or `refresh_symbol_index` blindly.

Every response of the four read-hot symbol tools now carries an `index_freshness` object:

```json
{
  "newest_indexed_at_epoch_secs": 1779032712,
  "newest_indexed_age_secs": 642,
  "staleness_hint": "possibly_stale",
  "refresh_recommended": false
}
```

Buckets (newest `files.indexed_at` vs wall-clock):

| `staleness_hint` | Age range | `refresh_recommended` |
|---|---|---|
| `fresh` | `< 60s` | `false` |
| `recent` | `60s .. 600s` | `false` |
| `possibly_stale` | `600s .. 3600s` | `false` |
| `stale` | `>= 3600s` | **`true`** |

Empty index → hint omitted (no noise on first run).

### Tools covered
- `find_referencing_symbols`
- `find_symbol`
- `get_ranked_context`
- `get_symbols_overview`

### Implementation
- `codelens_engine::db::IndexDb::{max,min}_files_indexed_at`: thin `SELECT MAX/MIN(indexed_at) FROM files` wrappers.
- `codelens_engine::symbols::SymbolIndex::{max,min}_indexed_at`: forwards through the existing reader handle.
- `crate::tool_runtime::index_freshness_hint(state)`: the 4-bucket heuristic. Returns `None` when the index is empty.
- `crate::dispatch::response::build_success_response`: attaches the hint to the four tools above. Existing handler-attached `index_freshness` keys win (so richer per-tool detail can still override).

No new daemon-side timestamp tracking — the existing `files.indexed_at` SQLite column is the ground truth and SQLite is already in every read-hot tool's path.

## Test plan
- [x] `cargo check -p codelens-mcp --bin codelens-mcp`
- [x] `cargo clippy --workspace --features http,semantic -- -D warnings`
- [x] `cargo test -p codelens-mcp --bin codelens-mcp` — 593 passed / 0 failed
- [x] `cargo test -p codelens-engine` — 1004 passed / 0 failed
- [x] `cargo fmt --all -- --check`
- [ ] Post-merge: live probe `find_referencing_symbols` and confirm `index_freshness` appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)