### PR TITLE
fix(rbac): fail closed on malformed principals in mutation-capable runtimes

### DIFF
--- a/crates/codelens-mcp/src/integration_tests/registry.rs
+++ b/crates/codelens-mcp/src/integration_tests/registry.rs
@@ -49,7 +49,10 @@ fn registry_resources_report_projects_and_memory_scopes() {
     assert!(scopes_body.contains("\\\"scope\\\": \\\"project\\\""));
     assert!(scopes_body.contains("\\\"scope\\\": \\\"global\\\""));
     assert!(scopes_body.contains("mutation_wired"));
-    assert!(scopes_body.contains("Passive scaffold"));
+    // Note now describes the actual tiered scope support (write/delete/read/
+    // list accept a scope param; rename/archive/restore/list_archived are
+    // project-only) instead of the old "project scope only" scaffold text.
+    assert!(scopes_body.contains("project-scoped only"));
 }
 
 #[test]

--- a/crates/codelens-mcp/src/principals.rs
+++ b/crates/codelens-mcp/src/principals.rs
@@ -94,8 +94,12 @@ impl Principals {
     /// - `strict` → [`Self::strict_default`] (every unknown id is
     ///   `ReadOnly`, so mutation tools are denied)
     ///
-    /// Parse errors propagate so misconfiguration is surfaced loudly
-    /// at startup instead of silently falling back.
+    /// Parse errors propagate to the caller (they are never swallowed
+    /// here). The caller's policy is mode-dependent — see
+    /// [`crate::state::AppState::principals`]: a read path (stdio,
+    /// read-only daemon) logs at `warn` and falls back to
+    /// [`Self::permissive_default`], while a mutation-enabled daemon
+    /// fails closed to [`Self::strict_default`] and logs at `error`.
     pub fn discover(project_audit_dir: &Path) -> Result<Self> {
         // project audit dir is `<project>/.codelens/audit/`; principals.toml
         // lives one directory up at `<project>/.codelens/principals.toml`.
@@ -170,20 +174,23 @@ impl Principals {
 /// Tier mapping:
 /// - `Admin` — `audit_log_query` and other administrative queries
 ///   that touch the durable audit log or principals registry.
-/// - `Refactor` — code-mutation tools (every entry in
-///   [`crate::tool_defs::is_content_mutation_tool`] except the
-///   memory carve-out).
-/// - `ReadOnly` — everything else, including memory tools.
+/// - `Refactor` — every code-mutation tool in
+///   [`crate::tool_defs::is_content_mutation_tool`], *including* the
+///   memory-mutation tools (`write_memory` / `delete_memory` /
+///   `rename_memory`).
+/// - `ReadOnly` — everything else (queries and navigation).
 ///
-/// Memory tools (`write_memory`/`delete_memory`/`rename_memory`)
-/// are a deliberate exception: they mutate agent-side context, not
-/// the project's source tree, so the role gate treats them as
-/// `ReadOnly`. They remain in `is_content_mutation_tool` so the
-/// audit sink still records each memory change.
+/// Memory-mutation tools were previously carved out to `ReadOnly` on
+/// the theory that they only touch agent-side context. That carve-out
+/// is removed: an agent's long-term memory is a trust surface whose
+/// corruption is comparable in blast radius to a source mutation
+/// (poisoned recall silently steers future work), so memory writes
+/// now require the same `Refactor` tier as any other content
+/// mutation. They keep falling through `is_content_mutation_tool`, so
+/// the audit sink still records each memory change.
 pub fn required_role_for(tool: &str) -> Role {
     match tool {
         "audit_log_query" => Role::Admin,
-        "write_memory" | "delete_memory" | "rename_memory" => Role::ReadOnly,
         other if crate::tool_defs::is_content_mutation_tool(other) => Role::Refactor,
         _ => Role::ReadOnly,
     }
@@ -250,9 +257,10 @@ mod tests {
             "strict default must deny code-mutation tools"
         );
         assert!(
-            p.resolve(Some("anyone"))
+            !p.resolve(Some("anyone"))
                 .satisfies(required_role_for("write_memory")),
-            "strict default must still allow memory-tier tools (M6)"
+            "strict default must now also deny memory-mutation tools \
+             (Refactor tier, no longer a ReadOnly carve-out)"
         );
     }
 
@@ -386,15 +394,20 @@ role = "Admin"
     }
 
     #[test]
-    fn memory_tools_are_readonly_despite_being_mutation_tools() {
-        // Memory writes are agent-context, not codebase mutation.
-        // The role gate must let read-only principals call them, but
-        // the audit sink still tracks them via is_content_mutation_tool.
+    fn memory_tools_require_refactor_like_other_mutations() {
+        // Memory writes are a trust surface on par with source
+        // mutation: the role gate now requires the Refactor tier (the
+        // old ReadOnly carve-out is gone), and the audit sink still
+        // tracks them via is_content_mutation_tool.
         for tool in ["write_memory", "delete_memory", "rename_memory"] {
             assert_eq!(
                 required_role_for(tool),
-                Role::ReadOnly,
-                "{tool} should be ReadOnly for the role gate"
+                Role::Refactor,
+                "{tool} should require Refactor for the role gate"
+            );
+            assert!(
+                !Role::ReadOnly.satisfies(required_role_for(tool)),
+                "{tool} must NOT be callable by a ReadOnly principal"
             );
             assert!(
                 crate::tool_defs::is_content_mutation_tool(tool),

--- a/crates/codelens-mcp/src/resources.rs
+++ b/crates/codelens-mcp/src/resources.rs
@@ -129,7 +129,7 @@ pub(crate) fn read_resource(state: &AppState, uri: &str, params: Option<&Value>)
                 uri,
                 json!({
                     "scopes": scopes,
-                    "note": "Passive scaffold (P3). Mutation tools (write_memory / read_memory) currently operate on project scope only. Global scope path is declared so the contract is visible before wiring the active half of P3.",
+                    "note": "write_memory / delete_memory / read_memory / list_memories accept a `scope` parameter and resolve to either tier (write/delete default `project`, read defaults `auto`, list defaults `project`; read also accepts `auto`, list also accepts `both`). rename_memory / archive_memory / restore_memory / list_archived are project-scoped only. The global tier resolves to $HOME/.codelens/memories/.",
                 }),
             )
         }

--- a/crates/codelens-mcp/src/state/audit.rs
+++ b/crates/codelens-mcp/src/state/audit.rs
@@ -9,9 +9,26 @@ impl AppState {
     /// pulls the right `principals.toml` from the cache or discovers
     /// it on first access.
     ///
-    /// Discovery failures fall back to the permissive default (every
-    /// id maps to `Refactor`) so a malformed file does not block the
-    /// dispatch path — the parse error is logged at warn.
+    /// Discovery failures (a `principals.toml` that is present but
+    /// unreadable / unparseable) resolve by whether the runtime can
+    /// mutate at all:
+    /// - **any mutation-capable mode** (`mutation_allowed_in_runtime()`
+    ///   is true — i.e. `Standard`, which is the stdio and
+    ///   unspecified-`--daemon-mode` default, and `MutationEnabled`):
+    ///   fail closed to `strict_default` (every id maps to `ReadOnly`,
+    ///   so code-mutation tools are denied) and log at `error`. A
+    ///   runtime that can apply mutations must not silently open up when
+    ///   its RBAC file is broken.
+    /// - **read-only daemon** (`RuntimeDaemonMode::ReadOnly`): fall back
+    ///   to `permissive_default` (every id maps to `Refactor`) and log
+    ///   at `warn`. It cannot mutate anyway, so a malformed file need
+    ///   not block its read/analysis path.
+    ///
+    /// A *missing* file is not an error — `discover` returns the
+    /// env-selected default and never reaches this branch — so an
+    /// install that never deployed a `principals.toml` is unaffected in
+    /// every mode. Fail-closed only bites once an RBAC file exists and
+    /// is broken.
     pub(crate) fn principals(&self) -> Arc<crate::principals::Principals> {
         let dir = self.audit_dir();
         {
@@ -23,8 +40,26 @@ impl AppState {
                 return Arc::clone(existing);
             }
         }
+        // Any runtime that can apply mutations (Standard — the stdio /
+        // unspecified default — and MutationEnabled) must fail closed on
+        // a broken RBAC file; only a read-only daemon keeps the legacy
+        // permissive fallback.
+        let mutation_allowed = self.mutation_allowed_in_runtime();
+        let mut failed_closed = false;
         let resolved = match crate::principals::Principals::discover(&dir) {
             Ok(p) => p,
+            Err(error) if mutation_allowed => {
+                failed_closed = true;
+                tracing::error!(
+                    error = %error,
+                    audit_dir = %dir.display(),
+                    daemon_mode = self.daemon_mode().as_str(),
+                    "failed to load principals.toml in a mutation-capable runtime — \
+                     refusing permissive fallback and denying all code-mutation tools \
+                     (every principal mapped to ReadOnly); fix principals.toml"
+                );
+                crate::principals::Principals::strict_default()
+            }
             Err(error) => {
                 tracing::warn!(
                     error = %error,
@@ -35,7 +70,13 @@ impl AppState {
                 crate::principals::Principals::permissive_default()
             }
         };
-        if resolved.default_role() == crate::principals::Role::ReadOnly
+        // Only emit the "strict by env with no principals.toml" notice
+        // for the genuine env-selected-strict path. The fail-closed
+        // branch above also yields a ReadOnly/0-explicit result, but its
+        // cause (a present-but-broken file) is already logged at `error`,
+        // and this notice's wording ("no principals.toml") would be false.
+        if !failed_closed
+            && resolved.default_role() == crate::principals::Role::ReadOnly
             && resolved.explicit_count() == 0
         {
             tracing::warn!(
@@ -131,5 +172,81 @@ fn run_audit_retention_sweep(sink: &crate::audit_sink::AuditSink) {
                 "audit retention sweep failed — sink remains usable"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AppState;
+    use crate::principals::Role;
+    use crate::state::RuntimeDaemonMode;
+    use codelens_engine::ProjectRoot;
+
+    /// Build a temp project whose `.codelens/principals.toml` is present
+    /// but unparseable (unknown role string → deserialize error), so
+    /// `Principals::discover` returns `Err` rather than a missing-file
+    /// default. Returns the project plus a keep-alive dir handle.
+    fn project_with_malformed_principals(label: &str) -> (ProjectRoot, std::path::PathBuf) {
+        let dir = std::env::temp_dir().join(format!(
+            "codelens-audit-principals-{label}-{}-{:?}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos(),
+            std::thread::current().id(),
+        ));
+        std::fs::create_dir_all(dir.join(".codelens")).unwrap();
+        std::fs::write(dir.join("lib.rs"), "fn sample() {}\n").unwrap();
+        std::fs::write(
+            dir.join(".codelens").join("principals.toml"),
+            "[default]\nrole = \"Superuser\"\n",
+        )
+        .unwrap();
+        let project = ProjectRoot::new_exact(&dir).unwrap();
+        (project, dir)
+    }
+
+    #[test]
+    fn mutation_daemon_fails_closed_on_malformed_principals() {
+        let (project, _dir) = project_with_malformed_principals("mutation");
+        let state = AppState::new_minimal(project, crate::tool_defs::ToolPreset::Full);
+        state.configure_daemon_mode(RuntimeDaemonMode::MutationEnabled);
+        let principals = state.principals();
+        assert_eq!(
+            principals.default_role(),
+            Role::ReadOnly,
+            "mutation-enabled daemon must fail closed (ReadOnly) on a malformed principals.toml"
+        );
+    }
+
+    #[test]
+    fn standard_mode_also_fails_closed_on_malformed_principals() {
+        let (project, _dir) = project_with_malformed_principals("standard");
+        let state = AppState::new_minimal(project, crate::tool_defs::ToolPreset::Full);
+        // Standard is the stdio / unspecified --daemon-mode default and is
+        // mutation-capable (mutation_allowed_in_runtime() == true), so it
+        // must fail closed just like MutationEnabled.
+        state.configure_daemon_mode(RuntimeDaemonMode::Standard);
+        let principals = state.principals();
+        assert_eq!(
+            principals.default_role(),
+            Role::ReadOnly,
+            "Standard (mutation-capable) mode must fail closed on a malformed principals.toml"
+        );
+    }
+
+    #[test]
+    fn read_path_keeps_permissive_fallback_on_malformed_principals() {
+        let (project, _dir) = project_with_malformed_principals("readpath");
+        let state = AppState::new_minimal(project, crate::tool_defs::ToolPreset::Full);
+        // Read-only daemon is a non-mutation mode: legacy permissive
+        // fallback (every principal → Refactor) is preserved.
+        state.configure_daemon_mode(RuntimeDaemonMode::ReadOnly);
+        let principals = state.principals();
+        assert_eq!(
+            principals.default_role(),
+            Role::Refactor,
+            "non-mutation modes must retain the permissive Refactor fallback"
+        );
     }
 }

--- a/crates/codelens-mcp/src/tool_defs/generated/build_generated.rs
+++ b/crates/codelens-mcp/src/tool_defs/generated/build_generated.rs
@@ -64,7 +64,7 @@ pub fn composite_tools(
         ).with_annotations(ro_w.clone()),
         Tool::new(
             "orchestrate_change",
-            "[CodeLens:Workflow] Bounded change-orchestration run for a described task — preflight evidence, approval-gate state machine, and audit events. Returns run_id and final state (approval_required / executing / cancelled / failed).",
+            "[CodeLens:Workflow] Advisory dry-run change-orchestration plan for a described task — preflight evidence, a session-scoped in-memory approval gate, and audit events. Performs no file mutation itself; the plan is enforced only when a later mutation call passes the returned orchestration_run_id. Returns run_id and final state (approval_required / executing / cancelled / failed).",
             json!({"type":"object","required":["task"],"properties":{"task":{"type":"string"},"mode":{"type":"string","enum":["solo","planner_builder","ci_audit"]},"target_paths":{"type":"array","items":{"type":"string"},"description":"Scope paths (max 16)"},"acceptance":{"type":"array","items":{"type":"string"},"description":"Acceptance criteria items (max 12)"},"profile_hint":{"type":"string"},"approval":{"type":"object","description":"Approval payload: { decision: granted|denied, actor?, reason?, actions? }"},"worktree":{"type":"string"},"requester":{"type":"string"}}}),
         ).with_annotations(ro_w.clone()),
         Tool::new(
@@ -239,23 +239,23 @@ pub fn memory_tools(
     vec![
         Tool::new(
             "list_memories",
-            "[CodeLens:Memory] List project memory files under .codelens/memories.",
-            json!({"type":"object","properties":{"topic":{"type":"string","description":"Optional topic to filter"}}}),
+            "[CodeLens:Memory] List project or global memory files under .codelens/memories.",
+            json!({"type":"object","properties":{"topic":{"type":"string","description":"Optional topic to filter"},"scope":{"type":"string","enum":["project","global","both"],"description":"Memory tier to list (default project)"}}}),
         ).with_output_schema(memory_list_output_schema()).with_annotations(ro_p.clone()),
         Tool::new(
             "read_memory",
-            "[CodeLens:Memory] Read a named project memory file.",
-            json!({"type":"object","required":["memory_name"],"properties":{"memory_name":{"type":"string"}}}),
+            "[CodeLens:Memory] Read a named project or global memory file.",
+            json!({"type":"object","required":["memory_name"],"properties":{"memory_name":{"type":"string"},"scope":{"type":"string","enum":["auto","project","global"],"description":"Memory tier to read (default auto: project then global)"}}}),
         ).with_annotations(ro_p.clone()),
         Tool::new(
             "write_memory",
-            "[CodeLens:Memory] Create or overwrite a project memory file.",
-            json!({"type":"object","required":["memory_name","content"],"properties":{"memory_name":{"type":"string"},"content":{"type":"string"}}}),
+            "[CodeLens:Memory] Create or overwrite a project or global memory file.",
+            json!({"type":"object","required":["memory_name","content"],"properties":{"memory_name":{"type":"string"},"content":{"type":"string"},"scope":{"type":"string","enum":["project","global"],"description":"Memory tier to write (default project)"}}}),
         ).with_annotations(mutating.clone()),
         Tool::new(
             "delete_memory",
-            "[CodeLens:Memory] Delete a project memory file.",
-            json!({"type":"object","required":["memory_name"],"properties":{"memory_name":{"type":"string"}}}),
+            "[CodeLens:Memory] Delete a project or global memory file.",
+            json!({"type":"object","required":["memory_name"],"properties":{"memory_name":{"type":"string"},"scope":{"type":"string","enum":["project","global"],"description":"Memory tier to delete from (default project)"}}}),
         ).with_annotations(destructive.clone()),
         Tool::new(
             "rename_memory",

--- a/crates/codelens-mcp/src/tools/mod.rs
+++ b/crates/codelens-mcp/src/tools/mod.rs
@@ -210,8 +210,15 @@ pub(crate) const TOMBSTONED_TOOLS: &[(&str, &str)] = &[
     ),
 ];
 
-/// Pending ADR-0009/D3 (#346): the symbolic edit core remains dispatch-only
-/// — callable but schemaless — until the re-listing decision.
+/// ADR-0009/D3 (#346) — **Decided 2026-07-03: keep dispatch-only (internal).**
+/// The symbolic edit core stays callable-but-schemaless rather than being
+/// re-listed. Rationale: host harnesses route schema-exposed symbolic edits
+/// through a dedicated editor (Serena et al.), while the `:7838` mutation
+/// daemon must keep calling these tools behind the mutation gate. Re-exposure
+/// is conditioned on evidence of host demand with no symbolic editor **and**
+/// a mature authoritative-apply path in the LSP backend. (The `PENDING_D3_`
+/// prefix is retained because CI drift gates and runtime report vocabulary
+/// key off these identifiers — see [`PENDING_D3_ALLOWLIST`].)
 pub(crate) const PENDING_D3_SYMBOLIC_EDIT_CORE: &[&str] = &[
     "replace_symbol_body",
     "insert_before_symbol",
@@ -219,8 +226,10 @@ pub(crate) const PENDING_D3_SYMBOLIC_EDIT_CORE: &[&str] = &[
     "rename_symbol",
 ];
 
-/// Pending ADR-0009/D3 (#346): substrate-preservation arms kept dispatch-only
-/// until the safe-delete/refactor-substrate decision.
+/// ADR-0009/D3 (#346) — **Decided 2026-07-03: keep dispatch-only (internal).**
+/// The substrate-preservation arms follow the same decision as
+/// [`PENDING_D3_SYMBOLIC_EDIT_CORE`]: retained dispatch-only behind the
+/// mutation gate, re-exposure gated on the same conditions.
 pub(crate) const PENDING_D3_REFACTOR_SUBSTRATE: &[&str] = &[
     "refactor_extract_function",
     "refactor_inline_function",

--- a/crates/codelens-mcp/tools.toml
+++ b/crates/codelens-mcp/tools.toml
@@ -593,7 +593,7 @@ changed_files = { type = "array", items = { type = "string" }, description = "Op
 name = "orchestrate_change"
 category = "composite"
 preset_tags = ["planner-readonly", "builder-minimal", "reviewer-graph"]
-description = "[CodeLens:Workflow] Bounded change-orchestration run for a described task — preflight evidence, approval-gate state machine, and audit events. Returns run_id and final state (approval_required / executing / cancelled / failed)."
+description = "[CodeLens:Workflow] Advisory dry-run change-orchestration plan for a described task — preflight evidence, a session-scoped in-memory approval gate, and audit events. Performs no file mutation itself; the plan is enforced only when a later mutation call passes the returned orchestration_run_id. Returns run_id and final state (approval_required / executing / cancelled / failed)."
 annotations = "ro_w"
 
 [tool.input_schema]
@@ -1413,13 +1413,13 @@ properties = { threshold_days = { type = "integer", minimum = 1, maximum = 3650,
 name = "list_memories"
 category = "memory"
 preset_tags = []
-description = "[CodeLens:Memory] List project memory files under .codelens/memories."
+description = "[CodeLens:Memory] List project or global memory files under .codelens/memories."
 annotations = "ro_p"
 output_schema = "memory_list_output_schema"
 
 [tool.input_schema]
 type = "object"
-properties = { topic = { type = "string", description = "Optional topic to filter" } }
+properties = { topic = { type = "string", description = "Optional topic to filter" }, scope = { type = "string", enum = ["project", "global", "both"], description = "Memory tier to list (default project)" } }
 
 # ─────
 
@@ -1427,13 +1427,13 @@ properties = { topic = { type = "string", description = "Optional topic to filte
 name = "read_memory"
 category = "memory"
 preset_tags = []
-description = "[CodeLens:Memory] Read a named project memory file."
+description = "[CodeLens:Memory] Read a named project or global memory file."
 annotations = "ro_p"
 
 [tool.input_schema]
 type = "object"
 required = ["memory_name"]
-properties = { memory_name = { type = "string" } }
+properties = { memory_name = { type = "string" }, scope = { type = "string", enum = ["auto", "project", "global"], description = "Memory tier to read (default auto: project then global)" } }
 
 # ─────
 
@@ -1441,13 +1441,13 @@ properties = { memory_name = { type = "string" } }
 name = "write_memory"
 category = "memory"
 preset_tags = []
-description = "[CodeLens:Memory] Create or overwrite a project memory file."
+description = "[CodeLens:Memory] Create or overwrite a project or global memory file."
 annotations = "mutating"
 
 [tool.input_schema]
 type = "object"
 required = ["memory_name", "content"]
-properties = { memory_name = { type = "string" }, content = { type = "string" } }
+properties = { memory_name = { type = "string" }, content = { type = "string" }, scope = { type = "string", enum = ["project", "global"], description = "Memory tier to write (default project)" } }
 
 # ─────
 
@@ -1455,13 +1455,13 @@ properties = { memory_name = { type = "string" }, content = { type = "string" } 
 name = "delete_memory"
 category = "memory"
 preset_tags = []
-description = "[CodeLens:Memory] Delete a project memory file."
+description = "[CodeLens:Memory] Delete a project or global memory file."
 annotations = "destructive"
 
 [tool.input_schema]
 type = "object"
 required = ["memory_name"]
-properties = { memory_name = { type = "string" } }
+properties = { memory_name = { type = "string" }, scope = { type = "string", enum = ["project", "global"], description = "Memory tier to delete from (default project)" } }
 
 # ─────
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,6 +15,7 @@
 - Canonical manifest: [`docs/generated/surface-manifest.json`](generated/surface-manifest.json)
 
 <!-- SURFACE_MANIFEST_ARCHITECTURE_SNAPSHOT:END -->
+- The registered-tool count in the snapshot above is measured against the default build surface; the absolute number of entries in `tools.toml` is higher because some tools are semantic-feature-gated and only compile in under their feature flags.
 - Runtime surface is profile- and session-dependent; use [`prepare_harness_session`](../crates/codelens-mcp/src/tools/session/project_ops.rs) and `tools/list` for live counts rather than this document
 - Published distribution channels: crates.io, GitHub Releases, Homebrew tap, installer script, source builds
 - Current release notes: [latest GitHub release](https://github.com/mupozg823/codelens-mcp-plugin/releases/latest). For local release-quality comparisons, resolve the baseline tag with `git tag --sort=-v:refname | head -1`.
@@ -43,7 +44,7 @@ Evidence:
 
 Prioritized architecture moves:
 
-1. Finish pending-D3 policy before adding new symbolic-edit abstractions: either re-list the 4-tool `pending_d3_symbolic_edit_core` behind the existing mutation gate, or remove it; decide the 5-tool `pending_d3_refactor_substrate` separately as safe-delete/refactor surface or deletion.
+1. Resolved (2026-07-03): pending-D3 stays dispatch-only (internal) by decision — this is no longer an open TODO. The 4-tool `pending_d3_symbolic_edit_core` and the 5-tool `pending_d3_refactor_substrate` remain callable behind the mutation gate but unlisted (schemaless). Rationale: hosts route schema-exposed symbolic edits through a dedicated editor (Serena et al.), while the `:7838` mutation daemon must keep calling these behind the gate. Re-listing is conditioned on host demand with no symbolic editor plus a mature LSP authoritative-apply path. The `pending_d3_` identifiers are retained deliberately because CI drift gates and runtime report vocabulary key off them.
 2. Completed: split `tools/workflows.rs` by real responsibility; duplicate-cleanup quality filters and tests now live in `tools/workflows/duplicate_cleanup.rs`, leaving workflow entrypoints as thin orchestration.
 3. Next: split `session_metrics_payload.rs` into KPI, token-bill, and session-classifier submodules. It is currently a mixed payload/KPI/cost-classification unit and does not map to Serena parity; this is plain maintainability work.
 4. Treat `dispatch/response.rs` as high-risk but second order: it is large, but the dispatch boundary has no cycle hit. Only extract cohesive delegate-hint or response-enrichment helpers when the diff removes real branching complexity.

--- a/docs/generated/surface-manifest.json
+++ b/docs/generated/surface-manifest.json
@@ -325,7 +325,7 @@
         "phase": null,
         "preferred_executor": null,
         "has_output_schema": false,
-        "estimated_tokens": 252
+        "estimated_tokens": 290
       },
       {
         "name": "module_boundary_report",
@@ -748,7 +748,7 @@
         "phase": null,
         "preferred_executor": null,
         "has_output_schema": true,
-        "estimated_tokens": 125
+        "estimated_tokens": 156
       },
       {
         "name": "read_memory",
@@ -757,7 +757,7 @@
         "phase": null,
         "preferred_executor": null,
         "has_output_schema": false,
-        "estimated_tokens": 86
+        "estimated_tokens": 122
       },
       {
         "name": "write_memory",
@@ -766,7 +766,7 @@
         "phase": null,
         "preferred_executor": null,
         "has_output_schema": false,
-        "estimated_tokens": 94
+        "estimated_tokens": 124
       },
       {
         "name": "delete_memory",
@@ -775,7 +775,7 @@
         "phase": null,
         "preferred_executor": null,
         "has_output_schema": false,
-        "estimated_tokens": 89
+        "estimated_tokens": 120
       },
       {
         "name": "rename_memory",

--- a/docs/multi-agent-integration.md
+++ b/docs/multi-agent-integration.md
@@ -26,12 +26,24 @@ The host or harness still provides:
 - branch policy, merge policy, and release policy
 - any Claude-specific or Codex-specific custom agent wrapper
 
-CodeLens is moving from shared coordination/verification into a bounded
-code-work orchestrator, per
-[ADR-0014](adr/ADR-0014-bounded-code-work-orchestrator.md). The boundary is
-deliberate: CodeLens may own a typed code-work run state machine, audit trail,
-preflight, approval, dispatch, and verification flow; the host still owns the
-general chat/runtime loop and any host-specific agent wrapper.
+CodeLens is exploring a move from shared coordination/verification toward a
+bounded code-work orchestrator, per
+[ADR-0014](adr/ADR-0014-bounded-code-work-orchestrator.md). Separate what ships
+today from where that ADR points:
+
+- **Today (shipped).** `orchestrate_change` produces an *advisory dry-run*
+  orchestration plan. It emits a `dry_run: true` artifact and performs no file
+  mutation of its own. Approval is session-scoped and held in memory only, so
+  it is lost when the daemon restarts. The plan is never self-enforcing; it is
+  enforced opt-in, only when a subsequent mutation call passes the matching
+  `orchestration_run_id` through the mutation gate.
+- **Direction (ADR-0014, not yet built).** A durable, typed code-work run
+  state machine — with a persistent audit trail, preflight, approval, dispatch,
+  and verification flow that survives restarts — is a future candidate, not
+  current behavior.
+
+Either way, the host still owns the general chat/runtime loop and any
+host-specific agent wrapper.
 
 ## Delegate Scaffold Correlation
 

--- a/docs/serena-comparison.md
+++ b/docs/serena-comparison.md
@@ -151,7 +151,7 @@ Concrete, phased design with acceptance criteria lives in:
 
 Summary of the recommendation:
 
-- **P1 (read core + hygiene)**: D1 read trio is now surfaced (`find_declaration` / `find_implementations` / `get_diagnostics_for_symbol`). Drift gates now report pending-D3 ghosts as `pending_d3_symbolic_edit_core` and `pending_d3_refactor_substrate`; remaining P1 hygiene is the final re-list/delete decision for those two classes.
+- **P1 (read core + hygiene)**: D1 read trio is now surfaced (`find_declaration` / `find_implementations` / `get_diagnostics_for_symbol`). Drift gates report the pending-D3 ghosts as `pending_d3_symbolic_edit_core` and `pending_d3_refactor_substrate`. The re-list/delete question for those two classes is **decided (2026-07-03): keep them dispatch-only (internal)** behind the mutation gate rather than re-listing, so P1 hygiene is closed; re-listing stays a conditional future (see docs/architecture.md for the rationale and conditions).
 - **P2 (edit core + enforcement)**: re-list a 4-tool symbolic edit core (`replace_symbol_body`, `insert_before_symbol`, `insert_after_symbol`, `rename_symbol`) behind the existing `verify_change_readiness` mutation gate — explicitly *keeping* the gate where Serena chose blind trust; ship an opt-in plugin hook (Serena hooks.py pattern, soft `additionalContext` reminder by default, strict deny opt-in) plus a task→tool mapping table in the plugin skills.
 - **P3 (memory conventions)**: `[[name]]`-style reference integrity + rename propagation in CodeLens memories, folded into `audit_memory_consistency`.
 - **P4 (internal architecture hygiene)**: split large mixed-responsibility CodeLens modules only where the split removes real ownership friction. The `tools/workflows.rs` duplicate-cleanup filter split is complete; next candidates are `session_metrics_payload.rs` KPI/token-bill/classifier logic and eventually `project.rs` detection helpers. Do not start with `dispatch/response.rs`; it is large but the current boundary has no cycle hit.
@@ -163,7 +163,7 @@ What **not** to adopt: thinking tools (Serena deleted theirs), per-edit diagnost
 > "Is CodeLens already clearly superior to Serena?"
 
 - **for harness-native bounded analysis and retrieval**: yes, and the lead is measurable.
-- **for symbolic editing and routing enforcement**: no — Serena still leads; CodeLens has recovered read-side parity but symbolic edit remains pending-D3 dispatch-only.
+- **for symbolic editing and routing enforcement**: no — Serena still leads; CodeLens has recovered read-side parity, but symbolic edit is, by decision (2026-07-03), kept pending-D3 dispatch-only (internal, unlisted) rather than surfaced.
 - **as a strict overall superset**: no.
 
 > "Can CodeLens become the better *symbolic* tool while keeping its harness edge?"


### PR DESCRIPTION
## Summary

Adversarially-verified hardening pass over the external architecture audit (fact claims verified against ground truth by a 9-cluster panel; proposals judged by a 3-lens refutation panel; the implementation itself re-reviewed by an adversarial finder/verify panel that caught and fixed one MAJOR gap).

- **RBAC fail-closed**: `principals.toml` discovery errors (file present but unreadable/unparseable) now fail closed to `strict_default` (every principal → ReadOnly) in any mutation-capable runtime mode — `Standard` (the stdio / unspecified `--daemon-mode` default) and `MutationEnabled`. Read-only daemons keep the legacy permissive fallback; a *missing* file is unchanged in every mode, so installs that never deployed RBAC are unaffected. The misleading env-strict "no principals.toml" warn is suppressed on the fail-closed path.
- **Memory mutation tier**: dropped the `write_memory`/`delete_memory`/`rename_memory` ReadOnly carve-out — memory mutation now requires `Refactor` like every other content mutation (agent long-term memory is a trust surface; poisoned recall ≈ source mutation blast radius). Consistent with `archive/restore_memory` which already required Refactor.
- **Orchestration honesty**: `orchestrate_change` description + `docs/multi-agent-integration.md` now state the shipped semantics — advisory dry-run plan, session-scoped in-memory approval, opt-in enforcement via `orchestration_run_id`; ADR-0014's durable run state machine is explicitly marked as direction, not current behavior.
- **pending-D3 closed as decided**: symbolic-edit core + refactor substrate stay dispatch-only (internal) by decision (2026-07-03); identifiers, member sets, and report vocabulary unchanged (CI drift gates key off them). Re-listing is conditioned on host demand without a symbolic editor plus LSP authoritative-apply maturity.
- **Memory scope drift**: `scope` parameter now exposed in tools.toml for write/delete/read/list memory tools (project/global; read `auto`, list `both`), and the memory-scopes resource note matches the runtime tiers.
- **Docs**: architecture snapshot tool-count methodology note (default-build surface vs tools.toml total incl. semantic-gated).

Explicitly **rejected** after adversarial judging (recorded, not implemented): the audit's 11-tool MVP surface cut (self-contradictory — rename_symbol's own preflight gate tools weren't in the list — and preset/profile surfaces already solve it) and the 10-tool "unused" removal (coverage-proxy evidence; archive/restore is the only memory undo path).

## Test plan

- `cargo test -p codelens-mcp --bin codelens-mcp` — 653 passed (3 new fail-closed tests: MutationEnabled / Standard / ReadOnly modes)
- `cargo test -p codelens-mcp --bin codelens-mcp --features http` — 753 passed
- `cargo nextest run --workspace` 1111 passed · `--features http` 1210 passed · `--no-default-features` 956 passed
- `cargo clippy --workspace -- -D warnings` (+ `--no-default-features`, `--features scip-backend`) clean
- `cargo fmt --all -- --check`, `cargo test --doc --workspace` clean
- `python3 scripts/regen-tool-defs.py --check`, `python3 scripts/surface-manifest.py --check`, `benchmarks/lint-datasets.py` all pass
- Daemons redeployed at this sha: `daemon-stale-check` in sync, `mcp-doctor --strict` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)