### PR TITLE
fix(http): resolve #300/#301 session lockout — stateless-on-session-axis + guarded auto-resurrect

### DIFF
--- a/crates/codelens-mcp/src/server/http_tests.rs
+++ b/crates/codelens-mcp/src/server/http_tests.rs
@@ -38,6 +38,23 @@ fn test_state_with_compat(compat_mode: ServerCompatMode) -> Arc<AppState> {
     state
 }
 
+/// Like `test_state` but forces the strict session policy (#300 guard #11),
+/// without depending on the `CODELENS_SESSION_STRICT` process env.
+fn test_state_strict() -> Arc<AppState> {
+    let dir = std::env::temp_dir().join(format!(
+        "codelens-http-test-strict-{}-{:?}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos(),
+        std::thread::current().id(),
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    let project = ProjectRoot::new(dir.to_str().unwrap()).unwrap();
+    let state = AppState::new(project, crate::tool_defs::ToolPreset::Balanced);
+    Arc::new(state.with_session_store_policy(crate::server::session::SessionPolicy::Strict))
+}
+
 fn temp_project_dir(name: &str) -> std::path::PathBuf {
     crate::test_helpers::fixtures::temp_project_dir(name)
 }

--- a/crates/codelens-mcp/src/server/http_tests/protocol_tests.rs
+++ b/crates/codelens-mcp/src/server/http_tests/protocol_tests.rs
@@ -139,6 +139,70 @@ async fn post_unknown_session_returns_not_found() {
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 }
 
+// #300/#301: a UUID-shaped unknown session is transparently resurrected under
+// the default lenient policy (no 404 lockout), with an observability header.
+#[tokio::test]
+async fn post_unknown_uuid_session_resurrects_under_lenient() {
+    let app = build_router(test_state());
+    let sid = uuid::Uuid::new_v4().to_string();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/mcp")
+                .header("content-type", "application/json")
+                .header("mcp-session-id", &sid)
+                .body(axum::body::Body::from(
+                    r#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(
+        resp.headers()
+            .get("x-codelens-session-resurrected")
+            .and_then(|value| value.to_str().ok()),
+        Some("1"),
+        "a resurrected session must carry the observability header"
+    );
+}
+
+// #300 guard #11: under strict policy an unknown session keeps the spec 404
+// envelope (also the first assertion of the envelope body contract).
+#[tokio::test]
+async fn post_unknown_uuid_session_strict_returns_envelope() {
+    let app = build_router(test_state_strict());
+    let sid = uuid::Uuid::new_v4().to_string();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/mcp")
+                .header("content-type", "application/json")
+                .header("mcp-session-id", &sid)
+                .body(axum::body::Body::from(
+                    r#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    assert_eq!(
+        resp.headers()
+            .get("x-codelens-session-rotate")
+            .and_then(|value| value.to_str().ok()),
+        Some("1")
+    );
+    let body = body_string(resp).await;
+    assert!(body.contains("\"error\":\"unknown_session\""));
+    assert!(body.contains("\"rotate_required\":true"));
+}
+
 #[tokio::test]
 async fn post_with_sse_accept_returns_event_stream() {
     let app = build_router(test_state());

--- a/crates/codelens-mcp/src/server/session.rs
+++ b/crates/codelens-mcp/src/server/session.rs
@@ -107,6 +107,19 @@ pub struct SessionSeed {
     pub client_name: Option<String>,
 }
 
+/// Guard #11 (#300/#301): how the POST gate handles an unknown session id.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SessionPolicy {
+    /// Default: a non-initialize request with an unknown (UUID-shaped,
+    /// non-tombstoned) session id is transparently resurrected — no client
+    /// cooperation required, so daemon-restart / idle-timeout never lock out.
+    #[default]
+    Lenient,
+    /// Opt-in via `CODELENS_SESSION_STRICT=1`: an unknown session returns the
+    /// structured 404 envelope so cooperative clients (e.g. Codex) re-initialize.
+    Strict,
+}
+
 /// Server-Sent Event for pushing to clients via GET /mcp SSE stream.
 #[derive(Debug, Clone)]
 pub struct SseEvent {
@@ -358,6 +371,8 @@ pub struct SessionStore {
     /// Guard #3: bounded short-TTL record of explicitly-DELETEd ids so DELETE
     /// stays authoritative (a tombstoned id is refused resurrection).
     tombstone: Tombstone,
+    /// Guard #11: unknown-session handling at the POST gate.
+    policy: SessionPolicy,
 }
 
 impl SessionStore {
@@ -366,7 +381,18 @@ impl SessionStore {
             sessions: RwLock::new(HashMap::new()),
             timeout,
             tombstone: Tombstone::new(Duration::from_secs(300), 256),
+            policy: SessionPolicy::Lenient,
         }
+    }
+
+    /// Builder: set the unknown-session policy (default [`SessionPolicy::Lenient`]).
+    pub fn with_policy(mut self, policy: SessionPolicy) -> Self {
+        self.policy = policy;
+        self
+    }
+
+    pub fn policy(&self) -> SessionPolicy {
+        self.policy
     }
 
     /// Maximum live sessions. `create()` evicts expired-then-oldest at this cap;
@@ -691,5 +717,20 @@ mod tests {
                 .get_or_resurrect(&id, &SessionSeed::default())
                 .is_none()
         );
+    }
+
+    // ── Task 5: session policy (strict opt-out) ──────────────────────
+
+    #[test]
+    fn session_store_defaults_to_lenient_policy() {
+        let store = SessionStore::new(Duration::from_secs(300));
+        assert!(matches!(store.policy(), SessionPolicy::Lenient));
+    }
+
+    #[test]
+    fn session_store_with_policy_sets_strict() {
+        let store =
+            SessionStore::new(Duration::from_secs(300)).with_policy(SessionPolicy::Strict);
+        assert!(matches!(store.policy(), SessionPolicy::Strict));
     }
 }

--- a/crates/codelens-mcp/src/server/session.rs
+++ b/crates/codelens-mcp/src/server/session.rs
@@ -96,6 +96,17 @@ pub struct SessionClientMetadata {
     pub full_tool_exposure: Option<bool>,
 }
 
+/// Guard #2/#8 (#300/#301): soft surface state seeded onto a resurrected
+/// session from request headers. Deliberately has NO `trusted_client` field —
+/// privilege-bearing state must never be seeded from a non-initialize request
+/// (that would let any client assert trust and bypass the mutation gate).
+#[derive(Debug, Clone, Default)]
+pub struct SessionSeed {
+    pub requested_profile: Option<String>,
+    pub deferred_tool_loading: Option<bool>,
+    pub client_name: Option<String>,
+}
+
 /// Server-Sent Event for pushing to clients via GET /mcp SSE stream.
 #[derive(Debug, Clone)]
 pub struct SseEvent {
@@ -191,6 +202,33 @@ impl SessionState {
     pub fn set_project_path(&self, project_path: impl Into<String>) {
         if let Ok(mut current) = self.client_metadata.write() {
             current.project_path = Some(project_path.into());
+        }
+    }
+
+    /// Guard #2/#8: apply a [`SessionSeed`] onto a freshly-resurrected session.
+    /// Sets only soft surface state (profile/deferred/client_name) and, when a
+    /// profile is supplied, mirrors initialize's surface+budget so the
+    /// `tools/list` shape stays stable across resurrection. NEVER seeds
+    /// `trusted_client` — that stays at its fail-closed default (false).
+    pub fn apply_seed(&self, seed: &SessionSeed) {
+        if let Ok(mut metadata) = self.client_metadata.write() {
+            if seed.requested_profile.is_some() {
+                metadata.requested_profile = seed.requested_profile.clone();
+            }
+            if seed.deferred_tool_loading.is_some() {
+                metadata.deferred_tool_loading = seed.deferred_tool_loading;
+            }
+            if seed.client_name.is_some() {
+                metadata.client_name = seed.client_name.clone();
+            }
+        }
+        if let Some(profile) = seed
+            .requested_profile
+            .as_deref()
+            .and_then(crate::tool_defs::ToolProfile::from_str)
+        {
+            self.set_surface(ToolSurface::Profile(profile));
+            self.set_token_budget(crate::tool_defs::default_budget_for_profile(profile));
         }
     }
 
@@ -327,20 +365,23 @@ impl SessionStore {
         }
     }
 
+    /// Maximum live sessions. `create()` evicts expired-then-oldest at this cap;
+    /// `get_or_resurrect()` refuses (never evicts a live session) at this cap.
+    const MAX_SESSIONS: usize = 1000;
+
     /// Create a new session and return it.
     /// Caps total sessions at 1000; evicts expired then oldest if over limit.
     pub fn create(&self) -> Arc<SessionState> {
-        const MAX_SESSIONS: usize = 1000;
         let id = uuid::Uuid::new_v4().to_string();
         let session = Arc::new(SessionState::new(id.clone()));
         if let Ok(mut sessions) = self.sessions.write() {
             // Evict expired sessions first
-            if sessions.len() >= MAX_SESSIONS {
+            if sessions.len() >= Self::MAX_SESSIONS {
                 let timeout = self.timeout;
                 sessions.retain(|_, s| !s.is_expired(timeout));
             }
             // If still over limit, remove oldest
-            if sessions.len() >= MAX_SESSIONS
+            if sessions.len() >= Self::MAX_SESSIONS
                 && let Some(oldest_id) = sessions
                     .iter()
                     .min_by_key(|(_, s)| {
@@ -366,6 +407,44 @@ impl SessionStore {
             return (session, true);
         }
         (self.create(), false)
+    }
+
+    /// Non-initialize recovery (#300/#301). Returns:
+    /// - `Some((s, false))` — an existing session was found,
+    /// - `Some((s, true))`  — a session was resurrected under the client id,
+    /// - `None`             — refused: the id is not UUID-shaped, or the map is
+    ///   full of *active* sessions (guard #6: never evict a live client).
+    ///
+    /// Single write-lock critical section (std `RwLock` is non-reentrant and has
+    /// no upgradable guard) so concurrent callers for the same lost id converge
+    /// on one `Arc`. Tombstone refusal is the caller's responsibility (the gate
+    /// owns the tombstone set). Poison is recovered so the `(Arc, bool)` contract
+    /// — and the "id sticks" invariant — survive a panic elsewhere.
+    pub fn get_or_resurrect(
+        &self,
+        id: &str,
+        seed: &SessionSeed,
+    ) -> Option<(Arc<SessionState>, bool)> {
+        if !is_valid_session_id(id) {
+            return None;
+        }
+        let mut sessions = self.sessions.write().unwrap_or_else(|p| p.into_inner());
+        if let Some(existing) = sessions.get(id) {
+            let session = Arc::clone(existing);
+            session.touch();
+            return Some((session, false));
+        }
+        // Guard #6: reclaim only EXPIRED slots; if the map is still full of
+        // active sessions, refuse rather than evict a live client.
+        let timeout = self.timeout;
+        sessions.retain(|_, session| !session.is_expired(timeout));
+        if sessions.len() >= Self::MAX_SESSIONS {
+            return None;
+        }
+        let session = Arc::new(SessionState::new(id.to_owned()));
+        session.apply_seed(seed);
+        sessions.insert(id.to_owned(), Arc::clone(&session));
+        Some((session, true))
     }
 
     /// Look up a session by ID and refresh its activity timestamp.
@@ -495,5 +574,79 @@ mod tests {
             tomb.mark(&format!("id{i}"));
         }
         assert!(tomb.len() <= 4); // cap honored, oldest dropped
+    }
+
+    // ── Task 2: get_or_resurrect + SessionSeed ───────────────────────
+
+    #[test]
+    fn get_or_resurrect_creates_under_client_id() {
+        let store = SessionStore::new(Duration::from_secs(300));
+        let id = uuid::Uuid::new_v4().to_string();
+        let (s, resurrected) = store.get_or_resurrect(&id, &SessionSeed::default()).unwrap();
+        assert!(resurrected);
+        assert_eq!(s.id, id); // client id, NOT a fresh uuid
+        let (s2, again) = store.get_or_resurrect(&id, &SessionSeed::default()).unwrap();
+        assert!(!again); // second call finds it
+        assert!(Arc::ptr_eq(&s, &s2)); // same Arc
+    }
+
+    #[test]
+    fn get_or_resurrect_rejects_non_uuid() {
+        let store = SessionStore::new(Duration::from_secs(300));
+        assert!(
+            store
+                .get_or_resurrect("garbage", &SessionSeed::default())
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn get_or_resurrect_seeds_profile_not_trusted_client() {
+        let store = SessionStore::new(Duration::from_secs(300));
+        let id = uuid::Uuid::new_v4().to_string();
+        let seed = SessionSeed {
+            requested_profile: Some("reviewer-graph".into()),
+            deferred_tool_loading: Some(true),
+            client_name: Some("codex".into()),
+        };
+        let (s, _) = store.get_or_resurrect(&id, &seed).unwrap();
+        let metadata = s.client_metadata();
+        assert_eq!(metadata.requested_profile.as_deref(), Some("reviewer-graph"));
+        assert_eq!(metadata.deferred_tool_loading, Some(true));
+        assert_eq!(metadata.trusted_client, None); // guard #2 — never seeded
+    }
+
+    #[test]
+    fn get_or_resurrect_refuses_when_full_of_active() {
+        // Long timeout → nothing expires, so the map is full of ACTIVE sessions.
+        let store = SessionStore::new(Duration::from_secs(3600));
+        for _ in 0..1000 {
+            store.create();
+        }
+        assert_eq!(store.len(), 1000);
+        let id = uuid::Uuid::new_v4().to_string();
+        // Guard #6: refuse rather than evict a live session.
+        assert!(store.get_or_resurrect(&id, &SessionSeed::default()).is_none());
+        assert_eq!(store.len(), 1000); // unchanged — no active eviction
+    }
+
+    #[test]
+    fn get_or_resurrect_concurrent_same_id_one_arc() {
+        let store = Arc::new(SessionStore::new(Duration::from_secs(300)));
+        let id = uuid::Uuid::new_v4().to_string();
+        let handles: Vec<_> = (0..8)
+            .map(|_| {
+                let store = Arc::clone(&store);
+                let id = id.clone();
+                std::thread::spawn(move || {
+                    store.get_or_resurrect(&id, &SessionSeed::default()).unwrap()
+                })
+            })
+            .collect();
+        let results: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+        let resurrected = results.iter().filter(|(_, r)| *r).count();
+        assert_eq!(resurrected, 1); // exactly one winner
+        let first = &results[0].0;
+        assert!(results.iter().all(|(s, _)| Arc::ptr_eq(s, first)));
     }
 }

--- a/crates/codelens-mcp/src/server/session.rs
+++ b/crates/codelens-mcp/src/server/session.rs
@@ -45,7 +45,10 @@ impl Tombstone {
         ttl: Duration,
         cap: usize,
     ) {
-        while entries.front().is_some_and(|(_, marked)| marked.elapsed() > ttl) {
+        while entries
+            .front()
+            .is_some_and(|(_, marked)| marked.elapsed() > ttl)
+        {
             entries.pop_front();
         }
         while entries.len() > cap {
@@ -624,10 +627,14 @@ mod tests {
     fn get_or_resurrect_creates_under_client_id() {
         let store = SessionStore::new(Duration::from_secs(300));
         let id = uuid::Uuid::new_v4().to_string();
-        let (s, resurrected) = store.get_or_resurrect(&id, &SessionSeed::default()).unwrap();
+        let (s, resurrected) = store
+            .get_or_resurrect(&id, &SessionSeed::default())
+            .unwrap();
         assert!(resurrected);
         assert_eq!(s.id, id); // client id, NOT a fresh uuid
-        let (s2, again) = store.get_or_resurrect(&id, &SessionSeed::default()).unwrap();
+        let (s2, again) = store
+            .get_or_resurrect(&id, &SessionSeed::default())
+            .unwrap();
         assert!(!again); // second call finds it
         assert!(Arc::ptr_eq(&s, &s2)); // same Arc
     }
@@ -653,7 +660,10 @@ mod tests {
         };
         let (s, _) = store.get_or_resurrect(&id, &seed).unwrap();
         let metadata = s.client_metadata();
-        assert_eq!(metadata.requested_profile.as_deref(), Some("reviewer-graph"));
+        assert_eq!(
+            metadata.requested_profile.as_deref(),
+            Some("reviewer-graph")
+        );
         assert_eq!(metadata.deferred_tool_loading, Some(true));
         assert_eq!(metadata.trusted_client, None); // guard #2 — never seeded
     }
@@ -668,7 +678,11 @@ mod tests {
         assert_eq!(store.len(), 1000);
         let id = uuid::Uuid::new_v4().to_string();
         // Guard #6: refuse rather than evict a live session.
-        assert!(store.get_or_resurrect(&id, &SessionSeed::default()).is_none());
+        assert!(
+            store
+                .get_or_resurrect(&id, &SessionSeed::default())
+                .is_none()
+        );
         assert_eq!(store.len(), 1000); // unchanged — no active eviction
     }
 
@@ -681,7 +695,9 @@ mod tests {
                 let store = Arc::clone(&store);
                 let id = id.clone();
                 std::thread::spawn(move || {
-                    store.get_or_resurrect(&id, &SessionSeed::default()).unwrap()
+                    store
+                        .get_or_resurrect(&id, &SessionSeed::default())
+                        .unwrap()
                 })
             })
             .collect();
@@ -698,7 +714,9 @@ mod tests {
     fn mark_tombstone_removes_and_records() {
         let store = SessionStore::new(Duration::from_secs(300));
         let id = uuid::Uuid::new_v4().to_string();
-        store.get_or_resurrect(&id, &SessionSeed::default()).unwrap();
+        store
+            .get_or_resurrect(&id, &SessionSeed::default())
+            .unwrap();
         assert!(store.get(&id).is_some());
         store.mark_tombstone(&id);
         assert!(store.get(&id).is_none()); // session removed
@@ -709,7 +727,9 @@ mod tests {
     fn get_or_resurrect_refuses_tombstoned_id() {
         let store = SessionStore::new(Duration::from_secs(300));
         let id = uuid::Uuid::new_v4().to_string();
-        store.get_or_resurrect(&id, &SessionSeed::default()).unwrap();
+        store
+            .get_or_resurrect(&id, &SessionSeed::default())
+            .unwrap();
         store.mark_tombstone(&id);
         // tombstoned → refused even though the id is UUID-shaped
         assert!(
@@ -729,8 +749,7 @@ mod tests {
 
     #[test]
     fn session_store_with_policy_sets_strict() {
-        let store =
-            SessionStore::new(Duration::from_secs(300)).with_policy(SessionPolicy::Strict);
+        let store = SessionStore::new(Duration::from_secs(300)).with_policy(SessionPolicy::Strict);
         assert!(matches!(store.policy(), SessionPolicy::Strict));
     }
 }

--- a/crates/codelens-mcp/src/server/session.rs
+++ b/crates/codelens-mcp/src/server/session.rs
@@ -15,6 +15,65 @@ use tokio::sync::mpsc;
 
 pub type SessionId = String;
 
+/// Guard #5 (#300/#301): accept only the canonical session-id shape the server
+/// itself mints (UUID). Resurrecting arbitrary client-chosen keys is refused so
+/// a misbehaving client cannot flood the map or collide with another id.
+pub fn is_valid_session_id(id: &str) -> bool {
+    uuid::Uuid::parse_str(id).is_ok()
+}
+
+/// Guard #3 (#300/#301): bounded, short-TTL set of explicitly-DELETEd session
+/// ids. A tombstoned id is refused resurrection so DELETE stays authoritative,
+/// without the unbounded growth of a permanent tombstone.
+pub struct Tombstone {
+    entries: Mutex<std::collections::VecDeque<(String, Instant)>>,
+    ttl: Duration,
+    cap: usize,
+}
+
+impl Tombstone {
+    pub fn new(ttl: Duration, cap: usize) -> Self {
+        Self {
+            entries: Mutex::new(std::collections::VecDeque::new()),
+            ttl,
+            cap,
+        }
+    }
+
+    fn prune(
+        entries: &mut std::collections::VecDeque<(String, Instant)>,
+        ttl: Duration,
+        cap: usize,
+    ) {
+        while entries.front().is_some_and(|(_, marked)| marked.elapsed() > ttl) {
+            entries.pop_front();
+        }
+        while entries.len() > cap {
+            entries.pop_front();
+        }
+    }
+
+    pub fn mark(&self, id: &str) {
+        let mut entries = self.entries.lock().unwrap_or_else(|p| p.into_inner());
+        entries.push_back((id.to_owned(), Instant::now()));
+        Self::prune(&mut entries, self.ttl, self.cap);
+    }
+
+    pub fn contains(&self, id: &str) -> bool {
+        let mut entries = self.entries.lock().unwrap_or_else(|p| p.into_inner());
+        Self::prune(&mut entries, self.ttl, self.cap);
+        entries.iter().any(|(key, _)| key == id)
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.lock().map(|e| e.len()).unwrap_or(0)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct SessionActivitySnapshot {
     pub id: String,
@@ -408,5 +467,33 @@ mod tests {
         assert!(was_resumed);
         assert_eq!(resumed.id, session_id);
         assert_eq!(resumed.resume_count(), 1);
+    }
+
+    // ── Task 1: store primitives (#300/#301 auto-resurrect) ──────────
+
+    #[test]
+    fn valid_session_id_accepts_uuid_rejects_garbage() {
+        let good = uuid::Uuid::new_v4().to_string();
+        assert!(is_valid_session_id(&good));
+        assert!(!is_valid_session_id("not-a-uuid"));
+        assert!(!is_valid_session_id(""));
+    }
+
+    #[test]
+    fn tombstone_marks_and_expires() {
+        let tomb = Tombstone::new(Duration::from_millis(20), 8);
+        tomb.mark("abc");
+        assert!(tomb.contains("abc"));
+        std::thread::sleep(Duration::from_millis(35));
+        assert!(!tomb.contains("abc")); // TTL expiry
+    }
+
+    #[test]
+    fn tombstone_is_bounded() {
+        let tomb = Tombstone::new(Duration::from_secs(300), 4);
+        for i in 0..10 {
+            tomb.mark(&format!("id{i}"));
+        }
+        assert!(tomb.len() <= 4); // cap honored, oldest dropped
     }
 }

--- a/crates/codelens-mcp/src/server/session.rs
+++ b/crates/codelens-mcp/src/server/session.rs
@@ -355,6 +355,9 @@ impl SessionState {
 pub struct SessionStore {
     sessions: RwLock<HashMap<SessionId, Arc<SessionState>>>,
     timeout: Duration,
+    /// Guard #3: bounded short-TTL record of explicitly-DELETEd ids so DELETE
+    /// stays authoritative (a tombstoned id is refused resurrection).
+    tombstone: Tombstone,
 }
 
 impl SessionStore {
@@ -362,6 +365,7 @@ impl SessionStore {
         Self {
             sessions: RwLock::new(HashMap::new()),
             timeout,
+            tombstone: Tombstone::new(Duration::from_secs(300), 256),
         }
     }
 
@@ -412,20 +416,20 @@ impl SessionStore {
     /// Non-initialize recovery (#300/#301). Returns:
     /// - `Some((s, false))` — an existing session was found,
     /// - `Some((s, true))`  — a session was resurrected under the client id,
-    /// - `None`             — refused: the id is not UUID-shaped, or the map is
-    ///   full of *active* sessions (guard #6: never evict a live client).
+    /// - `None`             — refused: the id is not UUID-shaped, was explicitly
+    ///   DELETEd (tombstoned), or the map is full of *active* sessions
+    ///   (guard #6: never evict a live client).
     ///
     /// Single write-lock critical section (std `RwLock` is non-reentrant and has
     /// no upgradable guard) so concurrent callers for the same lost id converge
-    /// on one `Arc`. Tombstone refusal is the caller's responsibility (the gate
-    /// owns the tombstone set). Poison is recovered so the `(Arc, bool)` contract
-    /// — and the "id sticks" invariant — survive a panic elsewhere.
+    /// on one `Arc`. Poison is recovered so the `(Arc, bool)` contract — and the
+    /// "id sticks" invariant — survive a panic elsewhere.
     pub fn get_or_resurrect(
         &self,
         id: &str,
         seed: &SessionSeed,
     ) -> Option<(Arc<SessionState>, bool)> {
-        if !is_valid_session_id(id) {
+        if !is_valid_session_id(id) || self.tombstone.contains(id) {
             return None;
         }
         let mut sessions = self.sessions.write().unwrap_or_else(|p| p.into_inner());
@@ -460,6 +464,18 @@ impl SessionStore {
         if let Ok(mut sessions) = self.sessions.write() {
             sessions.remove(id);
         }
+    }
+
+    /// Guard #3: record an explicitly-DELETEd id and drop its live session so a
+    /// later non-initialize request is refused resurrection for the tombstone
+    /// TTL — keeping DELETE authoritative even under the lenient session policy.
+    pub fn mark_tombstone(&self, id: &str) {
+        self.remove(id);
+        self.tombstone.mark(id);
+    }
+
+    pub fn is_tombstoned(&self, id: &str) -> bool {
+        self.tombstone.contains(id)
     }
 
     /// Remove all expired sessions. Returns number removed.
@@ -648,5 +664,32 @@ mod tests {
         assert_eq!(resurrected, 1); // exactly one winner
         let first = &results[0].0;
         assert!(results.iter().all(|(s, _)| Arc::ptr_eq(s, first)));
+    }
+
+    // ── Task 3: tombstone wiring (DELETE stays authoritative) ─────────
+
+    #[test]
+    fn mark_tombstone_removes_and_records() {
+        let store = SessionStore::new(Duration::from_secs(300));
+        let id = uuid::Uuid::new_v4().to_string();
+        store.get_or_resurrect(&id, &SessionSeed::default()).unwrap();
+        assert!(store.get(&id).is_some());
+        store.mark_tombstone(&id);
+        assert!(store.get(&id).is_none()); // session removed
+        assert!(store.is_tombstoned(&id)); // and recorded as deleted
+    }
+
+    #[test]
+    fn get_or_resurrect_refuses_tombstoned_id() {
+        let store = SessionStore::new(Duration::from_secs(300));
+        let id = uuid::Uuid::new_v4().to_string();
+        store.get_or_resurrect(&id, &SessionSeed::default()).unwrap();
+        store.mark_tombstone(&id);
+        // tombstoned → refused even though the id is UUID-shaped
+        assert!(
+            store
+                .get_or_resurrect(&id, &SessionSeed::default())
+                .is_none()
+        );
     }
 }

--- a/crates/codelens-mcp/src/server/transport_http.rs
+++ b/crates/codelens-mcp/src/server/transport_http.rs
@@ -182,20 +182,20 @@ async fn protected_resource_metadata_handler(
     }
 }
 
-/// Issue #298 (D5) / #300 / #318: client-side stored session id has
-/// gone stale (daemon restart, hot-reload, or session timeout). Surface
-/// a structured envelope plus the `x-codelens-session-rotate: 1`
-/// response header so well-behaved clients can reinitialize without
-/// human intervention. Both POST and SSE GET paths must funnel through
-/// this helper so the hint is uniform across MCP transport routes —
-/// #318 reproduction was the SSE path emitting raw "Unknown session"
-/// while only the legacy fix-up (#308) covered one POST path.
+/// Issue #300 / #301 / #318: the client-side stored session id has gone stale
+/// (daemon restart or idle timeout). Returned only on the **strict** session
+/// policy and on the SSE GET path; under the default **lenient** policy the POST
+/// gate resurrects instead (see `SessionStore::get_or_resurrect`). Surfaces a
+/// structured envelope plus the `x-codelens-session-rotate: 1` response header
+/// so a cooperative client can reinitialize. Both POST and SSE GET funnel
+/// through this helper so the hint is uniform (the #318 fix). Note: SCIP index
+/// hot-reload does NOT wipe the in-memory session store, so it is not a cause.
 fn unknown_session_response() -> Response {
     let body = serde_json::json!({
         "error": "unknown_session",
         "code": "session_rotate_required",
         "rotate_required": true,
-        "hint": "Daemon may have restarted, session may have timed out, or the SCIP index was hot-reloaded. Reinitialize the MCP session.",
+        "hint": "Daemon may have restarted or the session timed out. Reinitialize the MCP session.",
         "recommended_action": "reinitialize_mcp_session",
         "action_target": "mcp_client",
     })
@@ -471,13 +471,36 @@ async fn mcp_post_handler(
     };
     let mut request = request;
 
-    // Validate session for non-initialize requests
+    // Validate / recover session for non-initialize requests (#300/#301).
+    // Under the default lenient policy a UUID-shaped, non-tombstoned unknown
+    // session is resurrected so a daemon restart / idle timeout never locks the
+    // whole client out; strict policy keeps the spec 404 envelope.
+    let mut session_resurrected = false;
     if !is_initialize
         && let Some(ref sid) = session_id
         && let Some(store) = &state.session_store
         && store.get(sid).is_none()
     {
-        return unknown_session_response();
+        match store.policy() {
+            crate::server::session::SessionPolicy::Strict => return unknown_session_response(),
+            crate::server::session::SessionPolicy::Lenient => {
+                let seed = crate::server::session::SessionSeed::from_headers(&headers);
+                match store.get_or_resurrect(sid, &seed) {
+                    Some((_session, true)) => {
+                        session_resurrected = true;
+                        tracing::info!(
+                            session_id = sid.as_str(),
+                            "resurrected stale MCP session (#300): daemon restart or idle timeout — recovered without lockout"
+                        );
+                    }
+                    // A concurrent request already recreated it — proceed.
+                    Some((_session, false)) => {}
+                    // None: non-UUID id, tombstoned (explicit DELETE), or the map
+                    // is full of active sessions — keep the strict envelope.
+                    None => return unknown_session_response(),
+                }
+            }
+        }
     }
 
     // L1: thread the authenticated principal id through to the
@@ -549,15 +572,29 @@ async fn mcp_post_handler(
     let Some(resp) = response else {
         // Spec §"Sending Messages to the Server" item 4: a notification or
         // response body with no JSON-RPC reply returns 202 Accepted, not 204.
-        return StatusCode::ACCEPTED.into_response();
+        let mut accepted = StatusCode::ACCEPTED.into_response();
+        if session_resurrected {
+            accepted.headers_mut().insert(
+                "x-codelens-session-resurrected",
+                HeaderValue::from_static("1"),
+            );
+        }
+        return accepted;
     };
 
-    into_mcp_response(
+    let mut response = into_mcp_response(
         resp,
         accept,
         initialize_session.as_ref(),
         state.daemon_mode().as_str(),
-    )
+    );
+    if session_resurrected {
+        response.headers_mut().insert(
+            "x-codelens-session-resurrected",
+            HeaderValue::from_static("1"),
+        );
+    }
+    response
 }
 
 // ── GET /mcp (persistent SSE stream) ──────────────────────────────────

--- a/crates/codelens-mcp/src/server/transport_http.rs
+++ b/crates/codelens-mcp/src/server/transport_http.rs
@@ -627,7 +627,10 @@ async fn mcp_delete_handler(State(state): State<Arc<AppState>>, headers: HeaderM
     if let Some(id) = headers.get("mcp-session-id").and_then(|v| v.to_str().ok())
         && let Some(store) = &state.session_store
     {
-        store.remove(id);
+        // Guard #3: tombstone (not just remove) so an explicitly-terminated id
+        // is refused resurrection under the lenient policy — DELETE stays
+        // authoritative.
+        store.mark_tombstone(id);
         tracing::debug!(session_id = id, "session terminated by client");
     }
     StatusCode::NO_CONTENT.into_response()

--- a/crates/codelens-mcp/src/server/transport_http_support.rs
+++ b/crates/codelens-mcp/src/server/transport_http_support.rs
@@ -1,4 +1,4 @@
-use super::session::{SessionClientMetadata, SessionStore};
+use super::session::{SessionClientMetadata, SessionSeed, SessionStore};
 use crate::client_profile::ClientProfile;
 use crate::protocol::{JsonRpcRequest, JsonRpcResponse};
 use crate::tool_defs::ToolSurface;
@@ -96,6 +96,31 @@ pub(crate) fn extract_initialize_metadata(
         loaded_tiers: Vec::new(),
         full_tool_exposure: None,
     })
+}
+
+impl SessionSeed {
+    /// Guard #2/#8: build a resurrection seed from request headers. Reads only
+    /// soft surface knobs (`x-codelens-profile`, `x-codelens-deferred-tool-loading`,
+    /// `x-codelens-client`). It deliberately does NOT read
+    /// `x-codelens-trusted-client` — that privilege-bearing header is honored
+    /// only on `initialize`, so a non-initialize resurrection can never assert
+    /// trust and bypass the mutation gate.
+    pub fn from_headers(headers: &HeaderMap) -> Self {
+        let header = |key: &str| {
+            headers
+                .get(key)
+                .and_then(|value| value.to_str().ok())
+                .map(ToOwned::to_owned)
+        };
+        SessionSeed {
+            requested_profile: header("x-codelens-profile"),
+            deferred_tool_loading: headers
+                .get("x-codelens-deferred-tool-loading")
+                .and_then(|value| value.to_str().ok())
+                .and_then(parse_bool_header),
+            client_name: header("x-codelens-client"),
+        }
+    }
 }
 
 pub(crate) fn create_initialize_session(
@@ -223,5 +248,31 @@ fn apply_session_headers(response: &mut Response, session: Option<&InitializeSes
         response
             .headers_mut()
             .insert("x-codelens-session-resumed", val);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn session_seed_reads_profile_deferred_client_not_trusted() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-codelens-profile",
+            HeaderValue::from_static("reviewer-graph"),
+        );
+        headers.insert(
+            "x-codelens-deferred-tool-loading",
+            HeaderValue::from_static("1"),
+        );
+        headers.insert("x-codelens-client", HeaderValue::from_static("codex"));
+        // Guard #2: trusted_client must be ignored on the resurrection path.
+        headers.insert("x-codelens-trusted-client", HeaderValue::from_static("1"));
+        let seed = SessionSeed::from_headers(&headers);
+        assert_eq!(seed.requested_profile.as_deref(), Some("reviewer-graph"));
+        assert_eq!(seed.deferred_tool_loading, Some(true));
+        assert_eq!(seed.client_name.as_deref(), Some("codex"));
+        // SessionSeed has no trusted_client field — guard #2 enforced by type.
     }
 }

--- a/crates/codelens-mcp/src/state/session_host.rs
+++ b/crates/codelens-mcp/src/state/session_host.rs
@@ -150,9 +150,20 @@ impl AppState {
     /// Initialize the session store for HTTP mode.
     #[cfg(feature = "http")]
     pub(crate) fn with_session_store(mut self) -> Self {
-        self.session_store = Some(crate::server::session::SessionStore::new(
-            std::time::Duration::from_secs(30 * 60), // 30 minutes
-        ));
+        // Guard #11: default Lenient (auto-resurrect); CODELENS_SESSION_STRICT=1
+        // opts into the strict 404-envelope path for cooperative clients.
+        let policy = match std::env::var("CODELENS_SESSION_STRICT") {
+            Ok(value) if value == "1" || value.eq_ignore_ascii_case("true") => {
+                crate::server::session::SessionPolicy::Strict
+            }
+            _ => crate::server::session::SessionPolicy::Lenient,
+        };
+        self.session_store = Some(
+            crate::server::session::SessionStore::new(
+                std::time::Duration::from_secs(30 * 60), // 30 minutes
+            )
+            .with_policy(policy),
+        );
         self
     }
 

--- a/crates/codelens-mcp/src/state/session_host.rs
+++ b/crates/codelens-mcp/src/state/session_host.rs
@@ -149,7 +149,7 @@ impl AppState {
 
     /// Initialize the session store for HTTP mode.
     #[cfg(feature = "http")]
-    pub(crate) fn with_session_store(mut self) -> Self {
+    pub(crate) fn with_session_store(self) -> Self {
         // Guard #11: default Lenient (auto-resurrect); CODELENS_SESSION_STRICT=1
         // opts into the strict 404-envelope path for cooperative clients.
         let policy = match std::env::var("CODELENS_SESSION_STRICT") {
@@ -158,6 +158,17 @@ impl AppState {
             }
             _ => crate::server::session::SessionPolicy::Lenient,
         };
+        self.with_session_store_policy(policy)
+    }
+
+    /// Initialize the session store with an explicit unknown-session policy.
+    /// `with_session_store` resolves the policy from env and delegates here;
+    /// tests use it to force a strict store without touching process env.
+    #[cfg(feature = "http")]
+    pub(crate) fn with_session_store_policy(
+        mut self,
+        policy: crate::server::session::SessionPolicy,
+    ) -> Self {
         self.session_store = Some(
             crate::server::session::SessionStore::new(
                 std::time::Duration::from_secs(30 * 60), // 30 minutes

--- a/docs/superpowers/plans/2026-06-04-http-session-resurrect.md
+++ b/docs/superpowers/plans/2026-06-04-http-session-resurrect.md
@@ -1,0 +1,443 @@
+# HTTP Session Auto-Resurrect Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Eliminate the post-restart / idle-timeout "Unknown session" lockout (#300/#301) by making the daemon stateless-on-session-axis: a non-initialize POST with an unknown (but UUID-shaped, non-tombstoned) session id transparently re-creates a soft session under that id instead of returning HTTP 404.
+
+**Architecture:** New `SessionStore::get_or_resurrect` (single write-lock, cap-enforced, poison-tolerant, fail-closed seeding); a policy branch at the POST gate (default Lenient, `CODELENS_SESSION_STRICT` opt-in keeps the #318 envelope); a bounded short-TTL tombstone so explicit DELETE stays authoritative; resurrection observability via header + telemetry. GET/SSE stays strict. `session_injection.rs` is untouched (the gate resurrects first, so its `store.get` succeeds).
+
+**Tech Stack:** Rust (edition 2024), axum, std `RwLock<HashMap>`, `uuid`, tokio. Test runner `cargo test -p codelens-mcp --bin codelens-mcp --features http,semantic`.
+
+Spec: `docs/superpowers/specs/2026-06-04-http-session-resurrect-design.md`. Honor all 11 guards there.
+
+---
+
+## File Structure
+
+- `crates/codelens-mcp/src/server/session.rs` — add `SessionSeed`, `is_valid_session_id`, `Tombstone`, `trim_to_cap` (factored from `create`), `get_or_resurrect`, `mark_tombstone`; add `SessionState::apply_seed`. **Most logic lives here.**
+- `crates/codelens-mcp/src/server/transport_http.rs` — gate policy branch (474-481), resurrected header on the response, DELETE tombstone (617-634), hint text fix (193-213).
+- `crates/codelens-mcp/src/server/transport_http_support.rs` — `SessionSeed::from_headers`.
+- `crates/codelens-mcp/src/state.rs` (+ constructors) — `session_policy: SessionPolicy` field + accessor.
+- `crates/codelens-mcp/src/main.rs` or `cli.rs` — parse `CODELENS_SESSION_STRICT`.
+- Telemetry (`server/metrics` or `telemetry/registry`) — `record_session_resurrected`.
+
+---
+
+## Task 1: Store primitives — `SessionSeed`, id-shape, tombstone (session.rs)
+
+**Files:** Modify `crates/codelens-mcp/src/server/session.rs`; tests in the same file's `mod tests`.
+
+- [ ] **Step 1: Write failing tests**
+```rust
+#[test]
+fn valid_session_id_accepts_uuid_rejects_garbage() {
+    let good = uuid::Uuid::new_v4().to_string();
+    assert!(is_valid_session_id(&good));
+    assert!(!is_valid_session_id("not-a-uuid"));
+    assert!(!is_valid_session_id(""));
+}
+
+#[test]
+fn tombstone_marks_and_expires() {
+    let tomb = Tombstone::new(Duration::from_millis(20), 8);
+    tomb.mark("abc");
+    assert!(tomb.contains("abc"));
+    std::thread::sleep(Duration::from_millis(30));
+    assert!(!tomb.contains("abc")); // TTL expiry
+}
+
+#[test]
+fn tombstone_is_bounded() {
+    let tomb = Tombstone::new(Duration::from_secs(300), 4);
+    for i in 0..10 { tomb.mark(&format!("id{i}")); }
+    assert!(tomb.len() <= 4); // cap honored, oldest dropped
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** `cargo test -p codelens-mcp --bin codelens-mcp --features http session:: 2>&1 | tail` (unresolved `is_valid_session_id` / `Tombstone`).
+
+- [ ] **Step 3: Implement**
+```rust
+pub fn is_valid_session_id(id: &str) -> bool {
+    uuid::Uuid::parse_str(id).is_ok()
+}
+
+pub struct Tombstone {
+    entries: Mutex<std::collections::VecDeque<(String, Instant)>>,
+    ttl: Duration,
+    cap: usize,
+}
+impl Tombstone {
+    pub fn new(ttl: Duration, cap: usize) -> Self {
+        Self { entries: Mutex::new(std::collections::VecDeque::new()), ttl, cap }
+    }
+    fn prune(entries: &mut std::collections::VecDeque<(String, Instant)>, ttl: Duration, cap: usize) {
+        while entries.front().is_some_and(|(_, t)| t.elapsed() > ttl) { entries.pop_front(); }
+        while entries.len() > cap { entries.pop_front(); }
+    }
+    pub fn mark(&self, id: &str) {
+        let mut e = self.entries.lock().unwrap_or_else(|p| p.into_inner());
+        e.push_back((id.to_owned(), Instant::now()));
+        Self::prune(&mut e, self.ttl, self.cap);
+    }
+    pub fn contains(&self, id: &str) -> bool {
+        let mut e = self.entries.lock().unwrap_or_else(|p| p.into_inner());
+        Self::prune(&mut e, self.ttl, self.cap);
+        e.iter().any(|(k, _)| k == id)
+    }
+    pub fn len(&self) -> usize { self.entries.lock().map(|e| e.len()).unwrap_or(0) }
+}
+```
+Defaults when wiring into `SessionStore`: `Tombstone::new(Duration::from_secs(300), 256)`.
+
+- [ ] **Step 4: Run — expect PASS** (same command).
+- [ ] **Step 5: Commit** `git commit -am "feat(session): id-shape validation + bounded tombstone primitives"`
+
+---
+
+## Task 2: `trim_to_cap` refactor + `get_or_resurrect` (session.rs)
+
+**Files:** Modify `crates/codelens-mcp/src/server/session.rs`.
+
+- [ ] **Step 1: Write failing tests**
+```rust
+#[test]
+fn get_or_resurrect_creates_under_client_id() {
+    let store = SessionStore::new(Duration::from_secs(300));
+    let id = uuid::Uuid::new_v4().to_string();
+    let (s, resurrected) = store.get_or_resurrect(&id, &SessionSeed::default()).unwrap();
+    assert!(resurrected);
+    assert_eq!(s.id, id);                       // client id, NOT a fresh uuid
+    let (s2, again) = store.get_or_resurrect(&id, &SessionSeed::default()).unwrap();
+    assert!(!again);                            // second call finds it
+    assert!(Arc::ptr_eq(&s, &s2));              // same Arc
+}
+
+#[test]
+fn get_or_resurrect_rejects_non_uuid() {
+    let store = SessionStore::new(Duration::from_secs(300));
+    assert!(store.get_or_resurrect("garbage", &SessionSeed::default()).is_none());
+}
+
+#[test]
+fn get_or_resurrect_seeds_profile_not_trusted_client() {
+    let store = SessionStore::new(Duration::from_secs(300));
+    let id = uuid::Uuid::new_v4().to_string();
+    let seed = SessionSeed { requested_profile: Some("reviewer-graph".into()),
+                             deferred_tool_loading: Some(true), client_name: Some("codex".into()) };
+    let (s, _) = store.get_or_resurrect(&id, &seed).unwrap();
+    let m = s.client_metadata();
+    assert_eq!(m.requested_profile.as_deref(), Some("reviewer-graph"));
+    assert_eq!(m.deferred_tool_loading, Some(true));
+    assert_eq!(m.trusted_client, None);         // guard #2 — never seeded
+}
+
+#[test]
+fn get_or_resurrect_refuses_when_full_of_active() {
+    // MAX_SESSIONS active, none expired → refuse rather than evict a live client.
+    // (Use a small helper or assert len stays == cap and returns None.)
+}
+
+#[test]
+fn get_or_resurrect_concurrent_same_id_one_arc() {
+    use std::sync::Arc as StdArc;
+    let store = StdArc::new(SessionStore::new(Duration::from_secs(300)));
+    let id = uuid::Uuid::new_v4().to_string();
+    let handles: Vec<_> = (0..8).map(|_| {
+        let store = StdArc::clone(&store); let id = id.clone();
+        std::thread::spawn(move || store.get_or_resurrect(&id, &SessionSeed::default()).unwrap())
+    }).collect();
+    let results: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+    let resurrected_count = results.iter().filter(|(_, r)| *r).count();
+    assert_eq!(resurrected_count, 1);           // exactly one winner
+    let first = &results[0].0;
+    assert!(results.iter().all(|(s, _)| Arc::ptr_eq(s, first)));
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** `cargo test -p codelens-mcp --bin codelens-mcp --features http session::tests::get_or_resurrect 2>&1 | tail`.
+
+- [ ] **Step 3: Implement** — add `SessionSeed`, `SessionState::apply_seed`, factor `trim_to_cap`, add `get_or_resurrect`. Move `const MAX_SESSIONS: usize = 1000;` to the `impl SessionStore` scope.
+```rust
+#[derive(Debug, Clone, Default)]
+pub struct SessionSeed {
+    pub requested_profile: Option<String>,
+    pub deferred_tool_loading: Option<bool>,
+    pub client_name: Option<String>,
+    // NOTE: no trusted_client — guard #2, fail closed.
+}
+
+impl SessionState {
+    pub fn apply_seed(&self, seed: &SessionSeed) {
+        if let Ok(mut m) = self.client_metadata.write() {
+            if seed.requested_profile.is_some() { m.requested_profile = seed.requested_profile.clone(); }
+            if seed.deferred_tool_loading.is_some() { m.deferred_tool_loading = seed.deferred_tool_loading; }
+            if seed.client_name.is_some() { m.client_name = seed.client_name.clone(); }
+        }
+        // If a profile is supplied, mirror initialize's surface/budget so tools/list shape is stable.
+        if let Some(profile) = seed.requested_profile.as_deref()
+            .and_then(crate::tool_defs::ToolProfile::from_str)
+        {
+            self.set_surface(crate::tool_defs::ToolSurface::Profile(profile));
+            self.set_token_budget(crate::tool_defs::default_budget_for_profile(profile));
+        }
+    }
+}
+
+impl SessionStore {
+    const MAX_SESSIONS: usize = 1000;
+
+    fn trim_to_cap(&self, sessions: &mut HashMap<SessionId, Arc<SessionState>>) {
+        if sessions.len() >= Self::MAX_SESSIONS {
+            let timeout = self.timeout;
+            sessions.retain(|_, s| !s.is_expired(timeout));
+        }
+        if sessions.len() >= Self::MAX_SESSIONS
+            && let Some(oldest_id) = sessions.iter()
+                .min_by_key(|(_, s)| s.last_active.read().map(|t| *t).unwrap_or_else(|_| Instant::now()))
+                .map(|(id, _)| id.clone())
+        {
+            sessions.remove(&oldest_id);
+        }
+    }
+
+    /// Non-initialize recovery. Some((s,false))=found, Some((s,true))=resurrected,
+    /// None=refused (non-uuid id, or cap full of active sessions). Tombstone is
+    /// checked by the caller (it owns the tombstone set).
+    pub fn get_or_resurrect(&self, id: &str, seed: &SessionSeed) -> Option<(Arc<SessionState>, bool)> {
+        if !is_valid_session_id(id) { return None; }
+        let mut sessions = self.sessions.write().unwrap_or_else(|p| p.into_inner());
+        if let Some(existing) = sessions.get(id) {
+            let s = Arc::clone(existing);
+            s.touch();
+            return Some((s, false));
+        }
+        self.trim_to_cap(&mut sessions);
+        if sessions.len() >= Self::MAX_SESSIONS { return None; } // full of active → refuse
+        let s = Arc::new(SessionState::new(id.to_owned()));
+        s.apply_seed(seed);
+        sessions.insert(id.to_owned(), Arc::clone(&s));
+        Some((s, true))
+    }
+}
+```
+Refactor `create()` to call `self.trim_to_cap(&mut sessions)` in place of its inlined eviction (behavior byte-identical). Make `last_active` reachable from `trim_to_cap` (same module — it is `pub` within the file scope already as a struct field accessed in tests at line 288; keep it module-visible).
+
+- [ ] **Step 4: Run — expect PASS**. Also run the full `session::tests` module to confirm `create_*` tests still pass (refactor parity).
+- [ ] **Step 5: Commit** `git commit -am "feat(session): get_or_resurrect with capped, poison-tolerant, fail-closed seeding"`
+
+---
+
+## Task 3: Tombstone wiring into SessionStore + DELETE (session.rs + transport_http.rs)
+
+**Files:** Modify `session.rs` (add `tombstone` field + `mark_tombstone`/`is_tombstoned`), `transport_http.rs:617-634` (DELETE records tombstone).
+
+- [ ] **Step 1: Write failing test** (in transport_http http_tests or session tests)
+```rust
+#[test]
+fn tombstoned_id_is_not_resurrected() {
+    let store = SessionStore::new(Duration::from_secs(300));
+    let id = uuid::Uuid::new_v4().to_string();
+    store.get_or_resurrect(&id, &SessionSeed::default()).unwrap(); // create
+    store.mark_tombstone(&id);                                     // DELETE
+    // gate logic: tombstoned → refuse
+    assert!(store.is_tombstoned(&id));
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** (no `mark_tombstone`/`is_tombstoned`).
+
+- [ ] **Step 3: Implement** — add `tombstone: Tombstone` to `SessionStore` (init in `new`), plus:
+```rust
+pub fn mark_tombstone(&self, id: &str) { self.remove(id); self.tombstone.mark(id); }
+pub fn is_tombstoned(&self, id: &str) -> bool { self.tombstone.contains(id) }
+```
+In `mcp_delete_handler` (transport_http.rs:627-632) replace `store.remove(id)` with `store.mark_tombstone(id)`.
+
+- [ ] **Step 4: Run — expect PASS.**
+- [ ] **Step 5: Commit** `git commit -am "feat(session): bounded tombstone keeps DELETE authoritative"`
+
+---
+
+## Task 4: `SessionSeed::from_headers` (transport_http_support.rs)
+
+**Files:** Modify `crates/codelens-mcp/src/server/transport_http_support.rs`.
+
+- [ ] **Step 1: Write failing test**
+```rust
+#[test]
+fn session_seed_reads_profile_deferred_client_not_trusted() {
+    let mut h = HeaderMap::new();
+    h.insert("x-codelens-profile", HeaderValue::from_static("reviewer-graph"));
+    h.insert("x-codelens-deferred-tool-loading", HeaderValue::from_static("1"));
+    h.insert("x-codelens-client", HeaderValue::from_static("codex"));
+    h.insert("x-codelens-trusted-client", HeaderValue::from_static("1")); // must be ignored
+    let seed = SessionSeed::from_headers(&h);
+    assert_eq!(seed.requested_profile.as_deref(), Some("reviewer-graph"));
+    assert_eq!(seed.deferred_tool_loading, Some(true));
+    assert_eq!(seed.client_name.as_deref(), Some("codex"));
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL.**
+
+- [ ] **Step 3: Implement** (reuse `parse_bool_header`; never read `x-codelens-trusted-client`):
+```rust
+impl SessionSeed {
+    pub fn from_headers(headers: &HeaderMap) -> Self {
+        let h = |k: &str| headers.get(k).and_then(|v| v.to_str().ok()).map(ToOwned::to_owned);
+        Self {
+            requested_profile: h("x-codelens-profile"),
+            deferred_tool_loading: headers.get("x-codelens-deferred-tool-loading")
+                .and_then(|v| v.to_str().ok()).and_then(parse_bool_header),
+            client_name: h("x-codelens-client"),
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run — expect PASS.**
+- [ ] **Step 5: Commit** `git commit -am "feat(session): SessionSeed::from_headers (fail-closed, no trusted_client)"`
+
+---
+
+## Task 5: Policy flag `CODELENS_SESSION_STRICT` (state.rs + main.rs/cli.rs)
+
+**Files:** `state.rs` (+ `state/constructors.rs`), `main.rs` or `cli.rs`.
+
+- [ ] **Step 1: Write failing test** (state-level default)
+```rust
+#[test]
+fn session_policy_defaults_to_lenient() {
+    let state = AppState::new(project_root_for_test(), ToolPreset::Balanced);
+    assert!(matches!(state.session_policy(), SessionPolicy::Lenient));
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL.**
+
+- [ ] **Step 3: Implement** — `pub enum SessionPolicy { Lenient, Strict }` in `session.rs`; `session_policy: SessionPolicy` field on `AppState` (default `Lenient`); `fn session_policy(&self) -> SessionPolicy`; in startup, `if std::env::var("CODELENS_SESSION_STRICT").as_deref() == Ok("1") { SessionPolicy::Strict }`.
+
+- [ ] **Step 4: Run — expect PASS.**
+- [ ] **Step 5: Commit** `git commit -am "feat(session): CODELENS_SESSION_STRICT policy flag (default lenient)"`
+
+---
+
+## Task 6: Gate wiring + resurrected header + hint fix (transport_http.rs)
+
+**Files:** Modify `crates/codelens-mcp/src/server/transport_http.rs`.
+
+- [ ] **Step 1: Write/flip failing tests** in `server/http_tests/` (or `protocol_tests.rs`):
+```rust
+// FLIP: was post_unknown_session_returns_not_found
+#[tokio::test]
+async fn post_unknown_session_resurrects_under_lenient() {
+    // build router (Lenient default), POST tools/list with a random UUID Mcp-Session-Id, no prior init
+    // expect 200 (not 404) + header x-codelens-session-resurrected: 1
+}
+
+#[tokio::test]
+async fn post_unknown_session_strict_returns_envelope() {
+    // CODELENS_SESSION_STRICT path → 404 + body {"error":"unknown_session",...} + x-codelens-session-rotate:1
+}
+
+#[tokio::test]
+async fn delete_then_reuse_stays_terminated() {
+    // init → DELETE (204) → tools/list same sid → 404 envelope (tombstoned), NOT resurrected
+}
+
+#[tokio::test]
+async fn get_unknown_session_stays_strict() {
+    // GET /mcp with unknown sid → still unknown_session_response (guard #7), never resurrected
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL.**
+
+- [ ] **Step 3: Implement** — replace the gate (474-481):
+```rust
+let mut resurrected = false;
+if !is_initialize
+    && let Some(ref sid) = session_id
+    && let Some(store) = &state.session_store
+    && store.get(sid).is_none()
+{
+    match state.session_policy() {
+        crate::server::session::SessionPolicy::Strict => return unknown_session_response(),
+        crate::server::session::SessionPolicy::Lenient => {
+            if store.is_tombstoned(sid) { return unknown_session_response(); }
+            let seed = crate::server::session::SessionSeed::from_headers(&headers);
+            match store.get_or_resurrect(sid, &seed) {
+                Some((_s, true)) => {
+                    resurrected = true;
+                    state.metrics().record_session_resurrected(principal_id.as_deref());
+                }
+                Some((_s, false)) => {}                  // race: now exists, proceed
+                None => return unknown_session_response(),// non-uuid or cap-full-of-active
+            }
+        }
+    }
+}
+```
+After building the final `response` (line ~555, the non-initialize branch), attach the header:
+```rust
+let mut response = into_mcp_response(resp, accept, initialize_session.as_ref(), state.daemon_mode().as_str());
+if resurrected {
+    response.headers_mut().insert("x-codelens-session-resurrected", HeaderValue::from_static("1"));
+}
+response
+```
+Fix the hint in `unknown_session_response` (198): drop "or the SCIP index was hot-reloaded"; keep "Daemon may have restarted or the session timed out. Reinitialize the MCP session." Update the doc comment at 185-192 to match (remove the #298/hot-reload claim).
+
+- [ ] **Step 4: Run — expect PASS** (the 4 gate tests + GET stays strict).
+- [ ] **Step 5: Commit** `git commit -am "feat(http): lenient session resurrect at POST gate (#300/#301), GET stays strict"`
+
+---
+
+## Task 7: Telemetry + mutation-gate negative test + envelope-body lock
+
+**Files:** telemetry module; `server/http_tests/`.
+
+- [ ] **Step 1: Tests**
+```rust
+// CRITICAL guard #2: on a mutation-enabled daemon, resurrect via tools/call carrying
+// x-codelens-trusted-client:1 must NOT grant trusted_client → content mutation rejected.
+#[tokio::test]
+async fn resurrect_does_not_grant_trusted_client_on_mutation_daemon() { /* ... */ }
+
+// guard #9: resurrected session with no bearer → default role.
+#[tokio::test]
+async fn resurrected_session_grants_no_principal() { /* ... */ }
+
+// envelope body currently untested — lock it on the strict path.
+#[tokio::test]
+async fn strict_unknown_session_envelope_body_contract() { /* assert error/code/rotate_required/header */ }
+```
+
+- [ ] **Step 2: Run — expect FAIL** (missing `record_session_resurrected`).
+- [ ] **Step 3: Implement** `record_session_resurrected(&self, principal: Option<&str>)` on the metrics/telemetry registry (mirror an existing counter event); wire counters (`resurrected_total`, `id_shape_rejected`, `tombstoned_refused`).
+- [ ] **Step 4: Run — expect PASS.**
+- [ ] **Step 5: Commit** `git commit -am "feat(telemetry): session_resurrected event + mutation-gate/principal-agnostic regression tests"`
+
+---
+
+## Final verification gate (parent-run — subagent self-report 신뢰 0%)
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --features http -- -D warnings
+cargo test -p codelens-mcp --bin codelens-mcp --features http,semantic
+cargo test -p codelens-engine
+python3 scripts/regen-tool-defs.py --check
+```
+**Expected:** all green; prior baseline preserved minus the consciously-flipped `post_unknown_session_*` assertion. Live daemon redeploy is OUT OF SCOPE (separate user gate).
+
+---
+
+## Self-Review
+
+**Spec coverage:** Guards 1 (initialize untouched — `create_or_resume` not modified) ✓ T2; 2 (trusted_client fail-closed) ✓ T2/T4/T7; 3 (tombstone) ✓ T3; 4 (single write-lock/Entry-equivalent/poison) ✓ T2; 5 (uuid-shape) ✓ T1/T2; 6 (cap no-evict-active) ✓ T2; 7 (GET strict) ✓ T6; 8 (seed profile+deferred+client_name) ✓ T2/T4; 9 (principal-agnostic) ✓ T7; 10 (header+telemetry) ✓ T6/T7; 11 (strict flag) ✓ T5/T6. Test matrix items 1-10 all mapped.
+
+**Placeholder scan:** Task 6/7 leave a few `/* ... */` in async HTTP test bodies (router-setup boilerplate); the assertions are specified in prose. Fill using the existing `server/http_tests/lifecycle_tests.rs` router-build pattern as the template — not a design gap.
+
+**Type consistency:** `get_or_resurrect(&str, &SessionSeed) -> Option<(Arc<SessionState>, bool)>`, `SessionSeed{requested_profile,deferred_tool_loading,client_name}`, `SessionPolicy::{Lenient,Strict}`, `mark_tombstone`/`is_tombstoned`, `apply_seed`, `record_session_resurrected` — names consistent across tasks.

--- a/docs/superpowers/specs/2026-06-04-http-session-resurrect-design.md
+++ b/docs/superpowers/specs/2026-06-04-http-session-resurrect-design.md
@@ -1,0 +1,119 @@
+# HTTP MCP Session Lifecycle Redesign — Stateless-on-Session-Axis + Guarded Auto-Resurrect
+
+- **Status**: Approved design (2026-06-04). Implementation pending.
+- **Issues**: #300, #301 (primary), #298 (related symptom), #318 (envelope-not-surfaced finding)
+- **Branch**: `feat/session-resurrect-300`
+- **Author**: Claude (planner) + 4-lens adversarial judge panel (MCP-spec / security / concurrency / blast-radius)
+
+## 1. Context & Problem
+
+The HTTP daemon (`dev.codelens.mcp-readonly` :7839, `dev.codelens.mcp-mutation` :7838) keeps client sessions in an **in-memory** `SessionStore` (`RwLock<HashMap<SessionId, Arc<SessionState>>>`, `session.rs`). When the daemon process restarts (`launchctl kickstart`, crash, OOM) or a session idles past the 1800 s timeout, the store is wiped, but Claude Code's MCP client keeps sending its cached `Mcp-Session-Id`.
+
+The current non-initialize gate (`transport_http.rs:474-481`) returns **HTTP 404** via `unknown_session_response()` (a structured envelope + `x-codelens-session-rotate: 1` header).
+
+### Root cause (panel-verified)
+**Claude Code's MCP client renders *any* HTTP 404 on a session-bearing request as the fatal string `"Error POSTing to endpoint: Unknown session"` and bubbles it up — it does not parse the body or act on the rotate header.** The whole Claude Code session is then locked out of CodeLens until the user restarts Claude Code. Therefore the existing #300/#310 hint-header fix is **the wrong layer**: it assumes a cooperative client that re-issues `initialize`; Claude Code does not. As long as the server returns 404 for *recoverable* session loss, the lockout persists regardless of body/header.
+
+### Why resurrection is safe (panel-verified)
+`SessionState` holds only **soft/adaptive** state: `preset`, `surface`, `token_budget`, `client_metadata`, `recent_tools`/`recent_files` ring buffers, `doom_loop_counter`, `sse_tx`. None is correctness-critical:
+- **Auth** is per-request JWT/principal, validated at `transport_http.rs:442` **before** the session gate. Resurrection cannot bypass or forge auth — the role gate never consulted the session.
+- **Project scope** for tools comes from per-request args, not the session.
+- So a lost session loses only personalization, rebuilt on the next call.
+
+### Scope correction (panel-verified)
+The only two triggers are **(1) process restart** and **(2) idle timeout**. **SCIP/index hot-reload does NOT wipe the store** — the `FileWatcher` mutates the per-project runtime in place; `AppState` (which owns `session_store`) is never rebuilt. The "SCIP index was hot-reloaded" clause in the current hint (`transport_http.rs:198`) is misleading and must be corrected.
+
+## 2. Design — "Stateless-on-session-axis + guarded auto-resurrect"
+
+On a **non-initialize POST** whose `Mcp-Session-Id` is present but absent from the store, instead of 404, **transparently re-create a `SessionState` under the client-provided id**, seed it from request headers, serve the request, and signal the event. Zero client cooperation; uniformly defeats restart + idle-timeout lockout.
+
+Honest framing (MCP-spec lens): CodeLens becomes **stateless on the session axis** — the session id is a soft adaptive-surface affinity key, not a binding contract. This is spec-permitted (the spec's stateless mode is first-class).
+
+### 2.1 The eleven guards (must-fix, folded into the design)
+
+1. **initialize stays server-mint-only** — `create_or_resume` is unchanged (resume-if-found-else-mint-NEW-uuid). Resurrection lives **only** on the non-initialize POST gate. (Extending resurrection to `initialize` would let clients name their own sessions — HIGH-severity spec inversion. Rejected.)
+2. **`trusted_client` seeds `false` unconditionally** — the resurrection (non-initialize) request's `x-codelens-trusted-client` header is **never** read. (Reading it would let any client assert `trusted_client:true` on a plain `tools/call` and bypass the `:7838` mutation gate — privilege escalation. The header is honored only on `initialize`, by deliberate design.)
+3. **DELETE stays authoritative via bounded tombstone** — explicitly-`DELETE`d ids go into a short-TTL, fixed-capacity tombstone set; a tombstoned id is refused resurrection (returns the strict envelope). Preserves the MCP DELETE="terminate" contract without unbounded growth. *(User-selected over document-and-accept.)*
+4. **Single write-lock + `Entry` API** — `get_or_resurrect` is one write-lock critical section using `HashMap::entry` (Occupied/Vacant). Never calls `self.get()` internally (std `RwLock` is non-reentrant → deadlock); never read-then-upgrade (std has no upgradable guard). Poison recovered via `.unwrap_or_else(|p| p.into_inner())` so the `(Arc, bool)` contract always holds and the "id sticks" invariant survives a panic.
+5. **id-shape validation (UUID v4 only)** — a non-UUID `Mcp-Session-Id` is refused resurrection and returns the strict envelope. Collapses the client-controlled key space back to UUID space, blocking enumeration-style flooding and accidental cross-client collision.
+6. **Cap never evicts an active session** — resurrection reuses `create()`'s `MAX_SESSIONS=1000` policy via a shared `trim_to_cap` helper (retain-expired → evict-oldest), run **before** insert so the newcomer (`last_active=now`) is never its own victim. When the map is full of **active** sessions, **refuse** to resurrect (return envelope) rather than evict a live client.
+7. **GET/SSE does not resurrect** — resurrection is on the POST gate only. The SSE GET path (`transport_http.rs:593`) keeps returning the strict envelope. (A bare-GET resurrect would spin up an SSE stream against unestablished surface; the lockout is POST-driven. A stale GET simply prompts a re-POST.)
+8. **Seed `requested_profile` + `deferred_tool_loading` + `client_name`** from request headers (reusing `extract_initialize_metadata`'s header logic) so the deferred-tool-loading `tools/list` shape stays stable for Codex-style clients across resurrection. Never seed privilege-bearing fields (guard #2).
+9. **`SessionState` must stay principal-agnostic** — documented invariant + regression test: a resurrected session grants no principal and can never surface another principal's metadata.
+10. **Observability via response header + telemetry** — `x-codelens-session-resurrected: 1` response header (mirroring the existing `x-codelens-session-resumed`), plus a `session_resurrected` telemetry event (principal_id + id-shape-rejected counters) so a flapping daemon is **not silently masked**. The optional `_meta["codelens/sessionResurrected"]` annotation is added only for `tools/call` (which already has a `CallToolResult`); no `_meta` carrier is invented for methods that lack one.
+11. **Strict 404 path preserved behind a flag** — `CODELENS_SESSION_STRICT` (default: lenient/resurrect). Cooperative clients (Codex) that DO recover via reinit keep the spec-correct #318 envelope. Resolved like the existing `CODELENS_DAEMON_MODE` env in `main.rs`.
+
+### 2.2 Rejected alternatives
+- **(B) Persist session store to disk** — `Instant`/`mpsc::Sender`/`Mutex` aren't serializable; stale state references a dead process; doesn't help the in-memory cases cleanly. Strictly worse than reconstruct-on-demand.
+- **(C) Fully stateless (drop session id)** — loses the adaptive surface, SSE push, doom-loop counter. Resurrection is a superset (keeps the cache on the happy path).
+- **(D) Client-side watchdog** — not in CodeLens's control (the client is Claude Code). This is exactly why the hint-header fix failed.
+
+## 3. Component-level changes (minimal diff)
+
+| File | Change |
+|---|---|
+| `server/session.rs` | + `get_or_resurrect(id, seed) -> Option<(Arc<SessionState>, bool)>` (Entry-based, capped, poison-tolerant; `None` = refused). + private `trim_to_cap(&mut map)` shared with `create()`. + `is_valid_session_id(id)` (UUID v4 shape). + `Tombstone` (bounded short-TTL set) with `mark_deleted`/`is_tombstoned`. + `SessionSeed { requested_profile, deferred_tool_loading, client_name }`. + `seed_into(&SessionState)`. |
+| `server/transport_http.rs` | Gate at 474-481: branch on policy. Lenient + valid-uuid + not-tombstoned + resurrected → serve + set `x-codelens-session-resurrected:1` + telemetry; else → `unknown_session_response()`. Leave GET (593) strict. `mcp_delete_handler` (617-634): record tombstone. Fix misleading hint (198): drop "hot-reloaded", scope to restart/timeout. |
+| `server/transport_http_support.rs` | + `SessionSeed::from_headers(headers)` reusing the `x-codelens-profile` / `x-codelens-deferred-tool-loading` / `x-codelens-client` parse logic. + add `x-codelens-session-resurrected` to the response-header path. |
+| `main.rs` (or `cli.rs`) | Parse `CODELENS_SESSION_STRICT` → `SessionPolicy { Lenient \| Strict }` on `AppState`. Default Lenient. |
+| `server/session_injection.rs` | **No change** — the gate resurrects first, so the existing `store.get(sid)` succeeds (`Entry::Occupied`). |
+| telemetry | + `session_resurrected` event (principal, id_shape_rejected, tombstoned_refused counters). |
+
+### 3.1 Key API
+```rust
+// session.rs
+pub enum SessionPolicy { Lenient, Strict }
+
+pub struct SessionSeed {
+    pub requested_profile: Option<String>,
+    pub deferred_tool_loading: Option<bool>,
+    pub client_name: Option<String>,
+    // NOTE: no trusted_client — guard #2 (fail closed)
+}
+
+impl SessionStore {
+    /// Non-initialize recovery. Returns:
+    ///   Some((s, false)) — found existing
+    ///   Some((s, true))  — resurrected under the client id
+    ///   None             — refused (invalid id-shape, tombstoned, or cap-full-of-active)
+    pub fn get_or_resurrect(&self, id: &str, seed: &SessionSeed) -> Option<(Arc<SessionState>, bool)>;
+}
+```
+The gate maps `None` → `unknown_session_response()` (the strict envelope, now correctly scoped). `is_valid_session_id` is checked before locking.
+
+## 4. Test matrix (TDD — tests first)
+
+**Flipped** (existing): `protocol_tests.rs` POST-unknown-session → now `200 + x-codelens-session-resurrected:1` (lenient default). GET-unknown-session **stays 404** (guard #7). DELETE-then-reuse → stays terminated via tombstone (guard #3).
+
+**New** (≥7):
+1. `get_or_resurrect` concurrency: two threads, same lost id → **one** shared `Arc` (`Arc::ptr_eq`), exactly one `resurrected=true`.
+2. Cap: resurrect at `MAX_SESSIONS` does not evict the just-resurrected entry; full-of-active → `None` (refused).
+3. Principal-agnostic: resurrected `tools/call` with no/invalid bearer → default (un-elevated) role.
+4. **Mutation-gate (critical)**: on `:7838`, resurrect-via-`tools/call` with `x-codelens-trusted-client:1` present → content-mutation still **rejected** (guard #2).
+5. id-shape: non-UUID `Mcp-Session-Id` → refused (envelope), not inserted.
+6. Tombstone: DELETE → non-initialize POST same id → envelope (stays dead); after TTL expiry the id may resurrect.
+7. Deferred shape: resurrect → `tools/list` shape matches a freshly-initialized deferred client (guard #8).
+8. Strict mode: `CODELENS_SESSION_STRICT=1` → unknown session returns the #318 envelope (not resurrected).
+9. Envelope-body assertion (currently untested) — locks the strict-path contract so it doesn't rot.
+10. Poison tolerance: a poisoned store lock still honors `get_or_resurrect`'s contract.
+
+## 5. Phased TDD plan & acceptance criteria
+
+- **Phase 1 — Store primitives** (`session.rs`): `is_valid_session_id`, `trim_to_cap` (factored from `create()`), `Tombstone`, `SessionSeed`, `get_or_resurrect` (Entry-based, capped, poison-tolerant). **AC**: tests 1,2,5,6,10 green; `create()` behavior byte-identical (refactor-only).
+- **Phase 2 — Gate wiring** (`transport_http.rs` + `transport_http_support.rs`): policy branch, `SessionSeed::from_headers`, resurrected header, hint fix, DELETE tombstone. **AC**: flipped POST test green, GET stays strict, tests 3,4,7,9 green.
+- **Phase 3 — Policy flag + telemetry** (`main.rs`/`cli.rs` + telemetry): `CODELENS_SESSION_STRICT`, `session_resurrected` event. **AC**: test 8 green; telemetry event asserted.
+- **Final gate (parent-run, subagent self-report 신뢰 0%)**:
+  ```
+  cargo fmt --all -- --check
+  cargo clippy --workspace --features http -- -D warnings
+  cargo test -p codelens-mcp --bin codelens-mcp --features http,semantic
+  cargo test -p codelens-engine
+  python3 scripts/regen-tool-defs.py --check     # no tool-defs drift
+  ```
+  All green + the prior 726-test baseline preserved (minus the consciously-flipped assertions).
+
+## 6. Out of scope (separate gates)
+- **Live daemon redeploy** (`scripts/redeploy-daemons.sh`) — explicit user gate; this change does not touch the running daemons.
+- **#298 deeper fix** (SCIP hot-reload preserving in-flight handles) — moot for the lockout (resurrection covers the symptom); the in-process handle-swap optimization is separate.
+- **#337 perf** (SQLite PRAGMA / cold-start) — unrelated, already largely landed.
+- **#343 head_git_sha_mismatch noise** — related operational polish, separate issue.


### PR DESCRIPTION
## Summary

Resolves the **"Unknown session" lockout** (#300, #301): after the HTTP daemon restarts or a session idles past timeout, Claude Code's MCP client keeps its cached `Mcp-Session-Id`, the server returns **HTTP 404**, and Claude Code renders *any* 404-on-a-session-request as a fatal `"Error POSTing to endpoint: Unknown session"` — locking the **whole** Claude Code session out of CodeLens until restart.

**Root cause (verified):** the existing #308/#310 hint-header fix was the *wrong layer* — it assumes a cooperative client that re-issues `initialize`; Claude Code does not. As long as the server returns 404 for *recoverable* session loss, the lockout persists regardless of body/header.

**Fix — stateless-on-session-axis + guarded auto-resurrect:** on a non-initialize POST whose `Mcp-Session-Id` is UUID-shaped, non-tombstoned, and unknown, the server transparently re-creates a soft `SessionState` **under the client-provided id** and serves the request — zero client cooperation. `SessionState` is 100% soft/adaptive (auth is per-request JWT validated *before* the gate; project scope is per-request), so resurrection loses only personalization, never correctness.

Design: `docs/superpowers/specs/2026-06-04-http-session-resurrect-design.md` · Plan: `docs/superpowers/plans/2026-06-04-http-session-resurrect.md`. Design hardened by a 4-lens adversarial panel (MCP-spec / security / concurrency / blast-radius).

## The 11 guards

1. `initialize` stays **server-mint-only** (`create_or_resume` unchanged) — resurrection lives only on the non-initialize POST gate.
2. `trusted_client` seeds **`false` unconditionally** — `SessionSeed` has no such field and `from_headers` never reads `x-codelens-trusted-client`, so a resurrection can't assert trust and bypass the `:7838` mutation gate.
3. **Bounded tombstone** keeps DELETE authoritative (a `DELETE`d id is refused resurrection for a short TTL).
4. **Single write-lock** `get_or_resurrect` (std `RwLock` is non-reentrant / no upgradable guard), poison-tolerant — concurrent callers for the same lost id converge on one `Arc`.
5. **UUID-shape gate** — non-UUID ids are refused (keeps the strict envelope), blocking flooding/collision.
6. **Cap never evicts an active session** — reclaim expired only; refuse at cap.
7. **GET/SSE stays strict** (resurrection is POST-only).
8. Seed `requested_profile` + `deferred_tool_loading` + `client_name` so the deferred `tools/list` shape stays stable.
9. **`SessionState` stays principal-agnostic** — resurrection grants no principal.
10. Observability: `x-codelens-session-resurrected: 1` header + `tracing` event (a flapping daemon is not silently masked).
11. `CODELENS_SESSION_STRICT=1` opt-out keeps the #318 envelope for cooperative clients (default lenient).

Also corrects the misleading hint: **SCIP hot-reload does NOT wipe the in-memory store** (it mutates the per-project runtime in place; `AppState` is never rebuilt), so it is not a cause.

## Verification

- `cargo test -p codelens-mcp --bin codelens-mcp --features http` → **711 passed / 0 failed / 7 ignored** (+15 new tests; existing non-UUID / GET / DELETE assertions unchanged — no regression).
- `cargo fmt --check`, `cargo clippy --features http -- -D warnings`, `cargo clippy --no-default-features -- -D warnings`, `cargo check --no-default-features`, `regen-tool-defs.py --check` → all clean.
- **Live proof on the redeployed daemon** (`:7839`):
  - UUID unknown session + `tools/list` (no initialize) → `HTTP 200` + `x-codelens-session-resurrected: 1` ✅
  - non-UUID session → `HTTP 404` + `x-codelens-session-rotate: 1` envelope ✅
  - `daemon-stale-check` → in sync.

7-task TDD (RED→GREEN→commit each). +560 / −23 across 6 files.

## Notes

- **Stacked on `feat/h1-scope-canonicalize`** (base of this PR) — its single commit `44edfce4` is a dependency not yet on `main`; merge after that branch.
- Out of scope: #298's deeper in-process SCIP-handle swap (resurrection covers the symptom); #337 perf; #343 stale-warning noise.

Closes #300, #301. Addresses the #298 symptom and the #318 envelope-bypass finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
