### PR TITLE
fix(indexing): root-relative excludes + zero-file warning (#358)

### DIFF
--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -82,10 +82,18 @@ echo -e "Project : $PROJECT_PATH"
 echo -e "Binary  : $BINARY"
 echo
 
-echo -e "${CYAN}[1/2] Building release binary...${RESET}"
-cargo build --release --manifest-path "$(dirname "$(dirname "$BINARY")")/Cargo.toml" 2>&1 ||
-	cargo build --release 2>&1 ||
-	die "cargo build --release failed"
+echo -e "${CYAN}[1/2] Preparing binary...${RESET}"
+# Never rebuild over an existing binary: a bare `cargo build --release`
+# clobbers feature-rich builds (http/semantic/coreml) with a default-feature
+# binary, silently disabling semantic tools for every later consumer of
+# target/release (daemon redeploys, MRR harnesses). Only build when missing.
+if [[ -x "$BINARY" ]]; then
+	echo "  using existing binary (skipping rebuild to preserve its feature set)"
+else
+	cargo build --release --manifest-path "$(dirname "$(dirname "$BINARY")")/Cargo.toml" 2>&1 ||
+		cargo build --release 2>&1 ||
+		die "cargo build --release failed"
+fi
 
 [[ -x "$BINARY" ]] || die "Binary not found: $BINARY"
 echo -e "${GREEN}Build OK${RESET}"

--- a/benchmarks/tool-token-profile.py
+++ b/benchmarks/tool-token-profile.py
@@ -2,11 +2,15 @@
 """Per-tool response token profiler (MCP Interviewer prescription).
 
 Fires a fixed suite of read-only probe calls at the already-running daemon
-(default http://127.0.0.1:7839), measures the actual response size of each tool
-(chars, approx tokens = chars / 4), and compares against the declared
-``estimated_tokens`` in docs/generated/surface-manifest.json. Tools whose
-measured tokens exceed their estimate by more than the threshold (default 2x)
-are flagged.
+(default http://127.0.0.1:7839) and measures the actual response size of each
+tool (chars, approx tokens = chars / 4). Tools whose measured response exceeds
+an absolute budget (default 1500 tokens) are flagged as heavy.
+
+The manifest's ``estimated_tokens`` is reported as a side column named
+``schema_tokens`` for context only: that field measures the serialized size of
+the TOOL DEFINITION (its context-window cost in tools/list), not an expected
+response size — comparing response tokens against it as a ratio is a category
+error (an earlier revision of this script did exactly that).
 
 - read-only probes only; never calls a mutation tool.
 - probes are intersected with the daemon's active surface (tools/list), so
@@ -61,10 +65,10 @@ def parse_args():
     p.add_argument("--manifest", default=DEFAULT_MANIFEST)
     p.add_argument("--chars-per-token", type=float, default=4.0)
     p.add_argument(
-        "--threshold",
+        "--response-budget",
         type=float,
-        default=2.0,
-        help="Flag tools whose actual tokens exceed estimate by this factor",
+        default=1500.0,
+        help="Flag tools whose measured response exceeds this many tokens",
     )
     p.add_argument("--output", default=None, help="Optional JSON output path")
     return p.parse_args()
@@ -156,23 +160,21 @@ def profile(args) -> dict:
             continue
         chars = response_chars(raw)
         actual_tokens = round(chars / args.chars_per_token)
-        estimate = estimates.get(tool)
-        ratio = (actual_tokens / estimate) if estimate else None
-        flagged = bool(estimate and actual_tokens > estimate * args.threshold)
+        schema_tokens = estimates.get(tool)
+        flagged = actual_tokens > args.response_budget
         records.append(
             {
                 "tool": tool,
                 "status": "measured",
                 "actual_chars": chars,
                 "actual_tokens": actual_tokens,
-                "estimated_tokens": estimate,
-                "ratio": ratio,
+                "schema_tokens": schema_tokens,
                 "flagged": flagged,
             }
         )
     return {
         "skipped": False,
-        "threshold": args.threshold,
+        "response_budget": args.response_budget,
         "chars_per_token": args.chars_per_token,
         "records": records,
         "flagged": [r["tool"] for r in records if r.get("flagged")],
@@ -183,26 +185,30 @@ def render(report: dict) -> str:
     if report.get("skipped"):
         return f"Profiler skipped: {report.get('reason')}\n"
     lines = ["# Tool Response Token Profile", ""]
-    lines.append(f"- Flag threshold: actual > estimate x {report['threshold']}")
+    lines.append(f"- Flag: measured response > {report['response_budget']:.0f} tokens")
     lines.append(f"- chars/token: {report['chars_per_token']}")
+    lines.append(
+        "- schema_tokens = serialized tool-DEFINITION cost in tools/list "
+        "(context cost), shown for reference only — not a response estimate"
+    )
     lines.append("")
-    lines.append("| Tool | Actual tokens | Estimated | Ratio | Flag |")
-    lines.append("| --- | --- | --- | --- | --- |")
+    lines.append("| Tool | Response tokens | Schema tokens | Flag |")
+    lines.append("| --- | --- | --- | --- |")
     for r in report["records"]:
         if r["status"] != "measured":
-            lines.append(f"| {r['tool']} | — | — | — | {r['status']} |")
+            lines.append(f"| {r['tool']} | — | — | {r['status']} |")
             continue
-        ratio = f"{r['ratio']:.2f}x" if r["ratio"] is not None else "n/a"
-        flag = "OVER" if r["flagged"] else ""
+        flag = "HEAVY" if r["flagged"] else ""
         lines.append(
-            f"| {r['tool']} | {r['actual_tokens']} | {r['estimated_tokens']} | {ratio} | {flag} |"
+            f"| {r['tool']} | {r['actual_tokens']} | {r['schema_tokens']} | {flag} |"
         )
     lines.append("")
     if report["flagged"]:
-        lines.append(f"**Flagged (actual > {report['threshold']}x estimate):** "
-                     + ", ".join(report["flagged"]))
+        lines.append(
+            f"**Heavy responses (> {report['response_budget']:.0f} tokens):** "
+            + ", ".join(report["flagged"]))
     else:
-        lines.append("No tools exceeded the threshold.")
+        lines.append("No tool exceeded the response budget.")
     return "\n".join(lines) + "\n"
 
 

--- a/crates/codelens-engine/src/file_ops/reader.rs
+++ b/crates/codelens-engine/src/file_ops/reader.rs
@@ -1,4 +1,4 @@
-use crate::project::{ProjectRoot, is_excluded};
+use crate::project::{ProjectRoot, is_excluded_within};
 use anyhow::{Context, Result, bail};
 use regex::Regex;
 use std::fs;
@@ -58,7 +58,7 @@ pub fn list_dir(project: &ProjectRoot, path: &str, recursive: bool) -> Result<Ve
         for entry in WalkDir::new(&resolved)
             .min_depth(1)
             .into_iter()
-            .filter_entry(|entry| !is_excluded(entry.path()))
+            .filter_entry(|entry| !is_excluded_within(&resolved, entry.path()))
         {
             let entry = entry?;
             entries.push(to_directory_entry(project, entry.path())?);
@@ -92,7 +92,7 @@ pub fn find_files(
 
     for entry in WalkDir::new(&base)
         .into_iter()
-        .filter_entry(|entry| !is_excluded(entry.path()))
+        .filter_entry(|entry| !is_excluded_within(&base, entry.path()))
     {
         let entry = entry?;
         if entry.file_type().is_file() {
@@ -129,7 +129,7 @@ pub fn search_for_pattern(
     let mut files: Vec<PathBuf> = Vec::new();
     for entry in WalkDir::new(project.as_path())
         .into_iter()
-        .filter_entry(|entry| !is_excluded(entry.path()))
+        .filter_entry(|entry| !is_excluded_within(project.as_path(), entry.path()))
     {
         let entry = entry?;
         if !entry.file_type().is_file() {

--- a/crates/codelens-engine/src/project.rs
+++ b/crates/codelens-engine/src/project.rs
@@ -160,6 +160,23 @@ pub fn is_excluded(path: &Path) -> bool {
         .is_some_and(is_generated_or_lock_file)
 }
 
+/// Root-relative variant of [`is_excluded`]: only the components *below*
+/// `root` are matched against [`EXCLUDED_DIRS`], so a project legitimately
+/// rooted under an excluded-name ancestor (`~/.claude/worktrees/...`,
+/// `~/Library/...`, `~/dev/build/...`) is not silently emptied to zero
+/// files (#358). Walkers must pass the same `root` they hand to `WalkDir`
+/// so the prefix strips textually without canonicalization cost.
+///
+/// A `path` outside `root` falls back to whole-path matching — the
+/// fail-safe direction: the fallback can only exclude more, never leak an
+/// excluded directory back in.
+pub fn is_excluded_within(root: &Path, path: &Path) -> bool {
+    match path.strip_prefix(root) {
+        Ok(relative) => is_excluded(relative),
+        Err(_) => is_excluded(path),
+    }
+}
+
 fn is_generated_or_lock_file(file_name: &str) -> bool {
     matches!(
         file_name,
@@ -185,7 +202,7 @@ pub fn collect_files(root: &Path, filter: impl Fn(&Path) -> bool) -> Result<Vec<
     let project_excludes = ProjectExcludeConfig::load(root);
     let mut files = Vec::new();
     for entry in WalkDir::new(root).into_iter().filter_entry(|entry| {
-        !is_excluded(entry.path()) && !project_excludes.is_excluded(root, entry.path())
+        !is_excluded_within(root, entry.path()) && !project_excludes.is_excluded(root, entry.path())
     }) {
         let entry = entry?;
         if entry.file_type().is_file() && filter(entry.path()) {
@@ -308,7 +325,7 @@ pub fn compute_dominant_language(root: &Path) -> Option<String> {
 
     for entry in WalkDir::new(root)
         .into_iter()
-        .filter_entry(|entry| !is_excluded(entry.path()))
+        .filter_entry(|entry| !is_excluded_within(root, entry.path()))
     {
         let Ok(entry) = entry else {
             continue;
@@ -697,7 +714,7 @@ fn normalize_path(path: &Path) -> PathBuf {
 
 #[cfg(test)]
 mod tests {
-    use super::{ProjectRoot, collect_files, is_excluded};
+    use super::{ProjectRoot, collect_files, is_excluded, is_excluded_within};
     use std::{fs, path::Path};
 
     #[test]
@@ -827,6 +844,76 @@ mod tests {
         assert!(!is_excluded(Path::new("crates/codelens-engine/src/lib.rs")));
         assert!(!is_excluded(Path::new("src/claire_not_a_dir.rs")));
         assert!(!is_excluded(Path::new("src/release_notes.ts")));
+    }
+
+    #[test]
+    fn root_relative_exclusion_ignores_excluded_name_ancestors() {
+        // #358 regression: a project legitimately rooted under an
+        // excluded-name ancestor (`~/.claude/...`, `~/Library/...`,
+        // `~/dev/build/...`) must not have its entire tree filtered.
+        let root = Path::new("/Users/u/.claude/jobs/abc/tmp/external-repos/django");
+        assert!(!is_excluded_within(root, &root.join("django/shortcuts.py")));
+        let lib_root = Path::new("/Users/u/Library/Mobile Documents/proj");
+        assert!(!is_excluded_within(lib_root, &lib_root.join("src/main.rs")));
+        let build_root = Path::new("/home/u/dev/build/service");
+        assert!(!is_excluded_within(
+            build_root,
+            &build_root.join("api/handler.go")
+        ));
+
+        // Exclusions BELOW the root still apply unchanged.
+        assert!(is_excluded_within(
+            root,
+            &root.join("node_modules/pkg/index.js")
+        ));
+        assert!(is_excluded_within(root, &root.join(".git/config")));
+        assert!(is_excluded_within(
+            lib_root,
+            &lib_root.join("target/debug/main.rs")
+        ));
+
+        // A path outside the root falls back to whole-path matching
+        // (fail-safe: excludes more, never less).
+        assert!(is_excluded_within(
+            root,
+            Path::new("/somewhere/else/node_modules/x.js")
+        ));
+        // The root itself (empty relative path) is never excluded.
+        assert!(!is_excluded_within(root, root));
+    }
+
+    #[test]
+    fn collect_files_indexes_project_rooted_under_dot_directory() {
+        // #358 end-to-end: collect_files on a temp project whose ancestors
+        // include a `.claude` component must still discover source files.
+        let temp = std::env::temp_dir().join(format!(
+            "codelens-358-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let root = temp.join(".claude").join("worktrees").join("proj");
+        std::fs::create_dir_all(root.join("src")).expect("mkdir");
+        std::fs::create_dir_all(root.join("node_modules/dep")).expect("mkdir nm");
+        std::fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").expect("write");
+        std::fs::write(root.join("node_modules/dep/x.js"), "x\n").expect("write nm");
+
+        let files = collect_files(&root, |p| {
+            p.extension().is_some_and(|e| e == "rs" || e == "js")
+        })
+        .expect("collect");
+        let rels: Vec<String> = files
+            .iter()
+            .map(|f| f.strip_prefix(&root).unwrap().to_string_lossy().to_string())
+            .collect();
+        assert!(
+            rels.contains(&"src/lib.rs".to_string()),
+            "source file under dot-dir-rooted project must be collected, got {rels:?}"
+        );
+        assert!(
+            !rels.iter().any(|r| r.contains("node_modules")),
+            "in-project exclusions must still apply, got {rels:?}"
+        );
+        let _ = std::fs::remove_dir_all(&temp);
     }
 
     #[test]

--- a/crates/codelens-engine/src/scope_analysis.rs
+++ b/crates/codelens-engine/src/scope_analysis.rs
@@ -4,7 +4,7 @@
 
 use crate::db::{IndexDb, index_db_path};
 use crate::project::ProjectRoot;
-use crate::project::is_excluded;
+use crate::project::is_excluded_within;
 use crate::symbols::language_for_path;
 use anyhow::Result;
 use serde::Serialize;
@@ -207,7 +207,7 @@ pub fn find_scoped_references(
         // Fallback: full walk
         for entry in WalkDir::new(project.as_path())
             .into_iter()
-            .filter_entry(|e| !is_excluded(e.path()))
+            .filter_entry(|e| !is_excluded_within(project.as_path(), e.path()))
         {
             let entry = entry?;
             if !entry.file_type().is_file() {

--- a/crates/codelens-engine/src/symbols/mod.rs
+++ b/crates/codelens-engine/src/symbols/mod.rs
@@ -29,7 +29,7 @@ use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
 use walkdir::WalkDir;
 
-use crate::project::{collect_files, is_excluded};
+use crate::project::{collect_files, is_excluded_within};
 
 // Types (SymbolKind, SymbolInfo, ParsedSymbol, IndexStats, RankedContextEntry,
 // RankedContextResult, ReadDb) are in types.rs, re-exported above.
@@ -326,7 +326,7 @@ impl SymbolIndex {
             let mut symbols = Vec::new();
             for file in WalkDir::new(&resolved)
                 .into_iter()
-                .filter_entry(|entry| !is_excluded(entry.path()))
+                .filter_entry(|entry| !is_excluded_within(&resolved, entry.path()))
             {
                 let file = file?;
                 if !file.file_type().is_file() || language_for_path(file.path()).is_none() {
@@ -629,7 +629,7 @@ fn get_directory_symbols(
     let mut symbols = Vec::new();
     for entry in WalkDir::new(dir)
         .into_iter()
-        .filter_entry(|entry| !is_excluded(entry.path()))
+        .filter_entry(|entry| !is_excluded_within(dir, entry.path()))
     {
         let entry = entry?;
         if !entry.file_type().is_file() {

--- a/crates/codelens-engine/src/type_hierarchy.rs
+++ b/crates/codelens-engine/src/type_hierarchy.rs
@@ -4,7 +4,7 @@
 
 use crate::db::{IndexDb, index_db_path};
 use crate::project::ProjectRoot;
-use crate::project::is_excluded;
+use crate::project::is_excluded_within;
 use crate::symbols::language_for_path;
 use anyhow::Result;
 use serde::Serialize;
@@ -122,7 +122,7 @@ fn build_type_map(project: &ProjectRoot) -> Result<HashMap<String, TypeNode>> {
         // Fallback: full walk (no index available)
         for entry in WalkDir::new(project.as_path())
             .into_iter()
-            .filter_entry(|e| !is_excluded(e.path()))
+            .filter_entry(|e| !is_excluded_within(project.as_path(), e.path()))
         {
             let entry = entry?;
             if !entry.file_type().is_file() {

--- a/crates/codelens-engine/src/vfs.rs
+++ b/crates/codelens-engine/src/vfs.rs
@@ -5,11 +5,11 @@
 //! - Detects rename via delete+create with same content hash
 //! - Filters unsupported file types and excluded paths
 
-use crate::project::is_excluded;
+use crate::project::is_excluded_within;
 use crate::symbols::language_for_path;
 use serde::Serialize;
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Semantic file event after normalization.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -22,17 +22,20 @@ pub enum FileEvent {
 
 /// Normalize raw watcher events into semantic FileEvents.
 ///
-/// Takes lists of changed (created/modified) and removed paths,
-/// and produces a deduplicated list of FileEvents with rename detection.
-pub fn normalize_events(changed: &[PathBuf], removed: &[PathBuf]) -> Vec<FileEvent> {
+/// Takes the project root plus lists of changed (created/modified) and
+/// removed paths, and produces a deduplicated list of FileEvents with
+/// rename detection. Exclusion is evaluated root-relative so watcher
+/// events for a project rooted under an excluded-name ancestor (e.g.
+/// `~/.claude/...`) are not silently dropped (#358).
+pub fn normalize_events(root: &Path, changed: &[PathBuf], removed: &[PathBuf]) -> Vec<FileEvent> {
     // Filter to supported files only
     let changed: Vec<&PathBuf> = changed
         .iter()
-        .filter(|p| !is_excluded(p) && language_for_path(p).is_some())
+        .filter(|p| !is_excluded_within(root, p) && language_for_path(p).is_some())
         .collect();
     let removed: Vec<&PathBuf> = removed
         .iter()
-        .filter(|p| !is_excluded(p) && language_for_path(p).is_some())
+        .filter(|p| !is_excluded_within(root, p) && language_for_path(p).is_some())
         .collect();
 
     if removed.is_empty() && changed.is_empty() {
@@ -136,15 +139,34 @@ mod tests {
     use std::path::PathBuf;
 
     #[test]
+    fn dot_directory_rooted_project_events_are_not_dropped() {
+        // #358 regression: watcher events for a project rooted under an
+        // excluded-name ancestor must survive normalization.
+        let root = Path::new("/Users/u/.claude/worktrees/proj");
+        let changed = vec![PathBuf::from("/Users/u/.claude/worktrees/proj/src/main.py")];
+        let events = normalize_events(root, &changed, &[]);
+        assert_eq!(
+            events.len(),
+            1,
+            "event under dot-dir root must not be filtered"
+        );
+        // In-project exclusions still apply.
+        let nm = vec![PathBuf::from(
+            "/Users/u/.claude/worktrees/proj/node_modules/dep/x.py",
+        )];
+        assert!(normalize_events(root, &nm, &[]).is_empty());
+    }
+
+    #[test]
     fn empty_events() {
-        let events = normalize_events(&[], &[]);
+        let events = normalize_events(Path::new("/project"), &[], &[]);
         assert!(events.is_empty());
     }
 
     #[test]
     fn simple_modified() {
         let changed = vec![PathBuf::from("/project/src/main.py")];
-        let events = normalize_events(&changed, &[]);
+        let events = normalize_events(Path::new("/project"), &changed, &[]);
         assert_eq!(events.len(), 1);
         assert!(
             matches!(&events[0], FileEvent::Modified(p) if p.to_str().unwrap().contains("main.py"))
@@ -154,7 +176,7 @@ mod tests {
     #[test]
     fn simple_deleted() {
         let removed = vec![PathBuf::from("/project/src/old.py")];
-        let events = normalize_events(&[], &removed);
+        let events = normalize_events(Path::new("/project"), &[], &removed);
         assert_eq!(events.len(), 1);
         assert!(matches!(&events[0], FileEvent::Deleted(_)));
     }
@@ -163,7 +185,7 @@ mod tests {
     fn rename_detection_same_basename() {
         let removed = vec![PathBuf::from("/project/src/service.py")];
         let changed = vec![PathBuf::from("/project/lib/service.py")];
-        let events = normalize_events(&changed, &removed);
+        let events = normalize_events(Path::new("/project"), &changed, &removed);
         assert_eq!(events.len(), 1);
         assert!(matches!(&events[0], FileEvent::Renamed { from, to }
             if from.to_str().unwrap().contains("src/service.py")

--- a/crates/codelens-engine/src/watcher.rs
+++ b/crates/codelens-engine/src/watcher.rs
@@ -50,6 +50,9 @@ impl FileWatcher {
         let events_clone = events_processed.clone();
         let files_clone = files_reindexed.clone();
         let contention_clone = lock_contention_batches.clone();
+        // Owned copy for the move-closure: exclusion is evaluated relative to
+        // the watched root so dot-directory ancestors don't drop events (#358).
+        let watch_root = root.to_path_buf();
 
         let mut debouncer = new_debouncer(
             Duration::from_millis(300),
@@ -87,7 +90,7 @@ impl FileWatcher {
                 events_clone.fetch_add(events.len() as u64, Ordering::Relaxed);
 
                 // Normalize through VFS layer (filters, deduplicates, detects renames)
-                let file_events = vfs::normalize_events(&raw_changed, &raw_removed);
+                let file_events = vfs::normalize_events(&watch_root, &raw_changed, &raw_removed);
                 let (changed, removed, renamed) = vfs::partition_events(&file_events);
 
                 debug!(

--- a/crates/codelens-mcp/src/tools/symbols/inventory.rs
+++ b/crates/codelens-mcp/src/tools/symbols/inventory.rs
@@ -23,7 +23,7 @@ pub fn refresh_symbol_index(state: &AppState, _arguments: &Value) -> ToolResult 
     #[cfg(feature = "semantic")]
     let mut payload = json!(stats);
     #[cfg(not(feature = "semantic"))]
-    let payload = json!(stats);
+    let mut payload = json!(stats);
     #[cfg(feature = "semantic")]
     {
         let project = state.project();
@@ -50,6 +50,27 @@ pub fn refresh_symbol_index(state: &AppState, _arguments: &Value) -> ToolResult 
                 }
             }
         }
+    }
+    // #358 defense-in-depth: a zero-file refresh is almost always a
+    // misconfiguration (wrong project binding, over-broad excludes) or a
+    // discovery defect — flag it instead of returning a bare success the
+    // caller mistakes for a healthy empty index.
+    if let Some(map) = payload.as_object_mut()
+        && map
+            .get("supported_files")
+            .and_then(Value::as_u64)
+            .is_some_and(|count| count == 0)
+    {
+        map.insert(
+            "warning".to_owned(),
+            json!({
+                "code": "zero_supported_files",
+                "message": "No supported files were discovered under the project root. \
+                            Verify the project binding points at the intended workspace \
+                            and check .codelens/config.json exclude patterns — a wrong \
+                            root or over-broad excludes silently yield an empty index.",
+            }),
+        );
     }
     Ok((payload, success_meta(BackendKind::TreeSitter, 0.95)))
 }


### PR DESCRIPTION
## Summary

Fixes #358 — projects rooted under a dot-directory (e.g. `~/.claude/...`) silently indexed **0 files** because `is_excluded` matched the *absolute* path's dot-dir components instead of project-relative components.

- New `is_excluded_within(root, path)` strips the project root before exclusion matching; falls back to the legacy behavior for non-rooted paths.
- All 6 engine walkers converted (`collect_files`, detection walker, `file_ops/reader` list/find/search, `symbols` overview/directory, `scope_analysis`, `type_hierarchy`) + `vfs::normalize_events`/`watcher` (root threaded through).
- Defense in depth: `refresh_symbol_index` now emits a `zero_supported_files` warning payload when a project root yields no supported files, instead of reporting silent success.
- Also includes two benchmark-harness fixes found in the same dogfood pass: `tool-token-profile.py` no longer conflates schema tokens with response tokens (absolute `--response-budget` flag), and `bench.sh` stops rebuilding over an existing binary (feature-set preservation).

## Verification

- e2e: gin repo under `~/.claude/...` — 0 → 110 files indexed; `zero_supported_files` fires on a truly-empty git-init'd root.
- `cargo test -p codelens-engine` (incl. 2 new exclusion tests + vfs dot-root event test), fmt/clippy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)