### PR TITLE
fix(test): make prepare_harness stale-daemon fixture deterministic (filetime)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Pure Rust MCP server for multi-agent harnesses with hybrid retrieval (tree-sitte
 
 ## Surface Snapshot
 
-- Workspace version: `1.13.28`
+- Workspace version: `1.13.29`
 - Workspace members: `2` (`crates/codelens-engine`, `crates/codelens-mcp`)
 - Registered tool definitions: `72`
 - Tool output schemas: `52 / 72`

--- a/crates/codelens-mcp/src/integration_tests/workflow/harness.rs
+++ b/crates/codelens-mcp/src/integration_tests/workflow/harness.rs
@@ -2,18 +2,29 @@ use super::*;
 
 #[test]
 fn prepare_harness_session_warns_when_daemon_binary_is_stale() {
-    // Root cause of the prior chronic flake (PRs #174/#177/#184/#185/#187
-    // and PR #292 in the 2026-05-14 batch): the test mutates a process-wide
-    // env var (`CODELENS_EXECUTABLE_PATH_OVERRIDE`) without holding the
-    // `env_compat::TEST_ENV_LOCK` that the rest of the env-touching tests
-    // already coordinate on (`cli::startup_tests`, `main`,
-    // `workflow::session`, …). Under nextest parallel load any other test
-    // that read/wrote the same key between this test's `set_var` and the
-    // inner `call_tool` could swap the path out from under
-    // `current_executable_path()`, causing `prepare_harness_session` to
-    // fail early with `success=false`. Holding the global lock for the
-    // env+tool-call window makes the test independent of runner load —
-    // no more sleep-duration band-aids needed.
+    // Two layers of flake-resistance already in place from prior PRs:
+    //
+    //  1. `TEST_ENV_LOCK` (PRs #174/#177/#184/#185/#187/#292) — prevents
+    //     other env-touching tests from racing this one's
+    //     `set_var(CODELENS_EXECUTABLE_PATH_OVERRIDE)` and `call_tool`.
+    //  2. A 1.5 s `thread::sleep` — tried to push the override file's
+    //     `mtime` into a later wall-clock second than `daemon_started_at`.
+    //
+    // Layer 2 was still racy under heavy CI scheduler load and contributed
+    // to recurrences observed during the PR-K..#334 sweep (single-shot
+    // ubuntu fail with the rest of the matrix green). The mtime guarantee
+    // depended on `SystemTime::now()` advancing through a full second
+    // boundary during the sleep, which on a contended CI runner is not
+    // bounded by the requested sleep duration. Same root-cause class as
+    // #332 (`subsec_nanos`-only paths colliding under parallel load): the
+    // fixture relied on wall-clock side-effects rather than a deterministic
+    // assignment.
+    //
+    // Fix: set the override file's `mtime` explicitly via `filetime` to
+    // `daemon_started_at + 10 s`. The `mtime > daemon_started_seconds`
+    // relationship is now a property of the assignment, not of the
+    // runner's scheduling — race window collapsed to zero, sleep removed
+    // (~1.5 s reclaimed per run).
     let _env_guard = crate::env_compat::TEST_ENV_LOCK
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -26,13 +37,6 @@ fn prepare_harness_session_warns_when_daemon_binary_is_stale() {
     .unwrap();
     let state = make_state(&project);
 
-    // `daemon_started_at` is second-granularity RFC3339. Sleep > 1s so
-    // the override file's mtime lands in a later second than
-    // `daemon_started_at` even when the test happened to start just
-    // before a second rollover. 1.5s is plenty now that the env-var
-    // race is gone — no more parallel-load contention to amplify.
-    std::thread::sleep(std::time::Duration::from_millis(1_500));
-
     let override_path = std::env::temp_dir().join(format!(
         "codelens-stale-daemon-{}-{}",
         std::process::id(),
@@ -42,6 +46,18 @@ fn prepare_harness_session_warns_when_daemon_binary_is_stale() {
             .as_nanos()
     ));
     fs::write(&override_path, "newer-binary-marker").unwrap();
+
+    // Pin the override file's mtime explicitly to a point well after
+    // `daemon_started_at` (which `make_state` snapshots from
+    // `SystemTime::now()` a moment ago). The 10 s headroom comfortably
+    // clears any plausible second-boundary issue without depending on
+    // the runner advancing wall-clock time.
+    let future_mtime = std::time::SystemTime::now() + std::time::Duration::from_secs(10);
+    filetime::set_file_mtime(
+        &override_path,
+        filetime::FileTime::from_system_time(future_mtime),
+    )
+    .unwrap();
 
     let previous = std::env::var_os("CODELENS_EXECUTABLE_PATH_OVERRIDE");
     // SAFETY: this test mutates a process env var while holding

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,7 +7,7 @@
 
 <!-- SURFACE_MANIFEST_ARCHITECTURE_SNAPSHOT:BEGIN -->
 
-- Workspace version: `1.13.28`
+- Workspace version: `1.13.29`
 - Workspace members: `2` (`crates/codelens-engine`, `crates/codelens-mcp`)
 - Registered tool definitions in source: `72`
 - Tool output schemas in source: `52 / 72`

--- a/docs/generated/surface-manifest.json
+++ b/docs/generated/surface-manifest.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "codelens-surface-manifest-v2",
   "workspace": {
-    "version": "1.13.28",
+    "version": "1.13.29",
     "description": "Harness-native Rust MCP server for code intelligence with generated surface governance, hybrid retrieval, and mutation-gated workflows",
     "members": [
       "crates/codelens-engine",
@@ -2779,7 +2779,7 @@
   },
   "runtime": {
     "server_name": "codelens-mcp",
-    "version": "1.13.28",
+    "version": "1.13.29",
     "transport": [
       "stdio",
       "streamable-http"
@@ -2815,7 +2815,7 @@
     ]
   },
   "summary": {
-    "workspace_version": "1.13.28",
+    "workspace_version": "1.13.29",
     "workspace_member_count": 2,
     "registered_tool_definitions": 72,
     "tool_output_schemas": {

--- a/docs/platform-setup.md
+++ b/docs/platform-setup.md
@@ -590,7 +590,7 @@ agent = client.agents.create(
 
 <!-- SURFACE_MANIFEST_PLATFORM_SURFACES:BEGIN -->
 
-- Workspace version: `1.13.28`
+- Workspace version: `1.13.29`
 - Presets: `minimal` (21), `balanced` (59), `full` (72)
 - Profiles: `planner-readonly` (29), `builder-minimal` (29), `reviewer-graph` (34), `evaluator-compact` (29), `refactor-full` (29), `ci-audit` (34), `workflow-first` (29)
 - Canonical manifest: [`docs/generated/surface-manifest.json`](generated/surface-manifest.json)


### PR DESCRIPTION
## Summary

`prepare_harness_session_warns_when_daemon_binary_is_stale` had been flaking single-shot across our recent sweep (PR-K #328, #312, #334 each saw it fail exactly once on ubuntu while the rest of the matrix was green).

## Root cause (systematic-debugging)

Two earlier remediations had already landed (PRs #174/#177/#184/#185/#187/#292):

1. `TEST_ENV_LOCK` — serialises tests touching `CODELENS_EXECUTABLE_PATH_OVERRIDE`.
2. A 1.5 s `thread::sleep` — tried to advance wall-clock past `daemon_started_at`'s second boundary so the override file's `mtime` would land in a later RFC3339 second.

Layer 2 still depended on `SystemTime::now()` actually advancing through a full second during the sleep, which under contended CI scheduling is not bounded by the requested duration. Same root-cause class as **#332**'s `subsec_nanos`-only path collisions — the fixture relied on a wall-clock side-effect instead of a deterministic assignment.

## Fix

Replace the sleep with an explicit `filetime::set_file_mtime(override_path, now + 10s)`. The `mtime > daemon_started_seconds` relationship is now a property of the assignment, independent of the runner's scheduler. The 10 s headroom comfortably clears any plausible second-boundary issue without depending on wall-clock advancement.

`filetime = "0.2"` is already a dev-dep; the rest of the test tree already uses this exact pattern (`scip_health`, `metrics_config::capabilities`).

## Why TDD-spirited

Production code (`build_info::daemon_binary_drift_payload`) already enforces the second-precision contract correctly — `build_info::tests::classify_drift_*` covers the boolean combinations. The flake lived entirely in fixture timing, so this PR is a fixture-side fix only. No new production path, no behaviour change.

## Validation

- **10 consecutive local runs** — all PASS in 0.05-0.11 s (vs 1.68 s before — sleep removal saves ~1.5 s per run too).
- `cargo test -p codelens-mcp --bin codelens-mcp` — 593 passed / 0 failed.
- `cargo clippy --workspace --features http,semantic -- -D warnings`.
- `cargo clippy --workspace --no-default-features -- -D warnings`.
- `cargo fmt --all -- --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)