### PR TITLE
feat(transparency): stale index → suggest refresh + onboard_project freshness (PR-L)

### DIFF
--- a/crates/codelens-mcp/src/dispatch/response.rs
+++ b/crates/codelens-mcp/src/dispatch/response.rs
@@ -69,13 +69,30 @@ pub(crate) fn build_success_response(input: SuccessResponseInput<'_>) -> JsonRpc
     // callers can detect a stale daemon without diffing results against
     // the working tree. See `tool_runtime::index_freshness_hint` for
     // the four-bucket staleness heuristic.
+    //
+    // PR (this commit): include `onboard_project` in the whitelist (D).
+    // It synthesises project structure from the same SymbolIndex, so
+    // a stale index produces a misleading first-impression report.
+    //
+    // `refresh_recommended_from_freshness` records whether we should
+    // bubble `refresh_symbol_index` to the top of suggested_next_tools
+    // later in this function (C).
+    let mut refresh_recommended_from_freshness = false;
     if matches!(
         name,
-        "find_referencing_symbols" | "find_symbol" | "get_ranked_context" | "get_symbols_overview"
+        "find_referencing_symbols"
+            | "find_symbol"
+            | "get_ranked_context"
+            | "get_symbols_overview"
+            | "onboard_project"
     ) && let Some(obj) = payload.as_object_mut()
         && !obj.contains_key("index_freshness")
         && let Some(freshness) = crate::tool_runtime::index_freshness_hint(state)
     {
+        refresh_recommended_from_freshness = freshness
+            .get("refresh_recommended")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
         obj.insert("index_freshness".to_owned(), freshness);
     }
 
@@ -195,6 +212,23 @@ pub(crate) fn build_success_response(input: SuccessResponseInput<'_>) -> JsonRpc
                 "analyze_change_request".to_owned(),
                 "impact_report".to_owned(),
             ]);
+        }
+    }
+
+    // PR (this commit, C): when the index is stale, surface
+    // `refresh_symbol_index` at the top of `suggested_next_tools` so
+    // the agent doesn't have to know to call it before retrying.
+    // Idempotent: skip if it's already in the list.
+    if refresh_recommended_from_freshness {
+        match resp.suggested_next_tools.as_mut() {
+            Some(tools) => {
+                if !tools.iter().any(|t| t == "refresh_symbol_index") {
+                    tools.insert(0, "refresh_symbol_index".to_owned());
+                }
+            }
+            None => {
+                resp.suggested_next_tools = Some(vec!["refresh_symbol_index".to_owned()]);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Follow-up to PR-J (#329). Two small, dogfood-driven additions inside `build_success_response`. No new tools, no new surfaces, no engine changes.

### C — auto-suggest refresh on stale index

When `index_freshness.refresh_recommended` is true (newest indexed file ≥ 1 hour old), prepend `refresh_symbol_index` to `suggested_next_tools`. Idempotent. Sits *after* the doom-loop override (heavy retry guidance still wins) but *before* the calls-builder (harnesses pick up the refresh hint through their normal next-tool resolution path).

Closes the friction observed during PR-G/H's dogfood loop: the empty `find_referencing_symbols` result was correct given a stale index, but callers had no signal to refresh.

### D — `onboard_project` carries `index_freshness`

`onboard_project` synthesises a project structure / health report from the same SymbolIndex, so add it to the PR-J freshness whitelist. The first call into a new MCP session now reports its own index staleness up front.

## Scope discipline (per user request to avoid over-engineering)

Deliberately skipped:

| Skipped | Why |
|---|---|
| New `codelens_doctor` / `reload_index` composite tools | Refresh is already exposed; the missing piece was visibility, not a new surface |
| Daemon-restart MCP tool | Security-review surface, no MCP-side mechanism today |
| `review_architecture` disk-cache eviction | Separate invalidation model (analysis_id timestamps), tracked separately |

## Test plan

- [x] `cargo check -p codelens-mcp --bin codelens-mcp`
- [x] `cargo clippy --workspace --features http,semantic -- -D warnings`
- [x] `cargo clippy --workspace --no-default-features -- -D warnings`
- [x] `cargo test -p codelens-mcp --bin codelens-mcp` — 593 passed / 0 failed
- [x] `cargo fmt --all -- --check`
- [x] `python3 scripts/surface-manifest.py --check` — clean
- [ ] Post-merge: live probe `find_referencing_symbols` on a project with an artificially stale index, confirm `refresh_symbol_index` appears at the head of `suggested_next_tools`

🤖 Generated with [Claude Code](https://claude.com/claude-code)