### PR TITLE
fix(scope): canonicalize before matches_scope (G8-class root fix)

### DIFF
--- a/crates/codelens-mcp/src/artifact_store.rs
+++ b/crates/codelens-mcp/src/artifact_store.rs
@@ -7,6 +7,7 @@ use crate::error::CodeLensError;
 use crate::runtime_types::{
     AnalysisArtifact, AnalysisReadiness, AnalysisSummary, AnalysisVerifierCheck,
 };
+use crate::util::matches_scope;
 
 pub(crate) const MAX_ANALYSIS_ARTIFACTS: usize = 50;
 const TTL_MS: u64 = 6 * 60 * 60 * 1000; // 6 hours
@@ -469,14 +470,6 @@ impl AnalysisArtifactStore {
             a.created_at_ms = created_at_ms;
         }
         Ok(())
-    }
-}
-
-fn matches_scope(artifact_scope: Option<&str>, current_scope: Option<&str>) -> bool {
-    match (artifact_scope, current_scope) {
-        (Some(a), Some(c)) => a == c,
-        (None, _) => true,
-        (_, None) => true,
     }
 }
 

--- a/crates/codelens-mcp/src/job_store.rs
+++ b/crates/codelens-mcp/src/job_store.rs
@@ -5,6 +5,7 @@ use std::sync::Mutex;
 
 use crate::error::CodeLensError;
 use crate::runtime_types::{AnalysisJob, JobLifecycle};
+use crate::util::matches_scope;
 
 pub(crate) const MAX_ANALYSIS_JOBS: usize = 128;
 const TTL_MS: u64 = 24 * 60 * 60 * 1000;
@@ -304,14 +305,6 @@ impl AnalysisJobStore {
                 .push_back(job_id.to_owned());
         }
         Ok(job)
-    }
-}
-
-fn matches_scope(job_scope: Option<&str>, current_scope: Option<&str>) -> bool {
-    match (job_scope, current_scope) {
-        (Some(j), Some(c)) => j == c,
-        (None, _) => true,
-        (_, None) => true,
     }
 }
 

--- a/crates/codelens-mcp/src/util.rs
+++ b/crates/codelens-mcp/src/util.rs
@@ -53,10 +53,63 @@ fn canonicalise(value: &serde_json::Value) -> serde_json::Value {
     }
 }
 
+/// Lexical scope canonicalization (no filesystem access): collapses `.`/`..`
+/// components and trailing-slash differences so the same project under a
+/// different path representation compares equal. Avoids `fs::canonicalize`
+/// (which requires the path to exist and resolves symlinks) so scope matching
+/// stays pure and works for deleted/virtual scopes.
+fn canonicalize_scope(s: &str) -> String {
+    use std::path::{Component, Path, PathBuf};
+    let mut out = PathBuf::new();
+    for comp in Path::new(s).components() {
+        match comp {
+            Component::ParentDir => {
+                out.pop();
+            }
+            Component::CurDir => {}
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out.to_string_lossy().into_owned()
+}
+
+/// Scope-equality check shared by `job_store` and `artifact_store`. Either side
+/// `None` matches (unscoped). When both are present, paths are lexically
+/// canonicalized first so trailing-slash / `.`-`..` representation differences
+/// of the same project do not produce a silent miss (former G8-class bug, where
+/// an explicit `path` arg and `current_project_scope()` resolved the same
+/// project to different string forms).
+pub(crate) fn matches_scope(scope: Option<&str>, current: Option<&str>) -> bool {
+    match (scope, current) {
+        (Some(s), Some(c)) => canonicalize_scope(s) == canonicalize_scope(c),
+        (None, _) => true,
+        (_, None) => true,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::canonical_sha256_hex;
     use serde_json::json;
+
+    #[test]
+    fn matches_scope_canonicalizes_path_representation() {
+        use super::matches_scope;
+        // 같은 프로젝트의 다른 경로 표현은 match (canonicalize 일원화)
+        assert!(
+            matches_scope(Some("/proj"), Some("/proj/")),
+            "trailing slash"
+        );
+        assert!(
+            matches_scope(Some("/a/proj"), Some("/a/sub/../proj")),
+            "비정규화 경로(.. 포함)"
+        );
+        // 다른 프로젝트는 여전히 불일치 (검사 의미 보존)
+        assert!(!matches_scope(Some("/proj"), Some("/other")));
+        // None 의미 보존
+        assert!(matches_scope(None, Some("/proj")));
+        assert!(matches_scope(Some("/proj"), None));
+    }
 
     #[test]
     fn canonical_sha256_hex_is_key_order_independent() {


### PR DESCRIPTION
## Problem

`matches_scope` was defined **twice** (`job_store.rs`, `artifact_store.rs`),
both using raw string equality (`j == c`) with no path canonicalization.
The same project under a different path representation (trailing slash,
`./..`) silently missed — surfacing as the G8-class `"Unknown analysis_id"`
/ `"Unknown job"` errors.

The prior G8 fix (`get_analysis_any_scope` fallback) only patched the
`get_analysis_section` read path; the other 6 `matches_scope` call sites
(job lookup, tiered cache reuse) stayed strict — including `artifact_store`,
the actual G8 path.

## Fix

Unify both definitions into a single `util::matches_scope` that lexically
canonicalizes both sides via `Path::components` (collapsing `.`/`..` and
trailing-slash differences). Deliberately avoids `fs::canonicalize` so scope
matching stays pure and works for deleted/virtual scopes. Fixes all 7 call
sites at the root rather than per-path fallbacks.

## Verification

- New `util::matches_scope_canonicalizes_path_representation`:
  `matches_scope("/proj", "/proj/") == true`, `("/a/proj", "/a/sub/../proj") == true`
- 618 tests pass (scope 10/10); `tiered_miss_different_scope` /
  `foreign_project_scoped_*` still pass → **different projects still miss**
  (semantics preserved, only representation differences collapse)
- `clippy -D warnings` clean, `fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
