### PR TITLE
fix(db): set busy_timeout PRAGMA before journal_mode = WAL (defense in depth)

### DIFF
--- a/crates/codelens-engine/src/db/mod.rs
+++ b/crates/codelens-engine/src/db/mod.rs
@@ -121,8 +121,16 @@ impl IndexDb {
         open_derived_sqlite_with_recovery(db_path, "symbol index", || {
             let conn = Connection::open(db_path)
                 .with_context(|| format!("failed to open db at {}", db_path.display()))?;
+            // `busy_timeout` MUST come first. The subsequent
+            // `journal_mode = WAL` change needs a schema-level write
+            // lock; without an active busy timeout, a second connection
+            // racing the same database file gets `SQLITE_BUSY` returned
+            // immediately (Error code 5). See #332 for the test-side
+            // collision that surfaced this; this defence-in-depth fix
+            // also covers any production caller that ever opens the
+            // same index DB from two threads at once.
             conn.execute_batch(
-                "PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL; PRAGMA foreign_keys = ON; PRAGMA busy_timeout = 5000; PRAGMA cache_size = -8000; PRAGMA auto_vacuum = INCREMENTAL;",
+                "PRAGMA busy_timeout = 5000; PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL; PRAGMA foreign_keys = ON; PRAGMA cache_size = -8000; PRAGMA auto_vacuum = INCREMENTAL;",
             )?;
             let mut db = Self { conn };
             db.migrate()?;

--- a/crates/codelens-engine/src/embedding/vec_store.rs
+++ b/crates/codelens-engine/src/embedding/vec_store.rs
@@ -31,8 +31,12 @@ impl SqliteVecStore {
             ffi::register_sqlite_vec()?;
 
             let conn = Connection::open(db_path)?;
+            // `busy_timeout` first — see crate::db::IndexDb::open and #332.
+            // Without an active timeout, `journal_mode = WAL` returns
+            // SQLITE_BUSY immediately when two connections race the
+            // same file.
             conn.execute_batch(
-                "PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000; PRAGMA synchronous=NORMAL; PRAGMA auto_vacuum=INCREMENTAL;",
+                "PRAGMA busy_timeout=5000; PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL; PRAGMA auto_vacuum=INCREMENTAL;",
             )?;
 
             // Check if DB exists with a different model — if so, drop and recreate


### PR DESCRIPTION
## Summary

Follow-up to #332. The test-side fix (process-unique temp dirs via `tempfile::TempDir`) closed the immediate macOS flake, but the underlying production race window stays open as long as the PRAGMA batch executes `journal_mode = WAL` before `busy_timeout`.

## Why

`PRAGMA journal_mode = WAL` requires a schema-level write lock. A SQLite connection that's just been opened has `busy_timeout = 0` by default, so if a second connection is racing the same database file the loser of the race gets `SQLITE_BUSY` returned **immediately** (Error code 5) rather than waiting.

`PRAGMA busy_timeout = 5000` is already in both opener batches; this PR simply moves it to the **front** of the batch so the WAL-mode change (and every subsequent PRAGMA that needs a write lock) waits up to 5 s instead of failing instantly.

## Two openers fixed (same antipattern)

| File | Function |
|---|---|
| `crates/codelens-engine/src/db/mod.rs` | `IndexDb::open` |
| `crates/codelens-engine/src/embedding/vec_store.rs` | semantic-vec store open |

`IndexDb::open_readonly` already sets `busy_timeout` standalone with no WAL-mode change, so no fix needed there.

## Defense in depth

This is the production-side companion to #332. The class of bug that PR-F through PR-J accidentally surfaced on macOS CI (`Error code 5: database is locked`) is now fully closed at both layers:

- **Test layer (#332):** fixtures use `tempfile::TempDir` so no two tests pick the same DB path.
- **Production layer (this PR):** even if two threads do open the same DB simultaneously, they wait on the busy timeout instead of erroring out instantly.

## Test plan

- [x] `cargo clippy --workspace --features http,semantic -- -D warnings`
- [x] `cargo clippy --workspace --no-default-features -- -D warnings`
- [x] `cargo test -p codelens-engine` — 401 passed / 0 failed
- [x] `cargo test -p codelens-mcp --bin codelens-mcp` — 593 passed / 0 failed
- [x] `cargo fmt --all -- --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)