### PR TITLE
fix(test): use tempfile::TempDir for search fixture (macOS lock contention root cause)

### DIFF
--- a/crates/codelens-engine/src/search.rs
+++ b/crates/codelens-engine/src/search.rs
@@ -234,21 +234,34 @@ mod tests {
     use crate::db::{IndexDb, NewSymbol, index_db_path};
 
     /// Create a temp directory seeded with test symbols.
-    /// Returns the owned PathBuf (keep it alive for the test duration) and a ProjectRoot.
-    fn make_project_with_symbols() -> (std::path::PathBuf, ProjectRoot) {
-        use std::time::{SystemTime, UNIX_EPOCH};
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .subsec_nanos();
-        let root = std::env::temp_dir().join(format!("codelens_search_test_{nanos}"));
-        std::fs::create_dir_all(&root).unwrap();
+    ///
+    /// Returns the owned [`tempfile::TempDir`] (keep it alive for the
+    /// test duration so the directory isn't reaped early) plus a
+    /// [`ProjectRoot`] pointed at it.
+    ///
+    /// Why `tempfile::TempDir` instead of `std::env::temp_dir().join(nanos)`:
+    /// the previous version generated paths from `subsec_nanos()` alone,
+    /// which collided in macOS CI when nextest scheduled multiple
+    /// fixture-using tests on overlapping nanoseconds (9 tests in this
+    /// file share this helper). Two tests racing into the same SQLite
+    /// file hit `journal_mode = WAL`'s schema-level write lock before
+    /// our own `busy_timeout = 5000` PRAGMA could be applied (it's the
+    /// 6th PRAGMA in the open batch, so the first PRAGMA still uses
+    /// the default 0 ms timeout) — surfacing as `Error code 5:
+    /// The database file is locked` at ~0.14 s into the test. macOS
+    /// reproduced this on every CI run since 2026-04; Ubuntu happened
+    /// to schedule those nine tests in an order that avoided the
+    /// collision. `tempfile::tempdir()` guarantees a process-unique
+    /// path, removing the collision class entirely.
+    fn make_project_with_symbols() -> (tempfile::TempDir, ProjectRoot) {
+        let temp = tempfile::tempdir().expect("create temp dir for search test fixture");
+        let root = temp.path();
 
         // Write a dummy source file so ProjectRoot is happy
         std::fs::write(root.join("hello.txt"), "hello").unwrap();
 
         // Seed the SQLite index
-        let db_path = index_db_path(&root);
+        let db_path = index_db_path(root);
         let db = IndexDb::open(&db_path).unwrap();
         let fid = db
             .upsert_file("main.py", 100, "h1", 10, Some("py"))
@@ -294,7 +307,7 @@ mod tests {
         .unwrap();
 
         let project = ProjectRoot::new(root.to_str().unwrap()).unwrap();
-        (root, project)
+        (temp, project)
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes 6+ consecutive macOS-only CI failures (`codelens-engine search::tests::semantic_low_scores_filtered_out`) by removing the root cause: a path-collision bug in the shared search-test fixture.

## Root cause investigation (systematic-debugging skill)

### Phase 1 — Evidence

The recurring CI failure showed:

```
called `Result::unwrap()` on an `Err` value: database is locked
Caused by: Error code 5: The database file is locked

   at codelens_engine::db::IndexDb::open::{{closure}} (src/db/mod.rs:124:13)
   at codelens_engine::db::open_derived_sqlite_with_recovery (src/db/mod.rs:338:11)
   at codelens_engine::search::tests::make_project_with_symbols (src/search.rs:252:18)
```

Not an ONNX numerical noise issue (my initial wrong hypothesis), not the assertion — `make_project_with_symbols` was panicking inside `IndexDb::open` at ~0.14 s into the test.

### Phase 2 — Pattern

`make_project_with_symbols` is shared by **9 tests** in this file. It built the test directory path from `subsec_nanos()` only:

```rust
let nanos = SystemTime::now()
    .duration_since(UNIX_EPOCH).unwrap()
    .subsec_nanos();
let root = std::env::temp_dir().join(format!("codelens_search_test_{nanos}"));
```

Then opened a SQLite index there, whose `IndexDb::open` runs:

```rust
PRAGMA journal_mode = WAL;
PRAGMA synchronous = NORMAL;
PRAGMA foreign_keys = ON;
PRAGMA busy_timeout = 5000;   // 4th PRAGMA — not yet in effect!
...
```

### Phase 3 — Two-layer mechanism

1. **Path collision (platform-specific).** macOS's `CLOCK_REALTIME` quantises to ~1 µs while Ubuntu runs at 1 ns precision. Within the ~90 ms window where the 9 fixture-using tests start, macOS `subsec_nanos` has ~90,000 distinct values — nextest's parallel scheduler routinely picked the same value twice and pointed two tests at the same on-disk SQLite file.
2. **PRAGMA ordering (race surface).** `journal_mode = WAL` is the **first** PRAGMA in `IndexDb::open`'s batch, but it needs a schema-level write lock. The connection still has the default 0 ms `busy_timeout` when it asks for that lock, so the loser of the race gets `SQLITE_BUSY` immediately rather than waiting. The configured 5 s timeout is the 6th PRAGMA — it would have saved the test if it had been first.

The path collision is the proximate trigger; the PRAGMA ordering is the latent bug it surfaces. This PR fixes **(1)**, eliminating the collision class entirely; **(2)** is called out as a separate follow-up.

### Why every recent PR failed

Ubuntu got lucky on test scheduling for these nine tests; macOS reproduces the collision on every run since 2026-04. The pattern repeated identically across PR-F (#324), PR-G (#325), PR-H (#326), PR-I (#327, docs-only!), PR-K (#328), PR-J (#329) — six PRs in a row failed the same way despite touching unrelated code, which is the smoking gun for an infrastructure-level bug rather than per-PR regressions.

## The fix

Switch `make_project_with_symbols` to `tempfile::tempdir()`:

```rust
let temp = tempfile::tempdir().expect("create temp dir for search test fixture");
let root = temp.path();
```

`tempfile::tempdir()` uses `mkstemp`-style atomic creation, so each fixture invocation gets a process-unique path. The `_root` binding at each call site is unchanged — it stays as a sentinel that keeps the `TempDir` alive for the test's lifetime; on drop the directory is removed automatically (better than the old leaked `std::env::temp_dir()` directories).

`tempfile = "3.15"` was already a `[dev-dependencies]` entry, and the rest of the test suite already uses this exact pattern (`git.rs`, `lsp/registry.rs`).

## Follow-up tracked

Defence in depth — reorder the PRAGMA batch in `IndexDb::open` so `busy_timeout = 5000` precedes `journal_mode = WAL`. Out of scope for this PR (touches production code; the path-collision fix alone closes the failure on macOS).

## Test plan
- [x] `cargo test -p codelens-engine --lib search` — 23 passed (incl. the previously failing `semantic_low_scores_filtered_out`)
- [x] `cargo clippy --workspace --features http,semantic -- -D warnings`
- [x] `cargo clippy --workspace --no-default-features -- -D warnings`
- [x] `cargo clippy --workspace --features scip-backend -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] **macOS CI must pass** — this is the real proof; PR-F..PR-J are the failure-pattern control group

🤖 Generated with [Claude Code](https://claude.com/claude-code)