### PR TITLE
feat(response): lean response contract for token-expensive models (Fable)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Lean response contract for token-expensive models (Fable)** — a quality-neutral, scaffold-only envelope thrift, grounded in Anthropic tool-response guidance (keep responses lean; Claude Code counts/injects the **text** channel and warns at 10K tokens). Activation: per-call `_lean: true` (an explicit `_lean: false` overrides the env — per-call escape hatch), or daemon-wide `CODELENS_RESPONSE_CONTRACT=lean`. Drops from the text envelope: `suggestion_reasons` (prose duplication of `suggested_next_tools`), `token_estimate`/`elapsed_ms` (volatile telemetry, cache-hostile), `routing_hint` when `sync`, constant `schema_version`, under-budget `budget_hint` (kept when >75% budget / doom loop / missing preflight), and the `index_freshness` object **only in the `fresh` bucket** (degraded buckets stay attached — answer-affecting signal). Never touches `data`, `suggested_next_tools`/`_calls`, `error`, `recovery_hint`, or `structuredContent` (spec-required with `outputSchema`). Deliberately decoupled from the legacy `_compact` data pruning (adversarial review finding). Measured: 17–18% smaller text channel on `find_symbol` + body, symbol data byte-identical.
+
+### Fixed
+
+- **`index_freshness` staleness signal was inert (unit mismatch)** — `files.indexed_at` is written in epoch **milliseconds** but the hint compared it against `now.as_secs()`, so the age always clamped to 0 and every response reported `"fresh"` / `refresh_recommended: false`; `recent`/`possibly_stale`/`stale` could never fire. Timestamps are now normalised (ms→s, legacy second-scale values pass through). Side effect: the previously-dormant stale-index contract activates — on a >1h-old index, `refresh_symbol_index` is prepended to `suggested_next_tools` as documented.
+
 ## [1.13.33] - 2026-07-03
 
 ### Security

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -318,6 +318,64 @@ Controls compression aggressiveness. Set via `CODELENS_EFFORT_LEVEL` env var.
 - `medium` — default thresholds
 - `high` — compress later (thresholds +10pp), budget ×1.3 **(default, matching Claude Code v2.1.94)**
 
+## Lean Response Contract (token-frugal envelope)
+
+Separate lever from Effort Level. Effort trades **budget/compression** (which can
+touch answer depth); the lean contract only strips **low-signal envelope scaffold**
+and is **quality-neutral by construction** — it never removes `data`,
+`suggested_next_tools`/`_calls`, `error`, `recovery_hint`, `truncation_warning`,
+or any actionable state.
+
+Motivation: for token-expensive models (e.g. Fable, `$10`/`$50` per MTok — input is
+re-paid every turn a response persists in context), the repeated envelope scaffold
+on mechanical, high-frequency CodeLens calls is pure overhead. Grounded in Anthropic
+guidance: keep tool responses lean (Claude Code warns at 10K tokens), expose a
+concise response form, and avoid volatile fields that defeat prompt caching.
+
+**Activation (either path):**
+
+- Per-call: `_lean: true` in the tool arguments (agent/workflow opt-in). An explicit
+  `_lean: false` overrides the env var — the per-call escape hatch on a lean daemon.
+- Session/daemon: `CODELENS_RESPONSE_CONTRACT=lean` — the automatic frugal default
+  for a token-expensive deployment (e.g. a Fable-dedicated daemon). Case-insensitive.
+- Deliberately **independent of the legacy `_compact` flag**, which prunes a fixed
+  set of *data* fields (`next_actions`, `machine_summary`, verifier summaries, empty
+  fields) via `compact_response_payload` and is NOT quality-neutral. Lean never
+  triggers that path (adversarial review 2026-07-03).
+
+**What lean drops** (all pure scaffold, no answer signal):
+
+- `suggestion_reasons` — prose restating the `suggested_next_tools` names.
+- `token_estimate`, `elapsed_ms` — per-call telemetry (also volatile → cache-hostile).
+- `routing_hint` when `sync` — the default carries no decision; `async`/`cached*` kept.
+- `schema_version` — constant `"1.0"` marker.
+- `budget_hint` — dropped only when **under budget**; kept when actionable
+  (>75% budget, doom loop, or missing preflight).
+- `index_freshness` — suppressed only in the **`fresh` bucket** (<60s; its epoch/age
+  fields change every call and carry no signal). Every degraded bucket
+  (`recent`/`possibly_stale`/`stale`) stays attached — that is answer-affecting
+  signal (e.g. detecting a silently dead file watcher before the 1h refresh cliff).
+
+Measured effect (stdio MCP path, `find_symbol` + body): **17% smaller text
+channel** — the channel Claude Code injects into model context and counts
+against MCP output limits — and 8% smaller whole JSON-RPC response; larger
+relative share on small responses (scaffold is fixed-size). Symbol/body data
+byte-identical to the full contract in both channels. `structuredContent` is
+always kept: the MCP spec requires it when `outputSchema` is declared.
+
+Recommended Fable / mechanical-agent daemon config: `CODELENS_RESPONSE_CONTRACT=lean`
++ MCP tool search / deferred loading ON (small tool-definition prefix) + the default
+`high` effort (quality) — thrift the envelope, not the analysis.
+
+Correctness note (shipped alongside): the `index_freshness` staleness signal was
+previously inert — `files.indexed_at` is stored in epoch **milliseconds** but the hint
+compared it against `now.as_secs()`, so `age` always clamped to 0 / `"fresh"`. The
+unit is now normalised, so `recent`/`possibly_stale`/`stale` and `refresh_recommended`
+fire correctly. Side effect: the previously-dormant stale-index path now activates —
+on a >1h-old index, `refresh_symbol_index` is prepended to `suggested_next_tools`
+(the documented Index Freshness Signal contract, finally live), which also changes
+`suggestion_reasons` and telemetry rows for those calls.
+
 ## Backup Rotation
 
 Three backup patterns accumulate without retention if left unmanaged:

