### PR TITLE
feat(surface): rebalance alwaysLoad for agent-native navigation + repo auto-binding header

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,10 @@
   "mcpServers": {
     "codelens": {
       "type": "http",
-      "url": "http://127.0.0.1:7839/mcp"
+      "url": "http://127.0.0.1:7839/mcp",
+      "headers": {
+        "x-codelens-project": "/Users/bagjaeseog/codelens-mcp-plugin"
+      }
     }
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **alwaysLoad set rebalanced for agent-native navigation (Fable/workflow consumption)** — the `_meta["anthropic/alwaysLoad"]` set now pre-loads the four highest-frequency mechanical navigation verbs (`find_symbol`, `find_referencing_symbols`, `get_symbols_overview`, `get_ranked_context`) alongside the five workflow entrypoints (`prepare_harness_session`, `explore_codebase`, `review_changes`, `review_architecture`, `verify_change_readiness`). Measured motivation: workflow subagents skipped CodeLens navigation entirely when it cost a ToolSearch round trip (1–2 calls vs 10–47 grep sweeps). `plan_safe_refactor` / `trace_request_path` move to deferred-discoverable (still reachable via `suggested_next_tools` chains). Set stays ≤10 — every entry is upfront schema tokens in every session.
+
+- **Repo `.mcp.json` ships the `x-codelens-project` auto-binding header** — sessions opened in this repo bind at initialize, which (verified live) removes the per-response `project_binding` hint (~35% smaller `find_symbol` data payload), the per-session `prepare_harness_session` binding tax, and the wrong-project read risk for every workflow subagent sharing the session connection.
+
 ### Added
 
 - **Opt-in LSP pre-warm pool (P1.3)** — `CODELENS_LSP_PREWARM` spawns the project's language servers in the background at daemon/project-activation time so the latency-sensitive default reference path finds them **warm** (never paying a 2–30s cold start on a request). `auto` derives servers from the index's per-extension file counts (≥10 files, deduped by server, capped at 3); a comma-separated list pins servers explicitly; default `off` (spawning servers costs memory — a deployment decision). Failures (missing binary, non-whitelisted command) log and skip — pre-warm is an optimization, never a correctness dependency. `install-http-daemons-launchd.sh --lsp-prewarm MODE` wires it into the daemon plists. New engine APIs: `SymbolIndex::language_counts`, `LspSessionPool::prewarm_session` (idempotent, whitelist-enforced). e2e: `auto` on this repo pre-warmed rust-analyzer and the default `find_referencing_symbols` path routed `backend: lsp` / `cold_start_incurred: false`. Together with the warm-LSP stage this closes the Python import/type-annotation recall gap on the default path whenever pyright is installed.

--- a/crates/codelens-mcp/src/integration_tests/protocol_tools_list.rs
+++ b/crates/codelens-mcp/src/integration_tests/protocol_tools_list.rs
@@ -870,7 +870,20 @@ fn tools_list_exposes_claude_toolsearch_meta_for_bootstrap_tools() {
         review["_meta"]["anthropic/searchHint"],
         json!("review changed files and risk")
     );
-    assert!(symbol["_meta"].get("anthropic/alwaysLoad").is_none());
+    // 2026-07-03 rebalance: the mechanical navigation core is zero-setup
+    // (alwaysLoad) so agents stop skipping CodeLens over the ToolSearch
+    // round-trip cost; lower-frequency workflow reports stay deferred.
+    assert_eq!(symbol["_meta"]["anthropic/alwaysLoad"], json!(true));
+    let deferred_report = tools
+        .iter()
+        .find(|tool| tool["name"] == "plan_safe_refactor")
+        .expect("plan_safe_refactor present");
+    assert!(
+        deferred_report["_meta"]
+            .get("anthropic/alwaysLoad")
+            .is_none(),
+        "plan_safe_refactor must stay deferred-discoverable"
+    );
 }
 
 #[test]

--- a/crates/codelens-mcp/src/tool_defs/presets/metadata.rs
+++ b/crates/codelens-mcp/src/tool_defs/presets/metadata.rs
@@ -205,21 +205,33 @@ pub(crate) fn tool_anthropic_search_hint(name: &str) -> Option<&'static str> {
 /// Claude Code MCP tools are deferred by default. The always-load set
 /// is what gets `meta["anthropic/alwaysLoad"] = true` — schemas
 /// pre-loaded so the model can call them without a `ToolSearch` round
-/// trip. v1.10.1 widens this from 3 → 8 to cover the workflow-first
-/// surface that the product is positioned around. The remaining
-/// `DEFAULT_LISTED_TOOL_NAMES` entries stay deferred-discoverable but
-/// require explicit ToolSearch select before invocation, which keeps
-/// the initial tool prompt bounded.
+/// trip. The remaining `DEFAULT_LISTED_TOOL_NAMES` entries stay
+/// deferred-discoverable but require explicit ToolSearch select before
+/// invocation, which keeps the initial tool prompt bounded.
+///
+/// Composition (2026-07-03, Fable/agent-consumption rebalance): five
+/// workflow entrypoints (bootstrap, pre-merge review, mutation
+/// preflight, architecture audit, onboarding) PLUS the four
+/// highest-frequency mechanical navigation verbs (`find_symbol`,
+/// `find_referencing_symbols`, `get_symbols_overview`,
+/// `get_ranked_context`). Measured: workflow subagents skipped CodeLens
+/// navigation entirely when it cost a ToolSearch round trip (1–2 calls
+/// vs 10–47 grep sweeps), so the navigation core must be zero-setup.
+/// `plan_safe_refactor` / `trace_request_path` moved to deferred — both
+/// remain reachable via `suggested_next_tools` chains. Keep this set
+/// ≤10: every entry is upfront schema tokens in EVERY session.
 pub(crate) fn tool_anthropic_always_load(name: &str) -> bool {
     matches!(
         name,
         "prepare_harness_session"
             | "explore_codebase"
             | "review_changes"
-            | "plan_safe_refactor"
             | "review_architecture"
             | "verify_change_readiness"
-            | "trace_request_path"
+            | "find_symbol"
+            | "find_referencing_symbols"
+            | "get_symbols_overview"
+            | "get_ranked_context"
     )
 }
 


### PR DESCRIPTION
## Summary

Two structural fixes for **Fable/workflow mechanical consumption**, both grounded in measured friction from live ultracode fan-out sessions.

### 1. alwaysLoad rebalance (7 → 9)

| | Before | After |
|---|---|---|
| Workflow entrypoints | 7 (incl. plan_safe_refactor, trace_request_path) | 5 (bootstrap, review_changes, verify_change_readiness, review_architecture, explore_codebase) |
| **Navigation core** | **0 — all deferred** | **4: find_symbol, find_referencing_symbols, get_symbols_overview, get_ranked_context** |

Measured motivation: workflow subagents **skipped CodeLens navigation entirely** when it cost a ToolSearch round trip — 1–2 codelens calls vs 10–47 grep/Bash sweeps per agent. The highest-frequency verbs must be zero-setup. Demoted tools stay deferred-discoverable and are still surfaced via `suggested_next_tools` chains. Doc comment pins the ≤10 budget rule.

### 2. Repo `.mcp.json` auto-binding header

`x-codelens-project` header added (project-scoped — safe, unlike a user-global header). **Verified live** against the running daemon: header session → `project_binding` hint omitted entirely (`find_symbol` data payload −35%, 984B), per-session `prepare_harness_session` binding tax gone, wrong-project read risk eliminated for every workflow subagent sharing the session connection.

## Test plan

- [x] `tools_list` contract updated: navigation core asserts `alwaysLoad=true`, demoted report asserts deferred
- [x] mcp+http 798 tests, fmt, clippy `--features http`, regen/surface drift — green
- [x] Live daemon verification of header binding (hint omission + payload reduction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)