--- a/crates/codelens-mcp/src/dispatch/envelope.rs
+++ b/crates/codelens-mcp/src/dispatch/envelope.rs
@@ -11,6 +11,9 @@ pub(crate) struct ToolCallEnvelope {
     pub session: crate::session_context::SessionRequestContext,
     pub budget: usize,
     pub compact: bool,
+    /// Lean response contract — scaffold-only thrift, deliberately decoupled
+    /// from the legacy `_compact` data pruning. See `parse` for activation.
+    pub lean: bool,
     pub harness_phase: Option<String>,
 }
 
@@ -66,10 +69,28 @@ impl ToolCallEnvelope {
                     })
             })
             .unwrap_or(default_budget);
+        // Legacy aggressive compaction — per-call `_compact: true` prunes a
+        // fixed set of data fields via `compact_response_payload`. Unchanged.
         let compact = arguments
             .get("_compact")
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
+        // Lean response contract — scaffold-only thrift, deliberately a
+        // SEPARATE flag from `_compact` so it never inherits the legacy data
+        // pruning (adversarial review 2026-07-03 finding #1). Activation:
+        //   1. per-call `_lean: true`, or
+        //   2. `CODELENS_RESPONSE_CONTRACT=lean` on the daemon/session — the
+        //      frugal default for token-expensive deployments (e.g. a
+        //      Fable-dedicated daemon). An explicit per-call `_lean: false`
+        //      overrides the env (escape hatch on a lean daemon).
+        // Lean drops only low-signal envelope scaffold (telemetry, prose
+        // reasons, constant markers, fresh-bucket freshness) — never
+        // code/symbol data — so response quality is unchanged while per-call
+        // tokens shrink.
+        let lean = arguments
+            .get("_lean")
+            .and_then(|v| v.as_bool())
+            .unwrap_or_else(lean_response_contract_env);
         let harness_phase = arguments
             .get("_harness_phase")
             .and_then(|v| v.as_str())
@@ -80,9 +101,19 @@ impl ToolCallEnvelope {
             session,
             budget,
             compact,
+            lean,
             harness_phase,
         })
     }
+}
+
+/// True when `CODELENS_RESPONSE_CONTRACT=lean` selects the frugal envelope for
+/// every call on this daemon/session. Any other value (or unset) keeps the full
+/// contract. Case-insensitive, trimmed.
+fn lean_response_contract_env() -> bool {
+    std::env::var("CODELENS_RESPONSE_CONTRACT")
+        .ok()
+        .is_some_and(|v| v.trim().eq_ignore_ascii_case("lean"))
 }
 
 /// Check that all `required` fields from the tool's input_schema are present.

--- a/crates/codelens-mcp/src/dispatch/mod.rs
+++ b/crates/codelens-mcp/src/dispatch/mod.rs
@@ -56,6 +56,7 @@ pub(crate) fn dispatch_tool(
     let arguments = &envelope.arguments;
     let session = &envelope.session;
     let compact = envelope.compact;
+    let lean = envelope.lean;
     REQUEST_BUDGET.set(envelope.budget);
 
     let span = info_span!(
@@ -241,6 +242,7 @@ pub(crate) fn dispatch_tool(
             recent_tools: ctx.recent_tools,
             gate_allowance: gate_allowance.as_ref(),
             compact,
+            lean,
             harness_phase: harness_phase.as_deref(),
             request_budget: envelope.budget,
             start,

--- a/crates/codelens-mcp/src/dispatch/response.rs
+++ b/crates/codelens-mcp/src/dispatch/response.rs
@@ -2,6 +2,7 @@ use super::response_support::{
     apply_contextual_guidance, bounded_result_payload, budget_hint, compact_response_payload,
     effective_budget_for_tool, enrich_recovery_hint_for_signals, max_result_size_chars_for_tool,
     routing_hint_for_payload, success_jsonrpc_response, text_payload_for_response,
+    trim_scaffold_for_lean,
 };
 use crate::AppState;
 use crate::error::CodeLensError;
@@ -28,6 +29,9 @@ pub(crate) struct SuccessResponseInput<'a> {
     pub recent_tools: Vec<String>,
     pub gate_allowance: Option<&'a MutationGateAllowance>,
     pub compact: bool,
+    /// Lean response contract (scaffold-only thrift) — independent of the
+    /// legacy `compact` data pruning.
+    pub lean: bool,
     pub harness_phase: Option<&'a str>,
     pub request_budget: usize,
     pub start: std::time::Instant,
@@ -51,6 +55,7 @@ pub(crate) fn build_success_response(input: SuccessResponseInput<'_>) -> JsonRpc
         recent_tools,
         gate_allowance,
         compact,
+        lean,
         harness_phase,
         request_budget,
         start,
@@ -93,7 +98,19 @@ pub(crate) fn build_success_response(input: SuccessResponseInput<'_>) -> JsonRpc
             .get("refresh_recommended")
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
-        obj.insert("index_freshness".to_owned(), freshness);
+        // Lean contract: a *fresh* index (<60s bucket) needs no per-response
+        // freshness object — its epoch/age fields change on every call
+        // (defeating response-level caching) and carry no actionable signal.
+        // Every other bucket (`recent`/`possibly_stale`/`stale`) IS answer-
+        // affecting signal (e.g. a silently dead file watcher) and stays
+        // attached under lean (adversarial review 2026-07-03 finding #2).
+        let staleness_is_fresh = freshness
+            .get("staleness_hint")
+            .and_then(|v| v.as_str())
+            .is_some_and(|hint| hint == "fresh");
+        if should_attach_index_freshness(lean, staleness_is_fresh) {
+            obj.insert("index_freshness".to_owned(), freshness);
+        }
     }
 
     if is_verifier_source_tool(name) {
@@ -258,9 +275,22 @@ pub(crate) fn build_success_response(input: SuccessResponseInput<'_>) -> JsonRpc
     if compact {
         compact_response_payload(&mut resp);
     }
+    if lean {
+        // Lean scaffold thrift: drop low-signal envelope fields (prose reasons,
+        // telemetry, sync routing_hint, under-budget hints). Quality-neutral —
+        // no code/symbol data is touched. `suggested_next_tools`/`_calls` and
+        // any actionable budget_hint survive. Deliberately independent of the
+        // legacy `compact` data pruning above.
+        let budget_pct = if effective_budget == 0 {
+            100
+        } else {
+            (payload_estimate as u64).saturating_mul(100) / effective_budget as u64
+        };
+        trim_scaffold_for_lean(&mut resp, budget_pct, doom_loop_count, missing_preflight);
+    }
 
     let effort_offset = state.effort_level().compression_threshold_offset();
-    let text = text_payload_for_response(&resp, structured_content.as_ref());
+    let text = text_payload_for_response(&resp, structured_content.as_ref(), lean);
     let (text, mut structured_content, truncation_info) = bounded_result_payload(
         text,
         structured_content,
@@ -416,7 +446,7 @@ pub(crate) fn build_error_response(
             handoff_id,
         },
     );
-    let text = text_payload_for_response(&resp, None);
+    let text = text_payload_for_response(&resp, None, false);
     let mut body = json!({
         "content": [{ "type": "text", "text": text }],
         "isError": true,
@@ -426,6 +456,17 @@ pub(crate) fn build_error_response(
     });
     crate::tool_defs::apply_tool_deprecation_meta(&mut body["_meta"], name);
     JsonRpcResponse::result(id, body)
+}
+
+/// Whether to attach the volatile `index_freshness` object to a read-hot
+/// tool's payload. The full contract always attaches it (documented signal).
+/// The lean contract suppresses ONLY the `fresh` bucket — its epoch/age fields
+/// change every call and carry no actionable signal. All degraded buckets
+/// (`recent`/`possibly_stale`/`stale`) are answer-affecting and attach
+/// regardless of contract so a caller can detect a stale daemon (e.g. after a
+/// silent file-watcher death) before the 1-hour refresh cliff.
+fn should_attach_index_freshness(lean: bool, staleness_is_fresh: bool) -> bool {
+    !lean || !staleness_is_fresh
 }
 
 fn delegate_hint_telemetry_fields(
@@ -864,4 +905,25 @@ fn generate_delegate_handoff_id() -> String {
         .as_millis();
     let sequence = HANDOFF_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
     format!("codelens-handoff-{timestamp_ms:x}-{sequence:x}")
+}
+
+#[cfg(test)]
+mod lean_freshness_gate_tests {
+    use super::should_attach_index_freshness;
+
+    #[test]
+    fn full_contract_always_attaches_freshness() {
+        assert!(should_attach_index_freshness(false, true));
+        assert!(should_attach_index_freshness(false, false));
+    }
+
+    #[test]
+    fn lean_contract_suppresses_only_the_fresh_bucket() {
+        // Fresh index under lean: volatile freshness object is suppressed.
+        assert!(!should_attach_index_freshness(true, true));
+        // Any degraded bucket (recent/possibly_stale/stale) under lean:
+        // answer-affecting signal — must stay attached so a caller can
+        // detect a stale daemon (e.g. silent watcher death) early.
+        assert!(should_attach_index_freshness(true, false));
+    }
 }

--- a/crates/codelens-mcp/src/dispatch/response_support/mod.rs
+++ b/crates/codelens-mcp/src/dispatch/response_support/mod.rs
@@ -8,7 +8,7 @@ pub(super) mod truncation;
 // Re-export the 10 symbols consumed by dispatch/response.rs
 pub(crate) use budget::{budget_hint, effective_budget_for_tool, max_result_size_chars_for_tool};
 pub(crate) use envelope::success_jsonrpc_response;
-pub(crate) use payload_compact::compact_response_payload;
+pub(crate) use payload_compact::{compact_response_payload, trim_scaffold_for_lean};
 pub(crate) use routing_hint::{apply_contextual_guidance, routing_hint_for_payload};
 pub(crate) use text_channel::text_payload_for_response;
 pub(crate) use truncation::{bounded_result_payload, enrich_recovery_hint_for_signals};

--- a/crates/codelens-mcp/src/dispatch/response_support/payload_compact.rs
+++ b/crates/codelens-mcp/src/dispatch/response_support/payload_compact.rs
@@ -1,4 +1,4 @@
-use crate::protocol::ToolCallResponse;
+use crate::protocol::{RoutingHint, ToolCallResponse};
 use serde_json::{Map, Value, json};
 
 pub(crate) fn strip_empty_fields(value: &mut serde_json::Value) {
@@ -55,6 +55,38 @@ pub(crate) fn compact_response_payload(resp: &mut ToolCallResponse) {
                 }
             }
         }
+    }
+}
+
+/// Lean response contract: strip low-signal scaffold from the envelope after
+/// the payload/suggestions are built. Quality-neutral — this touches only
+/// telemetry, prose reasons, and default routing hints; it never removes
+/// `data`, `suggested_next_tools`, `suggested_next_calls`, `error`,
+/// `recovery_hint`, or any actionable state.
+///
+/// - `suggestion_reasons`: prose that restates the machine-readable
+///   `suggested_next_tools` names — pure duplication for a mechanical caller.
+/// - `token_estimate` / `elapsed_ms`: telemetry that changes every call
+///   (volatile, defeats response-level caching) and is not answer signal.
+/// - `routing_hint == Sync`: the overwhelming default carries no decision; the
+///   actionable `Async`/`Cached*` variants are preserved.
+/// - `budget_hint`: kept only when actionable (near/over budget, doom loop, or
+///   a missing preflight); the under-budget informational form is dropped.
+pub(crate) fn trim_scaffold_for_lean(
+    resp: &mut ToolCallResponse,
+    budget_pct: u64,
+    doom_loop_count: usize,
+    missing_preflight: bool,
+) {
+    resp.suggestion_reasons = None;
+    resp.token_estimate = None;
+    resp.elapsed_ms = None;
+    if matches!(resp.routing_hint, Some(RoutingHint::Sync)) {
+        resp.routing_hint = None;
+    }
+    let keep_hint = budget_pct > 75 || doom_loop_count >= 3 || missing_preflight;
+    if !keep_hint {
+        resp.budget_hint = None;
     }
 }
 
@@ -302,4 +334,78 @@ fn should_preserve_structured_array(key: &str, value: &Value) -> bool {
             | "preferred_entrypoints_omitted"
             | "preferred_entrypoints_with_executors"
     ) && value.is_array()
+}
+
+#[cfg(test)]
+mod lean_scaffold_tests {
+    use super::*;
+    use crate::protocol::BackendKind;
+    use crate::tool_runtime::success_meta;
+    use std::collections::HashMap;
+
+    fn sample_response() -> ToolCallResponse {
+        let mut r = ToolCallResponse::success(
+            json!({"symbol": "x"}),
+            success_meta(BackendKind::TreeSitter, 0.9),
+        );
+        r.suggested_next_tools = Some(vec!["find_referencing_symbols".to_owned()]);
+        let mut reasons = HashMap::new();
+        reasons.insert(
+            "find_referencing_symbols".to_owned(),
+            "Find all callers/users of this symbol".to_owned(),
+        );
+        r.suggestion_reasons = Some(reasons);
+        r.token_estimate = Some(733);
+        r.elapsed_ms = Some(27);
+        r.routing_hint = Some(RoutingHint::Sync);
+        r.budget_hint = Some("733 tokens (18% of 4000 budget)".to_owned());
+        r
+    }
+
+    #[test]
+    fn lean_trim_drops_low_signal_scaffold_keeps_data_and_suggestions() {
+        let mut r = sample_response();
+        trim_scaffold_for_lean(&mut r, 18, 0, false);
+        // Dropped: prose reasons + telemetry + sync routing + under-budget hint.
+        assert!(r.suggestion_reasons.is_none(), "prose reasons dropped");
+        assert!(r.token_estimate.is_none(), "token_estimate dropped");
+        assert!(r.elapsed_ms.is_none(), "elapsed_ms dropped");
+        assert!(r.routing_hint.is_none(), "sync routing_hint dropped");
+        assert!(r.budget_hint.is_none(), "under-budget hint dropped");
+        // Preserved: the answer + the machine-actionable next-step names.
+        assert!(r.data.is_some(), "data must never be dropped");
+        assert_eq!(
+            r.suggested_next_tools.as_deref(),
+            Some(&["find_referencing_symbols".to_owned()][..]),
+            "suggested_next_tools names must survive"
+        );
+    }
+
+    #[test]
+    fn lean_trim_keeps_budget_hint_when_near_limit() {
+        let mut r = sample_response();
+        trim_scaffold_for_lean(&mut r, 90, 0, false);
+        assert!(r.budget_hint.is_some(), "near-budget hint is actionable");
+    }
+
+    #[test]
+    fn lean_trim_keeps_budget_hint_on_doom_loop_or_missing_preflight() {
+        let mut a = sample_response();
+        trim_scaffold_for_lean(&mut a, 10, 3, false);
+        assert!(a.budget_hint.is_some(), "doom loop keeps hint");
+        let mut b = sample_response();
+        trim_scaffold_for_lean(&mut b, 10, 0, true);
+        assert!(b.budget_hint.is_some(), "missing preflight keeps hint");
+    }
+
+    #[test]
+    fn lean_trim_preserves_actionable_async_routing_hint() {
+        let mut r = sample_response();
+        r.routing_hint = Some(RoutingHint::Async);
+        trim_scaffold_for_lean(&mut r, 10, 0, false);
+        assert!(
+            matches!(r.routing_hint, Some(RoutingHint::Async)),
+            "async routing is an actionable decision — must survive"
+        );
+    }
 }

--- a/crates/codelens-mcp/src/dispatch/response_support/text_channel.rs
+++ b/crates/codelens-mcp/src/dispatch/response_support/text_channel.rs
@@ -19,6 +19,7 @@ use super::truncation::{
 pub(crate) fn text_payload_for_response(
     resp: &ToolCallResponse,
     structured_content: Option<&Value>,
+    lean: bool,
 ) -> String {
     if let Some(slim) = slim_text_payload_for_async_job(resp, structured_content) {
         return serde_json::to_string(&slim).unwrap_or_else(|_| {
@@ -34,18 +35,24 @@ pub(crate) fn text_payload_for_response(
     // Pretty-print the full response as structured JSON with readable formatting.
     // Agents get valid JSON (parseability preserved) but with indentation and
     // newlines instead of a single flat line.
-    format_structured_response(resp)
+    format_structured_response(resp, lean)
 }
 
 /// Format a ToolCallResponse as pretty-printed JSON.
 /// Preserves JSON validity for parsing while being much more readable than
 /// a single-line blob. Strips redundant metadata fields that waste tokens.
-fn format_structured_response(resp: &ToolCallResponse) -> String {
+///
+/// When `lean` is set (lean response contract), the constant `schema_version`
+/// marker is omitted — it repeats identically on every call and carries no
+/// per-response signal.
+fn format_structured_response(resp: &ToolCallResponse, lean: bool) -> String {
     // Build a clean output object with only the fields agents need.
     let mut out = serde_json::Map::new();
 
     out.insert("success".to_owned(), Value::Bool(resp.success));
-    out.insert("schema_version".to_owned(), Value::String("1.0".to_owned()));
+    if !lean {
+        out.insert("schema_version".to_owned(), Value::String("1.0".to_owned()));
+    }
 
     // Error message (if present)
     if let Some(ref err) = resp.error {
@@ -343,6 +350,36 @@ fn slim_text_payload_for_async_handle(
 mod text_channel_tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn lean_text_channel_omits_constant_schema_version() {
+        use crate::protocol::BackendKind;
+        use crate::tool_runtime::success_meta;
+        let resp = ToolCallResponse::success(
+            json!({"symbol": "x"}),
+            success_meta(BackendKind::TreeSitter, 0.9),
+        );
+
+        let full = text_payload_for_response(&resp, None, false);
+        let full_json: Value = serde_json::from_str(&full).expect("valid json");
+        assert!(
+            full_json.get("schema_version").is_some(),
+            "full contract keeps schema_version"
+        );
+
+        let lean = text_payload_for_response(&resp, None, true);
+        let lean_json: Value = serde_json::from_str(&lean).expect("valid json");
+        assert!(
+            lean_json.get("schema_version").is_none(),
+            "lean contract omits the constant schema_version marker"
+        );
+        // The actual answer channel is untouched by the lean flag.
+        assert!(
+            lean_json.get("data").is_some(),
+            "data survives lean text render"
+        );
+        assert!(lean.len() < full.len(), "lean render is smaller");
+    }
 
     #[test]
     fn summarize_text_object_records_omitted_keys_when_capped() {

--- a/crates/codelens-mcp/src/tool_runtime.rs
+++ b/crates/codelens-mcp/src/tool_runtime.rs
@@ -108,6 +108,65 @@ pub fn optional_usize_with_aliases(
     default
 }
 
+/// Normalise a raw `files.indexed_at` value to epoch **seconds** and classify
+/// staleness relative to `now_secs`.
+///
+/// Correctness note: `files.indexed_at` is written in epoch *milliseconds*
+/// (`db::ops` upsert path), but `index_freshness_hint` historically compared it
+/// against `now.as_secs()`. That unit mismatch made `age_secs` a large negative
+/// number that clamped to `0`, so every response reported `staleness_hint:
+/// "fresh"` / `refresh_recommended: false` — the documented freshness signal
+/// could never fire. We normalise defensively here: values above ~1e12 are
+/// milliseconds and are divided down; smaller values are already seconds
+/// (legacy/mixed indexes). Returns `(epoch_secs, age_secs, hint, refresh)`.
+fn classify_index_freshness(now_secs: i64, raw_indexed_at: i64) -> (i64, i64, &'static str, bool) {
+    let max_at = if raw_indexed_at > 1_000_000_000_000 {
+        raw_indexed_at / 1000
+    } else {
+        raw_indexed_at
+    };
+    let age_secs = (now_secs - max_at).max(0);
+    let (hint, refresh_recommended) = if age_secs < 60 {
+        ("fresh", false)
+    } else if age_secs < 600 {
+        ("recent", false)
+    } else if age_secs < 3600 {
+        ("possibly_stale", false)
+    } else {
+        ("stale", true)
+    };
+    (max_at, age_secs, hint, refresh_recommended)
+}
+
+/// Freshness hint for tool responses that read from the on-disk symbol
+/// index. Compares the index's newest `indexed_at` against wall-clock
+/// time so callers can detect a stale daemon without having to diff
+/// results against the working tree.
+///
+/// Buckets:
+///   - `fresh`           — newest file indexed < 60s ago
+///   - `recent`          — 60s..600s
+///   - `possibly_stale`  — 600s..3600s
+///   - `stale`           — >= 3600s (sets `refresh_recommended: true`)
+///
+/// Returns `None` when the index is empty (callers omit the hint to
+/// avoid noise on a fresh project).
+pub fn index_freshness_hint(state: &AppState) -> Option<serde_json::Value> {
+    use serde_json::json;
+    let raw = state.symbol_index().max_indexed_at().ok().flatten()?;
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()?
+        .as_secs() as i64;
+    let (max_at, age_secs, hint, refresh_recommended) = classify_index_freshness(now, raw);
+    Some(json!({
+        "newest_indexed_at_epoch_secs": max_at,
+        "newest_indexed_age_secs": age_secs,
+        "staleness_hint": hint,
+        "refresh_recommended": refresh_recommended,
+    }))
+}
+
 /// Return the names of every top-level key in `value` that does not
 /// appear in `known` — both the canonical names AND any registered
 /// aliases. Tools surface this list in their response so an agent that
@@ -125,44 +184,6 @@ pub fn optional_usize_with_aliases(
 /// Returns an empty Vec for non-object values so non-object inputs
 /// fall through to the handler's existing argument parsing without
 /// spurious "unknown" claims.
-/// Freshness hint for tool responses that read from the on-disk symbol
-/// index. Compares the index's newest `indexed_at` against wall-clock
-/// time so callers can detect a stale daemon without having to diff
-/// results against the working tree.
-///
-/// Buckets:
-///   - `fresh`           — newest file indexed < 60s ago
-///   - `recent`          — 60s..600s
-///   - `possibly_stale`  — 600s..3600s
-///   - `stale`           — >= 3600s (sets `refresh_recommended: true`)
-///
-/// Returns `None` when the index is empty (callers omit the hint to
-/// avoid noise on a fresh project).
-pub fn index_freshness_hint(state: &AppState) -> Option<serde_json::Value> {
-    use serde_json::json;
-    let max_at = state.symbol_index().max_indexed_at().ok().flatten()?;
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .ok()?
-        .as_secs() as i64;
-    let age_secs = (now - max_at).max(0);
-    let (hint, refresh_recommended) = if age_secs < 60 {
-        ("fresh", false)
-    } else if age_secs < 600 {
-        ("recent", false)
-    } else if age_secs < 3600 {
-        ("possibly_stale", false)
-    } else {
-        ("stale", true)
-    };
-    Some(json!({
-        "newest_indexed_at_epoch_secs": max_at,
-        "newest_indexed_age_secs": age_secs,
-        "staleness_hint": hint,
-        "refresh_recommended": refresh_recommended,
-    }))
-}
-
 pub fn collect_unknown_args(value: &serde_json::Value, known: &[&str]) -> Vec<String> {
     let Some(map) = value.as_object() else {
         return Vec::new();
@@ -181,6 +202,51 @@ pub fn collect_unknown_args(value: &serde_json::Value, known: &[&str]) -> Vec<St
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn freshness_millisecond_timestamp_is_normalised_not_always_fresh() {
+        // Regression: `files.indexed_at` is written in epoch ms, but the hint
+        // compared it against `now.as_secs()`. A 2h-old index (ms timestamp)
+        // used to clamp to age 0 / "fresh". After the unit fix it must report
+        // "stale" and recommend a refresh.
+        let now_secs = 2_000_000_000; // arbitrary fixed "now" in seconds
+        let two_hours_ago_ms = (now_secs - 7_200) * 1000;
+        let (epoch_secs, age_secs, hint, refresh) =
+            classify_index_freshness(now_secs, two_hours_ago_ms);
+        assert_eq!(
+            epoch_secs,
+            now_secs - 7_200,
+            "ms input must normalise to secs"
+        );
+        assert_eq!(age_secs, 7_200);
+        assert_eq!(hint, "stale");
+        assert!(refresh, "a >1h-old index must recommend refresh");
+    }
+
+    #[test]
+    fn freshness_recent_millisecond_timestamp_reports_fresh() {
+        let now_secs = 2_000_000_000;
+        let ten_secs_ago_ms = (now_secs - 10) * 1000;
+        let (_epoch, age_secs, hint, refresh) = classify_index_freshness(now_secs, ten_secs_ago_ms);
+        assert_eq!(age_secs, 10);
+        assert_eq!(hint, "fresh");
+        assert!(!refresh);
+    }
+
+    #[test]
+    fn freshness_legacy_second_timestamp_still_classified() {
+        // Defensive: a value already in seconds (< 1e12) must not be divided.
+        let now_secs = 2_000_000_000;
+        let legacy_secs = now_secs - 700; // 700s ago, already seconds
+        let (epoch_secs, age_secs, hint, _refresh) =
+            classify_index_freshness(now_secs, legacy_secs);
+        assert_eq!(
+            epoch_secs, legacy_secs,
+            "second-scale input must pass through"
+        );
+        assert_eq!(age_secs, 700);
+        assert_eq!(hint, "possibly_stale");
+    }
 
     #[test]
     fn optional_usize_with_aliases_prefers_canonical() {

--- a/scripts/install-http-daemons-launchd.sh
+++ b/scripts/install-http-daemons-launchd.sh
@@ -28,6 +28,10 @@ Options:
   --readonly-log-level LEVEL  CODELENS_LOG for read-only daemon (default: warn)
   --mutation-log-level LEVEL  CODELENS_LOG for mutation daemon (default: warn)
   --effort-level LEVEL        CODELENS_EFFORT_LEVEL for both daemons (default: high)
+  --response-contract MODE    CODELENS_RESPONSE_CONTRACT for both daemons
+                              (default: full; lean = scaffold-only token-frugal
+                              envelopes for token-expensive models, per-call
+                              override via _lean argument)
   --rerank VALUE              CODELENS_RERANK for both daemons (default: 0)
   --embed-resource-profile P  CODELENS_EMBED_RESOURCE_PROFILE for semantic runtime
                               (default: low_power; use balanced/throughput to trade power for speed)
@@ -60,6 +64,7 @@ MUTATION_PROFILE="refactor-full"
 READONLY_LOG_LEVEL="warn"
 MUTATION_LOG_LEVEL="warn"
 EFFORT_LEVEL="high"
+RESPONSE_CONTRACT="full"
 RERANK_VALUE="0"
 EMBED_RESOURCE_PROFILE="low_power"
 MODEL_DIR=""
@@ -130,6 +135,10 @@ while [[ $# -gt 0 ]]; do
 		;;
 	--effort-level)
 		EFFORT_LEVEL="${2:-}"
+		shift 2
+		;;
+	--response-contract)
+		RESPONSE_CONTRACT="${2:-}"
 		shift 2
 		;;
 	--rerank)
@@ -358,6 +367,8 @@ create_plist() {
     <string>${log_level}</string>
     <key>CODELENS_EFFORT_LEVEL</key>
     <string>${EFFORT_LEVEL}</string>
+    <key>CODELENS_RESPONSE_CONTRACT</key>
+    <string>${RESPONSE_CONTRACT}</string>
     <key>CODELENS_RERANK</key>
     <string>${RERANK_VALUE}</string>
     <key>CODELENS_EMBED_RESOURCE_PROFILE</key>


### PR DESCRIPTION
## Summary

Quality-neutral, **scaffold-only** response envelope thrift for token-expensive models (Fable: $10/$50 per MTok — every persisted response is re-paid as input each turn). Grounded in official Anthropic guidance: keep tool responses lean (Claude Code warns at 10K tokens / caps at 25K), the **text channel** is what gets counted/injected, and volatile per-call fields are cache-hostile.

### Lean Response Contract

- **Activation**: per-call `_lean: true` (explicit `_lean: false` overrides the env — per-call escape hatch), or daemon-wide `CODELENS_RESPONSE_CONTRACT=lean` (frugal default for a Fable-dedicated daemon).
- **Drops from the text envelope only**: `suggestion_reasons` (prose duplication of `suggested_next_tools`), `token_estimate`/`elapsed_ms` (volatile telemetry), `routing_hint` when `sync`, constant `schema_version`, under-budget `budget_hint` (kept when >75% budget / doom loop / missing preflight), and `index_freshness` **only in the `fresh` bucket**.
- **Never touches**: `data`, `suggested_next_tools`/`_calls`, `error`, `recovery_hint`, `truncation_warning`, `structuredContent` (spec-required with `outputSchema`). Errors never lean.
- **Deliberately decoupled from legacy `_compact`** (which prunes data fields and is not quality-neutral) — separate flag end to end.

### Bundled correctness fix

`index_freshness` was inert: `files.indexed_at` is epoch **milliseconds** but the hint compared it against `now.as_secs()`, clamping age to 0 — every response reported `"fresh"` and `refresh_recommended` could never fire. Timestamps are now normalised (ms→s; legacy second-scale passes through), activating the documented stale-index contract (`refresh_symbol_index` prepend on >1h-old indexes). 3 regression tests.

### Adversarial review (2 rounds, findings addressed)

1. ~~lean reused the `compact` flag → inherited legacy data pruning~~ → separate `_lean` flag, `_compact` behavior byte-identical to before.
2. ~~freshness gate suppressed `recent`/`possibly_stale` too~~ → suppress only the `fresh` bucket; degraded buckets are answer-affecting (silent watcher-death detection) and stay attached.

### Measured (stdio MCP path, `find_symbol` + body)

| case | text channel | keys |
|---|---|---|
| full | 2,942 B | 12 |
| lean (`_lean` ≡ env) | 2,405 B (**−18%**) | 6 |
| escape (`env` + `_lean:false`) | 2,942 B (= full) | 12 |
| legacy `_compact` | unchanged semantics | 12 |

Symbol/body data **byte-identical** in both channels.

## Test plan

- [x] `cargo fmt` / clippy (default, `--features http`, `--no-default-features`) `-D warnings`
- [x] `cargo test -p codelens-engine --lib` — 437 passed
- [x] `cargo test -p codelens-mcp --bin codelens-mcp --features http` — 793 passed
- [x] regen-tool-defs / surface-manifest drift checks
- [x] e2e stdio JSON-RPC: 5-case matrix above

🤖 Generated with [Claude Code](https://claude.com/claude-code)